### PR TITLE
Fix cell animations so they only trigger on valid cell key changes

### DIFF
--- a/change/office-ui-fabric-react-2019-07-25-18-15-26-details-animation-state.json
+++ b/change/office-ui-fabric-react-2019-07-25-18-15-26-details-animation-state.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Fix cell animations so they only trigger on cell key changes",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "commit": "d380472ca36a47aea323781ff94d87dbec4b3c0b",
+  "date": "2019-07-26T01:15:26.884Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -3539,6 +3539,8 @@ export interface IDetailsRowFieldsProps extends IOverrideColumnRenderProps {
     columns: IColumn[];
     columnStartIndex: number;
     compact?: boolean;
+    // (undocumented)
+    enableUpdateAnimations?: boolean;
     item: any;
     itemIndex: number;
     rowClassNames: {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
@@ -238,6 +238,7 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
         columnStartIndex={showCheckbox ? 1 : 0}
         onRenderItemColumn={onRenderItemColumn}
         getCellValueKey={getCellValueKey}
+        enableUpdateAnimations={enableUpdateAnimations}
       />
     );
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.tsx
@@ -29,8 +29,15 @@ export const DetailsRowFields: React.FunctionComponent<IDetailsRowFieldsProps> =
     itemIndex,
     onRenderItemColumn,
     getCellValueKey,
-    cellsByColumn
+    cellsByColumn,
+    enableUpdateAnimations
   } = props;
+
+  const cellValueKeysRef = React.useRef<{
+    [columnKey: string]: string | undefined;
+  }>();
+
+  const cellValueKeys = cellValueKeysRef.current || (cellValueKeysRef.current = {});
 
   return (
     <div className={rowClassNames.fields} data-automationid="DetailsRowFields" role="presentation">
@@ -51,8 +58,20 @@ export const DetailsRowFields: React.FunctionComponent<IDetailsRowFieldsProps> =
             ? onRender(item, itemIndex, column)
             : getCellText(item, column);
 
+        const previousValueKey = cellValueKeys[column.key];
+
+        const cellValueKey = enableUpdateAnimations && getValueKey ? getValueKey(item, itemIndex, column) : undefined;
+
+        let showAnimation = false;
+
+        if (cellValueKey !== undefined && previousValueKey !== undefined && cellValueKey !== previousValueKey) {
+          showAnimation = true;
+        }
+
+        cellValueKeys[column.key] = cellValueKey;
+
         // generate a key that auto-dirties when content changes, to force the container to re-render, to trigger animation
-        const key = getValueKey ? getValueKey(item, itemIndex, column) : column.key + itemIndex;
+        const key = `${column.key}${cellValueKey !== undefined ? `-${cellValueKey}` : ''}`;
         return (
           <div
             key={key}
@@ -64,7 +83,7 @@ export const DetailsRowFields: React.FunctionComponent<IDetailsRowFieldsProps> =
               column.isRowHeader && rowClassNames.isRowHeader,
               rowClassNames.cell,
               column.isPadded ? rowClassNames.cellPadded : rowClassNames.cellUnpadded,
-              rowClassNames.cellAnimation
+              showAnimation && rowClassNames.cellAnimation
             )}
             style={{ width }}
             data-automationid="DetailsRowCell"

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowFields.types.ts
@@ -56,4 +56,6 @@ export interface IDetailsRowFieldsProps extends IOverrideColumnRenderProps {
    * Style properties to customize cell render output.
    */
   cellStyleProps?: ICellStyleProps;
+
+  enableUpdateAnimations?: boolean;
 }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -5347,7 +5347,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="key"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -5531,7 +5530,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="key"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -5963,7 +5961,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="key"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -6147,7 +6144,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="key"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -6331,7 +6327,6 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="key"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -1977,7 +1977,6 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
           {
             padding-right: 8px;
           }
-
       data-automation-key="key"
       data-automationid="DetailsRowCell"
       role="gridcell"
