### PR TITLE
Shimmer: refactor out BaseComponent

### DIFF
--- a/change/office-ui-fabric-react-2019-07-23-18-38-27-vibraga-ShimmerRefactor.json
+++ b/change/office-ui-fabric-react-2019-07-23-18-38-27-vibraga-ShimmerRefactor.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Shimmer: refactor out the BaseComponent and deprecated React lifecycle methods.",
+  "type": "minor",
+  "packageName": "office-ui-fabric-react",
+  "email": "vibraga@microsoft.com",
+  "commit": "ac681c3ff6dd6361f22494c1f95e995758dcf573",
+  "date": "2019-07-24T01:38:27.931Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -8666,10 +8666,12 @@ export enum Shade {
 export const Shimmer: React.StatelessComponent<IShimmerProps>;
 
 // @public (undocumented)
-export class ShimmerBase extends BaseComponent<IShimmerProps, IShimmerState> {
+export class ShimmerBase extends React.Component<IShimmerProps, IShimmerState> {
     constructor(props: IShimmerProps);
     // (undocumented)
-    componentWillReceiveProps(nextProps: IShimmerProps): void;
+    componentDidUpdate(prevProps: IShimmerProps): void;
+    // (undocumented)
+    componentWillUnmount(): void;
     // (undocumented)
     static defaultProps: IShimmerProps;
     // (undocumented)
@@ -8680,11 +8682,7 @@ export class ShimmerBase extends BaseComponent<IShimmerProps, IShimmerState> {
 export const ShimmerCircle: React.StatelessComponent<IShimmerCircleProps>;
 
 // @public (undocumented)
-export class ShimmerCircleBase extends BaseComponent<IShimmerCircleProps, {}> {
-    constructor(props: IShimmerCircleProps);
-    // (undocumented)
-    render(): JSX.Element;
-}
+export const ShimmerCircleBase: React.FunctionComponent<IShimmerCircleProps>;
 
 // @public (undocumented)
 export const ShimmeredDetailsList: React.StatelessComponent<IShimmeredDetailsListProps>;
@@ -8707,13 +8705,7 @@ export enum ShimmerElementsDefaultHeights {
 export const ShimmerElementsGroup: React.StatelessComponent<IShimmerElementsGroupProps>;
 
 // @public (undocumented)
-export class ShimmerElementsGroupBase extends BaseComponent<IShimmerElementsGroupProps, {}> {
-    constructor(props: IShimmerElementsGroupProps);
-    // (undocumented)
-    static defaultProps: IShimmerElementsGroupProps;
-    // (undocumented)
-    render(): JSX.Element;
-}
+export const ShimmerElementsGroupBase: React.FunctionComponent<IShimmerElementsGroupProps>;
 
 // @public
 export enum ShimmerElementType {
@@ -8726,21 +8718,13 @@ export enum ShimmerElementType {
 export const ShimmerGap: React.StatelessComponent<IShimmerGapProps>;
 
 // @public (undocumented)
-export class ShimmerGapBase extends BaseComponent<IShimmerGapProps, {}> {
-    constructor(props: IShimmerGapProps);
-    // (undocumented)
-    render(): JSX.Element;
-}
+export const ShimmerGapBase: React.FunctionComponent<IShimmerGapProps>;
 
 // @public (undocumented)
 export const ShimmerLine: React.StatelessComponent<IShimmerLineProps>;
 
 // @public (undocumented)
-export class ShimmerLineBase extends BaseComponent<IShimmerLineProps, {}> {
-    constructor(props: IShimmerLineProps);
-    // (undocumented)
-    render(): JSX.Element;
-}
+export const ShimmerLineBase: React.FunctionComponent<IShimmerLineProps>;
 
 // @public (undocumented)
 export const sizeBoolean: (size: PersonaSize) => {

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.base.tsx
@@ -10,7 +10,7 @@ export interface IShimmerState {
   contentLoaded?: boolean;
 }
 
-const TRANSITION_ANIMATION_INTERVAL = 2000; /* ms */
+const TRANSITION_ANIMATION_INTERVAL = 200; /* ms */
 
 const getClassNames = classNamesFunction<IShimmerStyleProps, IShimmerStyles>();
 

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.base.tsx
@@ -42,6 +42,7 @@ export class ShimmerBase extends React.Component<IShimmerProps, IShimmerState> {
     this._async.clearTimeout(this._lastTimeoutId);
 
     if (isDataLoaded !== prevProps.isDataLoaded) {
+      // Removing the shimmerWrapper div from the DOM only after the fade out animation completed.
       if (isDataLoaded) {
         this._lastTimeoutId = this._async.setTimeout(() => {
           this.setState({

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { classNamesFunction, DelayedRender, getNativeProps, divProperties, Async } from '../../Utilities';
+import { classNamesFunction, DelayedRender, getNativeProps, divProperties, Async, initializeComponentRef } from '../../Utilities';
 import { IShimmerProps, IShimmerStyleProps, IShimmerStyles } from './Shimmer.types';
 import { ShimmerElementsGroup } from './ShimmerElementsGroup/ShimmerElementsGroup';
 
@@ -28,6 +28,8 @@ export class ShimmerBase extends React.Component<IShimmerProps, IShimmerState> {
 
   constructor(props: IShimmerProps) {
     super(props);
+
+    initializeComponentRef(this);
 
     this.state = {
       contentLoaded: props.isDataLoaded

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerCircle/ShimmerCircle.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerCircle/ShimmerCircle.base.tsx
@@ -1,33 +1,25 @@
 import * as React from 'react';
-import { BaseComponent, classNamesFunction } from '../../../Utilities';
+import { classNamesFunction } from '../../../Utilities';
 import { IShimmerCircleProps, IShimmerCircleStyleProps, IShimmerCircleStyles } from './ShimmerCircle.types';
 
 const getClassNames = classNamesFunction<IShimmerCircleStyleProps, IShimmerCircleStyles>();
 
-export class ShimmerCircleBase extends BaseComponent<IShimmerCircleProps, {}> {
-  private _classNames: { [key in keyof IShimmerCircleStyles]: string };
+export const ShimmerCircleBase: React.FunctionComponent<IShimmerCircleProps> = props => {
+  const { height, styles, borderStyle, theme } = props;
+  const classNames = getClassNames(styles!, {
+    theme: theme!,
+    height,
+    borderStyle
+  });
 
-  constructor(props: IShimmerCircleProps) {
-    super(props);
-  }
-
-  public render(): JSX.Element {
-    const { height, styles, borderStyle, theme } = this.props;
-    this._classNames = getClassNames(styles!, {
-      theme: theme!,
-      height,
-      borderStyle
-    });
-
-    return (
-      <div className={this._classNames.root}>
-        <svg viewBox="0 0 10 10" width={height} height={height} className={this._classNames.svg}>
-          <path
-            // tslint:disable-next-line:max-line-length
-            d="M0,0 L10,0 L10,10 L0,10 L0,0 Z M0,5 C0,7.76142375 2.23857625,10 5,10 C7.76142375,10 10,7.76142375 10,5 C10,2.23857625 7.76142375,2.22044605e-16 5,0 C2.23857625,-2.22044605e-16 0,2.23857625 0,5 L0,5 Z"
-          />
-        </svg>
-      </div>
-    );
-  }
-}
+  return (
+    <div className={classNames.root}>
+      <svg viewBox="0 0 10 10" width={height} height={height} className={classNames.svg}>
+        <path
+          // tslint:disable-next-line:max-line-length
+          d="M0,0 L10,0 L10,10 L0,10 L0,0 Z M0,5 C0,7.76142375 2.23857625,10 5,10 C7.76142375,10 10,7.76142375 10,5 C10,2.23857625 7.76142375,2.22044605e-16 5,0 C2.23857625,-2.22044605e-16 0,2.23857625 0,5 L0,5 Z"
+        />
+      </svg>
+    </div>
+  );
+};

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.base.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
-import { BaseComponent, classNamesFunction } from '../../../Utilities';
-import { IShimmerElementsGroupProps, IShimmerElementsGroupStyleProps, IShimmerElementsGroupStyles } from './ShimmerElementsGroup.types';
+import { classNamesFunction } from '../../../Utilities';
 import { IRawStyle } from '../../../Styling';
+import { IShimmerElementsGroupProps, IShimmerElementsGroupStyleProps, IShimmerElementsGroupStyles } from './ShimmerElementsGroup.types';
 import { ShimmerElementType, ShimmerElementsDefaultHeights, IShimmerElement } from '../Shimmer.types';
 import { ShimmerLine } from '../ShimmerLine/ShimmerLine';
 import { IShimmerLineStyles } from '../ShimmerLine/ShimmerLine.types';
@@ -15,138 +15,127 @@ const getClassNames = classNamesFunction<IShimmerElementsGroupStyleProps, IShimm
 /**
  * {@docCategory Shimmer}
  */
-export class ShimmerElementsGroupBase extends BaseComponent<IShimmerElementsGroupProps, {}> {
-  public static defaultProps: IShimmerElementsGroupProps = {
-    flexWrap: false
-  };
+export const ShimmerElementsGroupBase: React.FunctionComponent<IShimmerElementsGroupProps> = props => {
+  const { styles, width, shimmerElements, rowHeight, flexWrap = false, theme, backgroundColor } = props;
 
-  private _classNames: { [key in keyof IShimmerElementsGroupStyles]: string };
+  const classNames = getClassNames(styles!, {
+    theme: theme!,
+    flexWrap
+  });
 
-  constructor(props: IShimmerElementsGroupProps) {
-    super(props);
-  }
+  const height = rowHeight ? rowHeight : findMaxElementHeight(shimmerElements ? shimmerElements : []);
 
-  public render(): JSX.Element {
-    const { styles, width, shimmerElements, rowHeight, flexWrap, theme } = this.props;
+  return (
+    <div style={{ width: width ? width : 'auto' }} className={classNames.root}>
+      {getRenderedElements(shimmerElements, backgroundColor, height)}
+    </div>
+  );
+};
 
-    this._classNames = getClassNames(styles!, {
-      theme: theme!,
-      flexWrap
-    });
-
-    const height = rowHeight ? rowHeight : this._findMaxElementHeight(shimmerElements ? shimmerElements : []);
-
-    return (
-      // tslint:disable-next-line:jsx-ban-props
-      <div style={{ width: width ? width : 'auto' }} className={this._classNames.root}>
-        {this._getRenderedElements(shimmerElements, height)}
-      </div>
-    );
-  }
-
-  private _getRenderedElements = (shimmerElements?: IShimmerElement[], rowHeight?: number): React.ReactNode => {
-    const renderedElements: React.ReactNode = shimmerElements ? (
-      shimmerElements.map(
-        (elem: IShimmerElement, index: number): JSX.Element => {
-          const { type, ...filteredElem } = elem;
-          switch (elem.type) {
-            case ShimmerElementType.circle:
-              return <ShimmerCircle key={index} {...filteredElem} styles={this._getStyles(elem, rowHeight)} />;
-            case ShimmerElementType.gap:
-              return <ShimmerGap key={index} {...filteredElem} styles={this._getStyles(elem, rowHeight)} />;
-            case ShimmerElementType.line:
-              return <ShimmerLine key={index} {...filteredElem} styles={this._getStyles(elem, rowHeight)} />;
-          }
-        }
-      )
-    ) : (
-      <ShimmerLine height={ShimmerElementsDefaultHeights.line} styles={{ root: [{ borderWidth: '0px' }] }} />
-    );
-
-    return renderedElements;
-  };
-
-  private _getStyles = (elem: IShimmerElement, rowHeight?: number): IShimmerCircleStyles | IShimmerGapStyles | IShimmerLineStyles => {
-    const { backgroundColor } = this.props;
-    const { verticalAlign, type } = elem;
-    const elemHeight: number | undefined = elem.height;
-    const dif: number = rowHeight && elemHeight ? rowHeight - elemHeight : 0;
-
-    let borderStyle: IRawStyle | undefined;
-
-    if (!verticalAlign || verticalAlign === 'center') {
-      borderStyle = {
-        borderBottomWidth: `${dif ? Math.floor(dif / 2) : 0}px`,
-        borderTopWidth: `${dif ? Math.ceil(dif / 2) : 0}px`
-      };
-    } else if (verticalAlign && verticalAlign === 'top') {
-      borderStyle = {
-        borderBottomWidth: `${dif ? dif : 0}px`,
-        borderTopWidth: `0px`
-      };
-    } else if (verticalAlign && verticalAlign === 'bottom') {
-      borderStyle = {
-        borderBottomWidth: `0px`,
-        borderTopWidth: `${dif ? dif : 0}px`
-      };
-    }
-
-    if (backgroundColor) {
-      switch (type) {
-        case ShimmerElementType.circle:
-          return {
-            root: { ...borderStyle, borderColor: backgroundColor },
-            svg: { fill: backgroundColor }
-          };
-        case ShimmerElementType.gap:
-          return {
-            root: { ...borderStyle, borderColor: backgroundColor, backgroundColor: backgroundColor }
-          };
-        case ShimmerElementType.line:
-          return {
-            root: { ...borderStyle, borderColor: backgroundColor },
-            topLeftCorner: { fill: backgroundColor },
-            topRightCorner: { fill: backgroundColor },
-            bottomLeftCorner: { fill: backgroundColor },
-            bottomRightCorner: { fill: backgroundColor }
-          };
-      }
-    }
-
-    return {
-      root: { ...borderStyle }
-    };
-  };
-
-  /**
-   * User should not worry to provide which of the elements is the highest, we do the calculation for him.
-   * Plus if user forgot to specify the height we assign their defaults.
-   */
-  private _findMaxElementHeight = (elements: IShimmerElement[]): number => {
-    const itemsDefaulted: IShimmerElement[] = elements.map(
-      (elem: IShimmerElement): IShimmerElement => {
-        switch (elem.type) {
+function getRenderedElements(shimmerElements?: IShimmerElement[], backgroundColor?: string, rowHeight?: number): React.ReactNode {
+  const renderedElements: React.ReactNode = shimmerElements ? (
+    shimmerElements.map(
+      (element: IShimmerElement, index: number): JSX.Element => {
+        const { type, ...filteredElem } = element;
+        switch (element.type) {
           case ShimmerElementType.circle:
-            if (!elem.height) {
-              elem.height = ShimmerElementsDefaultHeights.circle;
-            }
-          case ShimmerElementType.line:
-            if (!elem.height) {
-              elem.height = ShimmerElementsDefaultHeights.line;
-            }
+            return <ShimmerCircle key={index} {...filteredElem} styles={getElementStyles(element, backgroundColor, rowHeight)} />;
           case ShimmerElementType.gap:
-            if (!elem.height) {
-              elem.height = ShimmerElementsDefaultHeights.gap;
-            }
+            return <ShimmerGap key={index} {...filteredElem} styles={getElementStyles(element, backgroundColor, rowHeight)} />;
+          case ShimmerElementType.line:
+            return <ShimmerLine key={index} {...filteredElem} styles={getElementStyles(element, backgroundColor, rowHeight)} />;
         }
-        return elem;
       }
-    );
+    )
+  ) : (
+    <ShimmerLine height={ShimmerElementsDefaultHeights.line} styles={{ root: [{ borderWidth: '0px' }] }} />
+  );
 
-    const rowHeight = itemsDefaulted.reduce((acc: number, next: IShimmerElement): number => {
-      return next.height ? (next.height > acc ? next.height : acc) : acc;
-    }, 0);
+  return renderedElements;
+}
 
-    return rowHeight;
+function getElementStyles(
+  element: IShimmerElement,
+  backgroundColor?: string,
+  rowHeight?: number
+): IShimmerCircleStyles | IShimmerGapStyles | IShimmerLineStyles {
+  const { verticalAlign, type, height: elementHeight } = element;
+  const dif: number = rowHeight && elementHeight ? rowHeight - elementHeight : 0;
+
+  let borderStyle: IRawStyle | undefined;
+
+  if (!verticalAlign || verticalAlign === 'center') {
+    borderStyle = {
+      borderBottomWidth: `${dif ? Math.floor(dif / 2) : 0}px`,
+      borderTopWidth: `${dif ? Math.ceil(dif / 2) : 0}px`
+    };
+  } else if (verticalAlign && verticalAlign === 'top') {
+    borderStyle = {
+      borderBottomWidth: `${dif}px`,
+      borderTopWidth: `0px`
+    };
+  } else if (verticalAlign && verticalAlign === 'bottom') {
+    borderStyle = {
+      borderBottomWidth: `0px`,
+      borderTopWidth: `${dif}px`
+    };
+  }
+
+  if (backgroundColor) {
+    switch (type) {
+      case ShimmerElementType.circle:
+        return {
+          root: { ...borderStyle, borderColor: backgroundColor },
+          svg: { fill: backgroundColor }
+        };
+      case ShimmerElementType.gap:
+        return {
+          root: { ...borderStyle, borderColor: backgroundColor, backgroundColor: backgroundColor }
+        };
+      case ShimmerElementType.line:
+        return {
+          root: { ...borderStyle, borderColor: backgroundColor },
+          topLeftCorner: { fill: backgroundColor },
+          topRightCorner: { fill: backgroundColor },
+          bottomLeftCorner: { fill: backgroundColor },
+          bottomRightCorner: { fill: backgroundColor }
+        };
+    }
+  }
+
+  return {
+    root: { ...borderStyle }
   };
+}
+
+/**
+ * User should not worry to provide which of the elements is the highest so we do the calculation for him.
+ * Plus if user forgot to specify the height we assign their defaults.
+ */
+function findMaxElementHeight(shimmerElements: IShimmerElement[]): number {
+  const shimmerElementsDefaulted: IShimmerElement[] = shimmerElements.map(
+    (element: IShimmerElement): IShimmerElement => {
+      switch (element.type) {
+        case ShimmerElementType.circle:
+          if (!element.height) {
+            element.height = ShimmerElementsDefaultHeights.circle;
+          }
+        case ShimmerElementType.line:
+          if (!element.height) {
+            element.height = ShimmerElementsDefaultHeights.line;
+          }
+        case ShimmerElementType.gap:
+          if (!element.height) {
+            element.height = ShimmerElementsDefaultHeights.gap;
+          }
+      }
+      return element;
+    }
+  );
+
+  const rowHeight = shimmerElementsDefaulted.reduce((acc: number, next: IShimmerElement): number => {
+    return next.height ? (next.height > acc ? next.height : acc) : acc;
+  }, 0);
+
+  return rowHeight;
 }

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerElementsGroup/ShimmerElementsGroup.base.tsx
@@ -16,18 +16,24 @@ const getClassNames = classNamesFunction<IShimmerElementsGroupStyleProps, IShimm
  * {@docCategory Shimmer}
  */
 export const ShimmerElementsGroupBase: React.FunctionComponent<IShimmerElementsGroupProps> = props => {
-  const { styles, width, shimmerElements, rowHeight, flexWrap = false, theme, backgroundColor } = props;
+  const {
+    styles,
+    width = 'auto',
+    shimmerElements,
+    rowHeight = findMaxElementHeight(shimmerElements || []),
+    flexWrap = false,
+    theme,
+    backgroundColor
+  } = props;
 
   const classNames = getClassNames(styles!, {
     theme: theme!,
     flexWrap
   });
 
-  const height = rowHeight ? rowHeight : findMaxElementHeight(shimmerElements ? shimmerElements : []);
-
   return (
-    <div style={{ width: width ? width : 'auto' }} className={classNames.root}>
-      {getRenderedElements(shimmerElements, backgroundColor, height)}
+    <div style={{ width: width }} className={classNames.root}>
+      {getRenderedElements(shimmerElements, backgroundColor, rowHeight)}
     </div>
   );
 };
@@ -48,7 +54,7 @@ function getRenderedElements(shimmerElements?: IShimmerElement[], backgroundColo
       }
     )
   ) : (
-    <ShimmerLine height={ShimmerElementsDefaultHeights.line} styles={{ root: [{ borderWidth: '0px' }] }} />
+    <ShimmerLine height={ShimmerElementsDefaultHeights.line} />
   );
 
   return renderedElements;
@@ -104,7 +110,7 @@ function getElementStyles(
   }
 
   return {
-    root: { ...borderStyle }
+    root: borderStyle
   };
 }
 

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerGap/ShimmerGap.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerGap/ShimmerGap.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, classNamesFunction } from '../../../Utilities';
+import { classNamesFunction } from '../../../Utilities';
 import { IShimmerGapProps, IShimmerGapStyleProps, IShimmerGapStyles } from './ShimmerGap.types';
 
 const getClassNames = classNamesFunction<IShimmerGapStyleProps, IShimmerGapStyles>();
@@ -7,27 +7,19 @@ const getClassNames = classNamesFunction<IShimmerGapStyleProps, IShimmerGapStyle
 /**
  * {@docCategory Shimmer}
  */
-export class ShimmerGapBase extends BaseComponent<IShimmerGapProps, {}> {
-  private _classNames: { [key in keyof IShimmerGapStyles]: string };
+export const ShimmerGapBase: React.FunctionComponent<IShimmerGapProps> = props => {
+  const { height, styles, width, borderStyle, theme } = props;
 
-  constructor(props: IShimmerGapProps) {
-    super(props);
-  }
+  const classNames = getClassNames(styles!, {
+    theme: theme!,
+    height,
+    borderStyle
+  });
 
-  public render(): JSX.Element {
-    const { height, styles, width, borderStyle, theme } = this.props;
-
-    this._classNames = getClassNames(styles!, {
-      theme: theme!,
-      height,
-      borderStyle
-    });
-
-    return (
-      <div
-        style={{ width: width ? width : '10px', minWidth: typeof width === 'number' ? `${width}px` : 'auto' }}
-        className={this._classNames.root}
-      />
-    );
-  }
-}
+  return (
+    <div
+      style={{ width: width ? width : '10px', minWidth: typeof width === 'number' ? `${width}px` : 'auto' }}
+      className={classNames.root}
+    />
+  );
+};

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerGap/ShimmerGap.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerGap/ShimmerGap.base.tsx
@@ -8,7 +8,7 @@ const getClassNames = classNamesFunction<IShimmerGapStyleProps, IShimmerGapStyle
  * {@docCategory Shimmer}
  */
 export const ShimmerGapBase: React.FunctionComponent<IShimmerGapProps> = props => {
-  const { height, styles, width, borderStyle, theme } = props;
+  const { height, styles, width = '10px', borderStyle, theme } = props;
 
   const classNames = getClassNames(styles!, {
     theme: theme!,
@@ -16,10 +16,5 @@ export const ShimmerGapBase: React.FunctionComponent<IShimmerGapProps> = props =
     borderStyle
   });
 
-  return (
-    <div
-      style={{ width: width ? width : '10px', minWidth: typeof width === 'number' ? `${width}px` : 'auto' }}
-      className={classNames.root}
-    />
-  );
+  return <div style={{ width: width, minWidth: typeof width === 'number' ? `${width}px` : 'auto' }} className={classNames.root} />;
 };

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerLine/ShimmerLine.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerLine/ShimmerLine.base.tsx
@@ -8,7 +8,7 @@ const getClassNames = classNamesFunction<IShimmerLineStyleProps, IShimmerLineSty
  * {@docCategory Shimmer}
  */
 export const ShimmerLineBase: React.FunctionComponent<IShimmerLineProps> = props => {
-  const { height, styles, width, borderStyle, theme } = props;
+  const { height, styles, width = '100%', borderStyle, theme } = props;
 
   const classNames = getClassNames(styles!, {
     theme: theme!,
@@ -17,7 +17,7 @@ export const ShimmerLineBase: React.FunctionComponent<IShimmerLineProps> = props
   });
 
   return (
-    <div style={{ width: width ? width : '100%', minWidth: typeof width === 'number' ? `${width}px` : 'auto' }} className={classNames.root}>
+    <div style={{ width: width, minWidth: typeof width === 'number' ? `${width}px` : 'auto' }} className={classNames.root}>
       <svg width="2" height="2" className={classNames.topLeftCorner}>
         <path d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z" />
       </svg>

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerLine/ShimmerLine.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerLine/ShimmerLine.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, classNamesFunction } from '../../../Utilities';
+import { classNamesFunction } from '../../../Utilities';
 import { IShimmerLineProps, IShimmerLineStyleProps, IShimmerLineStyles } from './ShimmerLine.types';
 
 const getClassNames = classNamesFunction<IShimmerLineStyleProps, IShimmerLineStyles>();
@@ -7,40 +7,29 @@ const getClassNames = classNamesFunction<IShimmerLineStyleProps, IShimmerLineSty
 /**
  * {@docCategory Shimmer}
  */
-export class ShimmerLineBase extends BaseComponent<IShimmerLineProps, {}> {
-  private _classNames: { [key in keyof IShimmerLineStyles]: string };
+export const ShimmerLineBase: React.FunctionComponent<IShimmerLineProps> = props => {
+  const { height, styles, width, borderStyle, theme } = props;
 
-  constructor(props: IShimmerLineProps) {
-    super(props);
-  }
+  const classNames = getClassNames(styles!, {
+    theme: theme!,
+    height,
+    borderStyle
+  });
 
-  public render(): JSX.Element {
-    const { height, styles, width, borderStyle, theme } = this.props;
-
-    this._classNames = getClassNames(styles!, {
-      theme: theme!,
-      height,
-      borderStyle
-    });
-
-    return (
-      <div
-        style={{ width: width ? width : '100%', minWidth: typeof width === 'number' ? `${width}px` : 'auto' }}
-        className={this._classNames.root}
-      >
-        <svg width="2" height="2" className={this._classNames.topLeftCorner}>
-          <path d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z" />
-        </svg>
-        <svg width="2" height="2" className={this._classNames.topRightCorner}>
-          <path d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z" />
-        </svg>
-        <svg width="2" height="2" className={this._classNames.bottomRightCorner}>
-          <path d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z" />
-        </svg>
-        <svg width="2" height="2" className={this._classNames.bottomLeftCorner}>
-          <path d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z" />
-        </svg>
-      </div>
-    );
-  }
-}
+  return (
+    <div style={{ width: width ? width : '100%', minWidth: typeof width === 'number' ? `${width}px` : 'auto' }} className={classNames.root}>
+      <svg width="2" height="2" className={classNames.topLeftCorner}>
+        <path d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z" />
+      </svg>
+      <svg width="2" height="2" className={classNames.topRightCorner}>
+        <path d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z" />
+      </svg>
+      <svg width="2" height="2" className={classNames.bottomRightCorner}>
+        <path d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z" />
+      </svg>
+      <svg width="2" height="2" className={classNames.bottomLeftCorner}>
+        <path d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z" />
+      </svg>
+    </div>
+  );
+};

--- a/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerLine/ShimmerLine.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/ShimmerLine/ShimmerLine.styles.ts
@@ -33,6 +33,7 @@ export function getStyles(props: IShimmerLineStyleProps): IShimmerLineStyles {
         borderTopStyle: 'solid',
         borderBottomStyle: 'solid',
         borderColor: semanticColors.bodyBackground,
+        borderWidth: 0,
         selectors: {
           [HighContrastSelector]: {
             borderColor: 'Window',

--- a/packages/office-ui-fabric-react/src/components/Shimmer/__snapshots__/Shimmer.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/__snapshots__/Shimmer.test.tsx.snap
@@ -170,6 +170,7 @@ exports[`Shimmer renders Shimmer correctly 1`] = `
               border-color: #ffffff;
               border-top-style: solid;
               border-top-width: 5px;
+              border-width: 0px;
               box-sizing: content-box;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
@@ -366,6 +367,7 @@ exports[`Shimmer renders Shimmer with custom elements correctly 1`] = `
                 border-color: #ffffff;
                 border-top-style: solid;
                 border-top-width: 0px;
+                border-width: 0px;
                 box-sizing: content-box;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
@@ -512,6 +514,7 @@ exports[`Shimmer renders Shimmer with custom elements correctly 1`] = `
                 border-color: #ffffff;
                 border-top-style: solid;
                 border-top-width: 5px;
+                border-width: 0px;
                 box-sizing: content-box;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
@@ -608,6 +611,7 @@ exports[`Shimmer renders Shimmer with custom elements correctly 1`] = `
                 border-color: #ffffff;
                 border-top-style: solid;
                 border-top-width: 5px;
+                border-width: 0px;
                 box-sizing: content-box;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Application.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Application.Example.tsx
@@ -50,7 +50,7 @@ export class ShimmerApplicationExample extends React.Component<{}, IShimmerAppli
     this._async = new Async(this);
   }
 
-  public componentWillMount(): void {
+  public componentWillUnmount(): void {
     this._async.dispose();
   }
 

--- a/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Application.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Application.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
+import { Async } from 'office-ui-fabric-react/lib/Utilities';
 import { createListItems, IExampleItem } from 'office-ui-fabric-react/lib/utilities/exampleData';
 import { IColumn, buildColumns, SelectionMode, Toggle } from 'office-ui-fabric-react/lib/index';
 import { ShimmeredDetailsList } from 'office-ui-fabric-react/lib/ShimmeredDetailsList';
@@ -33,9 +33,10 @@ export interface IShimmerApplicationExampleState {
   isDataLoaded?: boolean;
 }
 
-export class ShimmerApplicationExample extends BaseComponent<{}, IShimmerApplicationExampleState> {
+export class ShimmerApplicationExample extends React.Component<{}, IShimmerApplicationExampleState> {
   private _lastIntervalId: number;
   private _lastIndexWithData: number;
+  private _async: Async;
 
   constructor(props: {}) {
     super(props);
@@ -45,6 +46,12 @@ export class ShimmerApplicationExample extends BaseComponent<{}, IShimmerApplica
       columns: _buildColumns(),
       isDataLoaded: false
     };
+
+    this._async = new Async(this);
+  }
+
+  public componentWillMount(): void {
+    this._async.dispose();
   }
 
   public render(): JSX.Element {

--- a/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Basic.Example.tsx
@@ -6,72 +6,70 @@ import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
 const wrapperClass = mergeStyles({
   padding: 2,
   selectors: {
-    '& > *': {
+    '& > .ms-Shimmer-container': {
       margin: '10px 0'
     }
   }
 });
 
-export class ShimmerBasicExample extends React.Component<{}, {}> {
-  public render(): JSX.Element {
-    return (
-      <Fabric className={wrapperClass}>
-        Basic Shimmer with no elements provided. It defaults to a line of 16px height.
-        <Shimmer />
-        <Shimmer width="75%" />
-        <Shimmer width="50%" />
-        Basic Shimmer with elements provided.
-        <Shimmer
-          shimmerElements={[
-            { type: ShimmerElementType.circle },
-            { type: ShimmerElementType.gap, width: '2%' },
-            { type: ShimmerElementType.line }
-          ]}
-        />
-        <Shimmer
-          shimmerElements={[
-            { type: ShimmerElementType.circle, height: 24 },
-            { type: ShimmerElementType.gap, width: '2%' },
-            { type: ShimmerElementType.line, height: 16, width: '20%' },
-            { type: ShimmerElementType.gap, width: '5%' },
-            { type: ShimmerElementType.line, height: 16, width: '20%' },
-            { type: ShimmerElementType.gap, width: '10%' },
-            { type: ShimmerElementType.line, height: 16, width: '15%' },
-            { type: ShimmerElementType.gap, width: '10%' },
-            { type: ShimmerElementType.line, height: 16 }
-          ]}
-        />
-        <Shimmer
-          width={'70%'}
-          shimmerElements={[
-            { type: ShimmerElementType.circle, height: 24 },
-            { type: ShimmerElementType.gap, width: '2%' },
-            { type: ShimmerElementType.line, height: 16, width: '20%' },
-            { type: ShimmerElementType.gap, width: '5%' },
-            { type: ShimmerElementType.line, height: 16, width: '20%' },
-            { type: ShimmerElementType.gap, width: '10%' },
-            { type: ShimmerElementType.line, height: 16, width: '15%' },
-            { type: ShimmerElementType.gap, width: '10%' },
-            { type: ShimmerElementType.line, height: 16 }
-          ]}
-        />
-        Variations of vertical alignment for Circles and Lines.
-        <Shimmer
-          shimmerElements={[
-            { type: ShimmerElementType.circle },
-            { type: ShimmerElementType.gap, width: '2%' },
-            { type: ShimmerElementType.circle, height: 15, verticalAlign: 'top' },
-            { type: ShimmerElementType.gap, width: '2%' },
-            { type: ShimmerElementType.line, verticalAlign: 'bottom', width: '20%' },
-            { type: ShimmerElementType.gap, width: '2%' },
-            { type: ShimmerElementType.line, height: 5, verticalAlign: 'top', width: '20%' },
-            { type: ShimmerElementType.gap, width: '2%' },
-            { type: ShimmerElementType.line, height: 16, width: '15%' },
-            { type: ShimmerElementType.gap, width: '2%' },
-            { type: ShimmerElementType.line, height: 10, verticalAlign: 'bottom' }
-          ]}
-        />
-      </Fabric>
-    );
-  }
-}
+export const ShimmerBasicExample: React.StatelessComponent = () => {
+  return (
+    <Fabric className={wrapperClass}>
+      Basic Shimmer with no elements provided. It defaults to a line of 16px height.
+      <Shimmer />
+      <Shimmer width="75%" />
+      <Shimmer width="50%" />
+      Basic Shimmer with elements provided.
+      <Shimmer
+        shimmerElements={[
+          { type: ShimmerElementType.circle },
+          { type: ShimmerElementType.gap, width: '2%' },
+          { type: ShimmerElementType.line }
+        ]}
+      />
+      <Shimmer
+        shimmerElements={[
+          { type: ShimmerElementType.circle, height: 24 },
+          { type: ShimmerElementType.gap, width: '2%' },
+          { type: ShimmerElementType.line, height: 16, width: '20%' },
+          { type: ShimmerElementType.gap, width: '5%' },
+          { type: ShimmerElementType.line, height: 16, width: '20%' },
+          { type: ShimmerElementType.gap, width: '10%' },
+          { type: ShimmerElementType.line, height: 16, width: '15%' },
+          { type: ShimmerElementType.gap, width: '10%' },
+          { type: ShimmerElementType.line, height: 16 }
+        ]}
+      />
+      <Shimmer
+        width={'70%'}
+        shimmerElements={[
+          { type: ShimmerElementType.circle, height: 24 },
+          { type: ShimmerElementType.gap, width: '2%' },
+          { type: ShimmerElementType.line, height: 16, width: '20%' },
+          { type: ShimmerElementType.gap, width: '5%' },
+          { type: ShimmerElementType.line, height: 16, width: '20%' },
+          { type: ShimmerElementType.gap, width: '10%' },
+          { type: ShimmerElementType.line, height: 16, width: '15%' },
+          { type: ShimmerElementType.gap, width: '10%' },
+          { type: ShimmerElementType.line, height: 16 }
+        ]}
+      />
+      Variations of vertical alignment for Circles and Lines.
+      <Shimmer
+        shimmerElements={[
+          { type: ShimmerElementType.circle },
+          { type: ShimmerElementType.gap, width: '2%' },
+          { type: ShimmerElementType.circle, height: 15, verticalAlign: 'top' },
+          { type: ShimmerElementType.gap, width: '2%' },
+          { type: ShimmerElementType.line, verticalAlign: 'bottom', width: '20%' },
+          { type: ShimmerElementType.gap, width: '2%' },
+          { type: ShimmerElementType.line, height: 5, verticalAlign: 'top', width: '20%' },
+          { type: ShimmerElementType.gap, width: '2%' },
+          { type: ShimmerElementType.line, height: 16, width: '15%' },
+          { type: ShimmerElementType.gap, width: '2%' },
+          { type: ShimmerElementType.line, height: 10, verticalAlign: 'bottom' }
+        ]}
+      />
+    </Fabric>
+  );
+};

--- a/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.CustomElements.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.CustomElements.Example.tsx
@@ -6,7 +6,7 @@ import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
 const wrapperClass = mergeStyles({
   padding: 2,
   selectors: {
-    '& > *': {
+    '& > .ms-Shimmer-container': {
       margin: '10px 0'
     }
   }

--- a/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.LoadData.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.LoadData.Example.tsx
@@ -7,7 +7,7 @@ import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
 const wrapperClass = mergeStyles({
   padding: 2,
   selectors: {
-    '& > *': {
+    '& > .ms-Shimmer-container': {
       margin: '10px 0'
     }
   }

--- a/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Styling.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/examples/Shimmer.Styling.Example.tsx
@@ -18,7 +18,7 @@ const customThemeForShimmer: ITheme = createTheme({
 const classNames = mergeStyleSets({
   wrapper: {
     selectors: {
-      '& > *': {
+      '& > .ms-Shimmer-container': {
         margin: '10px 0'
       }
     }
@@ -33,7 +33,7 @@ const classNames = mergeStyleSets({
     justifyContent: 'stretch',
     background: customThemeForShimmer.palette.white, // using the palette color to match the gaps and borders of the shimmer.
     selectors: {
-      '& > :first-child': {
+      '& > .ms-Shimmer-container': {
         flexGrow: 1
       }
     }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
@@ -657,6 +657,7 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                         border-color: #ffffff;
                                         border-top-style: solid;
                                         border-top-width: 14px;
+                                        border-width: 0px;
                                         box-sizing: content-box;
                                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                         font-size: 14px;
@@ -966,6 +967,7 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                         border-color: #ffffff;
                                         border-top-style: solid;
                                         border-top-width: 14px;
+                                        border-width: 0px;
                                         box-sizing: content-box;
                                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                         font-size: 14px;
@@ -1275,6 +1277,7 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                         border-color: #ffffff;
                                         border-top-style: solid;
                                         border-top-width: 14px;
+                                        border-width: 0px;
                                         box-sizing: content-box;
                                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                         font-size: 14px;
@@ -1584,6 +1587,7 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                         border-color: #ffffff;
                                         border-top-style: solid;
                                         border-top-width: 14px;
+                                        border-width: 0px;
                                         box-sizing: content-box;
                                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                         font-size: 14px;
@@ -1893,6 +1897,7 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                         border-color: #ffffff;
                                         border-top-style: solid;
                                         border-top-width: 14px;
+                                        border-width: 0px;
                                         box-sizing: content-box;
                                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                         font-size: 14px;
@@ -2202,6 +2207,7 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                         border-color: #ffffff;
                                         border-top-style: solid;
                                         border-top-width: 14px;
+                                        border-width: 0px;
                                         box-sizing: content-box;
                                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                         font-size: 14px;
@@ -2511,6 +2517,7 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                         border-color: #ffffff;
                                         border-top-style: solid;
                                         border-top-width: 14px;
+                                        border-width: 0px;
                                         box-sizing: content-box;
                                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                         font-size: 14px;
@@ -2820,6 +2827,7 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                         border-color: #ffffff;
                                         border-top-style: solid;
                                         border-top-width: 14px;
+                                        border-width: 0px;
                                         box-sizing: content-box;
                                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                         font-size: 14px;
@@ -3129,6 +3137,7 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                         border-color: #ffffff;
                                         border-top-style: solid;
                                         border-top-width: 14px;
+                                        border-width: 0px;
                                         box-sizing: content-box;
                                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                         font-size: 14px;
@@ -3438,6 +3447,7 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                         border-color: #ffffff;
                                         border-top-style: solid;
                                         border-top-width: 14px;
+                                        border-width: 0px;
                                         box-sizing: content-box;
                                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                         font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Basic.Example.tsx.shot
@@ -25,7 +25,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
       & textarea {
         font-family: inherit;
       }
-      & > * {
+      & > .ms-Shimmer-container {
         margin-bottom: 10px;
         margin-left: 0;
         margin-right: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Basic.Example.tsx.shot
@@ -758,6 +758,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                 border-color: #ffffff;
                 border-top-style: solid;
                 border-top-width: 4px;
+                border-width: 0px;
                 box-sizing: content-box;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
@@ -1015,6 +1016,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                 border-color: #ffffff;
                 border-top-style: solid;
                 border-top-width: 4px;
+                border-width: 0px;
                 box-sizing: content-box;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
@@ -1140,6 +1142,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                 border-color: #ffffff;
                 border-top-style: solid;
                 border-top-width: 4px;
+                border-width: 0px;
                 box-sizing: content-box;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
@@ -1265,6 +1268,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                 border-color: #ffffff;
                 border-top-style: solid;
                 border-top-width: 4px;
+                border-width: 0px;
                 box-sizing: content-box;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
@@ -1390,6 +1394,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                 border-color: #ffffff;
                 border-top-style: solid;
                 border-top-width: 4px;
+                border-width: 0px;
                 box-sizing: content-box;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
@@ -1647,6 +1652,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                 border-color: #ffffff;
                 border-top-style: solid;
                 border-top-width: 4px;
+                border-width: 0px;
                 box-sizing: content-box;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
@@ -1772,6 +1778,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                 border-color: #ffffff;
                 border-top-style: solid;
                 border-top-width: 4px;
+                border-width: 0px;
                 box-sizing: content-box;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
@@ -1897,6 +1904,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                 border-color: #ffffff;
                 border-top-style: solid;
                 border-top-width: 4px;
+                border-width: 0px;
                 box-sizing: content-box;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
@@ -2022,6 +2030,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                 border-color: #ffffff;
                 border-top-style: solid;
                 border-top-width: 4px;
+                border-width: 0px;
                 box-sizing: content-box;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
@@ -2351,6 +2360,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                 border-color: #ffffff;
                 border-top-style: solid;
                 border-top-width: 8px;
+                border-width: 0px;
                 box-sizing: content-box;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
@@ -2476,6 +2486,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                 border-color: #ffffff;
                 border-top-style: solid;
                 border-top-width: 0px;
+                border-width: 0px;
                 box-sizing: content-box;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
@@ -2601,6 +2612,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                 border-color: #ffffff;
                 border-top-style: solid;
                 border-top-width: 4px;
+                border-width: 0px;
                 box-sizing: content-box;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
@@ -2726,6 +2738,7 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                 border-color: #ffffff;
                 border-top-style: solid;
                 border-top-width: 14px;
+                border-width: 0px;
                 box-sizing: content-box;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.CustomElements.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.CustomElements.Example.tsx.shot
@@ -25,7 +25,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
       & textarea {
         font-family: inherit;
       }
-      & > * {
+      & > .ms-Shimmer-container {
         margin-bottom: 10px;
         margin-left: 0;
         margin-right: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.CustomElements.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.CustomElements.Example.tsx.shot
@@ -138,6 +138,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                   border-color: #ffffff;
                   border-top-style: solid;
                   border-top-width: 0px;
+                  border-width: 0px;
                   box-sizing: content-box;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
@@ -284,6 +285,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                   border-color: #ffffff;
                   border-top-style: solid;
                   border-top-width: 5px;
+                  border-width: 0px;
                   box-sizing: content-box;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
@@ -380,6 +382,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                   border-color: #ffffff;
                   border-top-style: solid;
                   border-top-width: 5px;
+                  border-width: 0px;
                   box-sizing: content-box;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
@@ -695,6 +698,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                   border-color: #ffffff;
                   border-top-style: solid;
                   border-top-width: 5px;
+                  border-width: 0px;
                   box-sizing: content-box;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
@@ -820,6 +824,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                   border-color: #ffffff;
                   border-top-style: solid;
                   border-top-width: 5px;
+                  border-width: 0px;
                   box-sizing: content-box;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
@@ -1014,6 +1019,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                   border-color: #ffffff;
                   border-top-style: solid;
                   border-top-width: 0px;
+                  border-width: 0px;
                   box-sizing: content-box;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
@@ -1261,6 +1267,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                     border-color: #ffffff;
                     border-top-style: solid;
                     border-top-width: 5px;
+                    border-width: 0px;
                     box-sizing: content-box;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
@@ -1386,6 +1393,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                     border-color: #ffffff;
                     border-top-style: solid;
                     border-top-width: 5px;
+                    border-width: 0px;
                     box-sizing: content-box;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
@@ -1503,6 +1511,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                     border-color: #ffffff;
                     border-top-style: solid;
                     border-top-width: 10px;
+                    border-width: 0px;
                     box-sizing: content-box;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
@@ -1628,6 +1637,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                     border-color: #ffffff;
                     border-top-style: solid;
                     border-top-width: 10px;
+                    border-width: 0px;
                     box-sizing: content-box;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
@@ -1753,6 +1763,7 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                     border-color: #ffffff;
                     border-top-style: solid;
                     border-top-width: 10px;
+                    border-width: 0px;
                     box-sizing: content-box;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
@@ -10,7 +10,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
         padding-right: 2px;
         padding-top: 2px;
       }
-      & > * {
+      & > .ms-Shimmer-container {
         margin-bottom: 10px;
         margin-left: 0;
         margin-right: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
@@ -713,6 +713,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
                   border-color: #ffffff;
                   border-top-style: solid;
                   border-top-width: 10px;
+                  border-width: 0px;
                   box-sizing: content-box;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
@@ -809,6 +810,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
                   border-color: #ffffff;
                   border-top-style: solid;
                   border-top-width: 6px;
+                  border-width: 0px;
                   box-sizing: content-box;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Styling.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Styling.Example.tsx.shot
@@ -228,6 +228,7 @@ Array [
                   border-color: #0078D4;
                   border-top-style: solid;
                   border-top-width: 4px;
+                  border-width: 0px;
                   box-sizing: content-box;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
@@ -353,6 +354,7 @@ Array [
                   border-color: #0078D4;
                   border-top-style: solid;
                   border-top-width: 4px;
+                  border-width: 0px;
                   box-sizing: content-box;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
@@ -478,6 +480,7 @@ Array [
                   border-color: #0078D4;
                   border-top-style: solid;
                   border-top-width: 4px;
+                  border-width: 0px;
                   box-sizing: content-box;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
@@ -603,6 +606,7 @@ Array [
                   border-color: #0078D4;
                   border-top-style: solid;
                   border-top-width: 4px;
+                  border-width: 0px;
                   box-sizing: content-box;
                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                   font-size: 14px;
@@ -923,6 +927,7 @@ Array [
                     border-color: #0078D4;
                     border-top-style: solid;
                     border-top-width: 10px;
+                    border-width: 0px;
                     box-sizing: content-box;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
@@ -1019,6 +1024,7 @@ Array [
                     border-color: #0078D4;
                     border-top-style: solid;
                     border-top-width: 6px;
+                    border-width: 0px;
                     box-sizing: content-box;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
@@ -1363,6 +1369,7 @@ Array [
                     border-color: #0078D4;
                     border-top-style: solid;
                     border-top-width: 10px;
+                    border-width: 0px;
                     box-sizing: content-box;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
@@ -1459,6 +1466,7 @@ Array [
                     border-color: #0078D4;
                     border-top-style: solid;
                     border-top-width: 6px;
+                    border-width: 0px;
                     box-sizing: content-box;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Styling.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Styling.Example.tsx.shot
@@ -55,7 +55,7 @@ Array [
           padding-right: 20px;
           padding-top: 20px;
         }
-        & > :first-child {
+        & > .ms-Shimmer-container {
           flex-grow: 1;
         }
   >
@@ -1591,7 +1591,7 @@ Array [
   <div
     className=
 
-        & > * {
+        & > .ms-Shimmer-container {
           margin-bottom: 10px;
           margin-left: 0;
           margin-right: 0;


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ yarn change`

#### Description of changes

Cleaning up Shimmer related components from the BaseComponent inheritance and convert the leaf nodes to functional components. It’s a breaking change but I doubt that those components were ever inherited from. Also tweaked some of the examples.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9922)