### PR TITLE
bumps beachball to make repo compatible with node 8

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "dom-test": "cd apps/dom-tests && just-scripts jest-dom-with-webpack"
   },
   "devDependencies": {
-    "beachball": "^1.9.2",
+    "beachball": "^1.10.2",
     "lerna": "^3.15.0",
     "lint-staged": "^7.0.5"
   },

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -23,7 +23,7 @@
     "async": "^2.6.1",
     "autoprefixer": "^7.1.5",
     "babylon": "^7.0.0-beta.47",
-    "beachball": "^1.9.2",
+    "beachball": "^1.10.2",
     "bundlesize": "^0.15.2",
     "chalk": "^2.1.0",
     "codecov": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3876,10 +3876,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-beachball@^1.9.2:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/beachball/-/beachball-1.9.2.tgz#960f2141b5aa2f6d8ba6aada207698c11c1c632a"
-  integrity sha512-wOvfOhtP7vcdVOGKKXwVmmbmrznF00nOCnudlZ8L8cQBva/wDZNPOZ3Fx1623HKbtDu+dlvvZAdeipYdEt5kDQ==
+beachball@^1.10.2:
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/beachball/-/beachball-1.10.2.tgz#ca35c33e9064ee7951422b13384ac8f49df0985b"
+  integrity sha512-YfObcx2G9Knvzkuy+IUk7mJuO+QLPmg+LHiXKuBNgIUtZDg10LBO5c/wgCEbk5TP1ZKxL2x/bqrHARGjCyLOXg==
   dependencies:
     fs-extra "^8.0.1"
     git-url-parse "^11.1.2"


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

@natalieethell had reported that beachball only works on node 10+... this is due to a single line of code. This has been fixed upstream

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9916)