@@ -2034,7 +2033,6 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
           {
             padding-right: 8px;
           }
-
       data-automation-key="name"
       data-automationid="DetailsRowCell"
       role="gridcell"
@@ -2091,7 +2089,6 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
           {
             padding-right: 8px;
           }
-
       data-automation-key="value"
       data-automationid="DetailsRowCell"
       role="gridcell"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.BulkOperations.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.BulkOperations.Example.tsx.shot
@@ -1552,7 +1552,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="name"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -1666,7 +1665,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="modified"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -1723,7 +1721,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="modifiedby"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -1780,7 +1777,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="filesize"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -2157,7 +2153,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="name"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -2271,7 +2266,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="modified"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -2328,7 +2322,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="modifiedby"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -2385,7 +2378,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="filesize"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -2762,7 +2754,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="name"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -2876,7 +2867,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="modified"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -2933,7 +2923,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="modifiedby"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -2990,7 +2979,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="filesize"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3367,7 +3355,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="name"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3481,7 +3468,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="modified"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3538,7 +3524,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="modifiedby"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3595,7 +3580,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="filesize"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3972,7 +3956,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="name"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -4086,7 +4069,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="modified"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -4143,7 +4125,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="modifiedby"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -4200,7 +4181,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="filesize"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -4577,7 +4557,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="name"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -4691,7 +4670,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="modified"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -4748,7 +4726,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="modifiedby"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -4805,7 +4782,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="filesize"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -5182,7 +5158,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="name"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -5296,7 +5271,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="modified"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -5353,7 +5327,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="modifiedby"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -5410,7 +5383,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="filesize"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -5787,7 +5759,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="name"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -5901,7 +5872,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="modified"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -5958,7 +5928,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="modifiedby"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -6015,7 +5984,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="filesize"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -6392,7 +6360,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="name"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -6506,7 +6473,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="modified"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -6563,7 +6529,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="modifiedby"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -6620,7 +6585,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="filesize"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -6997,7 +6961,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="name"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -7111,7 +7074,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="modified"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -7168,7 +7130,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="modifiedby"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -7225,7 +7186,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="filesize"
                               data-automationid="DetailsRowCell"
                               role="gridcell"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.QuickActions.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.QuickActions.Example.tsx.shot
@@ -1496,7 +1496,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="name"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -1680,7 +1679,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="modified"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -1739,7 +1737,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="modifiedby"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -1798,7 +1795,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="filesize"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -2175,7 +2171,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="name"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -2359,7 +2354,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="modified"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -2418,7 +2412,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="modifiedby"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -2477,7 +2470,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="filesize"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -2854,7 +2846,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="name"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -3038,7 +3029,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="modified"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -3097,7 +3087,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="modifiedby"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -3156,7 +3145,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="filesize"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -3533,7 +3521,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="name"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -3717,7 +3704,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="modified"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -3776,7 +3762,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="modifiedby"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -3835,7 +3820,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="filesize"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -4212,7 +4196,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="name"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -4396,7 +4379,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="modified"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -4455,7 +4437,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="modifiedby"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -4514,7 +4495,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="filesize"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -4891,7 +4871,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="name"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -5075,7 +5054,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="modified"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -5134,7 +5112,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="modifiedby"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -5193,7 +5170,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="filesize"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -5570,7 +5546,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="name"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -5754,7 +5729,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="modified"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -5813,7 +5787,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="modifiedby"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -5872,7 +5845,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="filesize"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -6249,7 +6221,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="name"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -6433,7 +6404,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="modified"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -6492,7 +6462,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="modifiedby"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -6551,7 +6520,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="filesize"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -6928,7 +6896,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="name"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -7112,7 +7079,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="modified"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -7171,7 +7137,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="modifiedby"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -7230,7 +7195,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="filesize"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -7607,7 +7571,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="name"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -7791,7 +7754,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="modified"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -7850,7 +7812,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="modifiedby"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -7909,7 +7870,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="filesize"
                             data-automationid="DetailsRowCell"
                             role="gridcell"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -1774,7 +1774,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="thumbnail"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -2150,7 +2149,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="thumbnail"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -2526,7 +2524,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="thumbnail"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -2902,7 +2899,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="thumbnail"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -3278,7 +3274,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="thumbnail"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -3654,7 +3649,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="thumbnail"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -4030,7 +4024,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="thumbnail"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -4406,7 +4399,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="thumbnail"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -4782,7 +4774,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="thumbnail"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -5158,7 +5149,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="thumbnail"
                             data-automationid="DetailsRowCell"
                             role="gridcell"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Animation.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Animation.Example.tsx.shot
