### PR TITLE
Documentation: Add example of using defaultFontStyle

### DIFF
--- a/apps/fabric-website/src/pages/Styles/TypographyPage/TypographyPage.tsx
+++ b/apps/fabric-website/src/pages/Styles/TypographyPage/TypographyPage.tsx
@@ -54,6 +54,17 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
               }
             </Markdown>
           )
+        },
+        {
+          sectionName: 'Customization',
+          editUrl: `${baseUrl}/web/TypographyCustomization.md`,
+          content: (
+            <Markdown>
+              {
+                require('!raw-loader!@uifabric/fabric-website/src/pages/Styles/TypographyPage/docs/web/TypographyCustomization.md') as string
+              }
+            </Markdown>
+          )
         }
       ];
   }

--- a/apps/fabric-website/src/pages/Styles/TypographyPage/docs/web/TypographyCustomization.md
+++ b/apps/fabric-website/src/pages/Styles/TypographyPage/docs/web/TypographyCustomization.md
@@ -1,14 +1,19 @@
 You can add some of your own customizations to the default theme.
 For example, you can utilize `defaultFontStyle` to override the default font style and
-`fonts` to override the default medium font size.
+`fonts` to override the default font styles for specific fonts, like small, medium, large, etc.
+The example below shows how to override styles for the 'medium' fonts.
+You can override anything in `IRawStyle`.
 
 ```tsx
 import { loadTheme } from 'office-ui-fabric-react';
 
 loadTheme({
-  defaultFontStyle: { fontFamily: 'Comic Sans MS', fontWeight: 'bold' },
+  defaultFontStyle: { fontFamily: 'Arial Black', fontWeight: 'bold' },
   fonts: {
-    medium: { fontSize: 50 }
+    medium: {
+      fontFamily: 'Monaco, Menlo, Consolas',
+      fontSize: '30px'
+    }
   }
 });
 ```

--- a/apps/fabric-website/src/pages/Styles/TypographyPage/docs/web/TypographyCustomization.md
+++ b/apps/fabric-website/src/pages/Styles/TypographyPage/docs/web/TypographyCustomization.md
@@ -2,7 +2,7 @@ You can add some of your own customizations to the default theme.
 For example, you can set the `defaultFontStyle` property to modify every font variant
 (small, medium, large, etc.), or you can target specific variants through the `fonts` property.
 These can be used separately, or together, as shown in the example below.
