### PR TITLE
Remove accidental export of SelectionMode.

### DIFF
--- a/change/office-ui-fabric-react-2019-08-01-14-49-02-fix-duplicate-export.json
+++ b/change/office-ui-fabric-react-2019-08-01-14-49-02-fix-duplicate-export.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove extra export of SelectionMode",
+  "packageName": "office-ui-fabric-react",
+  "email": "jdh@microsoft.com",
+  "commit": "5feb2bba90ab5c4eb9a2cabd14ae0fc268df518f",
+  "date": "2019-08-01T21:49:02.562Z"
+}

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -10,7 +10,6 @@ import {
   isElementTabbable
 } from '../../Utilities';
 import { ISelection, SelectionMode, IObjectWithKey } from './interfaces';
-export { ISelection, SelectionMode, IObjectWithKey };
 
 // Selection definitions:
 //


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #9661 
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Remove export from `SelectionZone.tsx`. Appears to have been accidentally added during resolution of a merge conflict.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10024)