### PR TITLE
[MarqueeSelection] making mousemove event bind to capture phase to work inside Layers

### DIFF
--- a/change/office-ui-fabric-react-2019-07-22-18-36-03-lorejoh-fixingMarqueeSelectionCallout.json
+++ b/change/office-ui-fabric-react-2019-07-22-18-36-03-lorejoh-fixingMarqueeSelectionCallout.json
@@ -1,0 +1,8 @@
+{
+  "comment": "making mousemove event bind to capture phase to work inside Layers and Callouts",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "jolore@microsoft.com",
+  "commit": "551deacac2f6a74e727c98eff6c50bf2388545d3",
+  "date": "2019-07-23T01:36:03.219Z"
+}

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
@@ -143,7 +143,7 @@ export class MarqueeSelectionBase extends BaseComponent<IMarqueeSelectionProps, 
       if (this._scrollableSurface && ev.button === 0 && this._root.current) {
         this._selectedIndicies = {};
         this._preservedIndicies = undefined;
-        this._events.on(window, 'mousemove', this._onAsyncMouseMove);
+        this._events.on(window, 'mousemove', this._onAsyncMouseMove, true);
         this._events.on(this._scrollableParent, 'scroll', this._onAsyncMouseMove);
         this._events.on(window, 'click', this._onMouseUp, true);
 


### PR DESCRIPTION
See bug.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9904
- [x] Include a change request file using `$ npm run change`

#### Description of changes

Making MarqueeSelection bind the mousemove event in the capture phase during the mousedown to avoid having the wrapping Layer catch the event and stopPropagation() on it

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9905)