-The overrides can include any property from `IRawStyle`.
+The overrides can include any property from [`IRawStyle`](#/controls/web/references/irawstyle).
 
 ```tsx
 import { loadTheme } from 'office-ui-fabric-react';

--- a/apps/fabric-website/src/pages/Styles/TypographyPage/docs/web/TypographyCustomization.md
+++ b/apps/fabric-website/src/pages/Styles/TypographyPage/docs/web/TypographyCustomization.md
@@ -1,6 +1,6 @@
 You can add some of your own customizations to the default theme.
 For example, you can utilize `defaultFontStyle` to override the default font style and
-`fonts` to override the default font styles for specific fonts, like small, medium, large, etc.
+`fonts` to override the default font styles for specific font variants, like small, medium, large, etc.
 The example below shows how to override font styles for some of the fonts.
 You can override anything in `IRawStyle`.
 

--- a/apps/fabric-website/src/pages/Styles/TypographyPage/docs/web/TypographyCustomization.md
+++ b/apps/fabric-website/src/pages/Styles/TypographyPage/docs/web/TypographyCustomization.md
@@ -1,18 +1,28 @@
 You can add some of your own customizations to the default theme.
 For example, you can utilize `defaultFontStyle` to override the default font style and
 `fonts` to override the default font styles for specific fonts, like small, medium, large, etc.
-The example below shows how to override styles for the 'medium' fonts.
+The example below shows how to override font styles for some of the fonts.
 You can override anything in `IRawStyle`.
 
 ```tsx
 import { loadTheme } from 'office-ui-fabric-react';
 
 loadTheme({
-  defaultFontStyle: { fontFamily: 'Arial Black', fontWeight: 'bold' },
+  defaultFontStyle: { fontFamily: 'Monaco, Menlo, Consolas', fontWeight: 'regular' },
   fonts: {
+    small: {
+      fontSize: '11px'
+    },
     medium: {
-      fontFamily: 'Monaco, Menlo, Consolas',
-      fontSize: '30px'
+      fontSize: '13px'
+    },
+    large: {
+      fontSize: '20px',
+      fontWeight: 'semibold'
+    },
+    xLarge: {
+      fontSize: '22px',
+      fontWeight: 'semibold'
     }
   }
 });

--- a/apps/fabric-website/src/pages/Styles/TypographyPage/docs/web/TypographyCustomization.md
+++ b/apps/fabric-website/src/pages/Styles/TypographyPage/docs/web/TypographyCustomization.md
@@ -1,8 +1,8 @@
 You can add some of your own customizations to the default theme.
-For example, you can utilize `defaultFontStyle` to override the default font style and
-`fonts` to override the default font styles for specific font variants, like small, medium, large, etc.
-The example below shows how to override font styles for some of the font variants.
-You can override anything in `IRawStyle`.
+For example, you can set the `defaultFontStyle` property to modify every font variant
+(small, medium, large, etc.), or you can target specific variants through the `fonts` property.
+These can be used separately, or together, as shown in the example below.
+The overrides can include any property from `IRawStyle`.
 
 ```tsx
 import { loadTheme } from 'office-ui-fabric-react';

--- a/apps/fabric-website/src/pages/Styles/TypographyPage/docs/web/TypographyCustomization.md
+++ b/apps/fabric-website/src/pages/Styles/TypographyPage/docs/web/TypographyCustomization.md
@@ -1,0 +1,14 @@
+You can add some of your own customizations to the default theme.
+For example, you can utilize `defaultFontStyle` to override the default font style and
+`fonts` to override the default medium font size.
+
+```tsx
+import { loadTheme } from 'office-ui-fabric-react';
+
+loadTheme({
+  defaultFontStyle: { fontFamily: 'Comic Sans MS', fontWeight: 'bold' },
+  fonts: {
+    medium: { fontSize: 50 }
+  }
+});
+```

--- a/apps/fabric-website/src/pages/Styles/TypographyPage/docs/web/TypographyCustomization.md
+++ b/apps/fabric-website/src/pages/Styles/TypographyPage/docs/web/TypographyCustomization.md
@@ -1,7 +1,7 @@
 You can add some of your own customizations to the default theme.
 For example, you can utilize `defaultFontStyle` to override the default font style and
 `fonts` to override the default font styles for specific font variants, like small, medium, large, etc.
-The example below shows how to override font styles for some of the fonts.
+The example below shows how to override font styles for some of the font variants.
 You can override anything in `IRawStyle`.
 
 ```tsx

--- a/change/@uifabric-fabric-website-2019-07-29-14-39-02-customizationSections.json
+++ b/change/@uifabric-fabric-website-2019-07-29-14-39-02-customizationSections.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Add customization section to Themes and Typography pages",
+  "comment": "Add customization section to Typography pages",
   "packageName": "@uifabric/fabric-website",
   "email": "naethell@microsoft.com",
   "commit": "68361da1ab491641dc11bdf38447074eb360e680",

--- a/change/@uifabric-fabric-website-2019-07-29-14-39-02-customizationSections.json
+++ b/change/@uifabric-fabric-website-2019-07-29-14-39-02-customizationSections.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add customization section to Themes and Typography pages",
+  "packageName": "@uifabric/fabric-website",
+  "email": "naethell@microsoft.com",
+  "commit": "68361da1ab491641dc11bdf38447074eb360e680",
+  "date": "2019-07-29T21:38:30.751Z"
+}