@@ -1130,12 +1130,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 {
                                   padding-right: 8px;
                                 }
-                                {
-                                  animation-duration: 0.367s;
-                                  animation-fill-mode: both;
-                                  animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(40px,0,0);}to{transform:translate3d(0,0,0);};
-                                  animation-timing-function: cubic-bezier(.1,.9,.2,1);
-                                }
                             data-automation-key="column1"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -1191,12 +1185,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 }
                                 {
                                   padding-right: 8px;
-                                }
-                                {
-                                  animation-duration: 0.367s;
-                                  animation-fill-mode: both;
-                                  animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(40px,0,0);}to{transform:translate3d(0,0,0);};
-                                  animation-timing-function: cubic-bezier(.1,.9,.2,1);
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
@@ -1573,12 +1561,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 {
                                   padding-right: 8px;
                                 }
-                                {
-                                  animation-duration: 0.367s;
-                                  animation-fill-mode: both;
-                                  animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(40px,0,0);}to{transform:translate3d(0,0,0);};
-                                  animation-timing-function: cubic-bezier(.1,.9,.2,1);
-                                }
                             data-automation-key="column1"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -1634,12 +1616,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 }
                                 {
                                   padding-right: 8px;
-                                }
-                                {
-                                  animation-duration: 0.367s;
-                                  animation-fill-mode: both;
-                                  animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(40px,0,0);}to{transform:translate3d(0,0,0);};
-                                  animation-timing-function: cubic-bezier(.1,.9,.2,1);
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
@@ -2016,12 +1992,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 {
                                   padding-right: 8px;
                                 }
-                                {
-                                  animation-duration: 0.367s;
-                                  animation-fill-mode: both;
-                                  animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(40px,0,0);}to{transform:translate3d(0,0,0);};
-                                  animation-timing-function: cubic-bezier(.1,.9,.2,1);
-                                }
                             data-automation-key="column1"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -2077,12 +2047,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 }
                                 {
                                   padding-right: 8px;
-                                }
-                                {
-                                  animation-duration: 0.367s;
-                                  animation-fill-mode: both;
-                                  animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(40px,0,0);}to{transform:translate3d(0,0,0);};
-                                  animation-timing-function: cubic-bezier(.1,.9,.2,1);
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
@@ -2459,12 +2423,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 {
                                   padding-right: 8px;
                                 }
-                                {
-                                  animation-duration: 0.367s;
-                                  animation-fill-mode: both;
-                                  animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(40px,0,0);}to{transform:translate3d(0,0,0);};
-                                  animation-timing-function: cubic-bezier(.1,.9,.2,1);
-                                }
                             data-automation-key="column1"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -2520,12 +2478,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 }
                                 {
                                   padding-right: 8px;
-                                }
-                                {
-                                  animation-duration: 0.367s;
-                                  animation-fill-mode: both;
-                                  animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(40px,0,0);}to{transform:translate3d(0,0,0);};
-                                  animation-timing-function: cubic-bezier(.1,.9,.2,1);
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
@@ -2902,12 +2854,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 {
                                   padding-right: 8px;
                                 }
