### PR TITLE
MenuButton: Removing use of StackItem to improve performance

### DIFF
--- a/change/@uifabric-experiments-2019-07-30-15-39-42-menuButtonRemoveStackItem.json
+++ b/change/@uifabric-experiments-2019-07-30-15-39-42-menuButtonRemoveStackItem.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "MenuButton: Removing use of StackItem to improve performance.",
+  "packageName": "@uifabric/experiments",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "86861599655f59191d65fb7d844a4943f4ade6ca",
+  "date": "2019-07-30T22:39:42.555Z"
+}

--- a/packages/experiments/src/components/Button/MenuButton/MenuButton.styles.ts
+++ b/packages/experiments/src/components/Button/MenuButton/MenuButton.styles.ts
@@ -115,6 +115,10 @@ export const MenuButtonStyles: IMenuButtonComponent['styles'] = (props, theme, t
       },
       className
     ],
+    menuArea: {
+      height: 'auto',
+      width: 'auto'
+    },
     menuIcon: {
       fontSize: tokens.menuIconSize,
       paddingTop: '5px'

--- a/packages/experiments/src/components/Button/MenuButton/MenuButton.types.tsx
+++ b/packages/experiments/src/components/Button/MenuButton/MenuButton.types.tsx
@@ -1,4 +1,4 @@
-import { IComponent, IComponentStyles, ISlottableProps, ISlotProp, IStyleableComponentProps } from '../../../Foundation';
+import { IComponent, IComponentStyles, IHTMLSlot, ISlottableProps, ISlotProp, IStyleableComponentProps } from '../../../Foundation';
 import { IContextualMenuSlot, IIconSlot } from '../../../utilities/factoryComponents.types';
 import { IBaseProps } from '../../../Utilities';
 import { IButton, IButtonProps, IButtonSlot, IButtonSlots, IButtonTokens, IButtonViewProps, INativeButtonProps } from '../Button.types';
@@ -33,6 +33,11 @@ export interface IMenuButtonSlots extends IButtonSlots {
    * Defines the button that is going to be rendered.
    */
   button?: IButtonSlot;
+
+  /**
+   * Defines the section on the right of the MenuButton that contains the menu icon.
+   */
+  menuArea?: IHTMLSlot;
 
   /**
    * Defines the contextual menu that appears when you click on the MenuButton.

--- a/packages/experiments/src/components/Button/MenuButton/MenuButton.view.tsx
+++ b/packages/experiments/src/components/Button/MenuButton/MenuButton.view.tsx
@@ -1,5 +1,5 @@
 /** @jsx withSlots */
-import { ContextualMenu, DirectionalHint, Stack, Text } from 'office-ui-fabric-react';
+import { ContextualMenu, DirectionalHint, Text } from 'office-ui-fabric-react';
 import { withSlots, getSlots } from '../../../Foundation';
 import { Icon } from '../../../utilities/factoryComponents';
 
@@ -33,6 +33,7 @@ export const MenuButtonView: IMenuButtonComponent['view'] = props => {
     button: Button,
     icon: Icon,
     content: Text,
+    menuArea: 'div',
     menu: ContextualMenu,
     menuIcon: Icon
   });
@@ -48,9 +49,9 @@ export const MenuButtonView: IMenuButtonComponent['view'] = props => {
         {...rest}
       >
         {children}
-        <Stack.Item>
+        <Slots.menuArea>
           <Slots.menuIcon iconName="ChevronDown" />
-        </Stack.Item>
+        </Slots.menuArea>
       </Slots.button>
       {expanded && (
         <Slots.menu

--- a/packages/experiments/src/components/Button/SplitButton/SplitButton.view.tsx
+++ b/packages/experiments/src/components/Button/SplitButton/SplitButton.view.tsx
@@ -40,6 +40,7 @@ export const SplitButtonView: ISplitButtonComponent['view'] = props => {
     menuButton: MenuButton,
     icon: Icon,
     content: Text,
+    menuArea: 'span',
     menu: ContextualMenu,
     menuIcon: Icon,
     splitDividerContainer: 'span',


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The area in the `MenuButton` that housed the menu icon was using a `StackItem` to render correctly. This PR replaces that with a styled div to improve the performance of both `MenuButton` and `SplitButton`.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/9995)