### PR TITLE
ChoiceGroup: fix focusing on options and general cleanup

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -84,7 +84,7 @@ Callout/ @joschect
 react-cards/Card/  @khmakoto
 Check/ @KevinTCoughlin
 Checkbox/ @cliffkoh
-ChoiceGroup/ @srideshpande
+ChoiceGroup/ @srideshpande @ecraig12345
 Coachmark/ @leddie24
 CollapsibleSection/ @JasonGore
 ColorPicker/ @ecraig12345

--- a/change/office-ui-fabric-react-2019-07-30-16-24-33-choicegroup.json
+++ b/change/office-ui-fabric-react-2019-07-30-16-24-33-choicegroup.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "ChoiceGroup: fix focusing on options and general cleanup",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "commit": "e0eac43d64115bca62712ac742d7dd6258672cf9",
+  "date": "2019-07-30T23:24:33.133Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -494,7 +494,7 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> impl
 }
 
 // Warning: (ae-forgotten-export) The symbol "ICalloutState" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export class Callout extends React.Component<ICalloutProps, ICalloutState> {
     // (undocumented)
@@ -544,7 +544,7 @@ export class ChoiceGroupBase extends React.Component<IChoiceGroupProps, IChoiceG
     constructor(props: IChoiceGroupProps);
     readonly checkedOption: IChoiceGroupOption | undefined;
     // (undocumented)
-    componentWillReceiveProps(newProps: IChoiceGroupProps): void;
+    componentDidUpdate(prevProps: IChoiceGroupProps, prevState: IChoiceGroupState): void;
     // (undocumented)
     focus(): void;
     // (undocumented)
@@ -652,7 +652,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     static defaultProps: IComboBoxProps;
     dismissMenu: () => void;
     // Warning: (ae-unresolved-inheritdoc-base) The @inheritDoc tag needs a TSDoc declaration reference; signature matching is not supported yet
-    //
+    // 
     // (undocumented)
     focus: (shouldOpenOnFocus?: boolean | undefined, useFocusAsync?: boolean | undefined) => void;
     // (undocumented)