-                                {
-                                  animation-duration: 0.367s;
-                                  animation-fill-mode: both;
-                                  animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(40px,0,0);}to{transform:translate3d(0,0,0);};
-                                  animation-timing-function: cubic-bezier(.1,.9,.2,1);
-                                }
                             data-automation-key="column1"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -2963,12 +2909,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 }
                                 {
                                   padding-right: 8px;
-                                }
-                                {
-                                  animation-duration: 0.367s;
-                                  animation-fill-mode: both;
-                                  animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(40px,0,0);}to{transform:translate3d(0,0,0);};
-                                  animation-timing-function: cubic-bezier(.1,.9,.2,1);
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
@@ -3345,12 +3285,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 {
                                   padding-right: 8px;
                                 }
-                                {
-                                  animation-duration: 0.367s;
-                                  animation-fill-mode: both;
-                                  animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(40px,0,0);}to{transform:translate3d(0,0,0);};
-                                  animation-timing-function: cubic-bezier(.1,.9,.2,1);
-                                }
                             data-automation-key="column1"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -3406,12 +3340,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 }
                                 {
                                   padding-right: 8px;
-                                }
-                                {
-                                  animation-duration: 0.367s;
-                                  animation-fill-mode: both;
-                                  animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(40px,0,0);}to{transform:translate3d(0,0,0);};
-                                  animation-timing-function: cubic-bezier(.1,.9,.2,1);
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
@@ -3788,12 +3716,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 {
                                   padding-right: 8px;
                                 }
-                                {
-                                  animation-duration: 0.367s;
-                                  animation-fill-mode: both;
-                                  animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(40px,0,0);}to{transform:translate3d(0,0,0);};
-                                  animation-timing-function: cubic-bezier(.1,.9,.2,1);
-                                }
                             data-automation-key="column1"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -3849,12 +3771,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 }
                                 {
                                   padding-right: 8px;
-                                }
-                                {
-                                  animation-duration: 0.367s;
-                                  animation-fill-mode: both;
-                                  animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(40px,0,0);}to{transform:translate3d(0,0,0);};
-                                  animation-timing-function: cubic-bezier(.1,.9,.2,1);
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
@@ -4231,12 +4147,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 {
                                   padding-right: 8px;
                                 }
-                                {
-                                  animation-duration: 0.367s;
-                                  animation-fill-mode: both;
-                                  animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(40px,0,0);}to{transform:translate3d(0,0,0);};
-                                  animation-timing-function: cubic-bezier(.1,.9,.2,1);
-                                }
                             data-automation-key="column1"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -4292,12 +4202,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 }
                                 {
                                   padding-right: 8px;
-                                }
-                                {
-                                  animation-duration: 0.367s;
-                                  animation-fill-mode: both;
-                                  animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(40px,0,0);}to{transform:translate3d(0,0,0);};
-                                  animation-timing-function: cubic-bezier(.1,.9,.2,1);
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
@@ -4674,12 +4578,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 {
                                   padding-right: 8px;
                                 }
-                                {
-                                  animation-duration: 0.367s;
-                                  animation-fill-mode: both;
-                                  animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(40px,0,0);}to{transform:translate3d(0,0,0);};
-                                  animation-timing-function: cubic-bezier(.1,.9,.2,1);
-                                }
                             data-automation-key="column1"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -4735,12 +4633,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 }
                                 {
                                   padding-right: 8px;
-                                }
-                                {
-                                  animation-duration: 0.367s;
-                                  animation-fill-mode: both;
-                                  animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(40px,0,0);}to{transform:translate3d(0,0,0);};
-                                  animation-timing-function: cubic-bezier(.1,.9,.2,1);
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"
@@ -5117,12 +5009,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 {
                                   padding-right: 8px;
                                 }