--- a/change/office-ui-fabric-react-2019-07-29-14-39-02-customizationSections.json
+++ b/change/office-ui-fabric-react-2019-07-29-14-39-02-customizationSections.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add customization section to Themes page",
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com",
+  "commit": "68361da1ab491641dc11bdf38447074eb360e680",
+  "date": "2019-07-29T21:39:02.920Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Theme/docs/ThemesOverview.md
+++ b/packages/office-ui-fabric-react/src/components/Theme/docs/ThemesOverview.md
@@ -40,7 +40,7 @@ loadTheme({
 
 You can also add some of your own customizations to the default theme.
 For example, you can utilize `defaultFontStyle` to override the default font style and
-`fonts` to override the default font styles for specific fonts, like small, medium, large, etc.
+`fonts` to override the default font styles for specific font variants, like small, medium, large, etc.
 The example below shows how to override font styles for some of the fonts.
 You can override anything in `IRawStyle`.
 

--- a/packages/office-ui-fabric-react/src/components/Theme/docs/ThemesOverview.md
+++ b/packages/office-ui-fabric-react/src/components/Theme/docs/ThemesOverview.md
@@ -40,15 +40,20 @@ loadTheme({
 
 You can also add some of your own customizations to the default theme.
 For example, you can utilize `defaultFontStyle` to override the default font style and
-`fonts` to override the default medium font size.
+`fonts` to override the default font styles for specific fonts, like small, medium, large, etc.
+The example below shows how to override styles for the 'medium' fonts.
+You can override anything in `IRawStyle`.
 
 ```tsx
 import { loadTheme } from 'office-ui-fabric-react';
 
 loadTheme({
-  defaultFontStyle: { fontFamily: 'Comic Sans MS', fontWeight: 'bold' },
+  defaultFontStyle: { fontFamily: 'Arial Black', fontWeight: 'bold' },
   fonts: {
-    medium: { fontSize: 50 }
+    medium: {
+      fontFamily: 'Monaco, Menlo, Consolas',
+      fontSize: '30px'
+    }
   }
 });
 ```

--- a/packages/office-ui-fabric-react/src/components/Theme/docs/ThemesOverview.md
+++ b/packages/office-ui-fabric-react/src/components/Theme/docs/ThemesOverview.md
@@ -41,18 +41,28 @@ loadTheme({
 You can also add some of your own customizations to the default theme.
 For example, you can utilize `defaultFontStyle` to override the default font style and
 `fonts` to override the default font styles for specific fonts, like small, medium, large, etc.
-The example below shows how to override styles for the 'medium' fonts.
+The example below shows how to override font styles for some of the fonts.
 You can override anything in `IRawStyle`.
 
 ```tsx
 import { loadTheme } from 'office-ui-fabric-react';
 
 loadTheme({
-  defaultFontStyle: { fontFamily: 'Arial Black', fontWeight: 'bold' },
+  defaultFontStyle: { fontFamily: 'Monaco, Menlo, Consolas', fontWeight: 'regular' },
   fonts: {
+    small: {
+      fontSize: '11px'
+    },
     medium: {
-      fontFamily: 'Monaco, Menlo, Consolas',
-      fontSize: '30px'
+      fontSize: '13px'
+    },
+    large: {
+      fontSize: '20px',
+      fontWeight: 'semibold'
+    },
+    xLarge: {
+      fontSize: '22px',
+      fontWeight: 'semibold'
     }
   }
 });

--- a/packages/office-ui-fabric-react/src/components/Theme/docs/ThemesOverview.md
+++ b/packages/office-ui-fabric-react/src/components/Theme/docs/ThemesOverview.md
@@ -35,3 +35,20 @@ loadTheme({
   }
 });
 ```
+
+## Customization
+
+You can also add some of your own customizations to the default theme.
+For example, you can utilize `defaultFontStyle` to override the default font style and
+`fonts` to override the default medium font size.
+
+```tsx
+import { loadTheme } from 'office-ui-fabric-react';
+
+loadTheme({
+  defaultFontStyle: { fontFamily: 'Comic Sans MS', fontWeight: 'bold' },
+  fonts: {
+    medium: { fontSize: 50 }
+  }
+});
+```

--- a/packages/office-ui-fabric-react/src/components/Theme/docs/ThemesOverview.md
+++ b/packages/office-ui-fabric-react/src/components/Theme/docs/ThemesOverview.md
@@ -41,7 +41,7 @@ loadTheme({
 You can also add some of your own customizations to the default theme.
 For example, you can utilize `defaultFontStyle` to override the default font style and
 `fonts` to override the default font styles for specific font variants, like small, medium, large, etc.
-The example below shows how to override font styles for some of the fonts.
+The example below shows how to override font styles for some of the font variants.
 You can override anything in `IRawStyle`.
 
 ```tsx

--- a/packages/office-ui-fabric-react/src/components/Theme/docs/ThemesOverview.md
+++ b/packages/office-ui-fabric-react/src/components/Theme/docs/ThemesOverview.md
@@ -42,7 +42,7 @@ You can also add some of your own customizations to the default theme.
 For example, you can set the `defaultFontStyle` property to modify every font variant
 (small, medium, large, etc.), or you can target specific variants through the `fonts` property.
 These can be used separately, or together, as shown in the example below.
-The overrides can include any property from `IRawStyle`.
+The overrides can include any property from [`IRawStyle`](#/controls/web/references/irawstyle).
 
 ```tsx
 import { loadTheme } from 'office-ui-fabric-react';

--- a/packages/office-ui-fabric-react/src/components/Theme/docs/ThemesOverview.md
+++ b/packages/office-ui-fabric-react/src/components/Theme/docs/ThemesOverview.md
@@ -39,10 +39,10 @@ loadTheme({
 ## Customization
 
 You can also add some of your own customizations to the default theme.
-For example, you can utilize `defaultFontStyle` to override the default font style and
-`fonts` to override the default font styles for specific font variants, like small, medium, large, etc.
-The example below shows how to override font styles for some of the font variants.
-You can override anything in `IRawStyle`.
+For example, you can set the `defaultFontStyle` property to modify every font variant
+(small, medium, large, etc.), or you can target specific variants through the `fonts` property.
+These can be used separately, or together, as shown in the example below.
+The overrides can include any property from `IRawStyle`.
 
 ```tsx
 import { loadTheme } from 'office-ui-fabric-react';


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #7416
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Adds an example of using `defaultFontStyle` and `fonts` to both the Themes page and the Typography page.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9981)