### PR TITLE
Tooltip: Fixing hidden hover area overlapping with Tooltip targets

### DIFF
--- a/change/office-ui-fabric-react-2019-07-26-16-11-58-tooltipHover.json
+++ b/change/office-ui-fabric-react-2019-07-26-16-11-58-tooltipHover.json
@@ -1,0 +1,8 @@
+{
+  "comment": "Tooltip: Fixing hidden hover area overlapping with Tooltip targets.",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "03c6fe8e6c0f89a33071dd0bc30cf2831fe48f41",
+  "date": "2019-07-26T23:11:58.519Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -7668,6 +7668,7 @@ export interface ITooltipProps extends React.HTMLAttributes<HTMLDivElement | Too
 
 // @public (undocumented)
 export interface ITooltipStyleProps {
+    beakHeight?: number;
     className?: string;
     // @deprecated
     delay?: TooltipDelay;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -7668,7 +7668,7 @@ export interface ITooltipProps extends React.HTMLAttributes<HTMLDivElement | Too
 
 // @public (undocumented)
 export interface ITooltipStyleProps {
-    beakHeight?: number;
+    beakWidth?: number;
     className?: string;
     // @deprecated
     delay?: TooltipDelay;

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.base.tsx
@@ -40,6 +40,7 @@ export class TooltipBase extends React.Component<ITooltipProps, any> {
     this._classNames = getClassNames(styles!, {
       theme: theme!,
       className: className || (calloutProps && calloutProps.className),
+      beakHeight: calloutProps && calloutProps.beakWidth,
       gapSpace: calloutProps && calloutProps.gapSpace,
       maxWidth: maxWidth!
     });

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.base.tsx
@@ -40,7 +40,7 @@ export class TooltipBase extends React.Component<ITooltipProps, any> {
     this._classNames = getClassNames(styles!, {
       theme: theme!,
       className: className || (calloutProps && calloutProps.className),
-      beakHeight: calloutProps && calloutProps.beakWidth,
+      beakWidth: calloutProps && calloutProps.beakWidth,
       gapSpace: calloutProps && calloutProps.gapSpace,
       maxWidth: maxWidth!
     });

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
@@ -5,8 +5,8 @@ export const getStyles = (props: ITooltipStyleProps): ITooltipStyles => {
   const { className, beakWidth = 16, gapSpace = 0, maxWidth, theme } = props;
   const { palette, fonts, effects } = theme;
 
-  // The -4 is added so that hidden area doesn't overlap with the Tooltip target.
-  const tooltipGapSpace = -(beakWidth + gapSpace - 4);
+  // The math here is done to account for the 45 degree rotation of the beak
+  const tooltipGapSpace = -(Math.sqrt((beakWidth * beakWidth) / 2) + gapSpace);
 
   return {
     root: [

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
@@ -2,11 +2,11 @@ import { ITooltipStyleProps, ITooltipStyles } from './Tooltip.types';
 import { AnimationClassNames } from '../../Styling';
 
 export const getStyles = (props: ITooltipStyleProps): ITooltipStyles => {
-  const { className, beakHeight = 16, gapSpace = 0, maxWidth, theme } = props;
+  const { className, beakWidth = 16, gapSpace = 0, maxWidth, theme } = props;
   const { palette, fonts, effects } = theme;
 
   // The -4 is added so that hidden area doesn't overlap with the Tooltip target.
-  const tooltipGapSpace = -(beakHeight + gapSpace - 4);
+  const tooltipGapSpace = -(beakWidth + gapSpace - 4);
 
   return {
     root: [

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
@@ -2,10 +2,11 @@ import { ITooltipStyleProps, ITooltipStyles } from './Tooltip.types';
 import { AnimationClassNames } from '../../Styling';
 
 export const getStyles = (props: ITooltipStyleProps): ITooltipStyles => {
-  const { className, gapSpace = 0, maxWidth, theme } = props;
+  const { className, beakHeight = 16, gapSpace = 0, maxWidth, theme } = props;
   const { palette, fonts, effects } = theme;
 
-  const tooltipGapSpace = -15 - gapSpace;
+  // The -4 is added so that hidden area doesn't overlap with the Tooltip target.
+  const tooltipGapSpace = -(beakHeight + gapSpace - 4);
 
   return {
     root: [

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.types.ts
@@ -117,6 +117,12 @@ export interface ITooltipStyleProps {
    * @defaultvalue 0
    */
   gapSpace?: number;
+
+  /**
+   * The height of the Callout's beak
+   * @defaultvalue 16
+   */
+  beakHeight?: number;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.types.ts
@@ -119,10 +119,10 @@ export interface ITooltipStyleProps {
   gapSpace?: number;
 
   /**
-   * The height of the Callout's beak
+   * The width of the Callout's beak
    * @defaultvalue 16
    */
-  beakHeight?: number;
+  beakWidth?: number;
 }
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9947
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR fixes the hidden hover area added in #9775 so that it is dynamically rendered depending on the beak height.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9960)