### PR TITLE
Pivot: fix center alignment of pivot tab text

### DIFF
--- a/change/office-ui-fabric-react-2019-07-25-18-55-19-vibraga-PivotStylesFlex.json
+++ b/change/office-ui-fabric-react-2019-07-25-18-55-19-vibraga-PivotStylesFlex.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Pivot: align pivot link text in relation to the whole pivot tab.",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "vibraga@microsoft.com",
+  "commit": "a96b13bc6fc9482af6eb693a59d66d2b09663148",
+  "date": "2019-07-26T01:55:19.376Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.styles.ts
@@ -195,7 +195,7 @@ export const getStyles = (props: IPivotStyleProps): IPivotStyles => {
         }
       }
     ],
-    linkContent: [classNames.linkContent],
+    linkContent: [classNames.linkContent, { flex: '0 1 100%' }],
     text: [
       classNames.text,
       {

--- a/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.deprecated.test.tsx.snap
@@ -183,7 +183,9 @@ exports[`Pivot renders link Pivot correctly 1`] = `
           <span
             className=
                 ms-Pivot-linkContent
-
+                {
+                  flex: 0 1 100%;
+                }
           >
             <span
               className=
@@ -332,7 +334,9 @@ exports[`Pivot renders link Pivot correctly 1`] = `
           <span
             className=
                 ms-Pivot-linkContent
-
+                {
+                  flex: 0 1 100%;
+                }
           >
             <span
               className=

--- a/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
@@ -183,7 +183,9 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
           <span
             className=
                 ms-Pivot-linkContent
-
+                {
+                  flex: 0 1 100%;
+                }
           >
             <span
               className=
@@ -332,7 +334,9 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
           <span
             className=
                 ms-Pivot-linkContent
-
+                {
+                  flex: 0 1 100%;
+                }
           >
             <span
               className=
@@ -557,7 +561,9 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
           <span
             className=
                 ms-Pivot-linkContent
-
+                {
+                  flex: 0 1 100%;
+                }
           >
             <span
               className=
@@ -706,7 +712,9 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
           <span
             className=
                 ms-Pivot-linkContent
-
+                {
+                  flex: 0 1 100%;
+                }
           >
             <span
               className=
@@ -917,7 +925,9 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
           <span
             className=
                 ms-Pivot-linkContent
-
+                {
+                  flex: 0 1 100%;
+                }
           >
             <span
               className=
@@ -1068,7 +1078,9 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
           <span
             className=
                 ms-Pivot-linkContent
-
+                {
+                  flex: 0 1 100%;
+                }
           >
             <span
               className=
@@ -1230,7 +1242,9 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
           <span
             className=
                 ms-Pivot-linkContent
-
+                {
+                  flex: 0 1 100%;
+                }
           >
             <span
               className=
@@ -1467,7 +1481,9 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
           <span
             className=
                 ms-Pivot-linkContent
-
+                {
+                  flex: 0 1 100%;
+                }
           >
             <span
               className=
@@ -1616,7 +1632,9 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
           <span
             className=
                 ms-Pivot-linkContent
-
+                {
+                  flex: 0 1 100%;
+                }
           >
             <span
               className=
@@ -1837,7 +1855,9 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
           <span
             className=
                 ms-Pivot-linkContent
-
+                {
+                  flex: 0 1 100%;
+                }
           >
             <span
               className=
@@ -1999,7 +2019,9 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
           <span
             className=
                 ms-Pivot-linkContent
-
+                {
+                  flex: 0 1 100%;
+                }
           >
             <span
               className=
@@ -2209,7 +2231,9 @@ exports[`Pivot renders link Pivot correctly 1`] = `
           <span
             className=
                 ms-Pivot-linkContent
-
+                {
+                  flex: 0 1 100%;
+                }
           >
             <span
               className=
@@ -2358,7 +2382,9 @@ exports[`Pivot renders link Pivot correctly 1`] = `
           <span
             className=
                 ms-Pivot-linkContent
-
+                {
+                  flex: 0 1 100%;
+                }
           >
             <span
               className=
@@ -2578,7 +2604,9 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
           <span
             className=
                 ms-Pivot-linkContent
-
+                {
+                  flex: 0 1 100%;
+                }
           >
             <span
               className=
@@ -2740,7 +2768,9 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
           <span
             className=
                 ms-Pivot-linkContent
-
+                {
+                  flex: 0 1 100%;
+                }
           >
             <span
               className=
@@ -2939,7 +2969,9 @@ exports[`Pivot supports JSX expressions 1`] = `
           <span
             className=
                 ms-Pivot-linkContent
-
+                {
+                  flex: 0 1 100%;
+                }
           >
             <span
               className=
@@ -3099,7 +3131,9 @@ exports[`Pivot supports JSX expressions 1`] = `
           <span
             className=
                 ms-Pivot-linkContent
-
+                {
+                  flex: 0 1 100%;
+                }
           >
             <span
               className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -190,7 +190,9 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -342,7 +344,9 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -494,7 +498,9 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Basic.Example.tsx.shot
@@ -185,7 +185,9 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
           <span
             className=
                 ms-Pivot-linkContent
-
+                {
+                  flex: 0 1 100%;
+                }
           >
             <span
               className=
@@ -334,7 +336,9 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
           <span
             className=
                 ms-Pivot-linkContent
-
+                {
+                  flex: 0 1 100%;
+                }
           >
             <span
               className=
@@ -483,7 +487,9 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
           <span
             className=
                 ms-Pivot-linkContent
-
+                {
+                  flex: 0 1 100%;
+                }
           >
             <span
               className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Fabric.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Fabric.Example.tsx.shot
@@ -184,7 +184,9 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -333,7 +335,9 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -482,7 +486,9 @@ exports[`Component Examples renders Pivot.Fabric.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.IconCount.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.IconCount.Example.tsx.shot
@@ -184,7 +184,9 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -371,7 +373,9 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -547,7 +551,9 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -711,7 +717,9 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -900,7 +908,9 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
               <span
                 className=
                     ms-Pivot-linkContent
-
+                    {
+                      flex: 0 1 100%;
+                    }
               >
                 <span
                   className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Large.Example.tsx.shot
@@ -185,7 +185,9 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -334,7 +336,9 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -483,7 +487,9 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.OnChange.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.OnChange.Example.tsx.shot
@@ -195,7 +195,9 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -357,7 +359,9 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -519,7 +523,9 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -681,7 +687,9 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Override.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Override.Example.tsx.shot
@@ -184,7 +184,9 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -333,7 +335,9 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -482,7 +486,9 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Remove.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Remove.Example.tsx.shot
@@ -195,7 +195,9 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -357,7 +359,9 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -519,7 +523,9 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -681,7 +687,9 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Separate.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Separate.Example.tsx.shot
@@ -196,7 +196,9 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -345,7 +347,9 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -494,7 +498,9 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.SeparateNoSelectedKey.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.SeparateNoSelectedKey.Example.tsx.shot
@@ -196,7 +196,9 @@ exports[`Component Examples renders Pivot.SeparateNoSelectedKey.Example.tsx corr
               <span
                 className=
                     ms-Pivot-linkContent
-
+                    {
+                      flex: 0 1 100%;
+                    }
               >
                 <span
                   className=
@@ -345,7 +347,9 @@ exports[`Component Examples renders Pivot.SeparateNoSelectedKey.Example.tsx corr
               <span
                 className=
                     ms-Pivot-linkContent
-
+                    {
+                      flex: 0 1 100%;
+                    }
               >
                 <span
                   className=
@@ -494,7 +498,9 @@ exports[`Component Examples renders Pivot.SeparateNoSelectedKey.Example.tsx corr
               <span
                 className=
                     ms-Pivot-linkContent
-
+                    {
+                      flex: 0 1 100%;
+                    }
               >
                 <span
                   className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Tabs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Tabs.Example.tsx.shot
@@ -194,7 +194,9 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -356,7 +358,9 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -518,7 +522,9 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -680,7 +686,9 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.TabsLarge.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.TabsLarge.Example.tsx.shot
@@ -195,7 +195,9 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -357,7 +359,9 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -519,7 +523,9 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=
@@ -681,7 +687,9 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
             <span
               className=
                   ms-Pivot-linkContent
-
+                  {
+                    flex: 0 1 100%;
+                  }
             >
               <span
                 className=


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #9931 
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Center align the text of the `Pivot` tab. This was caused by `flex-start` alignment of the `linkContent` section all the way from the `CommandButton` styles introduced in this very old PR #1211 with this [commit](https://github.com/OfficeDev/office-ui-fabric-react/pull/1211/commits/32b8e257835d47b60c6171d9d2d1daac3ab731ab). It might be better to fix it in there but from @dzearing’s commit message: _`Polish on css. Making command buttons correctly left aligned.`_,  looks like this was intentional so there might be some design decision involved that I am not aware of.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9951)