-                                {
-                                  animation-duration: 0.367s;
-                                  animation-fill-mode: both;
-                                  animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(40px,0,0);}to{transform:translate3d(0,0,0);};
-                                  animation-timing-function: cubic-bezier(.1,.9,.2,1);
-                                }
                             data-automation-key="column1"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -5178,12 +5064,6 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                 }
                                 {
                                   padding-right: 8px;
-                                }
-                                {
-                                  animation-duration: 0.367s;
-                                  animation-fill-mode: both;
-                                  animation-name: keyframes from{opacity:0;}to{opacity:1;} keyframes from{transform:translate3d(40px,0,0);}to{transform:translate3d(0,0,0);};
-                                  animation-timing-function: cubic-bezier(.1,.9,.2,1);
                                 }
                             data-automation-key="column2"
                             data-automationid="DetailsRowCell"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -1311,7 +1311,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -1368,7 +1367,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -1744,7 +1742,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -1801,7 +1798,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -2177,7 +2173,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -2234,7 +2229,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -2610,7 +2604,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -2667,7 +2660,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3043,7 +3035,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3100,7 +3091,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3476,7 +3466,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3533,7 +3522,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3909,7 +3897,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3966,7 +3953,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -4342,7 +4328,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -4399,7 +4384,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -4775,7 +4759,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -4832,7 +4815,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -5208,7 +5190,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -5265,7 +5246,6 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="gridcell"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -1313,7 +1313,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -1370,7 +1369,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -1747,7 +1745,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -1804,7 +1801,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -2181,7 +2177,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -2238,7 +2233,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -2615,7 +2609,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -2672,7 +2665,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3049,7 +3041,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3106,7 +3097,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3483,7 +3473,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3540,7 +3529,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3917,7 +3905,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3974,7 +3961,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -4351,7 +4337,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -4408,7 +4393,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -4785,7 +4769,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -4842,7 +4825,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -5219,7 +5201,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -5276,7 +5257,6 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="gridcell"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
@@ -864,7 +864,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="thumbnail"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -1281,7 +1280,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="thumbnail"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -1698,7 +1696,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="thumbnail"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -2115,7 +2112,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="thumbnail"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -2532,7 +2528,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="thumbnail"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -2949,7 +2944,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="thumbnail"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -3366,7 +3360,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="thumbnail"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -3783,7 +3776,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="thumbnail"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -4200,7 +4192,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="thumbnail"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -4617,7 +4608,6 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="thumbnail"
                           data-automationid="DetailsRowCell"
                           role="gridcell"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
@@ -1108,7 +1108,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column1"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -1165,7 +1164,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column2"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -1541,7 +1539,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column1"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -1598,7 +1595,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column2"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -1974,7 +1970,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column1"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -2031,7 +2026,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column2"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -2407,7 +2401,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column1"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -2464,7 +2457,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column2"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -2840,7 +2832,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column1"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -2897,7 +2888,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column2"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -3171,7 +3161,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                 {
                   padding-right: 8px;
                 }
-
             data-automation-key="column1"
             data-automationid="DetailsRowCell"
             role="gridcell"
@@ -3232,7 +3221,6 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                 {
                   padding-right: 8px;
                 }
-
             data-automation-key="column2"
             data-automationid="DetailsRowCell"
             role="gridcell"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -1210,7 +1210,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="thumbnail"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -1595,7 +1594,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="thumbnail"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -1980,7 +1978,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="thumbnail"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -2365,7 +2362,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="thumbnail"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -2750,7 +2746,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="thumbnail"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -3135,7 +3130,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="thumbnail"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -3520,7 +3514,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="thumbnail"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -3905,7 +3898,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="thumbnail"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -4290,7 +4282,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="thumbnail"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -4675,7 +4666,6 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="thumbnail"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
