### PR TITLE
Adds aria label to custom picker on the demo page

### DIFF
--- a/change/office-ui-fabric-react-2019-07-24-15-54-55-susunda-add-aria-label-to-custom-picker.json
+++ b/change/office-ui-fabric-react-2019-07-24-15-54-55-susunda-add-aria-label-to-custom-picker.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Added aria label to demo page for custom picker",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "susunda@microsoft.com",
+  "commit": "68ea0bec1c98e56038683fc464e0002222e9a772",
+  "date": "2019-07-24T22:54:55.140Z"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/examples/Picker.CustomResult.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/examples/Picker.CustomResult.Example.tsx
@@ -346,7 +346,8 @@ export class PickerCustomResultExample extends React.Component<{}, IPeoplePicker
           disabled={this.state.isPickerDisabled}
           inputProps={{
             onFocus: () => console.log('onFocus called'),
-            onBlur: () => console.log('onBlur called')
+            onBlur: () => console.log('onBlur called'),
+            'aria-label': 'Document Picker'
           }}
         />
       </div>


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #8655
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Adds aria label to custom picker on the [demo page](https://uifabric-prod.azurewebsites.net/?example=jhkjhkj#/controls/web/pickers). This is not an issue with the custom picker component since the label should be defined by whoever creates the custom picker so that it's specific enough for screen readers



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9928)