### PR TITLE
TextField: fix onChange issue and async tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,7 +25,7 @@
       "program": "${workspaceRoot}/scripts/debug-test.js",
       "cwd": "${fileDirname}",
       "stopOnEntry": false,
-      "args": ["-i", "--testPathPattern=${fileBasenameNoExtension}", "--watch"],
+      "args": ["-i", "--testPathPattern=\\b${fileBasenameNoExtension}", "--watch"],
       "runtimeExecutable": null,
       "runtimeArgs": ["--nolazy", "--debug"],
       "env": {

--- a/change/office-ui-fabric-react-2019-08-13-17-58-11-textfield-onchange-wip.json
+++ b/change/office-ui-fabric-react-2019-08-13-17-58-11-textfield-onchange-wip.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "TextField: fix onChange issue and async tests",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "commit": "6d55bd23655d5dc84e7f2aa613184dcb7468ef67",
+  "date": "2019-08-14T00:58:11.431Z"
+}

--- a/packages/office-ui-fabric-react/src/common/testUtilities.ts
+++ b/packages/office-ui-fabric-react/src/common/testUtilities.ts
@@ -22,6 +22,7 @@ export function expectMissing(wrapper: ReactWrapper<any, any>, className: string
   expectNodes(wrapper, className, 0);
 }
 
+/** @deprecated Use fake timers and `jest.runAllTimers()` instead */
 export function delay(millisecond: number): Promise<void> {
   return new Promise<void>(resolve => setTimeout(resolve, millisecond));
 }
@@ -45,4 +46,12 @@ export function renderIntoDocument(element: React.ReactElement<any>): HTMLElemen
 export function mockEvent(targetValue: string = ''): ReactTestUtils.SyntheticEventData {
   const target: EventTarget = { value: targetValue } as HTMLInputElement;
   return { target };
+}
+
+/**
+ * Hack for forcing Jest to run pending promises
+ * https://github.com/facebook/jest/issues/2157#issuecomment-279171856
+ */
+export function flushPromises() {
+  return new Promise<void>(resolve => setImmediate(resolve));
 }

--- a/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
+++ b/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
@@ -121,6 +121,7 @@ export class Autofill extends BaseComponent<IAutofillProps, IAutofillState> impl
         autoComplete={'off'}
         onCompositionStart={this._onCompositionStart}
         onCompositionEnd={this._onCompositionEnd}
+        // TODO (Fabric 8?) - switch to calling only onChange. See notes in TextField._onInputChange.
         onChange={this._onChanged}
         onInput={this._onInputChanged}
         onKeyDown={this._onKeyDown}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -361,11 +361,13 @@ export class SpinButton extends React.Component<ISpinButtonProps, ISpinButtonSta
 
   private _onChange(): void {
     /**
-     * A noop input change handler.
-     * https://github.com/facebook/react/issues/7027.
-     * Using the native onInput handler fixes the issue but onChange
-     * still need to be wired to avoid React console errors
-     * TODO: Check if issue is resolved when React 16 is available.
+     * A noop input change handler. Using onInput instead of onChange was meant to address an issue
+     * which apparently has been resolved in React 16 (https://github.com/facebook/react/issues/7027).
+     * The no-op onChange handler was still needed because React gives console errors if an input
+     * doesn't have onChange.
+     *
+     * TODO (Fabric 8?) - switch to just calling onChange (this is a breaking change for any tests,
+     * ours or 3rd-party, which simulate entering text in an autofill)
      */
   }
 

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -367,7 +367,7 @@ export class SpinButton extends React.Component<ISpinButtonProps, ISpinButtonSta
      * doesn't have onChange.
      *
      * TODO (Fabric 8?) - switch to just calling onChange (this is a breaking change for any tests,
-     * ours or 3rd-party, which simulate entering text in an autofill)
+     * ours or 3rd-party, which simulate entering text in a SpinButton)
      */
   }
 

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -66,6 +66,8 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
   private _textElement = React.createRef<HTMLTextAreaElement | HTMLInputElement>();
   private _classNames: IProcessedStyleSet<ITextFieldStyles>;
   private _async: Async;