@@ -894,7 +894,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="thumbnail"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -1270,7 +1269,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="thumbnail"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -1647,7 +1645,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="thumbnail"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -2023,7 +2020,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="thumbnail"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -2400,7 +2396,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="thumbnail"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -2776,7 +2771,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="thumbnail"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -3153,7 +3147,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="thumbnail"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -3529,7 +3522,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="thumbnail"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -3906,7 +3898,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="thumbnail"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -4282,7 +4273,6 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="thumbnail"
                           data-automationid="DetailsRowCell"
                           role="gridcell"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -1492,7 +1492,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -1567,7 +1566,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   &.$checkCell {
                                     padding-right: 0px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="rowheader"
@@ -1627,7 +1625,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   &.$checkCell {
                                     padding-right: 0px;
                                   }
-
                               data-automation-key="column3"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -1811,7 +1808,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -1886,7 +1882,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   &.$checkCell {
                                     padding-right: 0px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="rowheader"
@@ -1946,7 +1941,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   &.$checkCell {
                                     padding-right: 0px;
                                   }
-
                               data-automation-key="column3"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -2130,7 +2124,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -2205,7 +2198,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   &.$checkCell {
                                     padding-right: 0px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="rowheader"
@@ -2265,7 +2257,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   &.$checkCell {
                                     padding-right: 0px;
                                   }
-
                               data-automation-key="column3"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -2449,7 +2440,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -2524,7 +2514,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   &.$checkCell {
                                     padding-right: 0px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="rowheader"
@@ -2584,7 +2573,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   &.$checkCell {
                                     padding-right: 0px;
                                   }
-
                               data-automation-key="column3"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -2768,7 +2756,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -2843,7 +2830,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   &.$checkCell {
                                     padding-right: 0px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="rowheader"
@@ -2903,7 +2889,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   &.$checkCell {
                                     padding-right: 0px;
                                   }
-
                               data-automation-key="column3"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3087,7 +3072,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3162,7 +3146,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   &.$checkCell {
                                     padding-right: 0px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="rowheader"
@@ -3222,7 +3205,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   &.$checkCell {
                                     padding-right: 0px;
                                   }
-
                               data-automation-key="column3"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3406,7 +3388,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3481,7 +3462,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   &.$checkCell {
                                     padding-right: 0px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="rowheader"
@@ -3541,7 +3521,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   &.$checkCell {
                                     padding-right: 0px;
                                   }
-
                               data-automation-key="column3"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3725,7 +3704,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3800,7 +3778,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   &.$checkCell {
                                     padding-right: 0px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="rowheader"
@@ -3860,7 +3837,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   &.$checkCell {
                                     padding-right: 0px;
                                   }
-
                               data-automation-key="column3"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -4044,7 +4020,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -4119,7 +4094,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   &.$checkCell {
                                     padding-right: 0px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="rowheader"
@@ -4179,7 +4153,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   &.$checkCell {
                                     padding-right: 0px;
                                   }
-
                               data-automation-key="column3"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -4363,7 +4336,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="column1"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -4438,7 +4410,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   &.$checkCell {
                                     padding-right: 0px;
                                   }
-
                               data-automation-key="column2"
                               data-automationid="DetailsRowCell"
                               role="rowheader"
@@ -4498,7 +4469,6 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                                   &.$checkCell {
                                     padding-right: 0px;
                                   }
-
                               data-automation-key="column3"
                               data-automationid="DetailsRowCell"
                               role="gridcell"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -1497,7 +1497,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="thumbnail"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -1875,7 +1874,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="thumbnail"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -2253,7 +2251,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="thumbnail"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -2631,7 +2628,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="thumbnail"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3009,7 +3005,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="thumbnail"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3387,7 +3382,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="thumbnail"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -3765,7 +3759,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="thumbnail"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -4143,7 +4136,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="thumbnail"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -4521,7 +4513,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="thumbnail"
                               data-automationid="DetailsRowCell"
                               role="gridcell"
@@ -4899,7 +4890,6 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                   {
                                     padding-right: 8px;
                                   }
-
                               data-automation-key="thumbnail"
                               data-automationid="DetailsRowCell"
                               role="gridcell"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -1928,7 +1928,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                             {
                                               padding-right: 8px;
                                             }
-
                                         data-automation-key="name"
                                         data-automationid="DetailsRowCell"
                                         role="gridcell"
@@ -1989,7 +1988,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                             {
                                               padding-right: 8px;
                                             }
-
                                         data-automation-key="color"
                                         data-automationid="DetailsRowCell"
                                         role="gridcell"
@@ -2378,7 +2376,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                             {
                                               padding-right: 8px;
                                             }
-
                                         data-automation-key="name"
                                         data-automationid="DetailsRowCell"
                                         role="gridcell"
@@ -2439,7 +2436,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                             {
                                               padding-right: 8px;
                                             }
-
                                         data-automation-key="color"
                                         data-automationid="DetailsRowCell"
                                         role="gridcell"
@@ -3600,7 +3596,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                             {
                                               padding-right: 8px;
                                             }
-
                                         data-automation-key="name"
                                         data-automationid="DetailsRowCell"
                                         role="gridcell"
@@ -3661,7 +3656,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                             {
                                               padding-right: 8px;
                                             }
-
                                         data-automation-key="color"
                                         data-automationid="DetailsRowCell"
                                         role="gridcell"
@@ -4050,7 +4044,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                             {
                                               padding-right: 8px;
                                             }
-
                                         data-automation-key="name"
                                         data-automationid="DetailsRowCell"
                                         role="gridcell"
@@ -4111,7 +4104,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                             {
                                               padding-right: 8px;
                                             }
-
                                         data-automation-key="color"
                                         data-automationid="DetailsRowCell"
                                         role="gridcell"
@@ -4500,7 +4492,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                             {
                                               padding-right: 8px;
                                             }
-
                                         data-automation-key="name"
                                         data-automationid="DetailsRowCell"
                                         role="gridcell"
@@ -4561,7 +4552,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                             {
                                               padding-right: 8px;
                                             }
-
                                         data-automation-key="color"
                                         data-automationid="DetailsRowCell"
                                         role="gridcell"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -1589,7 +1589,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="name"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -1646,7 +1645,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="value"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -2031,7 +2029,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="name"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -2088,7 +2085,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="value"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -2473,7 +2469,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="name"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -2530,7 +2525,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="value"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -2915,7 +2909,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="name"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -2972,7 +2965,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="value"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -3357,7 +3349,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="name"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -3414,7 +3405,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="value"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -3799,7 +3789,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="name"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -3856,7 +3845,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="value"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -4241,7 +4229,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="name"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -4298,7 +4285,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="value"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -4683,7 +4669,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="name"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -4740,7 +4725,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="value"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -5125,7 +5109,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="name"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -5182,7 +5165,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="value"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -5567,7 +5549,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="name"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"
@@ -5624,7 +5605,6 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                           {
                                             padding-right: 8px;
                                           }
-
                                       data-automation-key="value"
                                       data-automationid="DetailsRowCell"
                                       role="gridcell"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -996,7 +996,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="filepath"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -1109,7 +1108,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="size"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -1485,7 +1483,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="filepath"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -1598,7 +1595,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="size"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -1974,7 +1970,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="filepath"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -2087,7 +2082,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="size"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -2463,7 +2457,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="filepath"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -2576,7 +2569,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="size"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -2952,7 +2944,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="filepath"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -3065,7 +3056,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="size"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -3441,7 +3431,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="filepath"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -3554,7 +3543,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="size"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -3930,7 +3918,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="filepath"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -4043,7 +4030,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="size"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -4419,7 +4405,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="filepath"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -4532,7 +4517,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="size"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -4908,7 +4892,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="filepath"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -5021,7 +5004,6 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="size"
                           data-automationid="DetailsRowCell"
                           role="gridcell"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
@@ -149,7 +149,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="name"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -206,7 +205,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="link"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -296,7 +294,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="defaultButton"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -574,7 +571,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="name"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -631,7 +627,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="link"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -721,7 +716,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="defaultButton"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -999,7 +993,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="name"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -1056,7 +1049,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="link"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -1146,7 +1138,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="defaultButton"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -1424,7 +1415,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="name"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -1481,7 +1471,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="link"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -1571,7 +1560,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="defaultButton"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -1849,7 +1837,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="name"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -1906,7 +1893,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="link"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -1996,7 +1982,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="defaultButton"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -2274,7 +2259,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="name"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -2331,7 +2315,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="link"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -2421,7 +2404,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="defaultButton"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -2699,7 +2681,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="name"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -2756,7 +2737,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="link"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -2846,7 +2826,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="defaultButton"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -3124,7 +3103,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="name"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -3181,7 +3159,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="link"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -3271,7 +3248,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="defaultButton"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -3549,7 +3525,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="name"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -3606,7 +3581,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="link"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -3696,7 +3670,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="defaultButton"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -3974,7 +3947,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="name"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -4031,7 +4003,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="link"
         data-automationid="DetailsRowCell"
         role="gridcell"
@@ -4121,7 +4092,6 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-
         data-automation-key="defaultButton"
         data-automationid="DetailsRowCell"
         role="gridcell"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Basic.Example.tsx.shot
@@ -867,7 +867,6 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="key"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -1242,7 +1241,6 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="key"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -1617,7 +1615,6 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="key"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -1992,7 +1989,6 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="key"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -2367,7 +2363,6 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="key"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -2742,7 +2737,6 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="key"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -3117,7 +3111,6 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="key"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -3492,7 +3485,6 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="key"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -3867,7 +3859,6 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="key"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -4242,7 +4233,6 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="key"
                             data-automationid="DetailsRowCell"
                             role="gridcell"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.PlainCard.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.PlainCard.Example.tsx.shot
@@ -864,7 +864,6 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="color"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -1260,7 +1259,6 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="color"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -1656,7 +1654,6 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="color"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -2052,7 +2049,6 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="color"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -2448,7 +2444,6 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="color"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -2844,7 +2839,6 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="color"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -3240,7 +3234,6 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="color"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -3636,7 +3629,6 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="color"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -4032,7 +4024,6 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="color"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -4428,7 +4419,6 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="color"
                             data-automationid="DetailsRowCell"
                             role="gridcell"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Target.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Target.Example.tsx.shot
@@ -868,7 +868,6 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="key"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -1262,7 +1261,6 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="key"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -1656,7 +1654,6 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="key"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -2050,7 +2047,6 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="key"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -2444,7 +2440,6 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="key"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -2838,7 +2833,6 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="key"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -3232,7 +3226,6 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="key"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -3626,7 +3619,6 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="key"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -4020,7 +4012,6 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="key"
                             data-automationid="DetailsRowCell"
                             role="gridcell"
@@ -4414,7 +4405,6 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                 {
                                   padding-right: 8px;
                                 }
-
                             data-automation-key="key"
                             data-automationid="DetailsRowCell"
                             role="gridcell"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Ramp.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Ramp.Example.tsx.shot
@@ -668,7 +668,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column1"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -725,7 +724,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column2"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -915,7 +913,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column1"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -972,7 +969,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column2"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -1162,7 +1158,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column1"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -1219,7 +1214,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column2"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -1409,7 +1403,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column1"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -1466,7 +1459,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column2"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -1656,7 +1648,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column1"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -1713,7 +1704,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column2"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -1903,7 +1893,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column1"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -1960,7 +1949,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column2"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -2150,7 +2138,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column1"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -2207,7 +2194,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column2"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -2397,7 +2383,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column1"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -2454,7 +2439,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column2"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -2644,7 +2628,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column1"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -2701,7 +2684,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column2"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -2891,7 +2873,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column1"
                           data-automationid="DetailsRowCell"
                           role="gridcell"
@@ -2948,7 +2929,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                               {
                                 padding-right: 8px;
                               }
-
                           data-automation-key="column2"
                           data-automationid="DetailsRowCell"
                           role="gridcell"


### PR DESCRIPTION
Fixed cell animations so they only trigger when the value of `getValueKey` from a column has actually changed since last render; this is done by using a 'ref' hook in `DetailsRowFields`.

Also, fixed the `key` value assigned to each cell `<div />` so it remains stable and never has duplicates.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9949)