### PR TITLE
Add multiple item file icon type in Fabric 6

### DIFF
--- a/common/changes/@uifabric/file-type-icons/6.0_2019-07-24-16-36.json
+++ b/common/changes/@uifabric/file-type-icons/6.0_2019-07-24-16-36.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@uifabric/file-type-icons",
+      "comment": "Cherry-picked adding in 'multiple.png' from Fabric 7 in order to use icon du",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@uifabric/file-type-icons",
+  "email": "t-shfozd@microsoft.com"
+}

--- a/packages/file-type-icons/src/FileIconType.ts
+++ b/packages/file-type-icons/src/FileIconType.ts
@@ -10,7 +10,8 @@ export enum FileIconType {
   folder = 2,
   genericFile = 3,
   listItem = 4,
-  sharedFolder = 5
+  sharedFolder = 5,
+  multiple = 6
 }
 
-export type FileIconTypeInput = 1 | 2 | 3 | 4 | 5;
+export type FileIconTypeInput = 1 | 2 | 3 | 4 | 5 | 6;

--- a/packages/file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/file-type-icons/src/FileTypeIconMap.ts
@@ -311,6 +311,7 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   mpt: {
     extensions: ['mpt']
   },
+  multiple: {},
   one: {
     extensions: ['one'] // this is a format for exported single - file notebook pages
   },

--- a/packages/file-type-icons/src/getFileTypeIconProps.ts
+++ b/packages/file-type-icons/src/getFileTypeIconProps.ts
@@ -8,6 +8,7 @@ const FOLDER = 'folder';
 const SHARED_FOLDER = 'sharedfolder';
 const DOCSET_FOLDER = 'docset';
 const LIST_ITEM = 'splist';
+const MULTIPLE_ITEMS = 'multiple';
 const DEFAULT_ICON_SIZE: FileTypeIconSize = 16;
 
 export type FileTypeIconSize = 16 | 20 | 32 | 40 | 48 | 64 | 96;
@@ -64,6 +65,9 @@ export function getFileTypeIconProps(options: IFileTypeIconOptions): { iconName:
         break;
       case FileIconType.sharedFolder:
         iconBaseName = SHARED_FOLDER;
+        break;
+      case FileIconType.multiple:
+        iconBaseName = MULTIPLE_ITEMS;
     }
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Added multiple.png to fileIconType enum. Cherry-picked from #9903 in Fabric 7

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9915)