### PR TITLE
Panel: fix header and footer flex shrink issue

### DIFF
--- a/change/office-ui-fabric-react-2019-07-25-18-19-07-master.json
+++ b/change/office-ui-fabric-react-2019-07-25-18-19-07-master.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Panel: fix shrinking of the footer and make header not shrink.",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "vibraga@microsoft.com",
+  "commit": "30a61f806742f24cfdced1f3d508779420e1587c",
+  "date": "2019-07-26T01:19:07.617Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -300,7 +300,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       {
         margin: '14px 0',
         // Ensure that title doesn't shrink if screen is too small
-        flexGrow: 0,
+        flexShrink: 0,
         selectors: {
           [`@media (min-width: ${ScreenWidthMinXLarge}px)`]: {
             marginTop: '30px'
@@ -345,7 +345,6 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       classNames.footer,
       {
         // Ensure that footer doesn't shrink if screen is too small
-        flexGrow: 1,
         flexShrink: 0,
         borderTop: '1px solid transparent',
         transition: `opacity ${AnimationVariables.durationValue3} ${AnimationVariables.easeFunction2}`

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -318,7 +318,7 @@ exports[`Panel renders Panel correctly 1`] = `
               className=
                   ms-Panel-header
                   {
-                    flex-grow: 0;
+                    flex-shrink: 0;
                     margin-bottom: 14px;
                     margin-left: 0;
                     margin-right: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
@@ -403,7 +403,7 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
                 className=
                     ms-Panel-header
                     {
-                      flex-grow: 0;
+                      flex-shrink: 0;
                       margin-bottom: 14px;
                       margin-left: 0;
                       margin-right: 0;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #9913
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Fixing the shrinking bug of the Panel footer. Also, tweaked the header as it was not matching to the comment left above the `flex-grow` style. This was introduced in #1242 and honestly don’t know why the intention was to prevent shrinking but it was used `flex-grow: 0` property which is already by default 0. @micahgodbolt can you remember your thoughts in there? Am I missing some weird scenario that I can break?


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9950)