### PR TITLE
Searchbox: remove has input border

### DIFF
--- a/change/@uifabric-fluent-theme-2019-07-31-13-47-09-v-mare-Searchbox-remove-hasInput-border.json
+++ b/change/@uifabric-fluent-theme-2019-07-31-13-47-09-v-mare-Searchbox-remove-hasInput-border.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Searchbox: Removed hasInput border",
+  "packageName": "@uifabric/fluent-theme",
+  "email": "v-mare@microsoft.com",
+  "commit": "786a9b6f2aabe27be42fd1331ef0895c94ccbc1c",
+  "date": "2019-07-31T20:47:09.920Z"
+}

--- a/packages/fluent-theme/src/fluent/styles/SearchBox.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/SearchBox.styles.ts
@@ -8,7 +8,6 @@ export const SearchBoxStyles = (props: ISearchBoxStyleProps): Partial<ISearchBox
   const inputIconAlt = palette.neutralSecondary;
   const inputIconAltHovered = palette.neutralPrimary;
   const inputIconDisabled = palette.neutralTertiary;
-  const inputBorderHasInput = palette.neutralSecondary;
   const inputBackgroundHovered = palette.neutralLighter;
 
   return {
@@ -38,9 +37,6 @@ export const SearchBoxStyles = (props: ISearchBoxStyleProps): Partial<ISearchBox
             }
           }
         },
-      hasInput && {
-        borderColor: inputBorderHasInput
-      },
       hasFocus && {
         borderColor: semanticColors.inputFocusBorderAlt
       },


### PR DESCRIPTION
#### Pull request checklist

- [x] Removes Searchbox border when it has input that was added in  #9611 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The Go Abstract toolkit (Web Fluent > Commands, Menu & Nav > Suite Header > Secondary Searchbox) has a separate border color for when the Searchbox has input (i.e. is in "-Populated" state) but is neither hovered nor focused. Ben confirms this is incorrect so I'm reverting the changes.

#### Screenshots

Before
![Screen Shot 2019-07-31 at 1 54 41 PM](https://user-images.githubusercontent.com/13246181/62247596-ffd51180-b39a-11e9-8d07-0b8ffe56d658.png)

After
![Screen Shot 2019-07-31 at 1 57 11 PM](https://user-images.githubusercontent.com/13246181/62247669-2135fd80-b39b-11e9-8b31-292cf462eaae.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10007)