### PR TITLE
Added accessible name to tag picker remove button

### DIFF
--- a/change/office-ui-fabric-react-2019-07-26-14-16-29-susunda-add-accessible-name-to-tag-picker-remove-button.json
+++ b/change/office-ui-fabric-react-2019-07-26-14-16-29-susunda-add-accessible-name-to-tag-picker-remove-button.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Added aria label to remove button next to selected tag item",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "susunda@microsoft.com",
+  "commit": "1ec4da2daa2fc8a5b39453a6be7ea261da8468c9",
+  "date": "2019-07-26T21:16:29.148Z"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.tsx
@@ -48,7 +48,7 @@ export const TagItemBase = (props: ITagItemProps) => {
         disabled={disabled}
         iconProps={{ iconName: 'Cancel', styles: { root: { fontSize: '12px' } } }}
         className={classNames.close}
-        ariaLabel={removeButtonAriaLabel}
+        ariaLabel={removeButtonAriaLabel || 'Remove'}
       />
     </div>
   );


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #8655 Bug3
- [X] Include a change request file using `$ yarn change`

#### Description of changes

The `removeButtonAriaLabel` prop has a value of `undefined`. Added default value for aria label 

#### Focus areas to test

Tested using narrator. Narrator reads out "Remove button" when selected


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9959)