+  /** Most recent value from a change or input event, to help avoid processing events twice */
+  private _lastChangeValue: string | undefined;
 
   public constructor(props: ITextFieldProps) {
     super(props);
@@ -104,11 +106,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
    * Gets the current value of the text field.
    */
   public get value(): string | undefined {
-    const value = _getValue(this.props, this.state);
-    if (typeof value === 'number') {
-      return String(value);
-    }
-    return value;
+    return _getValue(this.props, this.state);
   }
 
   public componentDidMount(): void {
@@ -161,7 +159,6 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
       // TODO: #5875 added logic to trigger validation in componentWillReceiveProps and other places.
       // This seems a bit odd and hard to integrate with the new approach.
       // (Starting to think we should just put the validation logic in a separate wrapper component...?)
-      // TODO: VERIFY that debouncing prevents this from being called too many times, and the timing is right
       if (_shouldValidateAllChanges(props)) {
         this._delayedValidate(this.value);
       }
@@ -471,29 +468,47 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
   }
 
   private _onInputChange = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>): void => {
-    event.persist();
-    const element: HTMLInputElement = event.target as HTMLInputElement;
-    const value: string = element.value;
-    const props = this.props;
+    // Previously, we needed to call both onInput and onChange due to some weird IE/React issues,
+    // which have *probably* been fixed now:
+    // - https://github.com/OfficeDev/office-ui-fabric-react/issues/744 (likely fixed)
+    // - https://github.com/OfficeDev/office-ui-fabric-react/issues/824 (confirmed fixed)
 
-    // Avoid doing unnecessary work when the value has not changed.
-    if (value === this.value) {
+    // TODO (Fabric 8?) - Switch to calling only onChange. This switch is pretty disruptive for
+    // tests (ours and maybe consumers' too), so it seemed best to do the switch in a major bump.
+
+    const element = event.target as HTMLInputElement;
+    const value = element.value;
+    // Ignore this event if the value is undefined (in case one of the IE bugs comes back)
+    if (value === undefined || value === this._lastChangeValue) {
       return;
     }
+    this._lastChangeValue = value;
 
-    // ONLY is this is an uncontrolled component, update the displayed value.
-    // (Controlled components must update the `value` prop from `onChange`.)
-    if (!this._isControlled) {
-      // For uncontrolled components, wait to call onChange until after state is updated
-      this.setState({ uncontrolledValue: value }, () => {
-        if (props.onChange) {
-          props.onChange(event, value);
+    // This is so developers can access the event properties in asynchronous callbacks
+    // https://reactjs.org/docs/events.html#event-pooling
+    event.persist();
+
+    let isSameValue: boolean;
+    this.setState(
+      (prevState: ITextFieldState, props: ITextFieldProps) => {
+        const prevValue = _getValue(props, prevState) || '';
+        isSameValue = value === prevValue;
+        // Avoid doing unnecessary work when the value has not changed.
+        if (isSameValue) {
+          return null;
         }
-      });
-    } else if (props.onChange) {
-      // For controlled components, call onChange now
-      props.onChange(event, value);
-    }
+
+        // ONLY is this is an uncontrolled component, update the displayed value.
+        // (Controlled components must update the `value` prop from `onChange`.)
+        return this._isControlled ? null : { uncontrolledValue: value };
+      },
+      () => {
+        // Don't call onChange unless the value actually changed
+        if (!isSameValue && this.props.onChange) {
+          this.props.onChange(event, value);
+        }
+      }
+    );
   };
 
   private _validate(value: string | undefined): void {
@@ -503,7 +518,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
     }
 
     this._latestValidateValue = value;
-    const onGetErrorMessage = this.props.onGetErrorMessage as (value: string) => string | PromiseLike<string> | undefined;
+    const onGetErrorMessage = this.props.onGetErrorMessage;
     const result = onGetErrorMessage && onGetErrorMessage(value || '');
 
     if (result !== undefined) {
@@ -540,8 +555,13 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
   }
 }
 
+/** Get the value from the given state and props (converting from number to string if needed) */
 function _getValue(props: ITextFieldProps, state: ITextFieldState): string | undefined {
   const { value = state.uncontrolledValue } = props;
+  if (typeof value === 'number') {
+    // not allowed per typings, but happens anyway
+    return String(value);
+  }
   return value;
 }
 

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -498,14 +498,15 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
           return null;
         }
 
