### PR TITLE
Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,19 +1,20 @@
-<!-- delete this template for feature requests -->
+<!--
+Thanks for contacting us! We're here to help.
 
-### Bug Report
+Before you report an issue, check if it's been reported before:
 
-- __Package version(s)__: (fill this out)
-- __Browser and OS versions__: (fill this out if relevant)
+  * Search: https://github.com/OfficeDev/office-ui-fabric-react/search?type=Issues
+  * Search by area or component: https://github.com/OfficeDev/office-ui-fabric-react/issues/labels
 
-#### Priorities and help requested (not applicable if asking question):
+Note that if you do not provide enough information to reproduce the issue, we may not be able to take action on your report.
+-->
 
-Are you willing to submit a PR to fix? (Yes, No)
+### Environment Information
 
-Requested priority: (Blocking, High, Normal, Low) 
+- **Package version(s)**: (fill this out)
+- **Browser and OS versions**: (fill this out if relevant)
 
-Products/sites affected: (if applicable)
-
-#### Describe the issue:
+### Describe the issue:
 
 <!-- fill this out -->
 
@@ -27,5 +28,21 @@ Products/sites affected: (if applicable)
 
 ### If applicable, please provide a codepen repro:
 
-<!-- See https://codepen.io/FabricReact/ for a starting template -->
-<!-- See http://codepen.io/dzearing/pens/public/?grid_type=list for a variety of examples -->
+<!--
+Providing an isolated reproduction of the bug in a codepen makes it much easier for us to help you. Here are some ways to get started:
+
+  * Go to https://aka.ms/fabricpen for a starter codepen
+  * You can also use the "Export to Codepen" feature for the various components in our documentation site.
+  * See http://codepen.io/dzearing/pens/public/?grid_type=list for a variety of examples
+
+Alternatively, you can also use https://aka.ms/fabricdemo to get permanent repro links if the repro occurs with an example.
+(A permanent link is preferable to "use the website" as the website can change.)
+-->
+
+### Priorities and help requested (not applicable if asking question):
+
+Are you willing to submit a PR to fix? (Yes, No)
+
+Requested priority: (Blocking, High, Normal, Low)
+
+Products/sites affected: (if applicable)

--- a/.github/ISSUE_TEMPLATE/accessibility_issue.md
+++ b/.github/ISSUE_TEMPLATE/accessibility_issue.md
@@ -3,24 +3,49 @@ name: Accessibility Issue
 about: Have you identified an accessibility issue regarding a Fabric control?
 ---
 
-<!-- 
+<!--
 Before submitting an accessibility issue please ensure the following are true:
 
 1. This issue is caused by a Fabric control
 2. You can reproduce this bug in a CodePen
