### PR TITLE
Added multiple.png to FileIconType enum

### DIFF
--- a/change/@uifabric-file-type-icons-2019-07-22-17-46-35-t-shfozd.json
+++ b/change/@uifabric-file-type-icons-2019-07-22-17-46-35-t-shfozd.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Added multiple.png to FileIconType enum",
+  "type": "patch",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "t-shfozd@microsoft.com",
+  "commit": "4717c9370521adb2d8afa0d4398b5ece9fb4b311",
+  "date": "2019-07-23T00:46:35.951Z"
+}

--- a/packages/file-type-icons/src/FileIconType.ts
+++ b/packages/file-type-icons/src/FileIconType.ts
@@ -10,7 +10,8 @@ export enum FileIconType {
   folder = 2,
   genericFile = 3,
   listItem = 4,
-  sharedFolder = 5
+  sharedFolder = 5,
+  multiple = 6
 }
 
-export type FileIconTypeInput = 1 | 2 | 3 | 4 | 5;
+export type FileIconTypeInput = 1 | 2 | 3 | 4 | 5 | 6;

--- a/packages/file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/file-type-icons/src/FileTypeIconMap.ts
@@ -311,6 +311,7 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   mpt: {
     extensions: ['mpt']
   },
+  multiple: {},
   one: {
     extensions: ['one'] // this is a format for exported single - file notebook pages
   },

--- a/packages/file-type-icons/src/getFileTypeIconProps.ts
+++ b/packages/file-type-icons/src/getFileTypeIconProps.ts
@@ -8,6 +8,7 @@ const FOLDER = 'folder';
 const SHARED_FOLDER = 'sharedfolder';
 const DOCSET_FOLDER = 'docset';
 const LIST_ITEM = 'splist';
+const MULTIPLE_ITEMS = 'multiple';
 const DEFAULT_ICON_SIZE: FileTypeIconSize = 16;
 
 export type FileTypeIconSize = 16 | 20 | 32 | 40 | 48 | 64 | 96;
@@ -64,6 +65,9 @@ export function getFileTypeIconProps(options: IFileTypeIconOptions): { iconName:
         break;
       case FileIconType.sharedFolder:
         iconBaseName = SHARED_FOLDER;
+        break;
+      case FileIconType.multiple:
+        iconBaseName = MULTIPLE_ITEMS;
     }
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Added 'multiple' to FileIconType enum so that 'multiple.png' can be used. Running beachball said that no change files were needed. 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9903)