-        // ONLY is this is an uncontrolled component, update the displayed value.
+        // ONLY if this is an uncontrolled component, update the displayed value.
         // (Controlled components must update the `value` prop from `onChange`.)
         return this._isControlled ? null : { uncontrolledValue: value };
       },
       () => {
-        // Don't call onChange unless the value actually changed
-        if (!isSameValue && this.props.onChange) {
-          this.props.onChange(event, value);
+        // If the value actually changed, call onChange (for either controlled or uncontrolled)
+        const { onChange } = this.props;
+        if (!isSameValue && onChange) {
+          onChange(event, value);
         }
       }
     );

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -1,4 +1,3 @@
-import { Promise } from 'es6-promise';
 import * as React from 'react';
 import * as ReactTestUtils from 'react-dom/test-utils';
 import * as renderer from 'react-test-renderer';
@@ -6,7 +5,7 @@ import { mount, ReactWrapper } from 'enzyme';
 import { renderToStaticMarkup } from 'react-dom/server';
 
 import { resetIds, setWarningCallback, IRefObject, resetControlledWarnings } from '../../Utilities';
-import { delay, mountAttached } from '../../common/testUtilities';
+import { mountAttached, mockEvent, flushPromises } from '../../common/testUtilities';
 
 import { TextField } from './TextField';
 import { TextFieldBase, ITextFieldState } from './TextField.base';
@@ -39,18 +38,6 @@ function sharedAfterEach() {
     wrapper = undefined;
   }
   textField = undefined;