-3. There is documentation or best practice that supports your expected behavior (Review https://www.w3.org/TR/wai-aria-1.1/ for accessibility guidance)
+3. There is documentation or best practice that supports your expected behavior (review https://www.w3.org/TR/wai-aria-1.1/ for accessibility guidance)
 
-Do not link to, screenshot or reference a Microsoft product in this description
+Do not link to, screenshot or reference a Microsoft product in this description.
 
 Issues that do not meet these guidelines will be closed.
 -->
 
-## Codepen demonstrating the issue
-<!-- aka.ms/fabricpen --> 
+### Environment Information
 
-## Actual behavior:
+- **Package version(s)**: (fill this out)
+- **Browser and OS versions**: (fill this out)
+- **Screen reader(s)**: (fill this out if applicable)
 
-## Expected behavior:
+### Describe the issue:
 
-## Documentation describing expected behavior
+<!-- fill this out -->
 
+### Please provide a reproduction of the issue in a codepen:
+
+<!--
+Providing an isolated reproduction of the issue in a codepen makes it much easier for us to help you. Here are some ways to get started:
+
+  * Go to https://aka.ms/fabricpen for a starter codepen
+  * You can also use the "Export to Codepen" feature for the various components in our documentation site.
+  * See http://codepen.io/dzearing/pens/public/?grid_type=list for a variety of examples
+
+Alternatively, you can also use https://aka.ms/fabricdemo to get permanent repro links if the repro occurs with an example.
+(A permanent link is preferable to "use the website" as the website can change.)
+-->
+
+#### Actual behavior:
+
+<!-- fill this out -->
+
+#### Expected behavior:
+
+<!-- fill this out -->
+
+### Documentation describing expected behavior
+
+<!-- fill this out -->

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,50 +1,49 @@
 ---
 name: Bug report
 about: Found a bug in Fabric? Please let us know.
-
 ---
-<!--  
+
+<!--
 Thanks for contacting us! We're here to help.
 
 Before you report an issue, check if it's been reported before:
 
   * Search: https://github.com/OfficeDev/office-ui-fabric-react/search?type=Issues
   * Search by area or component: https://github.com/OfficeDev/office-ui-fabric-react/issues/labels
-  
-Please provide a reproduction of the bug in a codepen, if possible. Here’s how:
 
-  * Goto https://aka.ms/fabricpen for a starting codepen 
-  * You can also use the "Export to Codepen" feature for the various components in our documentation site.
-  * Alternatively, you can also use https://aka.ms/fabricdemo to get permanent repro links if the repro occurs with an example. 
-    (A permanent link is preferable to "use the website" as the website can change)
- 
 Note that if you do not provide enough information to reproduce the issue, we may not be able to take action on your report.
 -->
 
-### Environment Information 
- 
-- __Package version(s)__: (fill this out) 
-- __Browser and OS versions__: (fill this out if relevant)
+### Environment Information
+
+- **Package version(s)**: (fill this out)
+- **Browser and OS versions**: (fill this out if relevant)
 
 ### Please provide a reproduction of the bug in a codepen:
- 
-<!-- Goto https://aka.ms/fabricpen for a starting codepen -->
-<!-- See http://codepen.io/dzearing/pens/public/?grid_type=list for a variety of examples -->
-<!-- Alternatively, you can also use https://aka.ms/fabricdemo to get permanent repro links. -->
- 
+
+<!--
+Providing an isolated reproduction of the bug in a codepen makes it much easier for us to help you. Here are some ways to get started:
+
+  * Go to https://aka.ms/fabricpen for a starter codepen
+  * You can also use the "Export to Codepen" feature for the various components in our documentation site.
+  * See http://codepen.io/dzearing/pens/public/?grid_type=list for a variety of examples
+
+Alternatively, you can also use https://aka.ms/fabricdemo to get permanent repro links if the repro occurs with an example.
+(A permanent link is preferable to "use the website" as the website can change.)
+-->
+
 #### Actual behavior:
- 
-<!-- fill this out -->
- 
-#### Expected behavior:
- 
+
 <!-- fill this out -->
 
-#### Priorities and help requested:
- 
+#### Expected behavior:
+
+<!-- fill this out -->
+
+### Priorities and help requested:
+
 Are you willing to submit a PR to fix? (Yes, No)
- 
-Requested priority: (Blocking, High, Normal, Low) 
- 
+
+Requested priority: (Blocking, High, Normal, Low)
+
 Products/sites affected: (if applicable)
- 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,15 +1,20 @@
 ---
 name: Feature request
 about: Do you have Feature or improvement for Fabric? Let us know.
-
 ---
 
-<!-- Note: Feature requests will be moved to the prospective codeowner's backlog and then closed -->
+#### Describe the feature that you would like added
 
-**Describe the feature that you would like added**
+<!-- fill this out -->
 
-**What component or utility would this be added to**
+#### What component or utility would this be added to
 
-**Have you discussed this feature with our team, and if so, who**
+<!-- fill this out -->
 
-**Additional context/screenshots**
+#### Have you discussed this feature with our team, and if so, who
+
+<!-- fill this out -->
+
+#### Additional context/screenshots
+
+<!-- fill this out -->

--- a/.github/ISSUE_TEMPLATE/new_component.md
+++ b/.github/ISSUE_TEMPLATE/new_component.md
@@ -1,35 +1,41 @@
 ---
 name: New Component
 about: Interested in contributing a new component to Fabric? This template includes necessary information to get started, and steps to completion
-
 ---
+
 <!-- Use this template for new components or new component variants -->
 
 ## Component details
 
 ### Description
 
+<!-- fill this out -->
 
 ### Which product teams/scenarios need this control
+
 <!-- The more teams/scenarios that would use this control the better chance it will get prioritized -->
 
-
 ### Design assets
+
 <!-- Please provide links to redlines or screenshots of intended component design -->
 
 ### Component ownership
+
 <!-- Are there one or more people who can help maintain this component over time? Who will address bugs? -->
 
 ## Component composition
 
 ### Imports/Dependencies
+
 <!-- What other components/modules will your component be using -->
 
 ### Exports/Component breakdown
+
 <!-- Consider creating smaller composable components vs a single larger one
 See https://github.com/OfficeDev/office-ui-fabric-react/wiki/Component-Design#build-many-smaller-components-and-compose-them-together -->
 
 ### Intended package/s
+
 <!-- If this is a prototype component, start in @uifabric/experiments. If you feel that there is a new package required, please indicate the requested name here. -->
 
 ## Component code
@@ -43,29 +49,32 @@ See https://github.com/OfficeDev/office-ui-fabric-react/wiki/Component-Design#bu
 <!-- View naming guidelines here https://github.com/OfficeDev/office-ui-fabric-react/wiki/Component-Design#naming-guidance -->
 
 ### Public methods
-| Name      | Type     | Description |
-|-----------|----------|-------------|
-| focus | () => void   | Sets focus on the control |
+
+| Name  | Type       | Description               |
+| ----- | ---------- | ------------------------- |
+| focus | () => void | Sets focus on the control |
 
 ### Slots
-| Name      | Type     |  Description |
-|-----------|----------|-------------|
-| root | div   | The outermost element |
+
+| Name | Type | Description           |
+| ---- | ---- | --------------------- |
+| root | div  | The outermost element |
 
 ### Tokens
 
-| Name      | Type     | Default Value | Description |
-|-----------|----------|---------------|-------------|
-| textColor | color   | theme.white | text color for the control |
+| Name      | Type  | Default Value | Description                |
+| --------- | ----- | ------------- | -------------------------- |
+| textColor | color | theme.white   | text color for the control |
 
 ### Props
-| Name      | Type     | Default Value | Description |
-|-----------|----------|---------------|-------------|
-| className | string   |               | Optional class name to be added to the root |
+
+| Name      | Type   | Default Value | Description                                 |
+| --------- | ------ | ------------- | ------------------------------------------- |
+| className | string |               | Optional class name to be added to the root |
 
 ## Component Progress
 
-### Current state 
+### Current state
 
 ### Todos
 
@@ -84,5 +93,3 @@ See https://github.com/OfficeDev/office-ui-fabric-react/wiki/Component-Design#bu
 - [ ] API review
 - [ ] Public Preview
 - [ ] Ready for Publishing
-
-

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,7 +1,6 @@
 ---
 name: Question
 about: 'Please use Stack Overflow for questions #office-ui-fabric'
-
 ---
 
 For _how-to_ questions and other non-bugs, please use StackOverflow instead of Github issues. You can tag your questions with [office-ui-fabric](https://stackoverflow.com/questions/tagged/office-ui-fabric).


### PR DESCRIPTION
Various updates to the issue templates to hopefully help increase the quality of created issues!

Make the intro block of the templates shorter--my theory is this *might* reduce instances of people blanking the template. (The bit about making a codepen has moved into the codepen section of the templates.)

Update the accessibility issue template to request environment info and a codepen repro.

Add "fill this out" placeholders under section headers to hopefully help reduce formatting issues (where the author-entered section content gets combined with the header).

Update the generic issue template to more closely mirror the other templates.

### Links to proposed md files

[Issue Template](https://raw.githubusercontent.com/OfficeDev/office-ui-fabric-react/fee440e644d9f1624d33cbb59388ffd3a30fd71e/.github/ISSUE_TEMPLATE.md)
[Accessibility Template](https://raw.githubusercontent.com/OfficeDev/office-ui-fabric-react/fee440e644d9f1624d33cbb59388ffd3a30fd71e/.github/ISSUE_TEMPLATE/accessibility_issue.md)
[Bug Template](https://raw.githubusercontent.com/OfficeDev/office-ui-fabric-react/fee440e644d9f1624d33cbb59388ffd3a30fd71e/.github/ISSUE_TEMPLATE/bug_report.md)
[Feature Template](https://raw.githubusercontent.com/OfficeDev/office-ui-fabric-react/fee440e644d9f1624d33cbb59388ffd3a30fd71e/.github/ISSUE_TEMPLATE/feature_request.md)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9990)