### PR TITLE
Fix aria-owns attribute on extended picker

### DIFF
--- a/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
+++ b/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
@@ -1598,7 +1598,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<div class=\\"ms-BasePicker-text\\" role=\\"list\\">",
+              "text": "<div class=\\"ms-BasePicker-text\\" role=\\"list\\"><div class=\\"to-3\\" data-is-focusable=\\"true\\">To:</div><input aria-label=\\"People Picker\\" class=\\"ms-BasePicker-input\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" autocomplete=\\"off\\" role=\\"combobox\\" value=\\"\\" autocapitalize=\\"off\\" data-lpignore=\\"true\\"></div>",
             },
           },
         },
@@ -1611,38 +1611,6 @@ Array [
     },
     "ruleId": "aria-required-children",
     "ruleIndex": 8,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "input",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input aria-label=\\"People Picker\\" class=\\"ms-BasePicker-input\\" aria-owns=\\"suggestion-list\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" autocomplete=\\"off\\" role=\\"combobox\\" value=\\"\\" autocapitalize=\\"off\\" data-lpignore=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-owns=\\"suggestion-list\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-owns=\\"suggestion-list\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
   },
 ]
 `;
@@ -1667,7 +1635,7 @@ Array [
           },
           "region": Object {
             "snippet": Object {
-              "text": "<div class=\\"ms-BasePicker-text\\" role=\\"list\\">",
+              "text": "<div class=\\"ms-BasePicker-text\\" role=\\"list\\"><div class=\\"to-3\\" data-is-focusable=\\"true\\">To:</div><input aria-label=\\"People Picker\\" class=\\"ms-BasePicker-input\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" autocomplete=\\"off\\" role=\\"combobox\\" value=\\"\\" autocapitalize=\\"off\\" data-lpignore=\\"true\\"></div>",
             },
           },
         },
@@ -1680,38 +1648,6 @@ Array [
     },
     "ruleId": "aria-required-children",
     "ruleIndex": 8,
-  },
-  Object {
-    "kind": "fail",
-    "level": "error",
-    "locations": Array [
-      Object {
-        "logicalLocations": Array [
-          Object {
-            "fullyQualifiedName": "input",
-            "kind": "element",
-          },
-        ],
-        "physicalLocation": Object {
-          "artifactLocation": Object {
-            "index": 0,
-            "uri": "about:blank",
-          },
-          "region": Object {
-            "snippet": Object {
-              "text": "<input aria-label=\\"People Picker\\" class=\\"ms-BasePicker-input\\" aria-owns=\\"suggestion-list\\" aria-expanded=\\"false\\" aria-haspopup=\\"true\\" autocomplete=\\"off\\" role=\\"combobox\\" value=\\"\\" autocapitalize=\\"off\\" data-lpignore=\\"true\\">",
-            },
-          },
-        },
-      },
-    ],
-    "message": Object {
-      "markdown": "Fix all of the following:
-- Invalid ARIA attribute value: aria-owns=\\"suggestion-list\\".",
-      "text": "Fix all of the following: Invalid ARIA attribute value: aria-owns=\\"suggestion-list\\".",
-    },
-    "ruleId": "aria-valid-attr-value",
-    "ruleIndex": 12,
   },
 ]
 `;

--- a/change/office-ui-fabric-react-2019-07-25-10-58-51-andrescb-extended-picker-owns.json
+++ b/change/office-ui-fabric-react-2019-07-25-10-58-51-andrescb-extended-picker-owns.json
@@ -1,0 +1,8 @@
+{
+  "comment": "[BaseExtendedPicker] Only add aria-owns tag when the picker is expanded",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "andrescb@microsoft.com",
+  "commit": "2d761ca83281964abfa1de77f2dc42bd753cf90e",
+  "date": "2019-07-25T17:58:51.078Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -100,6 +100,7 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extend
       this.floatingPicker.current && this.floatingPicker.current.currentSelectedSuggestionIndex !== -1
         ? 'sug-' + this.floatingPicker.current.currentSelectedSuggestionIndex
         : undefined;
+    const isExpanded = this.floatingPicker.current ? this.floatingPicker.current.isSuggestionsShown : false;
 
     return (
       <div
@@ -122,8 +123,8 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extend
                   onClick={this.onInputClick}
                   onInputValueChange={this.onInputChange}
                   aria-activedescendant={activeDescendant}
-                  aria-owns="suggestion-list"
-                  aria-expanded={this.floatingPicker.current ? this.floatingPicker.current.isSuggestionsShown : false}
+                  aria-owns={isExpanded ? 'suggestion-list' : undefined}
+                  aria-expanded={isExpanded}
                   aria-haspopup="true"
                   autoCapitalize="off"
                   autoComplete="off"

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/__snapshots__/BaseExtendedPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/__snapshots__/BaseExtendedPicker.test.tsx.snap
@@ -37,7 +37,6 @@ exports[`Pickers BasePicker renders BaseExtendedPicker correctly with no items 1
         <input
           aria-expanded={false}
           aria-haspopup="true"
-          aria-owns="suggestion-list"
           autoCapitalize="off"
           autoComplete="off"
           className="ms-BasePicker-input"
@@ -107,7 +106,6 @@ exports[`Pickers BasePicker renders BaseExtendedPicker correctly with selected a
         <input
           aria-expanded={false}
           aria-haspopup="true"
-          aria-owns="suggestion-list"
           autoCapitalize="off"
           autoComplete="off"
           className="ms-BasePicker-input"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Basic.Example.tsx.shot
@@ -58,7 +58,6 @@ exports[`Component Examples renders ExtendedPeoplePicker.Basic.Example.tsx corre
             aria-expanded={false}
             aria-haspopup="true"
             aria-label="People Picker"
-            aria-owns="suggestion-list"
             autoCapitalize="off"
             autoComplete="off"
             className="ms-BasePicker-input"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Controlled.Example.tsx.shot
@@ -58,7 +58,6 @@ exports[`Component Examples renders ExtendedPeoplePicker.Controlled.Example.tsx 
             aria-expanded={false}
             aria-haspopup="true"
             aria-label="People Picker"
-            aria-owns="suggestion-list"
             autoCapitalize="off"
             autoComplete="off"
             className="ms-BasePicker-input"


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9940 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This change makes it so that the aria-owns tag in the BaseExtendedPicker's Autofill only gets set when the picker is enabled and showing suggestions. Otherwise it is set to null.

This is so that the aria attribute will always have a valid value

<!--#### Focus areas to test-->


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9942)