-}
-
-function mockEvent(targetValue: string = ''): ReactTestUtils.SyntheticEventData {
-  const target: EventTarget = { value: targetValue } as HTMLInputElement;
-  return { target };
-}
-
-/** Sledgehammer to try and run all pending stuff */
-function runEverythingAsync() {
-  jest.runAllImmediates();
-  jest.runAllTicks();
-  jest.runAllTimers();
 }
 
 describe('TextField snapshots', () => {
@@ -266,7 +253,10 @@ describe('TextField basic props', () => {
 }); // end basic props
 
 describe('TextField with error message', () => {
-  beforeEach(sharedBeforeEach);
+  beforeEach(() => {
+    sharedBeforeEach();
+    jest.useFakeTimers();
+  });
   afterEach(sharedAfterEach);
 
   const errorMessage = 'The string is too long, should not exceed 3 characters.';
@@ -291,100 +281,116 @@ describe('TextField with error message', () => {
     }
   }
 
+  it('should not validate on mount when validateOnLoad is false', () => {
+    const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
+
+    wrapper = mount(<TextField defaultValue="invalid value" onGetErrorMessage={validator} validateOnLoad={false} />);
+    expect(validator).toHaveBeenCalledTimes(0);
+  });
+
+  it('should validate on mount when validateOnLoad is true', () => {
+    const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
+
+    wrapper = mount(<TextField defaultValue="invalid value" onGetErrorMessage={validator} validateOnLoad={true} />);
+    jest.runAllTimers();
+    expect(validator).toHaveBeenCalledTimes(1);
+  });
+
   it('should render error message when onGetErrorMessage returns a string', () => {
-    function validator(value: string): string {
-      return value.length > 3 ? errorMessage : '';
-    }
+    const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
 
-    jest.useFakeTimers();
-    wrapper = mount(<TextField defaultValue="whatever value" onGetErrorMessage={validator} deferredValidationTime={5} />);
-    runEverythingAsync();
+    wrapper = mount(<TextField onGetErrorMessage={validator} validateOnLoad={false} />);
 
-    const inputDOM = wrapper.getDOMNode().querySelector('input');
-    ReactTestUtils.Simulate.change(inputDOM!, mockEvent('the input value'));
-    runEverythingAsync();
+    wrapper.find('input').simulate('input', mockEvent('also invalid'));
+    jest.runAllTimers();
 
-    assertErrorMessage(wrapper!.getDOMNode(), errorMessage);
+    expect(validator).toHaveBeenCalledTimes(1);
+    assertErrorMessage(wrapper.getDOMNode(), errorMessage);
   });
 
   it('should render error message when onGetErrorMessage returns a JSX.Element', () => {
-    function validator(value: string): string | JSX.Element {
-      return value.length > 3 ? errorMessageJSX : '';
-    }
+    const validator = jest.fn((value: string) => (value.length > 3 ? errorMessageJSX : ''));
 
-    jest.useFakeTimers();
-    wrapper = mount(<TextField defaultValue="whatever value" onGetErrorMessage={validator} deferredValidationTime={5} />);
-    runEverythingAsync();
+    wrapper = mount(<TextField onGetErrorMessage={validator} validateOnLoad={false} />);
 
-    const inputDOM = wrapper.getDOMNode().querySelector('input');
-    ReactTestUtils.Simulate.change(inputDOM as Element, mockEvent('the input value'));
-    runEverythingAsync();
+    wrapper.find('input').simulate('input', mockEvent('also invalid'));
+    jest.runAllTimers();
 
-    assertErrorMessage(wrapper!.getDOMNode(), errorMessageJSX);
+    expect(validator).toHaveBeenCalledTimes(1);
+    assertErrorMessage(wrapper.getDOMNode(), errorMessageJSX);
   });
 
-  // disabling due to inconsistent behavior
-  xit('should render error message when onGetErrorMessage returns a Promise<string>', () => {
-    function validator(value: string): Promise<string> {
-      return Promise.resolve(value.length > 3 ? errorMessage : '');
-    }
+  it('should render error message when onGetErrorMessage returns a Promise<string>', () => {
+    const validator = jest.fn((value: string) => Promise.resolve(value.length > 3 ? errorMessage : ''));
 
-    wrapper = mount(<TextField defaultValue="whatever value" onGetErrorMessage={validator} deferredValidationTime={5} />);
+    wrapper = mount(<TextField onGetErrorMessage={validator} validateOnLoad={false} />);
 
-    const inputDOM = wrapper.getDOMNode().querySelector('input');
-    ReactTestUtils.Simulate.change(inputDOM as Element, mockEvent('the input value'));
+    wrapper.find('input').simulate('input', mockEvent('also invalid'));
 
-    // TODO: make this work with fake timers not real timers
-    return delay(20).then(() => assertErrorMessage(wrapper!.getDOMNode(), errorMessage));
+    // Extra rounds of running everything to account for the debounced validator and the promise...
+    jest.runAllTimers();
+    return flushPromises().then(() => {
+      jest.runAllTimers();
+
+      expect(validator).toHaveBeenCalledTimes(1);
+      assertErrorMessage(wrapper!.getDOMNode(), errorMessage);
+    });
   });
 
-  // disabling due to inconsistent behavior
-  xit('should render error message when onGetErrorMessage returns a Promise<JSX.Element>', () => {
-    function validator(value: string): Promise<string | JSX.Element> {
-      return Promise.resolve(value.length > 3 ? errorMessageJSX : '');
-    }
+  it('should render error message when onGetErrorMessage returns a Promise<JSX.Element>', () => {
+    const validator = jest.fn((value: string) => Promise.resolve(value.length > 3 ? errorMessageJSX : ''));
 
-    wrapper = mount(<TextField defaultValue="whatever value" onGetErrorMessage={validator} deferredValidationTime={5} />);
+    wrapper = mount(<TextField onGetErrorMessage={validator} validateOnLoad={false} />);
 
-    const inputDOM = wrapper.getDOMNode().querySelector('input');
-    ReactTestUtils.Simulate.change(inputDOM as Element, mockEvent('the input value'));
+    wrapper.find('input').simulate('input', mockEvent('also invalid'));
 
-    // TODO: make this work with fake timers not real timers
-    return delay(20).then(() => assertErrorMessage(wrapper!.getDOMNode(), errorMessageJSX));
+    jest.runAllTimers();
+    return flushPromises().then(() => {
+      jest.runAllTimers();
+
+      expect(validator).toHaveBeenCalledTimes(1);
+      assertErrorMessage(wrapper!.getDOMNode(), errorMessageJSX);
+    });
   });
 
   it('should render error message on first render when onGetErrorMessage returns a string', () => {
-    jest.useFakeTimers();
-    wrapper = mount(<TextField defaultValue="whatever value" onGetErrorMessage={() => errorMessage} />);
-    runEverythingAsync();
+    const validator = jest.fn(() => errorMessage);
+    wrapper = mount(<TextField defaultValue="invalid value" onGetErrorMessage={validator} />);
+    jest.runAllTimers();
 
-    assertErrorMessage(wrapper!.getDOMNode(), errorMessage);
+    expect(validator).toHaveBeenCalledTimes(1);
+    assertErrorMessage(wrapper.getDOMNode(), errorMessage);
   });
 
-  // disabling due to inconsistent behavior
-  xit('should render error message on first render when onGetErrorMessage returns a Promise<string>', () => {
-    wrapper = mount(<TextField defaultValue="whatever value" onGetErrorMessage={() => Promise.resolve(errorMessage)} />);
+  it('should render error message on first render when onGetErrorMessage returns a Promise<string>', () => {
+    const validator = jest.fn(() => Promise.resolve(errorMessage));
+    wrapper = mount(<TextField defaultValue="invalid value" onGetErrorMessage={validator} />);
 
-    // TODO: make this work with fake timers not real timers
-    return delay(20).then(() => assertErrorMessage(wrapper!.getDOMNode(), errorMessage));
+    jest.runAllTimers();
+    return flushPromises().then(() => {
+      jest.runAllTimers();
+
+      expect(validator).toHaveBeenCalledTimes(1);
+      assertErrorMessage(wrapper!.getDOMNode(), errorMessage);
+    });
   });
 
   it('should not render error message when onGetErrorMessage return an empty string', () => {
-    jest.useFakeTimers();
-    wrapper = mount(<TextField defaultValue="whatever value" onGetErrorMessage={() => ''} />);
-    runEverythingAsync();
+    const validator = jest.fn(() => '');
+    wrapper = mount(<TextField defaultValue="invalid value" onGetErrorMessage={validator} />);
+    jest.runAllTimers();
 
-    assertErrorMessage(wrapper!.getDOMNode(), /* exist */ false);
+    expect(validator).toHaveBeenCalledTimes(1);
+    assertErrorMessage(wrapper.getDOMNode(), /* exist */ false);
   });
 
   it('should not render error message when no value is provided', () => {
     let actualValue: string | undefined = undefined;
 
-    jest.useFakeTimers();
     wrapper = mount(<TextField onGetErrorMessage={(value: string) => (actualValue = value)} />);
-    runEverythingAsync();
+    jest.runAllTimers();
 
-    assertErrorMessage(wrapper!.getDOMNode(), /* exist */ false);
+    assertErrorMessage(wrapper.getDOMNode(), /* exist */ false);
     expect(actualValue).toEqual('');
   });
 
@@ -393,160 +399,113 @@ describe('TextField with error message', () => {
       return value.length > 3 ? errorMessage : '';
     }
 
-    jest.useFakeTimers();
-
     wrapper = mount(<TextField value="initial value" onChange={noOp} onGetErrorMessage={validator} />);
+    jest.runAllTimers();
 
-    runEverythingAsync();
     assertErrorMessage(wrapper.getDOMNode(), errorMessage);
 
     wrapper.setProps({ value: '' });
-    runEverythingAsync();
+    jest.runAllTimers();
 
     assertErrorMessage(wrapper.getDOMNode(), /* exist */ false);
   });
 
   it('should not validate when receiving props when validating only on focus in', () => {
-    let validationCallCount = 0;
-    const validatorSpy = (value: string) => {
-      validationCallCount++;
-      return value.length > 3 ? errorMessage : '';
-    };
-
-    jest.useFakeTimers();
+    const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
 
     wrapper = mount(
-      <TextField
-        validateOnFocusIn
-        value="initial value"
-        onChange={noOp}
-        onGetErrorMessage={validatorSpy}
-        validateOnLoad={false}
-        deferredValidationTime={0}
-      />
+      <TextField validateOnFocusIn value="initial value" onChange={noOp} onGetErrorMessage={validator} validateOnLoad={false} />
     );
-    runEverythingAsync();
-    expect(validationCallCount).toEqual(0);
+    jest.runAllTimers();
+    expect(validator).toHaveBeenCalledTimes(0);
     assertErrorMessage(wrapper.getDOMNode(), false);
 
     wrapper.setProps({ value: 'failValidationValue' });
-    runEverythingAsync();
+    jest.runAllTimers();
 
-    expect(validationCallCount).toEqual(0);
+    expect(validator).toHaveBeenCalledTimes(0);
     assertErrorMessage(wrapper.getDOMNode(), false);
   });
 
   it('should not validate when receiving props when validating only on focus out', () => {
-    let validationCallCount = 0;
-    const validatorSpy = (value: string) => {
-      validationCallCount++;
-      return value.length > 3 ? errorMessage : '';
-    };
-
-    jest.useFakeTimers();
+    const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
 
     wrapper = mount(
-      <TextField
-        validateOnFocusOut
-        value="initial value"
-        onChange={noOp}
-        onGetErrorMessage={validatorSpy}
-        validateOnLoad={false}
-        deferredValidationTime={0}
-      />
+      <TextField validateOnFocusOut value="initial value" onChange={noOp} onGetErrorMessage={validator} validateOnLoad={false} />
     );
-    runEverythingAsync();
-    expect(validationCallCount).toEqual(0);
+    jest.runAllTimers();
+    expect(validator).toHaveBeenCalledTimes(0);
     assertErrorMessage(wrapper.getDOMNode(), false);
 
     wrapper.setProps({ value: 'failValidationValue' });
-    runEverythingAsync();
+    jest.runAllTimers();
 
-    expect(validationCallCount).toEqual(0);
+    expect(validator).toHaveBeenCalledTimes(0);
     assertErrorMessage(wrapper.getDOMNode(), false);
   });
 
   it('should trigger validation only on focus', () => {
-    let validationCallCount = 0;
-    const validatorSpy = (value: string) => {
-      validationCallCount++;
-      return value.length > 3 ? errorMessage : '';
-    };
+    const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
 
-    wrapper = mount(<TextField defaultValue="initial value" onGetErrorMessage={validatorSpy} validateOnFocusIn />);
+    wrapper = mount(<TextField defaultValue="initial value" onGetErrorMessage={validator} validateOnFocusIn />);
 
-    const inputDOM = wrapper.getDOMNode().querySelector('input') as Element;
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent('the input value'));
-    expect(validationCallCount).toEqual(1);
+    const input = wrapper.find('input');
+    input.simulate('input', mockEvent('invalid value'));
+    expect(validator).toHaveBeenCalledTimes(1);
 
-    ReactTestUtils.Simulate.focus(inputDOM);
-    expect(validationCallCount).toEqual(2);
+    input.simulate('focus');
+    expect(validator).toHaveBeenCalledTimes(2);
 
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent('the input '));
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent('the input value'));
-    ReactTestUtils.Simulate.focus(inputDOM);
-    expect(validationCallCount).toEqual(3);
+    input.simulate('input', mockEvent('also '));
+    input.simulate('input', mockEvent('also invalid'));
+    input.simulate('focus');
+    expect(validator).toHaveBeenCalledTimes(3);
   });
 
   it('should trigger validation only on blur', () => {
-    let validationCallCount = 0;
-    const validatorSpy = (value: string) => {
-      validationCallCount++;
-      return value.length > 3 ? errorMessage : '';
-    };
+    const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
 
-    wrapper = mount(<TextField defaultValue="initial value" onGetErrorMessage={validatorSpy} validateOnFocusOut />);
+    wrapper = mount(<TextField defaultValue="initial value" onGetErrorMessage={validator} validateOnFocusOut />);
 
-    const inputDOM = wrapper.getDOMNode().querySelector('input') as Element;
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent('the input value'));
-    expect(validationCallCount).toEqual(1);
+    const input = wrapper.find('input');
+    input.simulate('input', mockEvent('invalid value'));
+    expect(validator).toHaveBeenCalledTimes(1);
 
-    ReactTestUtils.Simulate.blur(inputDOM);
-    expect(validationCallCount).toEqual(2);
+    input.simulate('blur');
+    expect(validator).toHaveBeenCalledTimes(2);
 
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent('the input va'));
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent('the input value'));
+    input.simulate('input', mockEvent('also '));
+    input.simulate('input', mockEvent('also invalid'));
 
-    ReactTestUtils.Simulate.blur(inputDOM);
-    expect(validationCallCount).toEqual(3);
+    input.simulate('blur');
+    expect(validator).toHaveBeenCalledTimes(3);
   });
 
   it('should trigger validation on both blur and focus', () => {
-    let validationCallCount = 0;
-    const validatorSpy = (value: string) => {
-      validationCallCount++;
-      return value.length > 3 ? errorMessage : '';
-    };
+    const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
 
-    wrapper = mount(<TextField defaultValue="initial value" onGetErrorMessage={validatorSpy} validateOnFocusOut validateOnFocusIn />);
+    wrapper = mount(<TextField defaultValue="initial value" onGetErrorMessage={validator} validateOnFocusOut validateOnFocusIn />);
 
-    const inputDOM = wrapper.getDOMNode().querySelector('input') as Element;
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent('value before focus'));
-    expect(validationCallCount).toEqual(1);
+    const input = wrapper.find('input');
+    input.simulate('input', mockEvent('value before focus'));
+    expect(validator).toHaveBeenCalledTimes(1);
 
-    ReactTestUtils.Simulate.focus(inputDOM);
-    expect(validationCallCount).toEqual(2);
+    input.simulate('focus');
+    expect(validator).toHaveBeenCalledTimes(2);
 
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent('value before foc'));
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent('value before focus'));
-    ReactTestUtils.Simulate.focus(inputDOM);
-    expect(validationCallCount).toEqual(3);
+    input.simulate('input', mockEvent('value before foc'));
+    input.simulate('input', mockEvent('value before focus'));
+    input.simulate('focus');
+    expect(validator).toHaveBeenCalledTimes(3);
 
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent('value before blur'));
-    ReactTestUtils.Simulate.blur(inputDOM);
-    expect(validationCallCount).toEqual(4);
+    input.simulate('input', mockEvent('value before blur'));
+    input.simulate('blur');
+    expect(validator).toHaveBeenCalledTimes(4);
 
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent('value before bl'));
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent('value before blur'));
-    ReactTestUtils.Simulate.blur(inputDOM);
-    expect(validationCallCount).toEqual(5);
-  });
-
-  it('should not trigger validation on component mount', () => {
-    const validatorSpy = jest.fn();
-    wrapper = mount(<TextField defaultValue="initial value" onGetErrorMessage={validatorSpy} validateOnLoad={false} />);
-
-    expect(validatorSpy).toHaveBeenCalledTimes(0);
+    input.simulate('input', mockEvent('value before bl'));
+    input.simulate('input', mockEvent('value before blur'));
+    input.simulate('blur');
+    expect(validator).toHaveBeenCalledTimes(5);
   });
 }); // end error message
 
