### PR TITLE
TeachingBubble: Fix primary button high contrast styling issues

### DIFF
--- a/change/office-ui-fabric-react-2019-07-25-10-08-59-teachingBubbleHighContrast.json
+++ b/change/office-ui-fabric-react-2019-07-25-10-08-59-teachingBubbleHighContrast.json
@@ -1,0 +1,8 @@
+{
+  "comment": "TeachingBubble: Fix primary button high contrast styling issues.",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "5824e529e3e143bad4ea5c257140a38d82524926",
+  "date": "2019-07-25T17:08:59.289Z"
+}

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
@@ -200,21 +200,17 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
     primaryButton: [
       classNames.primaryButton,
       primaryButtonClassName,
+      DefaultFontStyles.medium,
       {
         backgroundColor: palette.white,
         borderColor: palette.white,
+        color: palette.themePrimary,
         whiteSpace: 'nowrap',
         selectors: {
-          // TODO: global class name usage should be converted to a button styles function once Button supports JS styling
-          [`.${classNames.buttonLabel}`]: [
-            DefaultFontStyles.medium,
-            {
-              color: palette.themePrimary
-            }
-          ],
           ':hover': {
             backgroundColor: palette.themeLighter,
-            borderColor: palette.themeLighter
+            borderColor: palette.themeLighter,
+            color: palette.themePrimary
           },
           ':focus': {
             backgroundColor: palette.themeLighter,
@@ -222,7 +218,8 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
           },
           ':active': {
             backgroundColor: palette.white,
-            borderColor: palette.white
+            borderColor: palette.white,
+            color: palette.themePrimary
           }
         }
       }

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
@@ -1,14 +1,5 @@
 import { ITeachingBubbleStyleProps, ITeachingBubbleStyles } from './TeachingBubble.types';
-import {
-  AnimationVariables,
-  DefaultFontStyles,
-  FontSizes,
-  FontWeights,
-  getGlobalClassNames,
-  GlobalClassNames,
-  IStyle,
-  keyframes
-} from '../../Styling';
+import { AnimationVariables, FontSizes, FontWeights, getGlobalClassNames, GlobalClassNames, IStyle, keyframes } from '../../Styling';
 
 const globalClassNames = {
   root: 'ms-TeachingBubble',
@@ -167,7 +158,7 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
       classNames.header,
       ...headerStyle(classNames, hasCondensedHeadline, hasSmallHeadline),
       (hasCondensedHeadline || hasSmallHeadline) && [
-        DefaultFontStyles.medium,
+        theme.fonts.medium,
         {
           marginRight: 10,
           fontWeight: FontWeights.semibold
@@ -207,7 +198,7 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
         whiteSpace: 'nowrap',
         selectors: {
           // TODO: global class name usage should be converted to a button styles function once Button supports JS styling
-          [`.${classNames.buttonLabel}`]: DefaultFontStyles.medium,
+          [`.${classNames.buttonLabel}`]: theme.fonts.medium,
           ':hover': {
             backgroundColor: palette.themeLighter,
             borderColor: palette.themeLighter,
@@ -235,7 +226,7 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
         selectors: {
           // TODO: global class name usage should be converted to a button styles function once Button supports JS styling
           [`.${classNames.buttonLabel}`]: [
-            DefaultFontStyles.medium,
+            theme.fonts.medium,
             {
               color: palette.white
             }

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
@@ -200,13 +200,14 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
     primaryButton: [
       classNames.primaryButton,
       primaryButtonClassName,
-      DefaultFontStyles.medium,
       {
         backgroundColor: palette.white,
         borderColor: palette.white,
         color: palette.themePrimary,
         whiteSpace: 'nowrap',
         selectors: {
+          // TODO: global class name usage should be converted to a button styles function once Button supports JS styling
+          [`.${classNames.buttonLabel}`]: DefaultFontStyles.medium,
           ':hover': {
             backgroundColor: palette.themeLighter,
             borderColor: palette.themeLighter,

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -390,6 +390,13 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
               background-color: WindowText;
               color: Window;
             }
+            & .ms-Button-label {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+            }
         data-is-focusable={true}
         onClick={[Function]}
         onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -314,7 +314,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
               border-radius: 2px;
               border: none;
               box-sizing: border-box;
-              color: #ffffff;
+              color: #0078d4;
               cursor: pointer;
               display: inline-block;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
@@ -370,7 +370,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
             &:hover {
               background-color: #deecf9;
               border-color: #deecf9;
-              color: #ffffff;
+              color: #0078d4;
             }
             @media screen and (-ms-high-contrast: active){&:hover {
               background-color: Highlight;
@@ -383,20 +383,12 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
             &:active {
               background-color: #ffffff;
               border-color: #ffffff;
-              color: #ffffff;
+              color: #0078d4;
             }
             @media screen and (-ms-high-contrast: active){&:active {
               -ms-high-contrast-adjust: none;
               background-color: WindowText;
               color: Window;
-            }
-            & .ms-Button-label {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              color: #0078d4;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
             }
         data-is-focusable={true}
         onClick={[Function]}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #7999
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR fixes a bug where the `PrimaryButton` inside `TeachingBubbles` was not adapting correctly to high contrast mode because of specificity issues in its styling.

__Before:__

![image](https://user-images.githubusercontent.com/13743867/52770415-0411aa80-3059-11e9-83f2-f2fa093e37a9.png)

__After:__

![image](https://user-images.githubusercontent.com/7798177/61894093-7d44e180-aec4-11e9-91e1-fa9bac2333d5.png)


#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9937)