@@ -2864,7 +2864,7 @@ export interface IContextualMenuItem {
     data?: any;
     disabled?: boolean;
     // Warning: (ae-forgotten-export) The symbol "IMenuItemClassNames" needs to be exported by the entry point index.d.ts
-    //
+    // 
     // @deprecated
     getItemClassNames?: (theme: ITheme, disabled: boolean, expanded: boolean, checked: boolean, isAnchorLink: boolean, knownIcon: boolean, itemClassName?: string, dividerClassName?: string, iconClassName?: string, subMenuClassName?: string, primaryDisabled?: boolean) => IMenuItemClassNames;
     getSplitButtonVerticalDividerClassNames?: (theme: ITheme) => IVerticalDividerClassNames;
@@ -2964,7 +2964,7 @@ export interface IContextualMenuListProps {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IWithResponsiveModeState" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public
 export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWithResponsiveModeState {
     alignTargetEdge?: boolean;
@@ -2984,7 +2984,7 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
     focusZoneProps?: IFocusZoneProps;
     gapSpace?: number;
     // Warning: (ae-forgotten-export) The symbol "IContextualMenuClassNames" needs to be exported by the entry point index.d.ts
-    //
+    // 
     // @deprecated
     getMenuClassNames?: (theme: ITheme, className?: string) => IContextualMenuClassNames;
     hidden?: boolean;
@@ -3733,7 +3733,7 @@ export interface IDialogFooterStyles {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IAccessiblePopupProps" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IDialogProps extends React.ClassAttributes<DialogBase>, IWithResponsiveModeState, IAccessiblePopupProps {
     // @deprecated
@@ -3837,7 +3837,7 @@ export interface IDocumentCardActions {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardActionsBase" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IDocumentCardActionsProps extends React.ClassAttributes<DocumentCardActionsBase> {
     actions: IButtonProps[];
@@ -3880,7 +3880,7 @@ export interface IDocumentCardActivityPerson {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardActivityBase" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IDocumentCardActivityProps extends React.ClassAttributes<DocumentCardActivityBase> {
     activity: string;
@@ -3919,7 +3919,7 @@ export interface IDocumentCardDetails {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardDetailsBase" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IDocumentCardDetailsProps extends React.Props<DocumentCardDetailsBase> {
     className?: string;
@@ -3978,7 +3978,7 @@ export interface IDocumentCardLocation {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardLocationBase" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IDocumentCardLocationProps extends React.ClassAttributes<DocumentCardLocationBase> {
     ariaLabel?: string;
@@ -4008,7 +4008,7 @@ export interface IDocumentCardLogo {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardLogoBase" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IDocumentCardLogoProps extends React.ClassAttributes<DocumentCardLogoBase> {
     className?: string;
@@ -4108,7 +4108,7 @@ export interface IDocumentCardStatus {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardStatusBase" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IDocumentCardStatusProps extends React.Props<DocumentCardStatusBase> {
     className?: string;
@@ -4150,7 +4150,7 @@ export interface IDocumentCardTitle {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardTitleBase" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IDocumentCardTitleProps extends React.ClassAttributes<DocumentCardTitleBase> {
     className?: string;
@@ -4353,7 +4353,7 @@ export interface IExpandingCard {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IBaseCardProps" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public
 export interface IExpandingCardProps extends IBaseCardProps<IExpandingCard, IExpandingCardStyles, IExpandingCardStyleProps> {
     compactCardHeight?: number;
@@ -4372,7 +4372,7 @@ export interface IExpandingCardState {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IBaseCardStyleProps" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IExpandingCardStyleProps extends IBaseCardStyleProps {
     compactCardHeight?: number;
@@ -4382,7 +4382,7 @@ export interface IExpandingCardStyleProps extends IBaseCardStyleProps {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IBaseCardStyles" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IExpandingCardStyles extends IBaseCardStyles {
     compactCard?: IStyle;
@@ -5706,7 +5706,7 @@ export interface IPanelHeaderRenderer extends IRenderFunction<IPanelProps> {
 }
 
 // Warning: (ae-forgotten-export) The symbol "PanelBase" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
     className?: string;
@@ -6864,7 +6864,7 @@ export interface ISpinButtonProps {
     keytipProps?: IKeytipProps;
     label?: string;
     // Warning: (ae-forgotten-export) The symbol "Position" needs to be exported by the entry point index.d.ts
-    //
+    // 
     // (undocumented)
     labelPosition?: Position;
     max?: number;
@@ -7480,14 +7480,14 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
 }
 
 // Warning: (ae-internal-missing-underscore) The name "ITextFieldSnapshot" should be prefixed with an underscore because the declaration is marked as @internal
-//
+// 
 // @internal (undocumented)
 export interface ITextFieldSnapshot {
     selection?: [number | null, number | null];
 }
 
 // Warning: (ae-internal-missing-underscore) The name "ITextFieldState" should be prefixed with an underscore because the declaration is marked as @internal
-//
+// 
 // @internal (undocumented)
 export interface ITextFieldState {
     errorMessage: string | JSX.Element;
@@ -7764,7 +7764,7 @@ export class Keytip extends React.Component<IKeytipProps, {}> {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IKeytipDataProps" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public
 export class KeytipData extends React.Component<IKeytipDataProps & IRenderComponent<{}>, {}> {
     // (undocumented)
@@ -7792,7 +7792,7 @@ export class KeytipLayerBase extends BaseComponent<IKeytipLayerProps, IKeytipLay
     // (undocumented)
     getCurrentSequence(): string;
     // Warning: (ae-forgotten-export) The symbol "KeytipTree" needs to be exported by the entry point index.d.ts
-    //
+    // 
     // (undocumented)
     getKeytipTree(): KeytipTree;
     processInput(key: string, ev?: React.KeyboardEvent<HTMLElement>): void;
@@ -7834,7 +7834,7 @@ export class LayerBase extends React.Component<ILayerProps, ILayerBaseState> {
     }
 
 // Warning: (ae-forgotten-export) The symbol "ILayerHostProps" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export class LayerHost extends React.Component<ILayerHostProps> {
     // (undocumented)
@@ -9197,7 +9197,7 @@ export const TextField: React.StatelessComponent<ITextFieldProps>;
 
 // Warning: (ae-incompatible-release-tags) The symbol "TextFieldBase" is marked as @public, but its signature references "ITextFieldState" which is marked as @internal
 // Warning: (ae-incompatible-release-tags) The symbol "TextFieldBase" is marked as @public, but its signature references "ITextFieldSnapshot" which is marked as @internal
-//
+// 
 // @public (undocumented)
 export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldState, ITextFieldSnapshot> implements ITextField {
     constructor(props: ITextFieldProps);
@@ -9354,7 +9354,7 @@ export * from "@uifabric/styling";
 export * from "@uifabric/utilities";
 
 // Warnings were encountered during analysis:
-//
+// 
 // lib/components/ColorPicker/ColorPicker.base.d.ts:8:9 - (ae-forgotten-export) The symbol "IRGBHex" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -546,8 +546,6 @@ export class ChoiceGroupBase extends React.Component<IChoiceGroupProps, IChoiceG
     // (undocumented)
     componentWillReceiveProps(newProps: IChoiceGroupProps): void;
     // (undocumented)
-    static defaultProps: IChoiceGroupProps;
-    // (undocumented)
     focus(): void;
     // (undocumented)
     render(): JSX.Element;
@@ -2218,6 +2216,7 @@ export interface IChoiceGroup {
 // @public (undocumented)
 export interface IChoiceGroupOption extends React.InputHTMLAttributes<HTMLElement | HTMLInputElement> {
     ariaLabel?: string;
+    // @deprecated
     checked?: boolean;
     disabled?: boolean;
     iconProps?: IIconProps;
@@ -2243,8 +2242,8 @@ export interface IChoiceGroupOptionProps extends IChoiceGroupOption {
     focused?: boolean;
     name?: string;
     onBlur?: (ev: React.FocusEvent<HTMLElement>, props?: IChoiceGroupOption) => void;
-    onChange?: OnChangeCallback;
-    onFocus?: OnFocusCallback;
+    onChange?: (evt?: React.FormEvent<HTMLElement | HTMLInputElement>, props?: IChoiceGroupOption) => void;
+    onFocus?: (ev?: React.FocusEvent<HTMLElement | HTMLInputElement>, props?: IChoiceGroupOption) => void | undefined;
     required?: boolean;
     theme?: ITheme;
 }
@@ -2303,8 +2302,7 @@ export interface IChoiceGroupProps extends React.InputHTMLAttributes<HTMLElement
 
 // @public (undocumented)
 export interface IChoiceGroupState {
-    // (undocumented)
-    keyChecked: string | number;
+    keyChecked?: string | number;
     keyFocused?: string | number;
 }
 
@@ -2320,13 +2318,12 @@ export interface IChoiceGroupStyleProps {
 
 // @public (undocumented)
 export interface IChoiceGroupStyles {
-    // (undocumented)
+    // @deprecated
     applicationRole?: IStyle;
     // (undocumented)
     flexContainer?: IStyle;
     // (undocumented)
     label?: IStyle;
-    // (undocumented)
     root?: IStyle;
 }
 
@@ -8058,11 +8055,11 @@ export class NormalPeoplePickerBase extends BasePeoplePicker {
     };
 }
 
-// @public (undocumented)
-export type OnChangeCallback = (evt?: React.FormEvent<HTMLElement | HTMLInputElement>, props?: IChoiceGroupOption) => void;
+// @public @deprecated (undocumented)
+export type OnChangeCallback = IChoiceGroupOptionProps['onChange'];
 
-// @public (undocumented)
-export type OnFocusCallback = (ev?: React.FocusEvent<HTMLElement | HTMLInputElement>, props?: IChoiceGroupOption) => void | undefined;
+// @public @deprecated (undocumented)
+export type OnFocusCallback = IChoiceGroupOptionProps['onFocus'];
 
 // @public (undocumented)
 export const ONKEYDOWN_TIMEOUT_DURATION = 1000;

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -8,18 +8,27 @@ import {
   classNamesFunction,
   find,
   getId,
+  isControlled,
   getNativeProps,
   divProperties
 } from '../../Utilities';
 import { IChoiceGroup, IChoiceGroupOption, IChoiceGroupProps, IChoiceGroupStyleProps, IChoiceGroupStyles } from './ChoiceGroup.types';
-import { ChoiceGroupOption, OnChangeCallback, OnFocusCallback } from './ChoiceGroupOption/index';
+import { ChoiceGroupOption, IChoiceGroupOptionProps } from './ChoiceGroupOption/index';
 
 const getClassNames = classNamesFunction<IChoiceGroupStyleProps, IChoiceGroupStyles>();
 
 export interface IChoiceGroupState {
-  keyChecked: string | number;
+  /**
+   * Current selected option, for **internal use only**.
+   * External users should access `IChoiceGroup.checkedOption` instead.
+   */
+  // TODO (Fabric 8?) - once we removed the checked property from individual options,
+  // we can probably store only the uncontrolled value in the state (right now it tracks
+  // the value regardless of controlled/uncontrolled--though if controlled, it only updates
+  // the value in state when the selectedKey prop updates)
+  keyChecked?: string | number;
 
-  /** Is true when the control has focus. */
+  /** Is set when the control has focus. */
   keyFocused?: string | number;
 }
 
@@ -27,15 +36,10 @@ export interface IChoiceGroupState {
  * {@docCategory ChoiceGroup}
  */
 export class ChoiceGroupBase extends React.Component<IChoiceGroupProps, IChoiceGroupState> implements IChoiceGroup {
-  public static defaultProps: IChoiceGroupProps = {
-    options: []
-  };
-
   private _id: string;
   private _labelId: string;
-  private _inputElement = React.createRef<HTMLInputElement>();
-  private focusedVars: { [key: string]: OnFocusCallback } = {};
-  private changedVars: { [key: string]: OnChangeCallback } = {};
+  private _focusCallbacks: { [key: string]: IChoiceGroupOptionProps['onFocus'] } = {};
+  private _changeCallbacks: { [key: string]: IChoiceGroupOptionProps['onBlur'] } = {};
 
   constructor(props: IChoiceGroupProps) {
     super(props);
@@ -49,12 +53,12 @@ export class ChoiceGroupBase extends React.Component<IChoiceGroupProps, IChoiceG
       });
     }
 
-    const validDefaultSelectedKey: boolean = !!props.options && props.options.some(option => option.key === props.defaultSelectedKey);
+    const { defaultSelectedKey, options = [] } = props;
+    const validDefaultSelectedKey =
+      !_isControlled(props) && defaultSelectedKey !== undefined && options.some(option => option.key === defaultSelectedKey);
 
     this.state = {
-      keyChecked:
-        props.defaultSelectedKey === undefined || !validDefaultSelectedKey ? this._getKeyChecked(props)! : props.defaultSelectedKey,
-      keyFocused: undefined
+      keyChecked: validDefaultSelectedKey ? defaultSelectedKey : this._getKeyChecked(props)
     };
 
     this._id = getId('ChoiceGroup');
@@ -66,23 +70,25 @@ export class ChoiceGroupBase extends React.Component<IChoiceGroupProps, IChoiceG
    */
   public get checkedOption(): IChoiceGroupOption | undefined {
     const { options = [] } = this.props;
-    const { keyChecked: key } = this.state;
-    return find(options, (value: IChoiceGroupOption) => value.key === key);
+    return find(options, (value: IChoiceGroupOption) => value.key === this.state.keyChecked);
   }
 
-  public componentWillReceiveProps(newProps: IChoiceGroupProps): void {
-    const newKeyChecked = this._getKeyChecked(newProps);
-    const oldKeyChecked = this._getKeyChecked(this.props);
+  public componentDidUpdate(prevProps: IChoiceGroupProps, prevState: IChoiceGroupState): void {
+    // Only update if a new props object has been passed in (don't care about state updates)
+    if (prevProps !== this.props) {
+      const newKeyChecked = this._getKeyChecked(this.props);
+      const oldKeyChecked = this._getKeyChecked(prevProps);
 
-    if (newKeyChecked !== oldKeyChecked) {
-      this.setState({
-        keyChecked: newKeyChecked!
-      });
+      if (newKeyChecked !== oldKeyChecked) {
+        this.setState({
+          keyChecked: newKeyChecked
+        });
+      }
     }
   }
 
   public render(): JSX.Element {
-    const { className, theme, styles, options, label, required, disabled, name, role } = this.props;
+    const { className, theme, styles, options = [], label, required, disabled, name } = this.props;
     const { keyChecked, keyFocused } = this.state;
 
     const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties, ['onChange', 'className', 'required']);
@@ -90,31 +96,30 @@ export class ChoiceGroupBase extends React.Component<IChoiceGroupProps, IChoiceG
     const classNames = getClassNames(styles!, {
       theme: theme!,
       className,
-      optionsContainIconOrImage: options!.some(option => Boolean(option.iconProps || option.imageSrc))
+      optionsContainIconOrImage: options.some(option => !!(option.iconProps || option.imageSrc))
     });
 
-    const ariaLabelledBy = this.props.ariaLabelledBy
-      ? this.props.ariaLabelledBy
-      : label
-      ? this._id + '-label'
-      : (this.props as any)['aria-labelledby'];
+    const labelId = this._id + '-label';
+    const ariaLabelledBy = this.props.ariaLabelledBy || (label ? labelId : this.props['aria-labelledby']);
 
+    // TODO (Fabric 8?) - if possible, move `root` class to the actual root and eliminate
+    // `applicationRole` class (but the div structure will stay the same by necessity)
     return (
-      <div role={role} className={classNames.applicationRole} {...divProps}>
+      <div className={classNames.applicationRole} {...divProps}>
         <div className={classNames.root} role="radiogroup" {...ariaLabelledBy && { 'aria-labelledby': ariaLabelledBy }}>
           {label && (
-            <Label className={classNames.label} required={required} id={this._id + '-label'} disabled={disabled}>
+            <Label className={classNames.label} required={required} id={labelId} disabled={disabled}>
               {label}
             </Label>
           )}
           <div className={classNames.flexContainer}>
-            {options!.map((option: IChoiceGroupOption) => {
+            {options.map((option: IChoiceGroupOption) => {
               const innerOptionProps = {
                 ...option,
                 focused: option.key === keyFocused,
                 checked: option.key === keyChecked,
                 disabled: option.disabled || disabled,
-                id: `${this._id}-${option.key}`,
+                id: this._getOptionId(option),
                 labelId: `${this._labelId}-${option.key}`,
                 name: name || this._id,
                 required
@@ -137,76 +142,77 @@ export class ChoiceGroupBase extends React.Component<IChoiceGroupProps, IChoiceG
   }
 
   public focus() {
-    const { options } = this.props;
-    if (options) {
-      for (const option of options) {
-        const elementToFocus = document.getElementById(`${this._id}-${option.key}`);
-        if (elementToFocus && elementToFocus.getAttribute('data-is-focusable') === 'true') {
-          elementToFocus.focus(); // focus on checked or default focusable key
-          return;
-        }
-      }
-    }
-    if (this._inputElement.current) {
-      this._inputElement.current.focus();
+    const { options = [] } = this.props;
+    const optionToFocus = this.checkedOption || options.filter(option => !option.disabled)[0];
+    const elementToFocus = optionToFocus && document.getElementById(this._getOptionId(optionToFocus));
+    if (elementToFocus) {
+      elementToFocus.focus();
     }
   }
 
-  private _onFocus = (key: string) =>
-    this.focusedVars[key]
-      ? this.focusedVars[key]
-      : (this.focusedVars[key] = (ev: React.FocusEvent<HTMLElement>, option: IChoiceGroupOption) => {
-          this.setState({
-            keyFocused: key,
-            keyChecked: this.state.keyChecked
-          });
+  private _onFocus(key: string) {
+    // This extra mess is necessary because React won't pass the `key` prop through to ChoiceGroupOption
+    if (!this._focusCallbacks[key]) {
+      this._focusCallbacks[key] = (ev: React.FocusEvent<HTMLElement | HTMLInputElement>, option: IChoiceGroupOption) => {
+        this.setState({
+          keyFocused: key
         });
+      };
+    }
+    return this._focusCallbacks[key];
+  }
 
   private _onBlur = (ev: React.FocusEvent<HTMLElement>, option: IChoiceGroupOption) => {
     this.setState({
-      keyFocused: undefined,
-      keyChecked: this.state.keyChecked
+      keyFocused: undefined
     });
   };
 
-  private _onChange = (key: string) =>
-    this.changedVars[key]
-      ? this.changedVars[key]
-      : (this.changedVars[key] = (evt, option: IChoiceGroupOption) => {
-          const { onChanged, onChange, selectedKey, options = [] } = this.props;
+  private _onChange(key: string) {
+    // This extra mess is necessary because React won't pass the `key` prop through to ChoiceGroupOption
+    if (!this._changeCallbacks[key]) {
+      this._changeCallbacks[key] = (evt: React.FormEvent<HTMLElement | HTMLInputElement>, option: IChoiceGroupOption) => {
+        const { onChanged, onChange } = this.props;
 
-          // Only manage state in uncontrolled scenarios.
-          if (selectedKey === undefined) {
-            this.setState({
-              keyChecked: key
-            });
-          }
+        // Only manage state in uncontrolled scenarios.
+        if (!_isControlled(this.props)) {
+          this.setState({
+            keyChecked: key
+          });
+        }
 
-          const originalOption = find(options, (value: IChoiceGroupOption) => value.key === key);
+        // Get the original option without the `key` prop removed
+        const originalOption = find(this.props.options || [], (value: IChoiceGroupOption) => value.key === key);
 
-          // TODO: onChanged deprecated, remove else if after 07/17/2017 when onChanged has been removed.
-          if (onChange) {
-            onChange(evt, originalOption);
-          } else if (onChanged) {
-            onChanged(originalOption!);
-          }
-        });
+        // TODO: onChanged deprecated, remove else if after 07/17/2017 when onChanged has been removed.
+        if (onChange) {
+          onChange(evt, originalOption);
+        } else if (onChanged) {
+          onChanged(originalOption!, evt);
+        }
+      };
+    }
+    return this._changeCallbacks[key];
+  }
 
+  /**
+   * Returns `selectedKey` if provided, or the key of the first option with the `checked` prop set.
+   */
   private _getKeyChecked(props: IChoiceGroupProps): string | number | undefined {
     if (props.selectedKey !== undefined) {
       return props.selectedKey;
     }
 
     const { options = [] } = props;
-
-    const optionsChecked = options.filter((option: IChoiceGroupOption) => {
-      return option.checked;
-    });
-
-    if (optionsChecked.length === 0) {
-      return undefined;
-    } else {
-      return optionsChecked[0].key;
-    }
+    const optionsChecked = options.filter((option: IChoiceGroupOption) => option.checked);
+    return optionsChecked[0] && optionsChecked[0].key;
   }
+
+  private _getOptionId(option: IChoiceGroupOption): string {
+    return `${this._id}-${option.key}`;
+  }
+}
+
+function _isControlled(props: IChoiceGroupProps): boolean {
+  return isControlled(props, 'selectedKey');
 }

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.doc.tsx
@@ -12,7 +12,9 @@ const ChoiceGroupBasicExampleCodepen = require('!@uifabric/codepen-loader!office
 const ChoiceGroupLabelExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Label.Example.tsx') as string;
 const ChoiceGroupLabelExampleCodepen = require('!@uifabric/codepen-loader!office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Label.Example.tsx') as string;
 const ChoiceGroupCustomExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Custom.Example.tsx') as string;
+const ChoiceGroupCustomExampleCodepen = require('!@uifabric/codepen-loader!office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Custom.Example.tsx') as string;
 const ChoiceGroupImageExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Image.Example.tsx') as string;
+const ChoiceGroupImageExampleCodepen = require('!@uifabric/codepen-loader!office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Image.Example.tsx') as string;
 const ChoiceGroupIconExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Icon.Example.tsx') as string;
 const ChoiceGroupIconExampleCodepen = require('!@uifabric/codepen-loader!office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Icon.Example.tsx') as string;
 
@@ -37,11 +39,13 @@ export const ChoiceGroupPageProps: IDocPageProps = {
     {
       title: 'ChoiceGroup with dropdown',
       code: ChoiceGroupCustomExampleCode,
+      codepenJS: ChoiceGroupCustomExampleCodepen,
       view: <ChoiceGroupCustomExample />
     },
     {
       title: 'ChoiceGroups with images',
       code: ChoiceGroupImageExampleCode,
+      codepenJS: ChoiceGroupImageExampleCodepen,
       view: <ChoiceGroupImageExample />
     },
     {

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.styles.ts
@@ -12,6 +12,8 @@ export const getStyles = (props: IChoiceGroupStyleProps): IChoiceGroupStyles => 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
   return {
+    // TODO (Fabric 8?) - merge className back into `root` and apply root style to
+    // the actual root role=application element
     applicationRole: className,
     root: [
       classNames.root,

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.test.tsx
@@ -1,25 +1,35 @@
 /* tslint:disable:no-unused-variable */
 import * as React from 'react';
 /* tslint:enable:no-unused-variable */
-import { mount } from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
 import * as ReactTestUtils from 'react-dom/test-utils';
 import * as renderer from 'react-test-renderer';
 
 import { ChoiceGroup } from './ChoiceGroup';
-import { IChoiceGroupOption, IChoiceGroup } from './ChoiceGroup.types';
+import { IChoiceGroupOption, IChoiceGroup, IChoiceGroupProps } from './ChoiceGroup.types';
 import { merge, resetIds } from '../../Utilities';
+import { mountAttached } from '../../common/testUtilities';
 
 const TEST_OPTIONS: IChoiceGroupOption[] = [
   { key: '1', text: '1', 'data-automation-id': 'auto1', autoFocus: true } as IChoiceGroupOption,
   { key: '2', text: '2' },
   { key: '3', text: '3' }
 ];
-const QUERY_SELECTOR = '.ms-ChoiceField-input';
+const CHOICE_QUERY_SELECTOR = '.ms-ChoiceField-input';
 
 describe('ChoiceGroup', () => {
+  let choiceGroup: ReactWrapper<IChoiceGroupProps> | undefined;
+
   beforeEach(() => {
     // Resetting ids to create predictability in generated ids.
     resetIds();
+  });
+
+  afterEach(() => {
+    if (choiceGroup) {
+      choiceGroup.unmount();
+      choiceGroup = undefined;
+    }
   });
 
   it('renders ChoiceGroup correctly', () => {
@@ -28,75 +38,83 @@ describe('ChoiceGroup', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('label does not have className prop from parent', () => {
-    const component = renderer.create(<ChoiceGroup className="testClassName" label="testLabel" options={TEST_OPTIONS} required />);
+  it('renders ChoiceGroup with label correctly', () => {
+    const component = renderer.create(<ChoiceGroup className="testClassName" label="test label" options={TEST_OPTIONS} required />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
-  it('can change options', () => {
-    const choiceGroup = mount(<ChoiceGroup label="testgroup" options={TEST_OPTIONS} required={true} />);
+  it('does not use className prop from parent on label', () => {
+    choiceGroup = mount(<ChoiceGroup className="testClassName" label="test label" options={TEST_OPTIONS} required />);
+    const label = choiceGroup.getDOMNode().querySelector('label');
+    expect(label).toBeDefined();
+    expect(label!.textContent).toBe('test label');
+    expect(label!.className).not.toContain('testClassName');
+  });
 
-    const choiceOptions = choiceGroup.getDOMNode().querySelectorAll(QUERY_SELECTOR);
+  it('can change options', () => {
+    choiceGroup = mount(<ChoiceGroup label="testgroup" options={TEST_OPTIONS} required={true} />);
+
+    const choiceOptions = choiceGroup.getDOMNode().querySelectorAll(CHOICE_QUERY_SELECTOR) as NodeListOf<HTMLInputElement>;
 
     expect(choiceOptions.length).toBe(3);
 
-    expect((choiceOptions[0] as HTMLInputElement).checked).toEqual(false);
-    expect((choiceOptions[1] as HTMLInputElement).checked).toEqual(false);
-    expect((choiceOptions[2] as HTMLInputElement).checked).toEqual(false);
+    expect(choiceOptions[0].checked).toEqual(false);
+    expect(choiceOptions[1].checked).toEqual(false);
+    expect(choiceOptions[2].checked).toEqual(false);
 
     ReactTestUtils.Simulate.change(choiceOptions[0]);
 
-    expect((choiceOptions[0] as HTMLInputElement).checked).toEqual(true);
-    expect((choiceOptions[1] as HTMLInputElement).checked).toEqual(false);
-    expect((choiceOptions[2] as HTMLInputElement).checked).toEqual(false);
+    expect(choiceOptions[0].checked).toEqual(true);
+    expect(choiceOptions[1].checked).toEqual(false);
+    expect(choiceOptions[2].checked).toEqual(false);
 
     ReactTestUtils.Simulate.change(choiceOptions[1]);
 
-    expect((choiceOptions[0] as HTMLInputElement).checked).toEqual(false);
-    expect((choiceOptions[1] as HTMLInputElement).checked).toEqual(true);
-    expect((choiceOptions[2] as HTMLInputElement).checked).toEqual(false);
+    expect(choiceOptions[0].checked).toEqual(false);
+    expect(choiceOptions[1].checked).toEqual(true);
+    expect(choiceOptions[2].checked).toEqual(false);
 
     ReactTestUtils.Simulate.change(choiceOptions[0]);
 
-    expect((choiceOptions[0] as HTMLInputElement).checked).toEqual(true);
-    expect((choiceOptions[1] as HTMLInputElement).checked).toEqual(false);
-    expect((choiceOptions[2] as HTMLInputElement).checked).toEqual(false);
+    expect(choiceOptions[0].checked).toEqual(true);
+    expect(choiceOptions[1].checked).toEqual(false);
+    expect(choiceOptions[2].checked).toEqual(false);
   });
 
   it('An individual choice option can be disabled', () => {
-    const options: IChoiceGroupOption[] = merge([], TEST_OPTIONS) as IChoiceGroupOption[];
+    const options: IChoiceGroupOption[] = merge([], TEST_OPTIONS);
     options[0].disabled = true;
 
-    const choiceGroup = mount(<ChoiceGroup label="testgroup" options={options} required={true} />);
+    choiceGroup = mount(<ChoiceGroup label="testgroup" options={options} required={true} />);
 
-    const choiceOptions = choiceGroup.getDOMNode().querySelectorAll(QUERY_SELECTOR);
+    const choiceOptions = choiceGroup.getDOMNode().querySelectorAll(CHOICE_QUERY_SELECTOR) as NodeListOf<HTMLInputElement>;
 
-    expect((choiceOptions[0] as HTMLInputElement).disabled).toEqual(true);
-    expect((choiceOptions[1] as HTMLInputElement).disabled).toEqual(false);
-    expect((choiceOptions[2] as HTMLInputElement).disabled).toEqual(false);
+    expect(choiceOptions[0].disabled).toEqual(true);
+    expect(choiceOptions[1].disabled).toEqual(false);
+    expect(choiceOptions[2].disabled).toEqual(false);
   });
 
   it('renders all choice options as disabled when disabled', () => {
-    const choiceGroup = mount(<ChoiceGroup label="testgroup" options={TEST_OPTIONS} required={true} disabled={true} />);
+    choiceGroup = mount(<ChoiceGroup label="testgroup" options={TEST_OPTIONS} required={true} disabled={true} />);
 
-    const choiceOptions = choiceGroup.getDOMNode().querySelectorAll(QUERY_SELECTOR);
+    const choiceOptions = choiceGroup.getDOMNode().querySelectorAll(CHOICE_QUERY_SELECTOR) as NodeListOf<HTMLInputElement>;
 
-    expect((choiceOptions[0] as HTMLInputElement).disabled).toEqual(true);
-    expect((choiceOptions[1] as HTMLInputElement).disabled).toEqual(true);
-    expect((choiceOptions[2] as HTMLInputElement).disabled).toEqual(true);
+    expect(choiceOptions[0].disabled).toEqual(true);
+    expect(choiceOptions[1].disabled).toEqual(true);
+    expect(choiceOptions[2].disabled).toEqual(true);
   });
 
   it('can act as an uncontrolled component', () => {
-    const choiceGroup = mount(<ChoiceGroup defaultSelectedKey="1" options={TEST_OPTIONS} />);
+    choiceGroup = mount(<ChoiceGroup defaultSelectedKey="1" options={TEST_OPTIONS} />);
 
-    const choiceOptions = choiceGroup.getDOMNode().querySelectorAll(QUERY_SELECTOR);
+    const choiceOptions = choiceGroup.getDOMNode().querySelectorAll(CHOICE_QUERY_SELECTOR) as NodeListOf<HTMLInputElement>;
 
-    expect((choiceOptions[0] as HTMLInputElement).checked).toEqual(true);
+    expect(choiceOptions[0].checked).toEqual(true);
 
     ReactTestUtils.Simulate.change(choiceOptions[1]);
 
-    expect((choiceOptions[1] as HTMLInputElement).checked).toEqual(true);
+    expect(choiceOptions[1].checked).toEqual(true);
   });
 
   it('can render as a controlled component', () => {
@@ -105,29 +123,29 @@ describe('ChoiceGroup', () => {
       _selectedItem = item;
     };
 
-    const choiceGroup = mount(<ChoiceGroup selectedKey="1" options={TEST_OPTIONS} onChange={onChange} />);
+    choiceGroup = mount(<ChoiceGroup selectedKey="1" options={TEST_OPTIONS} onChange={onChange} />);
 
-    const choiceOptions = choiceGroup.getDOMNode().querySelectorAll(QUERY_SELECTOR);
+    const choiceOptions = choiceGroup.getDOMNode().querySelectorAll(CHOICE_QUERY_SELECTOR) as NodeListOf<HTMLInputElement>;
 
-    expect((choiceOptions[0] as HTMLInputElement).checked).toEqual(true);
+    expect(choiceOptions[0].checked).toEqual(true);
 
     ReactTestUtils.Simulate.change(choiceOptions[1]);
 
-    expect((choiceOptions[0] as HTMLInputElement).checked).toEqual(true);
-    expect((choiceOptions[1] as HTMLInputElement).checked).toEqual(false);
+    expect(choiceOptions[0].checked).toEqual(true);
+    expect(choiceOptions[1].checked).toEqual(false);
 
     expect(_selectedItem).toEqual(TEST_OPTIONS[1]);
   });
 
-  it('extra <input> attributes appear in dom if specified', () => {
+  it('uses extra <input> attributes in dom if specified', () => {
     const onChange = (ev: React.FormEvent<HTMLElement | HTMLInputElement>, item: IChoiceGroupOption | undefined): void => undefined;
 
-    const choiceGroup = mount(<ChoiceGroup options={TEST_OPTIONS} onChange={onChange} />);
+    choiceGroup = mount(<ChoiceGroup options={TEST_OPTIONS} onChange={onChange} />);
 
-    const choiceOptions = choiceGroup.getDOMNode().querySelectorAll(QUERY_SELECTOR);
+    const choiceOptions = choiceGroup.getDOMNode().querySelectorAll(CHOICE_QUERY_SELECTOR) as NodeListOf<HTMLInputElement>;
 
     const extraAttributeGetter: (index: number) => string | null = (index: number): string | null => {
-      const input: HTMLInputElement = choiceOptions[index] as HTMLInputElement;
+      const input: HTMLInputElement = choiceOptions[index];
       return input.getAttribute('data-automation-id');
     };
 
@@ -135,48 +153,93 @@ describe('ChoiceGroup', () => {
     expect(extraAttributeGetter(1)).toBeNull();
   });
 
-  it('has role attribute that can be omitted', () => {
-    const choiceGroup = mount(<ChoiceGroup options={TEST_OPTIONS} role="" />);
-    const choiceGroupEl: Element = choiceGroup.getDOMNode();
-    const role = choiceGroupEl.getAttribute('role');
+  it('can set role attribute to empty string', () => {
+    choiceGroup = mount(<ChoiceGroup options={TEST_OPTIONS} role="" />);
+    const role = choiceGroup.getDOMNode().getAttribute('role');
     expect(role).toEqual('');
   });
 
-  it('can assign a role attribute to the containing element', () => {
-    const choiceGroup = mount(<ChoiceGroup options={TEST_OPTIONS} role="Test" />);
-    const choiceGroupEl: Element = choiceGroup.getDOMNode();
-    const role = choiceGroupEl.getAttribute('role');
+  it('can set role attribute on the containing element', () => {
+    choiceGroup = mount(<ChoiceGroup options={TEST_OPTIONS} role="Test" />);
+    const role = choiceGroup.getDOMNode().getAttribute('role');
     expect(role).toEqual('Test');
   });
 
   it('can assign a custom aria label', () => {
     const option4: IChoiceGroupOption[] = [{ key: '4', text: '4', ariaLabel: 'Custom aria label' }];
-    const choiceGroup = mount(<ChoiceGroup label="testgroup" options={TEST_OPTIONS.concat(option4)} required={true} />);
+    choiceGroup = mount(<ChoiceGroup label="testgroup" options={TEST_OPTIONS.concat(option4)} required={true} />);
 
-    const choiceOptions = choiceGroup.getDOMNode().querySelectorAll(QUERY_SELECTOR);
+    const choiceOptions = choiceGroup.getDOMNode().querySelectorAll(CHOICE_QUERY_SELECTOR) as NodeListOf<HTMLInputElement>;
 
     expect(choiceOptions.length).toBe(4);
 
-    expect((choiceOptions[0] as HTMLInputElement).getAttribute('aria-label')).toBeNull();
-    expect((choiceOptions[1] as HTMLInputElement).getAttribute('aria-label')).toBeNull();
-    expect((choiceOptions[2] as HTMLInputElement).getAttribute('aria-label')).toBeNull();
-    expect((choiceOptions[3] as HTMLInputElement).getAttribute('aria-label')).toEqual('Custom aria label');
+    expect(choiceOptions[0].getAttribute('aria-label')).toBeNull();
+    expect(choiceOptions[1].getAttribute('aria-label')).toBeNull();
+    expect(choiceOptions[2].getAttribute('aria-label')).toBeNull();
+    expect(choiceOptions[3].getAttribute('aria-label')).toEqual('Custom aria label');
   });
 
-  it('can be accessed to get the current checked option', () => {
+  it('returns the current checked option with user interaction', () => {
     const choiceGroupRef = React.createRef<IChoiceGroup>();
-    const choiceGroup = mount(<ChoiceGroup options={TEST_OPTIONS} role="" componentRef={choiceGroupRef} />);
+    choiceGroup = mount(<ChoiceGroup options={TEST_OPTIONS} componentRef={choiceGroupRef} />);
 
-    const choiceOptions = choiceGroup.getDOMNode().querySelectorAll(QUERY_SELECTOR);
+    const choiceOptions = choiceGroup.getDOMNode().querySelectorAll(CHOICE_QUERY_SELECTOR) as NodeListOf<HTMLInputElement>;
 
     expect(choiceGroupRef.current!.checkedOption).toBeUndefined();
     ReactTestUtils.Simulate.change(choiceOptions[0]);
-    expect(choiceGroupRef.current!.checkedOption).toBeDefined();
+    expect(choiceGroupRef.current!.checkedOption).toEqual(TEST_OPTIONS[0]);
+  });
+
+  it('returns the current checked option with defaultSelectedKey', () => {
+    const choiceGroupRef = React.createRef<IChoiceGroup>();
+    choiceGroup = mount(<ChoiceGroup options={TEST_OPTIONS} defaultSelectedKey="1" componentRef={choiceGroupRef} />);
+
+    const choiceOptions = choiceGroup.getDOMNode().querySelectorAll(CHOICE_QUERY_SELECTOR) as NodeListOf<HTMLInputElement>;
+
+    expect(choiceGroupRef.current!.checkedOption).toEqual(TEST_OPTIONS[0]);
+    ReactTestUtils.Simulate.change(choiceOptions[1]);
+    expect(choiceGroupRef.current!.checkedOption).toEqual(TEST_OPTIONS[1]);
+  });
+
+  it('returns the current checked option with selectedKey', () => {
+    const choiceGroupRef = React.createRef<IChoiceGroup>();
+    choiceGroup = mount(<ChoiceGroup options={TEST_OPTIONS} selectedKey="1" componentRef={choiceGroupRef} />);
+
+    const choiceOptions = choiceGroup.getDOMNode().querySelectorAll(CHOICE_QUERY_SELECTOR) as NodeListOf<HTMLInputElement>;
+
+    expect(choiceGroupRef.current!.checkedOption).toEqual(TEST_OPTIONS[0]);
+    ReactTestUtils.Simulate.change(choiceOptions[1]);
+    // selectedKey is still used even though it didn't get updated for latest user click
     expect(choiceGroupRef.current!.checkedOption).toEqual(TEST_OPTIONS[0]);
   });
 
   it('can render element id', () => {
-    const choiceGroup = mount(<ChoiceGroup defaultSelectedKey="1" id="foo" options={TEST_OPTIONS} />);
+    choiceGroup = mount(<ChoiceGroup defaultSelectedKey="1" id="foo" options={TEST_OPTIONS} />);
     expect(choiceGroup.getDOMNode().getAttribute('id')).toBe('foo');
+  });
+
+  it('can focus the checked option', () => {
+    // This test has to mount the element to the document since ChoiceGroup.focus() uses document.getElementById()
+    const choiceGroupRef = React.createRef<IChoiceGroup>();
+    choiceGroup = mountAttached(<ChoiceGroup options={TEST_OPTIONS} defaultSelectedKey="1" componentRef={choiceGroupRef} />);
+
+    const option = choiceGroup.getDOMNode().querySelector(CHOICE_QUERY_SELECTOR) as HTMLInputElement;
+    const focusSpy = jest.spyOn(option, 'focus');
+
+    choiceGroupRef.current!.focus();
+    expect(focusSpy).toHaveBeenCalled();
+  });
+
+  it('can focus the first enabled option', () => {
+    const choiceGroupRef = React.createRef<IChoiceGroup>();
+    choiceGroup = mountAttached(
+      <ChoiceGroup options={[{ key: '0', text: 'disabled', disabled: true }, ...TEST_OPTIONS]} componentRef={choiceGroupRef} />
+    );
+
+    const option = choiceGroup.getDOMNode().querySelectorAll(CHOICE_QUERY_SELECTOR)![1] as HTMLInputElement;
+    const focusSpy = jest.spyOn(option, 'focus');
+
+    choiceGroupRef.current!.focus();
+    expect(focusSpy).toHaveBeenCalled();
   });
 });

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.types.ts
@@ -15,7 +15,7 @@ export interface IChoiceGroup {
   checkedOption: IChoiceGroupOption | undefined;
 
   /**
-   * Sets focus to the choiceGroup.
+   * Sets focus to the checked option or the first enabled option in the ChoiceGroup.
    */
   focus: () => void;
 }
@@ -38,6 +38,8 @@ export interface IChoiceGroupProps extends React.InputHTMLAttributes<HTMLElement
   /**
    * The key of the option that will be initially checked.
    */
+  // TODO (Fabric 8?): defaultSelectedKey/selectedKey allow numbers but IChoiceGroupOption doesn't.
+  // This should be consistent one way or the other everywhere.
   defaultSelectedKey?: string | number;
 
   /**
@@ -135,7 +137,13 @@ export interface IChoiceGroupOption extends React.InputHTMLAttributes<HTMLElemen
 
   /**
    * Whether or not the option is checked.
+   * @deprecated Do not track checked state in the options themselves. Instead, either pass
+   * `defaultSelectedKey` to the `ChoiceGroup` and allow it to track selection state internally
+   * (uncontrolled), or pass `selectedKey` and `onChange` to the `ChoiceGroup` to track/update
+   * the selection state manually (controlled).
    */
+  // This should move from IChoiceGroupOption to IChoiceGroupOptionProps, so that the ChoiceGroup
+  // can still set the option as checked for rendering purposes
   checked?: boolean;
 
   /**
@@ -174,7 +182,15 @@ export interface IChoiceGroupStyleProps {
  * {@docCategory ChoiceGroup}
  */
 export interface IChoiceGroupStyles {
+  /**
+   * The actual root of the component.
+   * @deprecated Styles will be merged with `root` in a future release.
+   */
   applicationRole?: IStyle;
+  /**
+   * Not currently the actual root of the component (will be fixed in a future release).
+   * For now, to style the actual root, use `applicationRole`.
+   */
   root?: IStyle;
   label?: IStyle;
   flexContainer?: IStyle;

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Image } from '../../../Image';
 import { Icon } from '../../../Icon';
 import { IChoiceGroupOptionProps, IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles } from './ChoiceGroupOption.types';
-import { classNamesFunction, getNativeProps, inputProperties, css } from '../../../Utilities';
+import { classNamesFunction, getNativeProps, inputProperties, css, initializeComponentRef } from '../../../Utilities';
 import { IProcessedStyleSet } from '../../../Styling';
 
 const getClassNames = classNamesFunction<IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles>();
@@ -11,8 +11,12 @@ const getClassNames = classNamesFunction<IChoiceGroupOptionStyleProps, IChoiceGr
  * {@docCategory ChoiceGroup}
  */
 export class ChoiceGroupOptionBase extends React.Component<IChoiceGroupOptionProps, any> {
-  private _inputElement = React.createRef<HTMLInputElement>();
   private _classNames: IProcessedStyleSet<IChoiceGroupOptionStyles>;
+
+  constructor(props: IChoiceGroupOptionProps) {
+    super(props);
+    initializeComponentRef(this);
+  }
 
   public render(): JSX.Element {
     const {
@@ -49,8 +53,7 @@ export class ChoiceGroupOptionBase extends React.Component<IChoiceGroupOptionPro
       <div className={this._classNames.root}>
         <div className={this._classNames.choiceFieldWrapper}>
           <input
-            aria-label={ariaLabel ? ariaLabel : undefined}
-            ref={this._inputElement}
+            aria-label={ariaLabel}
             id={id}
             className={css(this._classNames.input, className)}
             type="radio"
@@ -58,10 +61,10 @@ export class ChoiceGroupOptionBase extends React.Component<IChoiceGroupOptionPro
             disabled={disabled}
             checked={checked}
             required={required}
-            onChange={this._onChange.bind(this, this.props)}
-            onFocus={this._onFocus.bind(this, this.props)}
-            onBlur={this._onBlur.bind(this, this.props)}
             {...nativeProps}
+            onChange={this._onChange}
+            onFocus={this._onFocus}
+            onBlur={this._onBlur}
           />
           {onRenderField(this.props, this._onRenderField)}
         </div>
@@ -69,29 +72,29 @@ export class ChoiceGroupOptionBase extends React.Component<IChoiceGroupOptionPro
     );
   }
 
-  private _onChange(props: IChoiceGroupOptionProps, evt: React.FormEvent<HTMLInputElement>): void {
-    const { onChange } = props;
+  private _onChange = (evt: React.FormEvent<HTMLInputElement>): void => {
+    const { onChange } = this.props;
     if (onChange) {
-      onChange(evt, props);
+      onChange(evt, this.props);
     }
-  }
+  };
 
-  private _onBlur(props: IChoiceGroupOptionProps, evt: React.FocusEvent<HTMLElement>) {
-    const { onBlur } = props;
+  private _onBlur = (evt: React.FocusEvent<HTMLElement>) => {
+    const { onBlur } = this.props;
     if (onBlur) {
-      onBlur(evt, props);
+      onBlur(evt, this.props);
     }
-  }
+  };
 
-  private _onFocus(props: IChoiceGroupOptionProps, evt: React.FocusEvent<HTMLElement>) {
-    const { onFocus } = props;
+  private _onFocus = (evt: React.FocusEvent<HTMLElement>) => {
+    const { onFocus } = this.props;
     if (onFocus) {
-      onFocus(evt, props);
+      onFocus(evt, this.props);
     }
-  }
+  };
 
   private _onRenderField = (props: IChoiceGroupOptionProps): JSX.Element => {
-    const { onRenderLabel = this._onRenderLabel, id, imageSrc, imageAlt, selectedImageSrc, iconProps } = props;
+    const { onRenderLabel = this._onRenderLabel, id, imageSrc, imageAlt = '', selectedImageSrc, iconProps } = props;
 
     const imageSize = props.imageSize ? props.imageSize : { width: 32, height: 32 };
 
@@ -100,20 +103,20 @@ export class ChoiceGroupOptionBase extends React.Component<IChoiceGroupOptionPro
         {imageSrc && (
           <div className={this._classNames.innerField}>
             <div className={this._classNames.imageWrapper}>
-              <Image src={imageSrc} alt={imageAlt ? imageAlt : ''} width={imageSize.width} height={imageSize.height} />
+              <Image src={imageSrc} alt={imageAlt} width={imageSize.width} height={imageSize.height} />
             </div>
             <div className={this._classNames.selectedImageWrapper}>
-              <Image src={selectedImageSrc} alt={imageAlt ? imageAlt : ''} width={imageSize.width} height={imageSize.height} />
+              <Image src={selectedImageSrc} alt={imageAlt} width={imageSize.width} height={imageSize.height} />
             </div>
           </div>
         )}
-        {iconProps ? (
+        {iconProps && (
           <div className={this._classNames.innerField}>
             <div className={this._classNames.iconWrapper}>
               <Icon {...iconProps} />
             </div>
           </div>
-        ) : null}
+        )}
         {imageSrc || iconProps ? <div className={this._classNames.labelWrapper}>{onRenderLabel!(props)}</div> : onRenderLabel!(props)}
       </label>
     );

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.types.ts
@@ -4,14 +4,16 @@ import { IRefObject } from '../../../Utilities';
 import { IChoiceGroupOption } from '../../ChoiceGroup/ChoiceGroup.types';
 
 /**
+ * @deprecated Use `IChoiceGroupOptionProps['onFocus']` directly
  * {@docCategory ChoiceGroup}
  */
-export type OnFocusCallback = (ev?: React.FocusEvent<HTMLElement | HTMLInputElement>, props?: IChoiceGroupOption) => void | undefined;
+export type OnFocusCallback = IChoiceGroupOptionProps['onFocus'];
 
 /**
+ * @deprecated Use `IChoiceGroupOptionProps['onChange']` directly
  * {@docCategory ChoiceGroup}
  */
-export type OnChangeCallback = (evt?: React.FormEvent<HTMLElement | HTMLInputElement>, props?: IChoiceGroupOption) => void;
+export type OnChangeCallback = IChoiceGroupOptionProps['onChange'];
 
 /**
  * {@docCategory ChoiceGroup}
@@ -26,12 +28,12 @@ export interface IChoiceGroupOptionProps extends IChoiceGroupOption {
   /**
    * A callback for receiving a notification when the choice has been changed.
    */
-  onChange?: OnChangeCallback;
+  onChange?: (evt?: React.FormEvent<HTMLElement | HTMLInputElement>, props?: IChoiceGroupOption) => void;
 
   /**
    * A callback for receiving a notification when the choice has received focus.
    */
-  onFocus?: OnFocusCallback;
+  onFocus?: (ev?: React.FocusEvent<HTMLElement | HTMLInputElement>, props?: IChoiceGroupOption) => void | undefined;
 
   /**
    * A callback for receiving a notification when the choice has lost focus.

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
@@ -1,13 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`ChoiceGroup label does not have className prop from parent 1`] = `
+exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
 <div
   className=
       testClassName
 
 >
   <div
-    aria-labelledby="ChoiceGroup0-label"
     className=
         ms-ChoiceFieldGroup
         {
@@ -20,39 +19,6 @@ exports[`ChoiceGroup label does not have className prop from parent 1`] = `
         }
     role="radiogroup"
   >
-    <label
-      className=
-          ms-Label
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #323130;
-            display: block;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 600;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            overflow-wrap: break-word;
-            padding-bottom: 5px;
-            padding-left: 0;
-            padding-right: 0;
-            padding-top: 5px;
-            word-wrap: break-word;
-          }
-          &::after {
-            color: #a4262c;
-            content: ' *';
-            padding-right: 12px;
-          }
-      id="ChoiceGroup0-label"
-    >
-      testLabel
-    </label>
     <div
       className=
           ms-ChoiceFieldGroup-flexContainer
@@ -476,13 +442,14 @@ exports[`ChoiceGroup label does not have className prop from parent 1`] = `
 </div>
 `;
 
-exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
+exports[`ChoiceGroup renders ChoiceGroup with label correctly 1`] = `
 <div
   className=
       testClassName
 
 >
   <div
+    aria-labelledby="ChoiceGroup0-label"
     className=
         ms-ChoiceFieldGroup
         {
@@ -495,6 +462,39 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
         }
     role="radiogroup"
   >
+    <label
+      className=
+          ms-Label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 600;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+          &::after {
+            color: #a4262c;
+            content: ' *';
+            padding-right: 12px;
+          }
+      id="ChoiceGroup0-label"
+    >
+      test label
+    </label>
     <div
       className=
           ms-ChoiceFieldGroup-flexContainer

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Basic.Example.tsx
@@ -1,58 +1,37 @@
 import * as React from 'react';
 import { ChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react/lib/ChoiceGroup';
 
-/**
- * Interface for ChoiceGroupBasicExample state.
- */
-export interface IChoiceGroupBasicExampleState {
-  imageKey: string;
-}
+export const ChoiceGroupBasicExample: React.FunctionComponent = () => {
+  return (
+    <ChoiceGroup
+      className="defaultChoiceGroup"
+      defaultSelectedKey="B"
+      options={[
+        {
+          key: 'A',
+          text: 'Option A'
+        },
+        {
+          key: 'B',
+          text: 'Option B'
+        },
+        {
+          key: 'C',
+          text: 'Option C',
+          disabled: true
+        },
+        {
+          key: 'D',
+          text: 'Option D'
+        }
+      ]}
+      onChange={_onChange}
+      label="Pick one"
+      required={true}
+    />
+  );
+};
 
-export class ChoiceGroupBasicExample extends React.Component<{}, IChoiceGroupBasicExampleState> {
-  constructor(props: {}) {
-    super(props);
-
-    this.state = {
-      imageKey: ''
-    };
-  }
-
-  public render() {
-    return (
-      <div>
-        <ChoiceGroup
-          className="defaultChoiceGroup"
-          defaultSelectedKey="B"
-          options={[
-            {
-              key: 'A',
-              text: 'Option A',
-              'data-automation-id': 'auto1'
-            } as IChoiceGroupOption,
-            {
-              key: 'B',
-              text: 'Option B'
-            },
-            {
-              key: 'C',
-              text: 'Option C',
-              disabled: true
-            },
-            {
-              key: 'D',
-              text: 'Option D',
-              disabled: true
-            }
-          ]}
-          onChange={this._onChange}
-          label="Pick one"
-          required={true}
-        />
-      </div>
-    );
-  }
-
-  private _onChange = (ev: React.FormEvent<HTMLInputElement>, option: any): void => {
-    console.dir(option);
-  };
+function _onChange(ev: React.FormEvent<HTMLInputElement>, option: IChoiceGroupOption): void {
+  console.dir(option);
 }

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Custom.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Custom.Example.scss
@@ -1,8 +1,0 @@
-.root {
-  display: flex;
-  align-items: baseline;
-  .dropdown {
-    margin-bottom: 0;
-    margin-left: 5px;
-  }
-}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Custom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Custom.Example.tsx
@@ -1,66 +1,68 @@
 import * as React from 'react';
-import { ChoiceGroup } from 'office-ui-fabric-react/lib/ChoiceGroup';
-import { css } from 'office-ui-fabric-react/lib/Utilities';
-import { Dropdown } from 'office-ui-fabric-react/lib/Dropdown';
+import { ChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react/lib/ChoiceGroup';
+import { Dropdown, IDropdownStyles } from 'office-ui-fabric-react/lib/Dropdown';
+import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
 
-import * as stylesImport from './ChoiceGroup.Custom.Example.scss';
-const styles: any = stylesImport;
-
-export class ChoiceGroupCustomExample extends React.Component {
-  public render() {
-    return (
-      <div>
-        <ChoiceGroup
-          defaultSelectedKey="B"
-          options={[
-            {
-              key: 'A',
-              text: 'Mark displayed items as read after',
-              ariaLabel: 'Mark displayed items as read after - Press tab for further action',
-              onRenderField: (props, render) => {
-                return (
-                  <div className={css(styles.root)}>
-                    {render!(props)}
-                    <Dropdown
-                      className={css(styles.dropdown)}
-                      defaultSelectedKey="A"
-                      options={[{ key: 'A', text: '5 seconds' }, { key: 'B', text: '10 seconds' }, { key: 'C', text: '20 seconds' }]}
-                      disabled={props ? !props.checked : false}
-                      ariaLabel="Select a time span"
-                    />
-                  </div>
-                );
-              }
-            },
-            {
-              key: 'B',
-              text: 'Option B',
-              styles: {
-                root: {
-                  border: '1px solid green'
-                }
-              }
-            },
-            {
-              key: 'C',
-              text: 'Option C',
-              disabled: true
-            },
-            {
-              key: 'D',
-              text: 'Option D',
-              disabled: false
-            }
-          ]}
-          onChange={this._onChange}
-          label="Pick one"
-          required={true}
-        />
-      </div>
-    );
+const optionRootClass = mergeStyles({
+  display: 'flex',
+  alignItems: 'baseline'
+});
+const dropdownStyles: Partial<IDropdownStyles> = {
+  root: {
+    marginBottom: 0,
+    marginLeft: 5
   }
+};
 
-  private _onChange = (ev: React.FormEvent<HTMLInputElement>, option: any): void => {
-    console.dir(option);
-  };
+export const ChoiceGroupCustomExample: React.FunctionComponent = () => {
+  return (
+    <ChoiceGroup
+      defaultSelectedKey="B"
+      options={[
+        {
+          key: 'A',
+          text: 'Mark displayed items as read after',
+          ariaLabel: 'Mark displayed items as read after - Press tab for further action',
+          onRenderField: (props, render) => {
+            return (
+              <div className={optionRootClass}>
+                {render!(props)}
+                <Dropdown
+                  defaultSelectedKey="A"
+                  styles={dropdownStyles}
+                  options={[{ key: 'A', text: '5 seconds' }, { key: 'B', text: '10 seconds' }, { key: 'C', text: '20 seconds' }]}
+                  disabled={props ? !props.checked : false}
+                  ariaLabel="Select a time span"
+                />
+              </div>
+            );
+          }
+        },
+        {
+          key: 'B',
+          text: 'Option B',
+          styles: {
+            root: {
+              border: '1px solid green'
+            }
+          }
+        },
+        {
+          key: 'C',
+          text: 'Option C',
+          disabled: true
+        },
+        {
+          key: 'D',
+          text: 'Option D'
+        }
+      ]}
+      onChange={_onChange}
+      label="Pick one"
+    />
+  );
+};
+
+function _onChange(ev: React.FormEvent<HTMLInputElement>, option: IChoiceGroupOption): void {
+  console.dir(option);
 }

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Icon.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Icon.Example.tsx
@@ -1,31 +1,29 @@
 import * as React from 'react';
 import { ChoiceGroup } from 'office-ui-fabric-react/lib/ChoiceGroup';
 
-export class ChoiceGroupIconExample extends React.Component<any, any> {
-  public render(): JSX.Element {
-    return (
-      <ChoiceGroup
-        label="Pick one icon"
-        defaultSelectedKey="day"
-        options={[
-          {
-            key: 'day',
-            iconProps: { iconName: 'CalendarDay' },
-            text: 'Day'
-          },
-          {
-            key: 'week',
-            iconProps: { iconName: 'CalendarWeek' },
-            text: 'Week'
-          },
-          {
-            key: 'month',
-            iconProps: { iconName: 'Calendar' },
-            text: 'Month',
-            disabled: true
-          }
-        ]}
-      />
-    );
-  }
-}
+export const ChoiceGroupIconExample: React.FunctionComponent = () => {
+  return (
+    <ChoiceGroup
+      label="Pick one icon"
+      defaultSelectedKey="day"
+      options={[
+        {
+          key: 'day',
+          iconProps: { iconName: 'CalendarDay' },
+          text: 'Day'
+        },
+        {
+          key: 'week',
+          iconProps: { iconName: 'CalendarWeek' },
+          text: 'Week'
+        },
+        {
+          key: 'month',
+          iconProps: { iconName: 'Calendar' },
+          text: 'Month',
+          disabled: true
+        }
+      ]}
+    />
+  );
+};

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Image.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Image.Example.tsx
@@ -2,58 +2,37 @@ import * as React from 'react';
 import { ChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react/lib/ChoiceGroup';
 import { TestImages } from '../../../common/TestImages';
 
-/**
- * Interface for ChoiceGroupImageExample state.
- */
-export interface IChoiceGroupImageExampleState {
-  selectedKey: string;
-}
+export const ChoiceGroupImageExample: React.FunctionComponent = () => {
+  const [selectedKey, setSelectedKey] = React.useState<string>('bar');
 
-export class ChoiceGroupImageExample extends React.Component<{}, IChoiceGroupImageExampleState> {
-  constructor(props: {}) {
-    super(props);
+  const onChange = (ev: React.SyntheticEvent<HTMLElement>, option: IChoiceGroupOption) => {
+    setSelectedKey(option.key);
+  };
 
-    this.state = {
-      selectedKey: 'bar'
-    };
-
-    this._onImageChoiceGroupChange = this._onImageChoiceGroupChange.bind(this);
-  }
-
-  public render(): JSX.Element {
-    const { selectedKey } = this.state;
-
-    return (
-      <div>
-        <ChoiceGroup
-          label="Pick one image"
-          selectedKey={selectedKey}
-          options={[
-            {
-              key: 'bar',
-              imageSrc: TestImages.choiceGroupBarUnselected,
-              imageAlt: 'Bar chart icon',
-              selectedImageSrc: TestImages.choiceGroupBarSelected,
-              imageSize: { width: 32, height: 32 },
-              text: 'Clustered bar chart' // This text is long to show text wrapping.
-            },
-            {
-              key: 'pie',
-              imageSrc: TestImages.choiceGroupBarUnselected,
-              selectedImageSrc: TestImages.choiceGroupBarSelected,
-              imageSize: { width: 32, height: 32 },
-              text: 'Pie chart'
-            }
-          ]}
-          onChange={this._onImageChoiceGroupChange}
-        />
-      </div>
-    );
-  }
-
-  private _onImageChoiceGroupChange(ev: React.SyntheticEvent<HTMLElement>, option: IChoiceGroupOption): void {
-    this.setState({
-      selectedKey: option.key
-    });
-  }
-}
+  return (
+    <div>
+      <ChoiceGroup
+        label="Pick one image"
+        selectedKey={selectedKey}
+        options={[
+          {
+            key: 'bar',
+            imageSrc: TestImages.choiceGroupBarUnselected,
+            imageAlt: 'Bar chart icon',
+            selectedImageSrc: TestImages.choiceGroupBarSelected,
+            imageSize: { width: 32, height: 32 },
+            text: 'Clustered bar chart' // This text is long to show text wrapping.
+          },
+          {
+            key: 'pie',
+            imageSrc: TestImages.choiceGroupBarUnselected,
+            selectedImageSrc: TestImages.choiceGroupBarSelected,
+            imageSize: { width: 32, height: 32 },
+            text: 'Pie chart'
+          }
+        ]}
+        onChange={onChange}
+      />
+    </div>
+  );
+};

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Label.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Label.Example.tsx
@@ -3,60 +3,46 @@ import { ChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react/lib/Choi
 import { Label } from 'office-ui-fabric-react/lib/Label';
 import { getId } from 'office-ui-fabric-react/lib/Utilities';
 
-/**
- * Interface for ChoiceGroupLabelExample state.
- */
-export interface IChoiceGroupLabelExampleState {
-  imageKey: string;
-}
+export const ChoiceGroupLabelExample: React.FunctionComponent = () => {
+  // Use getId() to ensure that the label ID is unique on the page. Notes:
+  // - It's also okay to use a plain string without getId() and manually ensure its uniqueness.
+  // - In a function component, we get the ID inside React.useMemo() so that it will stay the same.
+  //   (In a class component, you'd create the ID in the constructor and save it in a private member.)
+  const labelId = React.useMemo(() => getId('labelElement'), []);
 
-export class ChoiceGroupLabelExample extends React.Component<{}, IChoiceGroupLabelExampleState> {
-  public state: IChoiceGroupLabelExampleState = {
-    imageKey: ''
-  };
+  return (
+    <div>
+      <Label id={labelId} required={true}>
+        Custom label
+      </Label>
+      <ChoiceGroup
+        defaultSelectedKey="B"
+        options={[
+          {
+            key: 'A',
+            text: 'Option A'
+          },
+          {
+            key: 'B',
+            text: 'Option B'
+          },
+          {
+            key: 'C',
+            text: 'Option C',
+            disabled: true
+          },
+          {
+            key: 'D',
+            text: 'Option D'
+          }
+        ]}
+        onChange={_onChange}
+        ariaLabelledBy={labelId}
+      />
+    </div>
+  );
+};
 
-  // Use getId() to ensure that the label ID is unique on the page.
-  // (It's also okay to use a plain string without getId() and manually ensure its uniqueness.)
-  private _labelId: string = getId('labelElement');
-
-  public render() {
-    return (
-      <div>
-        <Label id={this._labelId} required={true}>
-          Custom label
-        </Label>
-        <ChoiceGroup
-          defaultSelectedKey="B"
-          options={[
-            {
-              key: 'A',
-              text: 'Option A',
-              'data-automation-id': 'auto1'
-            } as IChoiceGroupOption,
-            {
-              key: 'B',
-              text: 'Option B'
-            },
-            {
-              key: 'C',
-              text: 'Option C',
-              disabled: true
-            },
-            {
-              key: 'D',
-              text: 'Option D',
-              disabled: true
-            }
-          ]}
-          onChange={this._onChange}
-          ariaLabelledBy={this._labelId}
-          required={true}
-        />
-      </div>
-    );
-  }
-
-  private _onChange = (ev: React.FormEvent<HTMLInputElement>, option: any): void => {
-    console.dir(option);
-  };
+function _onChange(ev: React.FormEvent<HTMLInputElement>, option: IChoiceGroupOption): void {
+  console.dir(option);
 }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
@@ -1,572 +1,589 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] = `
-<div>
-  <div
-    className=
-        defaultChoiceGroup
+<div
+  className=
+      defaultChoiceGroup
 
+>
+  <div
+    aria-labelledby="ChoiceGroup0-label"
+    className=
+        ms-ChoiceFieldGroup
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+        }
+    role="radiogroup"
   >
-    <div
-      aria-labelledby="ChoiceGroup0-label"
+    <label
       className=
-          ms-ChoiceFieldGroup
+          ms-Label
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
             display: block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
-            font-weight: 400;
+            font-weight: 600;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
           }
-      role="radiogroup"
+          &::after {
+            color: #a4262c;
+            content: ' *';
+            padding-right: 12px;
+          }
+      id="ChoiceGroup0-label"
     >
-      <label
+      Pick one
+    </label>
+    <div
+      className=
+          ms-ChoiceFieldGroup-flexContainer
+
+    >
+      <div
         className=
-            ms-Label
+            ms-ChoiceField
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              box-shadow: none;
+              align-items: center;
+              border: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: flex;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
-              font-weight: 600;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              overflow-wrap: break-word;
-              padding-bottom: 5px;
-              padding-left: 0;
-              padding-right: 0;
-              padding-top: 5px;
-              word-wrap: break-word;
+              font-weight: 400;
+              margin-top: 8px;
+              min-height: 26px;
+              position: relative;
             }
-            &::after {
-              color: #a4262c;
-              content: ' *';
-              padding-right: 12px;
+            & .ms-ChoiceFieldLabel {
+              display: inline-block;
+              padding-left: 26px;
             }
-        id="ChoiceGroup0-label"
       >
-        Pick one
-      </label>
+        <div
+          className=
+              ms-ChoiceField-wrapper
+
+        >
+          <input
+            checked={false}
+            className=
+                ms-ChoiceField-input
+                {
+                  height: 100%;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  opacity: 0;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  width: 100%;
+                }
+            id="ChoiceGroup0-A"
+            name="ChoiceGroup0"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            required={true}
+            type="radio"
+          />
+          <label
+            className=
+                ms-ChoiceField-field
+                {
+                  cursor: pointer;
+                  display: inline-block;
+                  margin-top: 0px;
+                  min-height: 20px;
+                  position: relative;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &:hover .ms-ChoiceFieldLabel {
+                  color: #201f1e;
+                }
+                &:hover:before {
+                  border-color: #323130;
+                }
+                &:hover:after {
+                  background-color: #605e5c;
+                  content: "";
+                  height: 10px;
+                  left: 5px;
+                  top: 5px;
+                  transition-property: background-color;
+                  width: 10px;
+                }
+                &:focus .ms-ChoiceFieldLabel {
+                  color: #201f1e;
+                }
+                &:focus:before {
+                  border-color: #323130;
+                }
+                &:focus:after {
+                  background-color: #605e5c;
+                  content: "";
+                  height: 10px;
+                  left: 5px;
+                  top: 5px;
+                  transition-property: background-color;
+                  width: 10px;
+                }
+                &:before {
+                  background-color: #ffffff;
+                  border-color: #323130;
+                  border-radius: 50%;
+                  border-style: solid;
+                  border-width: 1px;
+                  box-sizing: border-box;
+                  content: "";
+                  display: inline-block;
+                  font-weight: normal;
+                  height: 20px;
+                  left: 0px;
+                  position: absolute;
+                  top: 0px;
+                  transition-duration: 200ms;
+                  transition-property: border-color;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 20px;
+                }
+                &:after {
+                  border-radius: 50%;
+                  box-sizing: border-box;
+                  content: "";
+                  height: 0px;
+                  left: 10px;
+                  position: absolute;
+                  right: 0px;
+                  transition-duration: 200ms;
+                  transition-property: border-width;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 0px;
+                }
+            htmlFor="ChoiceGroup0-A"
+          >
+            <span
+              className="ms-ChoiceFieldLabel"
+              id="ChoiceGroupLabel1-A"
+            >
+              Option A
+            </span>
+          </label>
+        </div>
+      </div>
       <div
         className=
-            ms-ChoiceFieldGroup-flexContainer
-
+            ms-ChoiceField
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-items: center;
+              border: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-top: 8px;
+              min-height: 26px;
+              position: relative;
+            }
+            & .ms-ChoiceFieldLabel {
+              display: inline-block;
+              padding-left: 26px;
+            }
       >
         <div
           className=
-              ms-ChoiceField
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                align-items: center;
-                border: none;
-                box-sizing: border-box;
-                color: #323130;
-                display: flex;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                margin-top: 8px;
-                min-height: 26px;
-                position: relative;
-              }
-              & .ms-ChoiceFieldLabel {
-                display: inline-block;
-                padding-left: 26px;
-              }
-        >
-          <div
-            className=
-                ms-ChoiceField-wrapper
+              ms-ChoiceField-wrapper
 
+        >
+          <input
+            checked={true}
+            className=
+                ms-ChoiceField-input
+                {
+                  height: 100%;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  opacity: 0;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  width: 100%;
+                }
+            id="ChoiceGroup0-B"
+            name="ChoiceGroup0"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            required={true}
+            type="radio"
+          />
+          <label
+            className=
+                ms-ChoiceField-field
+                is-checked
+                {
+                  border-color: #0078d4;
+                  cursor: pointer;
+                  display: inline-block;
+                  margin-top: 0px;
+                  min-height: 20px;
+                  position: relative;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &:hover .ms-ChoiceFieldLabel {
+                  color: #201f1e;
+                }
+                &:hover:before {
+                  border-color: #005a9e;
+                }
+                &:hover:after {
+                  border-color: #005a9e;
+                }
+                &:focus .ms-ChoiceFieldLabel {
+                  color: #201f1e;
+                }
+                &:focus:before {
+                  border-color: #005a9e;
+                }
+                &:focus:after {
+                  border-color: #005a9e;
+                }
+                &:before {
+                  background-color: #ffffff;
+                  border-color: #0078d4;
+                  border-radius: 50%;
+                  border-style: solid;
+                  border-width: 1px;
+                  box-sizing: border-box;
+                  content: "";
+                  display: inline-block;
+                  font-weight: normal;
+                  height: 20px;
+                  left: 0px;
+                  position: absolute;
+                  top: 0px;
+                  transition-duration: 200ms;
+                  transition-property: border-color;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 20px;
+                }
+                @media screen and (-ms-high-contrast: active){&:before {
+                  border-color: Highlight;
+                }
+                &:after {
+                  border-color: #0078d4;
+                  border-radius: 50%;
+                  border-style: solid;
+                  border-width: 5px;
+                  box-sizing: border-box;
+                  content: "";
+                  height: 10px;
+                  left: 5px;
+                  position: absolute;
+                  right: 0px;
+                  top: 5px;
+                  transition-duration: 200ms;
+                  transition-property: border-width;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 10px;
+                }
+                @media screen and (-ms-high-contrast: active){&:after {
+                  border-color: Highlight;
+                }
+            htmlFor="ChoiceGroup0-B"
           >
-            <input
-              checked={false}
-              className=
-                  ms-ChoiceField-input
-                  {
-                    height: 100%;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    opacity: 0;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                    width: 100%;
-                  }
-              data-automation-id="auto1"
-              id="ChoiceGroup0-A"
-              name="ChoiceGroup0"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              required={true}
-              type="radio"
-            />
-            <label
-              className=
-                  ms-ChoiceField-field
-                  {
-                    cursor: pointer;
-                    display: inline-block;
-                    margin-top: 0px;
-                    min-height: 20px;
-                    position: relative;
-                    user-select: none;
-                    vertical-align: top;
-                  }
-                  &:hover .ms-ChoiceFieldLabel {
-                    color: #201f1e;
-                  }
-                  &:hover:before {
-                    border-color: #323130;
-                  }
-                  &:hover:after {
-                    background-color: #605e5c;
-                    content: "";
-                    height: 10px;
-                    left: 5px;
-                    top: 5px;
-                    transition-property: background-color;
-                    width: 10px;
-                  }
-                  &:focus .ms-ChoiceFieldLabel {
-                    color: #201f1e;
-                  }
-                  &:focus:before {
-                    border-color: #323130;
-                  }
-                  &:focus:after {
-                    background-color: #605e5c;
-                    content: "";
-                    height: 10px;
-                    left: 5px;
-                    top: 5px;
-                    transition-property: background-color;
-                    width: 10px;
-                  }
-                  &:before {
-                    background-color: #ffffff;
-                    border-color: #323130;
-                    border-radius: 50%;
-                    border-style: solid;
-                    border-width: 1px;
-                    box-sizing: border-box;
-                    content: "";
-                    display: inline-block;
-                    font-weight: normal;
-                    height: 20px;
-                    left: 0px;
-                    position: absolute;
-                    top: 0px;
-                    transition-duration: 200ms;
-                    transition-property: border-color;
-                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
-                    width: 20px;
-                  }
-                  &:after {
-                    border-radius: 50%;
-                    box-sizing: border-box;
-                    content: "";
-                    height: 0px;
-                    left: 10px;
-                    position: absolute;
-                    right: 0px;
-                    transition-duration: 200ms;
-                    transition-property: border-width;
-                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
-                    width: 0px;
-                  }
-              htmlFor="ChoiceGroup0-A"
+            <span
+              className="ms-ChoiceFieldLabel"
+              id="ChoiceGroupLabel1-B"
             >
-              <span
-                className="ms-ChoiceFieldLabel"
-                id="ChoiceGroupLabel1-A"
-              >
-                Option A
-              </span>
-            </label>
-          </div>
+              Option B
+            </span>
+          </label>
         </div>
+      </div>
+      <div
+        className=
+            ms-ChoiceField
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-items: center;
+              border: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-top: 8px;
+              min-height: 26px;
+              position: relative;
+            }
+            & .ms-ChoiceFieldLabel {
+              display: inline-block;
+              padding-left: 26px;
+            }
+      >
         <div
           className=
-              ms-ChoiceField
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                align-items: center;
-                border: none;
-                box-sizing: border-box;
-                color: #323130;
-                display: flex;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                margin-top: 8px;
-                min-height: 26px;
-                position: relative;
-              }
-              & .ms-ChoiceFieldLabel {
-                display: inline-block;
-                padding-left: 26px;
-              }
-        >
-          <div
-            className=
-                ms-ChoiceField-wrapper
+              ms-ChoiceField-wrapper
 
+        >
+          <input
+            checked={false}
+            className=
+                ms-ChoiceField-input
+                {
+                  height: 100%;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  opacity: 0;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  width: 100%;
+                }
+            disabled={true}
+            id="ChoiceGroup0-C"
+            name="ChoiceGroup0"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            required={true}
+            type="radio"
+          />
+          <label
+            className=
+                ms-ChoiceField-field
+                {
+                  cursor: default;
+                  display: inline-block;
+                  margin-top: 0px;
+                  min-height: 20px;
+                  position: relative;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &:before {
+                  background-color: #ffffff;
+                  border-color: #c8c6c4;
+                  border-radius: 50%;
+                  border-style: solid;
+                  border-width: 1px;
+                  box-sizing: border-box;
+                  content: "";
+                  display: inline-block;
+                  font-weight: normal;
+                  height: 20px;
+                  left: 0px;
+                  position: absolute;
+                  top: 0px;
+                  transition-duration: 200ms;
+                  transition-property: border-color;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 20px;
+                }
+                @media screen and (-ms-high-contrast: active){&:before {
+                  color: GrayText;
+                }
+                &:after {
+                  border-radius: 50%;
+                  box-sizing: border-box;
+                  content: "";
+                  height: 0px;
+                  left: 10px;
+                  position: absolute;
+                  right: 0px;
+                  transition-duration: 200ms;
+                  transition-property: border-width;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 0px;
+                }
+                & .ms-ChoiceFieldLabel {
+                  color: #a19f9d;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: GrayText;
+                }
+            htmlFor="ChoiceGroup0-C"
           >
-            <input
-              checked={true}
-              className=
-                  ms-ChoiceField-input
-                  {
-                    height: 100%;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    opacity: 0;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                    width: 100%;
-                  }
-              id="ChoiceGroup0-B"
-              name="ChoiceGroup0"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              required={true}
-              type="radio"
-            />
-            <label
-              className=
-                  ms-ChoiceField-field
-                  is-checked
-                  {
-                    border-color: #0078d4;
-                    cursor: pointer;
-                    display: inline-block;
-                    margin-top: 0px;
-                    min-height: 20px;
-                    position: relative;
-                    user-select: none;
-                    vertical-align: top;
-                  }
-                  &:hover .ms-ChoiceFieldLabel {
-                    color: #201f1e;
-                  }
-                  &:hover:before {
-                    border-color: #005a9e;
-                  }
-                  &:hover:after {
-                    border-color: #005a9e;
-                  }
-                  &:focus .ms-ChoiceFieldLabel {
-                    color: #201f1e;
-                  }
-                  &:focus:before {
-                    border-color: #005a9e;
-                  }
-                  &:focus:after {
-                    border-color: #005a9e;
-                  }
-                  &:before {
-                    background-color: #ffffff;
-                    border-color: #0078d4;
-                    border-radius: 50%;
-                    border-style: solid;
-                    border-width: 1px;
-                    box-sizing: border-box;
-                    content: "";
-                    display: inline-block;
-                    font-weight: normal;
-                    height: 20px;
-                    left: 0px;
-                    position: absolute;
-                    top: 0px;
-                    transition-duration: 200ms;
-                    transition-property: border-color;
-                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
-                    width: 20px;
-                  }
-                  @media screen and (-ms-high-contrast: active){&:before {
-                    border-color: Highlight;
-                  }
-                  &:after {
-                    border-color: #0078d4;
-                    border-radius: 50%;
-                    border-style: solid;
-                    border-width: 5px;
-                    box-sizing: border-box;
-                    content: "";
-                    height: 10px;
-                    left: 5px;
-                    position: absolute;
-                    right: 0px;
-                    top: 5px;
-                    transition-duration: 200ms;
-                    transition-property: border-width;
-                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
-                    width: 10px;
-                  }
-                  @media screen and (-ms-high-contrast: active){&:after {
-                    border-color: Highlight;
-                  }
-              htmlFor="ChoiceGroup0-B"
+            <span
+              className="ms-ChoiceFieldLabel"
+              id="ChoiceGroupLabel1-C"
             >
-              <span
-                className="ms-ChoiceFieldLabel"
-                id="ChoiceGroupLabel1-B"
-              >
-                Option B
-              </span>
-            </label>
-          </div>
+              Option C
+            </span>
+          </label>
         </div>
+      </div>
+      <div
+        className=
+            ms-ChoiceField
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-items: center;
+              border: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-top: 8px;
+              min-height: 26px;
+              position: relative;
+            }
+            & .ms-ChoiceFieldLabel {
+              display: inline-block;
+              padding-left: 26px;
+            }
+      >
         <div
           className=
-              ms-ChoiceField
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                align-items: center;
-                border: none;
-                box-sizing: border-box;
-                color: #323130;
-                display: flex;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                margin-top: 8px;
-                min-height: 26px;
-                position: relative;
-              }
-              & .ms-ChoiceFieldLabel {
-                display: inline-block;
-                padding-left: 26px;
-              }
-        >
-          <div
-            className=
-                ms-ChoiceField-wrapper
+              ms-ChoiceField-wrapper
 
-          >
-            <input
-              checked={false}
-              className=
-                  ms-ChoiceField-input
-                  {
-                    height: 100%;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    opacity: 0;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                    width: 100%;
-                  }
-              disabled={true}
-              id="ChoiceGroup0-C"
-              name="ChoiceGroup0"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              required={true}
-              type="radio"
-            />
-            <label
-              className=
-                  ms-ChoiceField-field
-                  {
-                    cursor: default;
-                    display: inline-block;
-                    margin-top: 0px;
-                    min-height: 20px;
-                    position: relative;
-                    user-select: none;
-                    vertical-align: top;
-                  }
-                  &:before {
-                    background-color: #ffffff;
-                    border-color: #c8c6c4;
-                    border-radius: 50%;
-                    border-style: solid;
-                    border-width: 1px;
-                    box-sizing: border-box;
-                    content: "";
-                    display: inline-block;
-                    font-weight: normal;
-                    height: 20px;
-                    left: 0px;
-                    position: absolute;
-                    top: 0px;
-                    transition-duration: 200ms;
-                    transition-property: border-color;
-                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
-                    width: 20px;
-                  }
-                  @media screen and (-ms-high-contrast: active){&:before {
-                    color: GrayText;
-                  }
-                  &:after {
-                    border-radius: 50%;
-                    box-sizing: border-box;
-                    content: "";
-                    height: 0px;
-                    left: 10px;
-                    position: absolute;
-                    right: 0px;
-                    transition-duration: 200ms;
-                    transition-property: border-width;
-                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
-                    width: 0px;
-                  }
-                  & .ms-ChoiceFieldLabel {
-                    color: #a19f9d;
-                  }
-                  @media screen and (-ms-high-contrast: active){& {
-                    color: GrayText;
-                  }
-              htmlFor="ChoiceGroup0-C"
-            >
-              <span
-                className="ms-ChoiceFieldLabel"
-                id="ChoiceGroupLabel1-C"
-              >
-                Option C
-              </span>
-            </label>
-          </div>
-        </div>
-        <div
-          className=
-              ms-ChoiceField
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                align-items: center;
-                border: none;
-                box-sizing: border-box;
-                color: #323130;
-                display: flex;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                margin-top: 8px;
-                min-height: 26px;
-                position: relative;
-              }
-              & .ms-ChoiceFieldLabel {
-                display: inline-block;
-                padding-left: 26px;
-              }
         >
-          <div
+          <input
+            checked={false}
             className=
-                ms-ChoiceField-wrapper
-
+                ms-ChoiceField-input
+                {
+                  height: 100%;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  opacity: 0;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  width: 100%;
+                }
+            id="ChoiceGroup0-D"
+            name="ChoiceGroup0"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            required={true}
+            type="radio"
+          />
+          <label
+            className=
+                ms-ChoiceField-field
+                {
+                  cursor: pointer;
+                  display: inline-block;
+                  margin-top: 0px;
+                  min-height: 20px;
+                  position: relative;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &:hover .ms-ChoiceFieldLabel {
+                  color: #201f1e;
+                }
+                &:hover:before {
+                  border-color: #323130;
+                }
+                &:hover:after {
+                  background-color: #605e5c;
+                  content: "";
+                  height: 10px;
+                  left: 5px;
+                  top: 5px;
+                  transition-property: background-color;
+                  width: 10px;
+                }
+                &:focus .ms-ChoiceFieldLabel {
+                  color: #201f1e;
+                }
+                &:focus:before {
+                  border-color: #323130;
+                }
+                &:focus:after {
+                  background-color: #605e5c;
+                  content: "";
+                  height: 10px;
+                  left: 5px;
+                  top: 5px;
+                  transition-property: background-color;
+                  width: 10px;
+                }
+                &:before {
+                  background-color: #ffffff;
+                  border-color: #323130;
+                  border-radius: 50%;
+                  border-style: solid;
+                  border-width: 1px;
+                  box-sizing: border-box;
+                  content: "";
+                  display: inline-block;
+                  font-weight: normal;
+                  height: 20px;
+                  left: 0px;
+                  position: absolute;
+                  top: 0px;
+                  transition-duration: 200ms;
+                  transition-property: border-color;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 20px;
+                }
+                &:after {
+                  border-radius: 50%;
+                  box-sizing: border-box;
+                  content: "";
+                  height: 0px;
+                  left: 10px;
+                  position: absolute;
+                  right: 0px;
+                  transition-duration: 200ms;
+                  transition-property: border-width;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 0px;
+                }
+            htmlFor="ChoiceGroup0-D"
           >
-            <input
-              checked={false}
-              className=
-                  ms-ChoiceField-input
-                  {
-                    height: 100%;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    opacity: 0;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                    width: 100%;
-                  }
-              disabled={true}
-              id="ChoiceGroup0-D"
-              name="ChoiceGroup0"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              required={true}
-              type="radio"
-            />
-            <label
-              className=
-                  ms-ChoiceField-field
-                  {
-                    cursor: default;
-                    display: inline-block;
-                    margin-top: 0px;
-                    min-height: 20px;
-                    position: relative;
-                    user-select: none;
-                    vertical-align: top;
-                  }
-                  &:before {
-                    background-color: #ffffff;
-                    border-color: #c8c6c4;
-                    border-radius: 50%;
-                    border-style: solid;
-                    border-width: 1px;
-                    box-sizing: border-box;
-                    content: "";
-                    display: inline-block;
-                    font-weight: normal;
-                    height: 20px;
-                    left: 0px;
-                    position: absolute;
-                    top: 0px;
-                    transition-duration: 200ms;
-                    transition-property: border-color;
-                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
-                    width: 20px;
-                  }
-                  @media screen and (-ms-high-contrast: active){&:before {
-                    color: GrayText;
-                  }
-                  &:after {
-                    border-radius: 50%;
-                    box-sizing: border-box;
-                    content: "";
-                    height: 0px;
-                    left: 10px;
-                    position: absolute;
-                    right: 0px;
-                    transition-duration: 200ms;
-                    transition-property: border-width;
-                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
-                    width: 0px;
-                  }
-                  & .ms-ChoiceFieldLabel {
-                    color: #a19f9d;
-                  }
-                  @media screen and (-ms-high-contrast: active){& {
-                    color: GrayText;
-                  }
-              htmlFor="ChoiceGroup0-D"
+            <span
+              className="ms-ChoiceFieldLabel"
+              id="ChoiceGroupLabel1-D"
             >
-              <span
-                className="ms-ChoiceFieldLabel"
-                id="ChoiceGroupLabel1-D"
-              >
-                Option D
-              </span>
-            </label>
-          </div>
+              Option D
+            </span>
+          </label>
         </div>
       </div>
     </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -1,762 +1,759 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`] = `
-<div>
+<div
+  className=
+
+
+>
   <div
+    aria-labelledby="ChoiceGroup0-label"
     className=
-
-
+        ms-ChoiceFieldGroup
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+        }
+    role="radiogroup"
   >
-    <div
-      aria-labelledby="ChoiceGroup0-label"
+    <label
       className=
-          ms-ChoiceFieldGroup
+          ms-Label
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
             display: block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
-            font-weight: 400;
+            font-weight: 600;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
           }
-      role="radiogroup"
+      id="ChoiceGroup0-label"
     >
-      <label
+      Pick one
+    </label>
+    <div
+      className=
+          ms-ChoiceFieldGroup-flexContainer
+
+    >
+      <div
         className=
-            ms-Label
+            ms-ChoiceField
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              box-shadow: none;
+              align-items: center;
+              border: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: flex;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
-              font-weight: 600;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              overflow-wrap: break-word;
-              padding-bottom: 5px;
-              padding-left: 0;
-              padding-right: 0;
-              padding-top: 5px;
-              word-wrap: break-word;
+              font-weight: 400;
+              margin-top: 8px;
+              min-height: 26px;
+              position: relative;
             }
-            &::after {
-              color: #a4262c;
-              content: ' *';
-              padding-right: 12px;
+            & .ms-ChoiceFieldLabel {
+              display: inline-block;
+              padding-left: 26px;
             }
-        id="ChoiceGroup0-label"
-      >
-        Pick one
-      </label>
-      <div
-        className=
-            ms-ChoiceFieldGroup-flexContainer
-
       >
         <div
           className=
-              ms-ChoiceField
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                align-items: center;
-                border: none;
-                box-sizing: border-box;
-                color: #323130;
-                display: flex;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                margin-top: 8px;
-                min-height: 26px;
-                position: relative;
-              }
-              & .ms-ChoiceFieldLabel {
-                display: inline-block;
-                padding-left: 26px;
-              }
+              ms-ChoiceField-wrapper
+
         >
+          <input
+            aria-label="Mark displayed items as read after - Press tab for further action"
+            checked={false}
+            className=
+                ms-ChoiceField-input
+                {
+                  height: 100%;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  opacity: 0;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  width: 100%;
+                }
+            id="ChoiceGroup0-A"
+            name="ChoiceGroup0"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="radio"
+          />
           <div
             className=
-                ms-ChoiceField-wrapper
 
+                {
+                  align-items: baseline;
+                  display: flex;
+                }
           >
-            <input
-              aria-label="Mark displayed items as read after - Press tab for further action"
-              checked={false}
+            <label
               className=
-                  ms-ChoiceField-input
+                  ms-ChoiceField-field
                   {
-                    height: 100%;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
+                    cursor: pointer;
+                    display: inline-block;
                     margin-top: 0px;
-                    opacity: 0;
+                    min-height: 20px;
+                    position: relative;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &:hover .ms-ChoiceFieldLabel {
+                    color: #201f1e;
+                  }
+                  &:hover:before {
+                    border-color: #323130;
+                  }
+                  &:hover:after {
+                    background-color: #605e5c;
+                    content: "";
+                    height: 10px;
+                    left: 5px;
+                    top: 5px;
+                    transition-property: background-color;
+                    width: 10px;
+                  }
+                  &:focus .ms-ChoiceFieldLabel {
+                    color: #201f1e;
+                  }
+                  &:focus:before {
+                    border-color: #323130;
+                  }
+                  &:focus:after {
+                    background-color: #605e5c;
+                    content: "";
+                    height: 10px;
+                    left: 5px;
+                    top: 5px;
+                    transition-property: background-color;
+                    width: 10px;
+                  }
+                  &:before {
+                    background-color: #ffffff;
+                    border-color: #323130;
+                    border-radius: 50%;
+                    border-style: solid;
+                    border-width: 1px;
+                    box-sizing: border-box;
+                    content: "";
+                    display: inline-block;
+                    font-weight: normal;
+                    height: 20px;
+                    left: 0px;
+                    position: absolute;
+                    top: 0px;
+                    transition-duration: 200ms;
+                    transition-property: border-color;
+                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                    width: 20px;
+                  }
+                  &:after {
+                    border-radius: 50%;
+                    box-sizing: border-box;
+                    content: "";
+                    height: 0px;
+                    left: 10px;
                     position: absolute;
                     right: 0px;
-                    top: 0px;
-                    width: 100%;
+                    transition-duration: 200ms;
+                    transition-property: border-width;
+                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                    width: 0px;
                   }
-              id="ChoiceGroup0-A"
-              name="ChoiceGroup0"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              required={true}
-              type="radio"
-            />
-            <div
-              className=""
+              htmlFor="ChoiceGroup0-A"
             >
-              <label
+              <span
+                className="ms-ChoiceFieldLabel"
+                id="ChoiceGroupLabel1-A"
+              >
+                Mark displayed items as read after
+              </span>
+            </label>
+            <div
+              className=
+                  ms-Dropdown-container
+                  {
+                    margin-bottom: 0px;
+                    margin-left: 5px;
+                  }
+            >
+              <div
+                aria-describedby="Dropdown2-option"
+                aria-disabled={true}
+                aria-expanded="false"
+                aria-label="Select a time span"
                 className=
-                    ms-ChoiceField-field
+                    ms-Dropdown
+                    is-disabled
                     {
-                      cursor: pointer;
-                      display: inline-block;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      border-color: #605e5c;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
                       margin-top: 0px;
-                      min-height: 20px;
+                      outline: 0px;
+                      padding-bottom: 0px;
+                      padding-left: 0px;
+                      padding-right: 0px;
+                      padding-top: 0px;
                       position: relative;
                       user-select: none;
-                      vertical-align: top;
                     }
-                    &:hover .ms-ChoiceFieldLabel {
-                      color: #201f1e;
-                    }
-                    &:hover:before {
+                    &:hover .ms-Dropdown-title {
                       border-color: #323130;
                     }
-                    &:hover:after {
-                      background-color: #605e5c;
-                      content: "";
-                      height: 10px;
-                      left: 5px;
-                      top: 5px;
-                      transition-property: background-color;
-                      width: 10px;
+                    @media screen and (-ms-high-contrast: active){&:hover .ms-Dropdown-title {
+                      border-color: Highlight;
                     }
-                    &:focus .ms-ChoiceFieldLabel {
-                      color: #201f1e;
+                    &:focus .ms-Dropdown-title {
+                      border-color: #0078d4;
                     }
-                    &:focus:before {
-                      border-color: #323130;
+                    @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title {
+                      background-color: Highlight;
+                      border-color: Highlight;
+                      color: HighlightText;
                     }
-                    &:focus:after {
-                      background-color: #605e5c;
-                      content: "";
-                      height: 10px;
-                      left: 5px;
-                      top: 5px;
-                      transition-property: background-color;
-                      width: 10px;
+                    @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
+                      color: HighlightText;
                     }
-                    &:before {
-                      background-color: #ffffff;
-                      border-color: #323130;
-                      border-radius: 50%;
-                      border-style: solid;
-                      border-width: 1px;
-                      box-sizing: border-box;
-                      content: "";
-                      display: inline-block;
-                      font-weight: normal;
-                      height: 20px;
-                      left: 0px;
-                      position: absolute;
-                      top: 0px;
-                      transition-duration: 200ms;
-                      transition-property: border-color;
-                      transition-timing-function: cubic-bezier(.4, 0, .23, 1);
-                      width: 20px;
+                    @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
+                      -ms-high-contrast-adjust: none;
                     }
-                    &:after {
-                      border-radius: 50%;
-                      box-sizing: border-box;
-                      content: "";
-                      height: 0px;
-                      left: 10px;
-                      position: absolute;
-                      right: 0px;
-                      transition-duration: 200ms;
-                      transition-property: border-width;
-                      transition-timing-function: cubic-bezier(.4, 0, .23, 1);
-                      width: 0px;
+                    &:active .ms-Dropdown-title {
+                      border-color: #0078d4;
                     }
-                htmlFor="ChoiceGroup0-A"
+                    @media screen and (-ms-high-contrast: active){&:active .ms-Dropdown-title {
+                      border-color: Highlight;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-caretDown {
+                      color: HighlightText;
+                    }
+                    @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-caretDown {
+                      -ms-high-contrast-adjust: none;
+                    }
+                    &:hover .ms-Dropdown-title--hasError {
+                      border-color: #a4262c;
+                    }
+                    &:active .ms-Dropdown-title--hasError {
+                      border-color: #a4262c;
+                    }
+                    &:focus .ms-Dropdown-title--hasError {
+                      border-color: #a4262c;
+                    }
+                data-is-focusable={false}
+                id="Dropdown2"
+                onBlur={[Function]}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onKeyUp={[Function]}
+                tabIndex={-1}
               >
                 <span
-                  className="ms-ChoiceFieldLabel"
-                  id="ChoiceGroupLabel1-A"
-                >
-                  Mark displayed items as read after
-                </span>
-              </label>
-              <div
-                className=
-                    ms-Dropdown-container
-
-              >
-                <div
-                  aria-describedby="Dropdown2-option"
-                  aria-disabled={true}
-                  aria-expanded="false"
-                  aria-label="Select a time span"
+                  aria-atomic={true}
+                  aria-label="5 seconds"
+                  aria-live="off"
                   className=
-                      ms-Dropdown
-                      is-disabled
+                      ms-Dropdown-title
                       {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        border-color: #605e5c;
+                        background-color: #f3f2f1;
+                        border-color: #8a8886;
+                        border-radius: 2px;
+                        border-style: solid;
+                        border-width: 1px;
+                        border: none;
                         box-shadow: none;
                         box-sizing: border-box;
-                        color: #323130;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 14px;
-                        font-weight: 400;
+                        color: #a19f9d;
+                        cursor: default;
+                        display: block;
+                        height: 32px;
+                        line-height: 30px;
                         margin-bottom: 0px;
                         margin-left: 0px;
                         margin-right: 0px;
                         margin-top: 0px;
-                        outline: 0px;
-                        padding-bottom: 0px;
-                        padding-left: 0px;
-                        padding-right: 0px;
-                        padding-top: 0px;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 28px;
+                        padding-top: 0;
                         position: relative;
-                        user-select: none;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
                       }
-                      &:hover .ms-Dropdown-title {
-                        border-color: #323130;
+                      @media screen and (-ms-high-contrast: active){& {
+                        border: 1px solid GrayText;
+                        color: GrayText;
                       }
-                      @media screen and (-ms-high-contrast: active){&:hover .ms-Dropdown-title {
-                        border-color: Highlight;
-                      }
-                      &:focus .ms-Dropdown-title {
-                        border-color: #0078d4;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title {
-                        background-color: Highlight;
-                        border-color: Highlight;
-                        color: HighlightText;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-                        color: HighlightText;
-                      }
-                      @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
-                        -ms-high-contrast-adjust: none;
-                      }
-                      &:active .ms-Dropdown-title {
-                        border-color: #0078d4;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:active .ms-Dropdown-title {
-                        border-color: Highlight;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-caretDown {
-                        color: HighlightText;
-                      }
-                      @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-caretDown {
-                        -ms-high-contrast-adjust: none;
-                      }
-                      &:hover .ms-Dropdown-title--hasError {
-                        border-color: #a4262c;
-                      }
-                      &:active .ms-Dropdown-title--hasError {
-                        border-color: #a4262c;
-                      }
-                      &:focus .ms-Dropdown-title--hasError {
-                        border-color: #a4262c;
-                      }
-                  data-is-focusable={false}
-                  id="Dropdown2"
-                  onBlur={[Function]}
-                  onClick={[Function]}
-                  onFocus={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyUp={[Function]}
-                  tabIndex={-1}
+                  id="Dropdown2-option"
                 >
-                  <span
-                    aria-atomic={true}
-                    aria-label="5 seconds"
-                    aria-live="off"
+                  <span>
+                    5 seconds
+                  </span>
+                </span>
+                <span
+                  className=
+                      ms-Dropdown-caretDownWrapper
+                      {
+                        height: 32px;
+                        line-height: 30px;
+                        position: absolute;
+                        right: 8px;
+                        top: 1px;
+                      }
+                >
+                  <i
+                    aria-hidden={true}
                     className=
-                        ms-Dropdown-title
+                        ms-Dropdown-caretDown
                         {
-                          background-color: #f3f2f1;
-                          border-color: #8a8886;
-                          border-radius: 2px;
-                          border-style: solid;
-                          border-width: 1px;
-                          border: none;
-                          box-shadow: none;
-                          box-sizing: border-box;
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
                           color: #a19f9d;
-                          cursor: default;
-                          display: block;
-                          height: 32px;
-                          line-height: 30px;
-                          margin-bottom: 0px;
-                          margin-left: 0px;
-                          margin-right: 0px;
-                          margin-top: 0px;
-                          overflow: hidden;
-                          padding-bottom: 0;
-                          padding-left: 8px;
-                          padding-right: 28px;
-                          padding-top: 0;
-                          position: relative;
-                          text-overflow: ellipsis;
-                          white-space: nowrap;
+                          display: inline-block;
+                          font-family: "FabricMDL2Icons";
+                          font-size: 12px;
+                          font-style: normal;
+                          font-weight: normal;
+                          pointer-events: none;
+                          speak: none;
                         }
                         @media screen and (-ms-high-contrast: active){& {
-                          border: 1px solid GrayText;
                           color: GrayText;
                         }
-                    id="Dropdown2-option"
+                    data-icon-name="ChevronDown"
+                    role="presentation"
                   >
-                    <span>
-                      5 seconds
-                    </span>
-                  </span>
-                  <span
-                    className=
-                        ms-Dropdown-caretDownWrapper
-                        {
-                          height: 32px;
-                          line-height: 30px;
-                          position: absolute;
-                          right: 8px;
-                          top: 1px;
-                        }
-                  >
-                    <i
-                      aria-hidden={true}
-                      className=
-                          ms-Dropdown-caretDown
-                          {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            color: #a19f9d;
-                            display: inline-block;
-                            font-family: "FabricMDL2Icons";
-                            font-size: 12px;
-                            font-style: normal;
-                            font-weight: normal;
-                            pointer-events: none;
-                            speak: none;
-                          }
-                          @media screen and (-ms-high-contrast: active){& {
-                            color: GrayText;
-                          }
-                      data-icon-name="ChevronDown"
-                      role="presentation"
-                    >
-                      
-                    </i>
-                  </span>
-                </div>
+                    
+                  </i>
+                </span>
               </div>
             </div>
           </div>
         </div>
+      </div>
+      <div
+        className=
+            ms-ChoiceField
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-items: center;
+              border: 1px solid green;
+              box-sizing: border-box;
+              color: #323130;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-top: 8px;
+              min-height: 26px;
+              position: relative;
+            }
+            & .ms-ChoiceFieldLabel {
+              display: inline-block;
+              padding-left: 26px;
+            }
+      >
         <div
           className=
-              ms-ChoiceField
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                align-items: center;
-                border: 1px solid green;
-                box-sizing: border-box;
-                color: #323130;
-                display: flex;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                margin-top: 8px;
-                min-height: 26px;
-                position: relative;
-              }
-              & .ms-ChoiceFieldLabel {
-                display: inline-block;
-                padding-left: 26px;
-              }
-        >
-          <div
-            className=
-                ms-ChoiceField-wrapper
+              ms-ChoiceField-wrapper
 
+        >
+          <input
+            checked={true}
+            className=
+                ms-ChoiceField-input
+                {
+                  height: 100%;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  opacity: 0;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  width: 100%;
+                }
+            id="ChoiceGroup0-B"
+            name="ChoiceGroup0"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="radio"
+          />
+          <label
+            className=
+                ms-ChoiceField-field
+                is-checked
+                {
+                  border-color: #0078d4;
+                  cursor: pointer;
+                  display: inline-block;
+                  margin-top: 0px;
+                  min-height: 20px;
+                  position: relative;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &:hover .ms-ChoiceFieldLabel {
+                  color: #201f1e;
+                }
+                &:hover:before {
+                  border-color: #005a9e;
+                }
+                &:hover:after {
+                  border-color: #005a9e;
+                }
+                &:focus .ms-ChoiceFieldLabel {
+                  color: #201f1e;
+                }
+                &:focus:before {
+                  border-color: #005a9e;
+                }
+                &:focus:after {
+                  border-color: #005a9e;
+                }
+                &:before {
+                  background-color: #ffffff;
+                  border-color: #0078d4;
+                  border-radius: 50%;
+                  border-style: solid;
+                  border-width: 1px;
+                  box-sizing: border-box;
+                  content: "";
+                  display: inline-block;
+                  font-weight: normal;
+                  height: 20px;
+                  left: 0px;
+                  position: absolute;
+                  top: 0px;
+                  transition-duration: 200ms;
+                  transition-property: border-color;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 20px;
+                }
+                @media screen and (-ms-high-contrast: active){&:before {
+                  border-color: Highlight;
+                }
+                &:after {
+                  border-color: #0078d4;
+                  border-radius: 50%;
+                  border-style: solid;
+                  border-width: 5px;
+                  box-sizing: border-box;
+                  content: "";
+                  height: 10px;
+                  left: 5px;
+                  position: absolute;
+                  right: 0px;
+                  top: 5px;
+                  transition-duration: 200ms;
+                  transition-property: border-width;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 10px;
+                }
+                @media screen and (-ms-high-contrast: active){&:after {
+                  border-color: Highlight;
+                }
+            htmlFor="ChoiceGroup0-B"
           >
-            <input
-              checked={true}
-              className=
-                  ms-ChoiceField-input
-                  {
-                    height: 100%;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    opacity: 0;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                    width: 100%;
-                  }
-              id="ChoiceGroup0-B"
-              name="ChoiceGroup0"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              required={true}
-              type="radio"
-            />
-            <label
-              className=
-                  ms-ChoiceField-field
-                  is-checked
-                  {
-                    border-color: #0078d4;
-                    cursor: pointer;
-                    display: inline-block;
-                    margin-top: 0px;
-                    min-height: 20px;
-                    position: relative;
-                    user-select: none;
-                    vertical-align: top;
-                  }
-                  &:hover .ms-ChoiceFieldLabel {
-                    color: #201f1e;
-                  }
-                  &:hover:before {
-                    border-color: #005a9e;
-                  }
-                  &:hover:after {
-                    border-color: #005a9e;
-                  }
-                  &:focus .ms-ChoiceFieldLabel {
-                    color: #201f1e;
-                  }
-                  &:focus:before {
-                    border-color: #005a9e;
-                  }
-                  &:focus:after {
-                    border-color: #005a9e;
-                  }
-                  &:before {
-                    background-color: #ffffff;
-                    border-color: #0078d4;
-                    border-radius: 50%;
-                    border-style: solid;
-                    border-width: 1px;
-                    box-sizing: border-box;
-                    content: "";
-                    display: inline-block;
-                    font-weight: normal;
-                    height: 20px;
-                    left: 0px;
-                    position: absolute;
-                    top: 0px;
-                    transition-duration: 200ms;
-                    transition-property: border-color;
-                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
-                    width: 20px;
-                  }
-                  @media screen and (-ms-high-contrast: active){&:before {
-                    border-color: Highlight;
-                  }
-                  &:after {
-                    border-color: #0078d4;
-                    border-radius: 50%;
-                    border-style: solid;
-                    border-width: 5px;
-                    box-sizing: border-box;
-                    content: "";
-                    height: 10px;
-                    left: 5px;
-                    position: absolute;
-                    right: 0px;
-                    top: 5px;
-                    transition-duration: 200ms;
-                    transition-property: border-width;
-                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
-                    width: 10px;
-                  }
-                  @media screen and (-ms-high-contrast: active){&:after {
-                    border-color: Highlight;
-                  }
-              htmlFor="ChoiceGroup0-B"
+            <span
+              className="ms-ChoiceFieldLabel"
+              id="ChoiceGroupLabel1-B"
             >
-              <span
-                className="ms-ChoiceFieldLabel"
-                id="ChoiceGroupLabel1-B"
-              >
-                Option B
-              </span>
-            </label>
-          </div>
+              Option B
+            </span>
+          </label>
         </div>
+      </div>
+      <div
+        className=
+            ms-ChoiceField
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-items: center;
+              border: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-top: 8px;
+              min-height: 26px;
+              position: relative;
+            }
+            & .ms-ChoiceFieldLabel {
+              display: inline-block;
+              padding-left: 26px;
+            }
+      >
         <div
           className=
-              ms-ChoiceField
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                align-items: center;
-                border: none;
-                box-sizing: border-box;
-                color: #323130;
-                display: flex;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                margin-top: 8px;
-                min-height: 26px;
-                position: relative;
-              }
-              & .ms-ChoiceFieldLabel {
-                display: inline-block;
-                padding-left: 26px;
-              }
-        >
-          <div
-            className=
-                ms-ChoiceField-wrapper
+              ms-ChoiceField-wrapper
 
+        >
+          <input
+            checked={false}
+            className=
+                ms-ChoiceField-input
+                {
+                  height: 100%;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  opacity: 0;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  width: 100%;
+                }
+            disabled={true}
+            id="ChoiceGroup0-C"
+            name="ChoiceGroup0"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="radio"
+          />
+          <label
+            className=
+                ms-ChoiceField-field
+                {
+                  cursor: default;
+                  display: inline-block;
+                  margin-top: 0px;
+                  min-height: 20px;
+                  position: relative;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &:before {
+                  background-color: #ffffff;
+                  border-color: #c8c6c4;
+                  border-radius: 50%;
+                  border-style: solid;
+                  border-width: 1px;
+                  box-sizing: border-box;
+                  content: "";
+                  display: inline-block;
+                  font-weight: normal;
+                  height: 20px;
+                  left: 0px;
+                  position: absolute;
+                  top: 0px;
+                  transition-duration: 200ms;
+                  transition-property: border-color;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 20px;
+                }
+                @media screen and (-ms-high-contrast: active){&:before {
+                  color: GrayText;
+                }
+                &:after {
+                  border-radius: 50%;
+                  box-sizing: border-box;
+                  content: "";
+                  height: 0px;
+                  left: 10px;
+                  position: absolute;
+                  right: 0px;
+                  transition-duration: 200ms;
+                  transition-property: border-width;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 0px;
+                }
+                & .ms-ChoiceFieldLabel {
+                  color: #a19f9d;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: GrayText;
+                }
+            htmlFor="ChoiceGroup0-C"
           >
-            <input
-              checked={false}
-              className=
-                  ms-ChoiceField-input
-                  {
-                    height: 100%;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    opacity: 0;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                    width: 100%;
-                  }
-              disabled={true}
-              id="ChoiceGroup0-C"
-              name="ChoiceGroup0"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              required={true}
-              type="radio"
-            />
-            <label
-              className=
-                  ms-ChoiceField-field
-                  {
-                    cursor: default;
-                    display: inline-block;
-                    margin-top: 0px;
-                    min-height: 20px;
-                    position: relative;
-                    user-select: none;
-                    vertical-align: top;
-                  }
-                  &:before {
-                    background-color: #ffffff;
-                    border-color: #c8c6c4;
-                    border-radius: 50%;
-                    border-style: solid;
-                    border-width: 1px;
-                    box-sizing: border-box;
-                    content: "";
-                    display: inline-block;
-                    font-weight: normal;
-                    height: 20px;
-                    left: 0px;
-                    position: absolute;
-                    top: 0px;
-                    transition-duration: 200ms;
-                    transition-property: border-color;
-                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
-                    width: 20px;
-                  }
-                  @media screen and (-ms-high-contrast: active){&:before {
-                    color: GrayText;
-                  }
-                  &:after {
-                    border-radius: 50%;
-                    box-sizing: border-box;
-                    content: "";
-                    height: 0px;
-                    left: 10px;
-                    position: absolute;
-                    right: 0px;
-                    transition-duration: 200ms;
-                    transition-property: border-width;
-                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
-                    width: 0px;
-                  }
-                  & .ms-ChoiceFieldLabel {
-                    color: #a19f9d;
-                  }
-                  @media screen and (-ms-high-contrast: active){& {
-                    color: GrayText;
-                  }
-              htmlFor="ChoiceGroup0-C"
+            <span
+              className="ms-ChoiceFieldLabel"
+              id="ChoiceGroupLabel1-C"
             >
-              <span
-                className="ms-ChoiceFieldLabel"
-                id="ChoiceGroupLabel1-C"
-              >
-                Option C
-              </span>
-            </label>
-          </div>
+              Option C
+            </span>
+          </label>
         </div>
+      </div>
+      <div
+        className=
+            ms-ChoiceField
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-items: center;
+              border: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-top: 8px;
+              min-height: 26px;
+              position: relative;
+            }
+            & .ms-ChoiceFieldLabel {
+              display: inline-block;
+              padding-left: 26px;
+            }
+      >
         <div
           className=
-              ms-ChoiceField
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                align-items: center;
-                border: none;
-                box-sizing: border-box;
-                color: #323130;
-                display: flex;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                margin-top: 8px;
-                min-height: 26px;
-                position: relative;
-              }
-              & .ms-ChoiceFieldLabel {
-                display: inline-block;
-                padding-left: 26px;
-              }
-        >
-          <div
-            className=
-                ms-ChoiceField-wrapper
+              ms-ChoiceField-wrapper
 
+        >
+          <input
+            checked={false}
+            className=
+                ms-ChoiceField-input
+                {
+                  height: 100%;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  opacity: 0;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  width: 100%;
+                }
+            id="ChoiceGroup0-D"
+            name="ChoiceGroup0"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="radio"
+          />
+          <label
+            className=
+                ms-ChoiceField-field
+                {
+                  cursor: pointer;
+                  display: inline-block;
+                  margin-top: 0px;
+                  min-height: 20px;
+                  position: relative;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &:hover .ms-ChoiceFieldLabel {
+                  color: #201f1e;
+                }
+                &:hover:before {
+                  border-color: #323130;
+                }
+                &:hover:after {
+                  background-color: #605e5c;
+                  content: "";
+                  height: 10px;
+                  left: 5px;
+                  top: 5px;
+                  transition-property: background-color;
+                  width: 10px;
+                }
+                &:focus .ms-ChoiceFieldLabel {
+                  color: #201f1e;
+                }
+                &:focus:before {
+                  border-color: #323130;
+                }
+                &:focus:after {
+                  background-color: #605e5c;
+                  content: "";
+                  height: 10px;
+                  left: 5px;
+                  top: 5px;
+                  transition-property: background-color;
+                  width: 10px;
+                }
+                &:before {
+                  background-color: #ffffff;
+                  border-color: #323130;
+                  border-radius: 50%;
+                  border-style: solid;
+                  border-width: 1px;
+                  box-sizing: border-box;
+                  content: "";
+                  display: inline-block;
+                  font-weight: normal;
+                  height: 20px;
+                  left: 0px;
+                  position: absolute;
+                  top: 0px;
+                  transition-duration: 200ms;
+                  transition-property: border-color;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 20px;
+                }
+                &:after {
+                  border-radius: 50%;
+                  box-sizing: border-box;
+                  content: "";
+                  height: 0px;
+                  left: 10px;
+                  position: absolute;
+                  right: 0px;
+                  transition-duration: 200ms;
+                  transition-property: border-width;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 0px;
+                }
+            htmlFor="ChoiceGroup0-D"
           >
-            <input
-              checked={false}
-              className=
-                  ms-ChoiceField-input
-                  {
-                    height: 100%;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    opacity: 0;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                    width: 100%;
-                  }
-              id="ChoiceGroup0-D"
-              name="ChoiceGroup0"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              required={true}
-              type="radio"
-            />
-            <label
-              className=
-                  ms-ChoiceField-field
-                  {
-                    cursor: pointer;
-                    display: inline-block;
-                    margin-top: 0px;
-                    min-height: 20px;
-                    position: relative;
-                    user-select: none;
-                    vertical-align: top;
-                  }
-                  &:hover .ms-ChoiceFieldLabel {
-                    color: #201f1e;
-                  }
-                  &:hover:before {
-                    border-color: #323130;
-                  }
-                  &:hover:after {
-                    background-color: #605e5c;
-                    content: "";
-                    height: 10px;
-                    left: 5px;
-                    top: 5px;
-                    transition-property: background-color;
-                    width: 10px;
-                  }
-                  &:focus .ms-ChoiceFieldLabel {
-                    color: #201f1e;
-                  }
-                  &:focus:before {
-                    border-color: #323130;
-                  }
-                  &:focus:after {
-                    background-color: #605e5c;
-                    content: "";
-                    height: 10px;
-                    left: 5px;
-                    top: 5px;
-                    transition-property: background-color;
-                    width: 10px;
-                  }
-                  &:before {
-                    background-color: #ffffff;
-                    border-color: #323130;
-                    border-radius: 50%;
-                    border-style: solid;
-                    border-width: 1px;
-                    box-sizing: border-box;
-                    content: "";
-                    display: inline-block;
-                    font-weight: normal;
-                    height: 20px;
-                    left: 0px;
-                    position: absolute;
-                    top: 0px;
-                    transition-duration: 200ms;
-                    transition-property: border-color;
-                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
-                    width: 20px;
-                  }
-                  &:after {
-                    border-radius: 50%;
-                    box-sizing: border-box;
-                    content: "";
-                    height: 0px;
-                    left: 10px;
-                    position: absolute;
-                    right: 0px;
-                    transition-duration: 200ms;
-                    transition-property: border-width;
-                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
-                    width: 0px;
-                  }
-              htmlFor="ChoiceGroup0-D"
+            <span
+              className="ms-ChoiceFieldLabel"
+              id="ChoiceGroupLabel1-D"
             >
-              <span
-                className="ms-ChoiceFieldLabel"
-                id="ChoiceGroupLabel1-D"
-              >
-                Option D
-              </span>
-            </label>
-          </div>
+              Option D
+            </span>
+          </label>
         </div>
       </div>
     </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
@@ -103,13 +103,11 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
                     top: 0px;
                     width: 100%;
                   }
-              data-automation-id="auto1"
               id="ChoiceGroup1-A"
               name="ChoiceGroup1"
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
-              required={true}
               type="radio"
             />
             <label
@@ -246,7 +244,6 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
-              required={true}
               type="radio"
             />
             <label
@@ -384,7 +381,6 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
-              required={true}
               type="radio"
             />
             <label
@@ -495,20 +491,18 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
                     top: 0px;
                     width: 100%;
                   }
-              disabled={true}
               id="ChoiceGroup1-D"
               name="ChoiceGroup1"
               onBlur={[Function]}
               onChange={[Function]}
               onFocus={[Function]}
-              required={true}
               type="radio"
             />
             <label
               className=
                   ms-ChoiceField-field
                   {
-                    cursor: default;
+                    cursor: pointer;
                     display: inline-block;
                     margin-top: 0px;
                     min-height: 20px;
@@ -516,9 +510,39 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
                     user-select: none;
                     vertical-align: top;
                   }
+                  &:hover .ms-ChoiceFieldLabel {
+                    color: #201f1e;
+                  }
+                  &:hover:before {
+                    border-color: #323130;
+                  }
+                  &:hover:after {
+                    background-color: #605e5c;
+                    content: "";
+                    height: 10px;
+                    left: 5px;
+                    top: 5px;
+                    transition-property: background-color;
+                    width: 10px;
+                  }
+                  &:focus .ms-ChoiceFieldLabel {
+                    color: #201f1e;
+                  }
+                  &:focus:before {
+                    border-color: #323130;
+                  }
+                  &:focus:after {
+                    background-color: #605e5c;
+                    content: "";
+                    height: 10px;
+                    left: 5px;
+                    top: 5px;
+                    transition-property: background-color;
+                    width: 10px;
+                  }
                   &:before {
                     background-color: #ffffff;
-                    border-color: #c8c6c4;
+                    border-color: #323130;
                     border-radius: 50%;
                     border-style: solid;
                     border-width: 1px;
@@ -535,9 +559,6 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
                     transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                     width: 20px;
                   }
-                  @media screen and (-ms-high-contrast: active){&:before {
-                    color: GrayText;
-                  }
                   &:after {
                     border-radius: 50%;
                     box-sizing: border-box;
@@ -550,12 +571,6 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
                     transition-property: border-width;
                     transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                     width: 0px;
-                  }
-                  & .ms-ChoiceFieldLabel {
-                    color: #a19f9d;
-                  }
-                  @media screen and (-ms-high-contrast: active){& {
-                    color: GrayText;
                   }
               htmlFor="ChoiceGroup1-D"
             >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -4,7 +4,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
 <div
   className=
 
-      & .headerDivider-526:hover + .headerDividerBar-527 {
+      & .headerDivider-528:hover + .headerDividerBar-529 {
         display: inline;
       }
 >


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9901
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Make `ChoiceGroup.focus()` properly focus on the selected option or first enabled option, and add a test.

Clean up the ChoiceGroup examples.

Bunch of other cleanup of the ChoiceGroup and ChoiceGroupOption, including deprecating `IChoiceGroupOption.checked` since the ability to set checked state that way (as opposed to just with `selectedKey` or `defaultSelectedKey`) results in excessive code complication and the possibility of unpredictable behavior.

Add myself as codeowner for ChoiceGroup since I went and did so much with it...

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10000)