@@ -642,7 +601,7 @@ describe('TextField controlled vs uncontrolled usage', () => {
     wrapper.setProps({ value: undefined, onChange: noOp });
 
     expect(warnFn).toHaveBeenCalledTimes(1);
-    const inputDOM = wrapper!.getDOMNode().querySelector('input');
+    const inputDOM = wrapper.getDOMNode().querySelector('input');
     expect(textField!.value).toEqual(undefined);
     expect(inputDOM!.value).toEqual('');
   });
@@ -690,21 +649,6 @@ describe('TextField onChange', () => {
     onChange = jest.fn();
   });
 
-  it('should be called for input change and apply edits if uncontrolled (not strict)', () => {
-    wrapper = mount(<TextField componentRef={textFieldRef} defaultValue={initialValue} onChange={onChange} />);
-
-    expect(onChange).toHaveBeenCalledTimes(0);
-    simulateAndVerifyChange('value change', 1);
-    simulateAndVerifyChange('', 2);
-  });
-
-  it('should not be called when initial value is undefined and input change is an empty string (not strict)', () => {
-    wrapper = mount(<TextField componentRef={textFieldRef} onChange={onChange} />);
-
-    expect(onChange).toHaveBeenCalledTimes(0);
-    simulateAndVerifyChange('', 0);
-  });
-
   it('should be called for input change and apply edits if uncontrolled', () => {
     wrapper = mount(<TextField componentRef={textFieldRef} defaultValue={initialValue} onChange={onChange} />);
 
@@ -731,28 +675,6 @@ describe('TextField onChange', () => {
 
     expect(onChange).toHaveBeenCalledTimes(0);
     simulateAndVerifyChange('value change', 1, initialValue);
-  });
-
-  it('should not be called with a persisted event', () => {
-    let textFieldTarget: any = null;
-    const onChangeSpy = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, value: string) => {
-      textFieldTarget = ev.target;
-    };
-
-    const wrapperOne = mount(<TextField onChange={onChangeSpy} />);
-    const wrapperTwo = mount(<TextField onChange={onChangeSpy} />);
-
-    const inputDOMOne = wrapperOne.getDOMNode().querySelector('input') as Element;
-    const inputDOMTwo = wrapperTwo.getDOMNode().querySelector('input') as Element;
-
-    const valueOne = 'textfield one';
-    const valueTwo = 'textfield two';
-
-    ReactTestUtils.Simulate.input(inputDOMOne, mockEvent(valueOne));
-    expect(textFieldTarget!.value).toEqual(valueOne);
-
-    ReactTestUtils.Simulate.change(inputDOMTwo, mockEvent(valueTwo));
-    expect(textFieldTarget!.value).toEqual(valueTwo);
   });
 }); // end on change
 

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -638,6 +638,8 @@ describe('TextField onChange', () => {
     expectedValue = typeof expectedValue === 'string' ? expectedValue : changeValue;
 
     const inputDOM = wrapper!.getDOMNode().querySelector('input')!;
+    // Fire input AND change events to more realistically test
+    ReactTestUtils.Simulate.input(inputDOM, mockEvent(changeValue));
     ReactTestUtils.Simulate.change(inputDOM, mockEvent(changeValue));
 
     expect(onChange).toHaveBeenCalledTimes(calls);

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
@@ -161,7 +161,8 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
 
   /**
    * Callback for when the input value changes.
-   * This is called on both `input` and `change` native events.
+   * This is called on both `input` and `change` events.
+   * (In a later version, this will probably only be called for the `change` event.)
    */
   onChange?: (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => void;
 
@@ -249,6 +250,7 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
   autoComplete?: string;
 
   /**
+   * Only used by MaskedTextField:
    * The masking string that defines the mask's behavior.
    * A backslash will escape any character.
    * Special format characters are:
@@ -261,12 +263,14 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
   mask?: string;
 
   /**
+   * Only used by MaskedTextField:
    * The character to show in place of unfilled characters of the mask.
    * @defaultvalue '_'
    */
   maskChar?: string;
 
   /**
+   * Only used by MaskedTextField:
    * An object defining the format characters and corresponding regexp values.
    * Default format characters: \{
    *  '9': /[0-9]/,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9522
- [x] Include a change request file using `$ yarn change`

#### Description of changes

As of the controlled TextField change #8723, the TextField started calling `onChange` twice per change due to handling both `input` and `change` events, and no longer unconditionally storing the last entered value in the state. This led me to question *why* we needed to call both, and it turns out to be historical reasons which no longer apply. (see bottom of description for details)

Unfortunately...handling only `change` in the TextField (and a couple other components containing text inputs) turns out to be very disruptive to tests and possibly also to real consumers in other ways, so I'm leaving that to do in a major version. For now I've added a check to ensure we only call `onChange` once per new text value. I also updated the logic so that both controlled and uncontrolled scenarios call `onChange` async, for consistency.

While working on this, I finally figured out why some of the TextField's async tests didn't work with `jest.useFakeTimers()`. It turns out to be a combination of using `es6-promise` (which for some reason doesn't respect mocked `setTimeout` handlers) and difficulties with flushing the queue of pending promises in Jest. So I removed `es6-promise` and added a promise-flushing workaround to relevant tests.

#### Historical reasons for handling `input`+`change`

I'm pretty sure these are both fixed now, but in case anybody needs the info later for reference...

- Due to an [IE11+`onChange` issue in React](https://github.com/facebook/react/issues/7027), listening to `onChange` could miss keystrokes if typing quickly (reported to Fabric in #744). So we usually listened to `onInput` instead. This has *probably* been fixed in React (I'm not 100% sure since I couldn't repro in older React versions--see [codepen attempt](https://codepen.io/ecraig12345/pen/qejrXV?editors=1010)).

- There used to be an issue in IE 11 with document mode 10 where the `input` event is missing `target.value` (see #824), but I confirmed React has now fixed/worked around this (verified with [this codepen](https://codepen.io/ecraig12345/pen/PMjjZm?editors=1010) in debug mode and using F12=>Emulation to set document mode 10). 

Again, I decided to continue handling both events for now, but in future versions or for new components, this isn't necessary.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10016)