### PR TITLE
Replace the usage of `FontSizes` variable with font styles pulled from the theme object and minor cleanup

### DIFF
--- a/change/office-ui-fabric-react-2019-08-01-16-53-38-vibraga-FontStyle-from-theme.json
+++ b/change/office-ui-fabric-react-2019-08-01-16-53-38-vibraga-FontStyle-from-theme.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Replace the usage of `FontSizes` variable with font styles pulled from the theme object and minor cleanup.",
+  "packageName": "office-ui-fabric-react",
+  "email": "vibraga@microsoft.com",
+  "commit": "94f9a344ec8204f2646c8c8fc4f5a60cdc316be0",
+  "date": "2019-08-01T23:53:38.055Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.styles.ts
@@ -39,7 +39,7 @@ const MediumScreenSelector = getScreenSelector(ScreenWidthMinMedium, ScreenWidth
 
 export const getStyles = (props: IBreadcrumbStyleProps): IBreadcrumbStyles => {
   const { className, theme } = props;
-  const { palette, semanticColors } = theme;
+  const { palette, semanticColors, fonts } = theme;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
@@ -94,7 +94,7 @@ export const getStyles = (props: IBreadcrumbStyleProps): IBreadcrumbStyles => {
   return {
     root: [
       classNames.root,
-      theme.fonts.medium,
+      fonts.medium,
       {
         margin: '11px 0 1px'
       },
@@ -132,7 +132,7 @@ export const getStyles = (props: IBreadcrumbStyleProps): IBreadcrumbStyles => {
       classNames.chevron,
       {
         color: chevronButtonColor,
-        fontSize: theme.fonts.small.fontSize,
+        fontSize: fonts.small.fontSize,
         selectors: {
           [HighContrastSelector]: {
             color: 'WindowText',
@@ -172,7 +172,7 @@ export const getStyles = (props: IBreadcrumbStyleProps): IBreadcrumbStyles => {
             padding: '4px 6px'
           },
           [MediumScreenSelector]: {
-            fontSize: theme.fonts.mediumPlus.fontSize
+            fontSize: fonts.mediumPlus.fontSize
           }
         }
       }

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.styles.ts
@@ -1,19 +1,21 @@
 import { IButtonStyles } from './Button.types';
 import { memoizeFunction } from '../../Utilities';
-import { HighContrastSelector, ITheme, IRawStyle, getFocusStyle, FontSizes, hiddenContentStyle } from '../../Styling';
+import { HighContrastSelector, ITheme, IRawStyle, getFocusStyle, hiddenContentStyle } from '../../Styling';
 
 const noOutline: IRawStyle = {
   outline: 0
 };
 
-const iconStyle = {
-  fontSize: FontSizes.icon,
-  margin: '0 4px',
-  height: '16px',
-  lineHeight: '16px',
-  textAlign: 'center',
-  verticalAlign: 'middle',
-  flexShrink: 0
+const iconStyle = (fontSize?: string | number): IRawStyle => {
+  return {
+    fontSize: fontSize,
+    margin: '0 4px',
+    height: '16px',
+    lineHeight: '16px',
+    textAlign: 'center',
+    verticalAlign: 'middle',
+    flexShrink: 0
+  };
 };
 
 /**
@@ -23,7 +25,7 @@ const iconStyle = {
  */
 export const getStyles = memoizeFunction(
   (theme: ITheme): IButtonStyles => {
-    const { semanticColors, effects } = theme;
+    const { semanticColors, effects, fonts } = theme;
 
     const border = semanticColors.buttonBorder;
     const disabledBackground = semanticColors.disabledBackground;
@@ -103,14 +105,9 @@ export const getStyles = memoizeFunction(
         flexGrow: 1
       },
 
-      icon: iconStyle,
+      icon: iconStyle(fonts.mediumPlus.fontSize),
 
-      menuIcon: [
-        iconStyle,
-        {
-          fontSize: FontSizes.small
-        }
-      ],
+      menuIcon: iconStyle(fonts.small.fontSize),
 
       label: {
         margin: '0 4px',

--- a/packages/office-ui-fabric-react/src/components/Check/Check.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Check/Check.styles.ts
@@ -1,5 +1,5 @@
 import { ICheckStyleProps, ICheckStyles } from './Check.types';
-import { HighContrastSelector, IStyle, getGlobalClassNames } from '../../Styling';
+import { HighContrastSelector, IStyle, getGlobalClassNames, IconFontSizes } from '../../Styling';
 import { getRTL } from '../../Utilities';
 
 export const CheckGlobalClassNames = {
@@ -13,7 +13,7 @@ export const CheckGlobalClassNames = {
 export const getStyles = (props: ICheckStyleProps): ICheckStyles => {
   const { height = props.checkBoxHeight || '18px', checked, className, theme } = props;
 
-  const { palette, semanticColors } = theme;
+  const { palette, semanticColors, fonts } = theme;
   const isRTL = getRTL();
 
   const classNames = getGlobalClassNames(CheckGlobalClassNames, theme);
@@ -32,7 +32,7 @@ export const getStyles = (props: ICheckStyleProps): ICheckStyles => {
   return {
     root: [
       classNames.root,
-      theme.fonts.medium,
+      fonts.medium,
       {
         // lineHeight currently needs to be a string to output without 'px'
         lineHeight: '1',
@@ -107,7 +107,7 @@ export const getStyles = (props: ICheckStyleProps): ICheckStyles => {
       {
         opacity: 0,
         color: palette.neutralSecondary,
-        fontSize: '16px',
+        fontSize: IconFontSizes.medium,
         left: isRTL ? '-0.5px' : '.5px', // for centering the check icon inside the circle.
 
         selectors: {

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
@@ -1,5 +1,5 @@
 import { ICheckboxStyleProps, ICheckboxStyles } from './Checkbox.types';
-import { FontSizes, HighContrastSelector, getGlobalClassNames } from '../../Styling';
+import { HighContrastSelector, getGlobalClassNames } from '../../Styling';
 import { IsFocusVisibleClassName } from '../../Utilities';
 
 const GlobalClassNames = {
@@ -16,7 +16,7 @@ const MS_CHECKBOX_TRANSITION_TIMING = 'cubic-bezier(.4, 0, .23, 1)';
 
 export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
   const { className, theme, reversed, checked, disabled, isUsingCustomLabelRender } = props;
-  const { semanticColors, effects, palette } = theme;
+  const { semanticColors, effects, palette, fonts } = theme;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
@@ -112,25 +112,23 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
       ],
       className
     ],
-    input: [
-      {
-        position: 'absolute',
-        background: 'none',
+    input: {
+      position: 'absolute',
+      background: 'none',
 
-        opacity: 0,
-        selectors: {
-          [`.${IsFocusVisibleClassName} &:focus + label::before`]: {
-            outline: '1px solid ' + theme.palette.neutralSecondary,
-            outlineOffset: '2px',
-            selectors: {
-              [HighContrastSelector]: {
-                outline: '1px solid ActiveBorder'
-              }
+      opacity: 0,
+      selectors: {
+        [`.${IsFocusVisibleClassName} &:focus + label::before`]: {
+          outline: '1px solid ' + theme.palette.neutralSecondary,
+          outlineOffset: '2px',
+          selectors: {
+            [HighContrastSelector]: {
+              outline: '1px solid ActiveBorder'
             }
           }
         }
       }
-    ],
+    },
     label: [
       classNames.label,
       theme.fonts.medium,
@@ -232,7 +230,7 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
       classNames.text,
       {
         color: disabled ? checkboxTextColorDisabled : checkboxTextColor,
-        fontSize: FontSizes.medium,
+        fontSize: fonts.medium.fontSize,
         lineHeight: '20px'
       },
       !reversed

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
@@ -1,4 +1,4 @@
-import { FontSizes, FontWeights, HighContrastSelector, IStyle, getGlobalClassNames } from '../../../Styling';
+import { HighContrastSelector, IStyle, getGlobalClassNames } from '../../../Styling';
 import { IsFocusVisibleClassName } from '../../../Utilities';
 import { IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles } from './ChoiceGroupOption.types';
 
@@ -89,7 +89,7 @@ function getImageWrapperStyle(isSelectedImageWrapper: boolean, className?: strin
 
 export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOptionStyles => {
   const { theme, hasIcon, hasImage, checked, disabled, imageIsLarge, focused, imageSize } = props;
-  const { palette, semanticColors } = theme;
+  const { palette, semanticColors, fonts } = theme;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
@@ -242,15 +242,12 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
         alignItems: 'center',
         boxSizing: 'border-box',
         color: semanticColors.bodyText,
-        fontSize: FontSizes.medium,
-        fontWeight: FontWeights.regular,
         minHeight: 26,
         border: 'none',
         position: 'relative',
         marginTop: 8,
         selectors: {
           '.ms-ChoiceFieldLabel': {
-            fontSize: FontSizes.medium,
             display: 'inline-block'
           }
         }
@@ -393,6 +390,7 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
     ],
     labelWrapper: [
       classNames.labelWrapper,
+      fonts.medium,
       (hasIcon || hasImage) && {
         display: 'block',
         position: 'relative',
@@ -402,9 +400,7 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
         maxWidth: imageSize!.width * 2, // using non-null assertion because we have a default in `ChoiceGroupOptionBase` class.
         overflow: 'hidden',
         whiteSpace: 'pre-wrap',
-        textOverflow: 'ellipsis',
-        fontSize: FontSizes.medium,
-        fontWeight: FontWeights.regular
+        textOverflow: 'ellipsis'
       }
     ]
   };

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
@@ -22,7 +22,6 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
         & .ms-ChoiceFieldLabel {
           display: inline-block;
-          font-size: 14px;
           padding-left: 26px;
         }
   >
@@ -154,7 +153,6 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
         & .ms-ChoiceFieldLabel {
           display: inline-block;
-          font-size: 14px;
           padding-left: 26px;
         }
   >
@@ -307,7 +305,6 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
         & .ms-ChoiceFieldLabel {
           display: inline-block;
-          font-size: 14px;
           padding-left: 26px;
         }
   >
@@ -461,7 +458,6 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
         & .ms-ChoiceFieldLabel {
           display: inline-block;
-          font-size: 14px;
           padding-left: 26px;
         }
   >
@@ -573,7 +569,6 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
         & .ms-ChoiceFieldLabel {
           display: inline-block;
-          font-size: 14px;
           padding-left: 26px;
         }
   >
@@ -703,7 +698,6 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
         & .ms-ChoiceFieldLabel {
           display: inline-block;
-          font-size: 14px;
         }
   >
     <div
@@ -855,7 +849,10 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
           className=
               ms-ChoiceField-labelWrapper
               {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
                 height: 30px;
@@ -907,7 +904,6 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
         & .ms-ChoiceFieldLabel {
           display: inline-block;
-          font-size: 14px;
         }
   >
     <div
@@ -1080,7 +1076,10 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
           className=
               ms-ChoiceField-labelWrapper
               {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
                 height: 30px;
@@ -1132,7 +1131,6 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
         & .ms-ChoiceFieldLabel {
           display: inline-block;
-          font-size: 14px;
         }
   >
     <div
@@ -1303,7 +1301,10 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
           className=
               ms-ChoiceField-labelWrapper
               {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
                 height: 30px;
@@ -1355,7 +1356,6 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
         }
         & .ms-ChoiceFieldLabel {
           display: inline-block;
-          font-size: 14px;
         }
   >
     <div
@@ -1502,7 +1502,10 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
           className=
               ms-ChoiceField-labelWrapper
               {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
                 display: block;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
                 height: 30px;

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
@@ -78,7 +78,6 @@ exports[`ChoiceGroup label does not have className prop from parent 1`] = `
             }
             & .ms-ChoiceFieldLabel {
               display: inline-block;
-              font-size: 14px;
               padding-left: 26px;
             }
       >
@@ -218,7 +217,6 @@ exports[`ChoiceGroup label does not have className prop from parent 1`] = `
             }
             & .ms-ChoiceFieldLabel {
               display: inline-block;
-              font-size: 14px;
               padding-left: 26px;
             }
       >
@@ -356,7 +354,6 @@ exports[`ChoiceGroup label does not have className prop from parent 1`] = `
             }
             & .ms-ChoiceFieldLabel {
               display: inline-block;
-              font-size: 14px;
               padding-left: 26px;
             }
       >
@@ -523,7 +520,6 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
             }
             & .ms-ChoiceFieldLabel {
               display: inline-block;
-              font-size: 14px;
               padding-left: 26px;
             }
       >
@@ -663,7 +659,6 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
             }
             & .ms-ChoiceFieldLabel {
               display: inline-block;
-              font-size: 14px;
               padding-left: 26px;
             }
       >
@@ -801,7 +796,6 @@ exports[`ChoiceGroup renders ChoiceGroup correctly 1`] = `
             }
             & .ms-ChoiceFieldLabel {
               display: inline-block;
-              font-size: 14px;
               padding-left: 26px;
             }
       >

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.styles.ts
@@ -32,8 +32,8 @@ export const getStyles = (props: IColorPickerStyleProps): IColorPickerStyles => 
       }
     ],
     tableHeader: [
+      theme.fonts.small,
       {
-        ...theme.fonts.small,
         selectors: {
           td: {
             paddingBottom: 4

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -1,5 +1,4 @@
 import {
-  FontSizes,
   FontWeights,
   IRawStyle,
   ITheme,
@@ -157,7 +156,7 @@ export const getOptionStyles = memoizeFunction(
 
 export const getCaretDownButtonStyles = memoizeFunction(
   (theme: ITheme, customStyles?: Partial<IButtonStyles>): IButtonStyles => {
-    const { semanticColors } = theme;
+    const { semanticColors, fonts } = theme;
 
     const caretButtonTextColor = semanticColors.bodySubtext;
     const caretButtonTextColorHoveredChecked = semanticColors.buttonTextChecked;
@@ -168,7 +167,7 @@ export const getCaretDownButtonStyles = memoizeFunction(
     const styles: IButtonStyles = {
       root: {
         color: caretButtonTextColor,
-        fontSize: FontSizes.small,
+        fontSize: fonts.small.fontSize,
         position: 'absolute',
         // The negative positioning accounts for the 1px root border now that box-sizing is border-box
         top: '-1px',
@@ -188,7 +187,7 @@ export const getCaretDownButtonStyles = memoizeFunction(
         }
       },
       icon: {
-        fontSize: FontSizes.small
+        fontSize: fonts.small.fontSize
       },
       rootHovered: {
         backgroundColor: caretButtonBackgroundHovered,

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.cnstyles.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.cnstyles.ts
@@ -1,6 +1,5 @@
 import {
   concatStyleSets,
-  FontSizes,
   getFocusStyle,
   HighContrastSelector,
   IRawStyle,
@@ -213,7 +212,7 @@ export const getMenuItemStyles = memoizeFunction(
         display: 'inline-block',
         verticalAlign: 'middle',
         flexShrink: '0',
-        fontSize: FontSizes.small, // 12px
+        fontSize: IconFontSizes.small, // 12px
         selectors: {
           ':hover': {
             color: palette.neutralPrimary
@@ -222,7 +221,7 @@ export const getMenuItemStyles = memoizeFunction(
             color: palette.neutralPrimary
           },
           [MediumScreenSelector]: {
-            fontSize: FontSizes.icon // 16px
+            fontSize: IconFontSizes.medium // 16px
           }
         }
       },

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.styles.ts
@@ -65,7 +65,7 @@ export const getStyles = (props: IContextualMenuStyleProps): IContextualMenuStyl
     title: [
       classNames.title,
       {
-        fontSize: '16px',
+        fontSize: fonts.mediumPlus.fontSize,
         paddingRight: '14px',
         paddingLeft: '14px',
         paddingBottom: '5px',

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.styles.ts
@@ -1,5 +1,5 @@
 import { IDatePickerStyleProps, IDatePickerStyles } from './DatePicker.types';
-import { IStyle, normalize, getGlobalClassNames, FontSizes } from '../../Styling';
+import { IStyle, normalize, getGlobalClassNames } from '../../Styling';
 
 const GlobalClassNames = {
   root: 'ms-DatePicker',
@@ -11,12 +11,12 @@ const GlobalClassNames = {
 
 export const styles = (props: IDatePickerStyleProps): IDatePickerStyles => {
   const { className, theme, disabled, label, isDatePickerShown } = props;
-  const { palette, semanticColors, effects } = theme;
+  const { palette, semanticColors, effects, fonts } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
   const DatePickerEvent: IStyle = {
     color: palette.neutralSecondary,
-    fontSize: FontSizes.icon,
+    fontSize: fonts.mediumPlus.fontSize,
     lineHeight: '18px',
     pointerEvents: 'none',
     position: 'absolute',

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.styles.ts
@@ -38,7 +38,7 @@ export const getStyles = (props: IDetailsColumnStyleProps): IDetailsColumnStyles
     transitionDurationDrop
   } = props;
 
-  const { semanticColors, palette } = theme;
+  const { semanticColors, palette, fonts } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
   const colors = {
@@ -66,7 +66,7 @@ export const getStyles = (props: IDetailsColumnStyleProps): IDetailsColumnStyles
   return {
     root: [
       getCellStyles(props),
-      theme.fonts.small,
+      fonts.small,
       isActionable && [
         classNames.isActionable,
         {
@@ -134,7 +134,7 @@ export const getStyles = (props: IDetailsColumnStyleProps): IDetailsColumnStyles
         color: colors.dropdownChevronForegroundColor,
         paddingLeft: 6,
         verticalAlign: 'middle',
-        fontSize: 12 // TODO needs to be updated after type ramp reconcile
+        fontSize: fonts.small.fontSize
       }
     ],
 
@@ -166,7 +166,7 @@ export const getStyles = (props: IDetailsColumnStyleProps): IDetailsColumnStyles
         overflow: 'hidden',
         textOverflow: 'ellipsis',
         fontWeight: FontWeights.semibold,
-        fontSize: 14
+        fontSize: fonts.medium.fontSize
       },
       isIconOnly && {
         selectors: {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
@@ -1,14 +1,5 @@
 import { IDetailsHeaderStyleProps, IDetailsHeaderStyles } from './DetailsHeader.types';
-import {
-  getFocusStyle,
-  focusClear,
-  IStyle,
-  getGlobalClassNames,
-  HighContrastSelector,
-  hiddenContentStyle,
-  ITheme,
-  FontSizes
-} from '../../Styling';
+import { getFocusStyle, focusClear, IStyle, getGlobalClassNames, HighContrastSelector, hiddenContentStyle, ITheme } from '../../Styling';
 import { IsFocusVisibleClassName } from '../../Utilities';
 import { DEFAULT_CELL_STYLE_PROPS } from './DetailsRow.styles';
 import { ICellStyleProps } from './DetailsRow.types';
@@ -75,7 +66,7 @@ export const getStyles = (props: IDetailsHeaderStyleProps): IDetailsHeaderStyles
     cellStyleProps = DEFAULT_CELL_STYLE_PROPS
   } = props;
 
-  const { semanticColors, palette } = theme;
+  const { semanticColors, palette, fonts } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
   const colors = {
@@ -168,7 +159,7 @@ export const getStyles = (props: IDetailsHeaderStyleProps): IDetailsHeaderStyles
         display: 'inline-flex',
         alignItems: 'center',
         justifyContent: 'center',
-        fontSize: FontSizes.small,
+        fontSize: fonts.small.fontSize,
         padding: 0,
         border: 'none',
         width: GROUP_EXPANDER_WIDTH, // align with GroupedList's first expandIcon cell width.

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
@@ -87,7 +87,7 @@ export const getStyles = (props: IDetailsHeaderStyleProps): IDetailsHeaderStyles
   return {
     root: [
       classNames.root,
-      theme.fonts.small,
+      fonts.small,
       {
         display: 'inline-block',
         background: colors.headerBackgroundColor,
@@ -302,7 +302,7 @@ export const getStyles = (props: IDetailsHeaderStyleProps): IDetailsHeaderStyles
         position: 'absolute',
         top: 22,
         left: -7.5,
-        fontSize: 16,
+        fontSize: fonts.mediumPlus.fontSize,
         color: palette.themePrimary,
         overflow: 'visible',
         zIndex: 10

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.styles.ts
@@ -1,5 +1,5 @@
 import { IDetailsListStyleProps, IDetailsListStyles } from './DetailsList.types';
-import { getGlobalClassNames, FontSizes } from '../../Styling';
+import { getGlobalClassNames } from '../../Styling';
 
 const GlobalClassNames = {
   root: 'ms-DetailsList',
@@ -22,7 +22,6 @@ export const getStyles = (props: IDetailsListStyleProps): IDetailsListStyles => 
       theme.fonts.small,
       {
         position: 'relative',
-        fontSize: FontSizes.small,
         background: semanticColors.listBackground,
         color: semanticColors.listText,
         selectors: {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.styles.ts
@@ -2,7 +2,6 @@ import { IDetailsRowStyleProps, IDetailsRowStyles, ICellStyleProps } from './Det
 import {
   AnimationClassNames,
   AnimationStyles,
-  FontSizes,
   HighContrastSelector,
   IStyle,
   getFocusStyle,
@@ -61,7 +60,8 @@ export const getStyles = (props: IDetailsRowStyleProps): IDetailsRowStyles => {
     enableUpdateAnimations
   } = props;
 
-  const { neutralPrimary, white, neutralSecondary, neutralLighter, neutralLight, neutralDark, neutralQuaternaryAlt } = theme.palette;
+  const { palette, fonts } = theme;
+  const { neutralPrimary, white, neutralSecondary, neutralLighter, neutralLight, neutralDark, neutralQuaternaryAlt } = palette;
   const { focusBorder } = theme.semanticColors;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
@@ -367,7 +367,7 @@ export const getStyles = (props: IDetailsRowStyleProps): IDetailsRowStyles => {
       classNames.isRowHeader,
       {
         color: colors.defaultHeaderText,
-        fontSize: FontSizes.medium
+        fontSize: fonts.medium.fontSize
       },
       isSelected && {
         color: colors.selectedHeaderText,

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.styles.ts
@@ -1,5 +1,6 @@
 import { IDialogContentStyleProps, IDialogContentStyles } from './DialogContent.types';
 import { FontWeights, getGlobalClassNames } from '../../Styling';
+import { IconFontSizes } from '@uifabric/styling';
 
 const GlobalClassNames = {
   contentLgHeader: 'ms-Dialog-lgHeader',
@@ -72,7 +73,7 @@ export const getStyles = (props: IDialogContentStyleProps): IDialogContentStyles
         selectors: {
           '.ms-Icon.ms-Icon--Cancel': {
             color: palette.neutralSecondary,
-            fontSize: '16px'
+            fontSize: IconFontSizes.medium
           }
         }
       }
@@ -100,20 +101,15 @@ export const getStyles = (props: IDialogContentStyleProps): IDialogContentStyles
         color: palette.neutralPrimary,
         margin: '0',
         padding: '16px 46px 24px 24px',
-        fontSize: 20, // TODO: after updating the type ramp this needs reevaluated
-        fontWeight: FontWeights.semibold,
         lineHeight: 'normal'
       },
-      isLargeHeader && [
-        fonts.xxLarge,
-        {
-          color: palette.white,
-          marginBottom: '8px',
-          padding: '22px 24px',
-          fontWeight: FontWeights.semibold
-        }
-      ],
-      isMultiline && fonts.xxLarge
+      isLargeHeader && {
+        fontSize: fonts.xxLarge.fontSize,
+        color: palette.white,
+        marginBottom: '8px',
+        padding: '22px 24px'
+      },
+      isMultiline && { fontSize: fonts.xxLarge.fontSize }
     ],
 
     topButton: [

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.styles.ts
@@ -1,4 +1,4 @@
-import { getGlobalClassNames, FontSizes } from '../../Styling';
+import { getGlobalClassNames } from '../../Styling';
 import { IDocumentCardStyleProps, IDocumentCardStyles } from './DocumentCard.types';
 import { DocumentCardPreviewGlobalClassNames as previewClassNames } from './DocumentCardPreview.styles';
 import { DocumentCardActivityGlobalClassNames as activityClassNames } from './DocumentCardActivity.styles';
@@ -13,7 +13,7 @@ const GlobalClassNames = {
 
 export const getStyles = (props: IDocumentCardStyleProps): IDocumentCardStyles => {
   const { className, theme, actionable, compact } = props;
-  const { palette } = theme;
+  const { palette, fonts } = theme;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
@@ -78,7 +78,7 @@ export const getStyles = (props: IDocumentCardStyleProps): IDocumentCardStyles =
             },
             [`.${titleClassNames.root}`]: {
               paddingBottom: '12px 16px 8px 16px',
-              fontSize: FontSizes.mediumPlus,
+              fontSize: fonts.mediumPlus.fontSize,
               lineHeight: '16px'
             }
           }

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardActions.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardActions.styles.ts
@@ -1,4 +1,4 @@
-import { getGlobalClassNames, FontSizes } from '../../Styling';
+import { getGlobalClassNames } from '../../Styling';
 import { IDocumentCardActionsStyleProps, IDocumentCardActionsStyles } from './DocumentCardActions.types';
 
 const ACTION_SIZE = 34;
@@ -13,7 +13,7 @@ const GlobalClassNames = {
 
 export const getStyles = (props: IDocumentCardActionsStyleProps): IDocumentCardActionsStyles => {
   const { className, theme } = props;
-  const { palette } = theme;
+  const { palette, fonts } = theme;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
@@ -37,7 +37,7 @@ export const getStyles = (props: IDocumentCardActionsStyleProps): IDocumentCardA
 
         selectors: {
           '.ms-Button': {
-            fontSize: '16px',
+            fontSize: fonts.mediumPlus.fontSize,
             height: ACTION_SIZE,
             width: ACTION_SIZE
           },
@@ -57,7 +57,7 @@ export const getStyles = (props: IDocumentCardActionsStyleProps): IDocumentCardA
     ],
     viewsIcon: {
       marginRight: '8px',
-      fontSize: FontSizes.medium,
+      fontSize: fonts.medium.fontSize,
       verticalAlign: 'top'
     }
   };

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardActivity.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardActivity.styles.ts
@@ -1,4 +1,4 @@
-import { getGlobalClassNames, FontSizes, FontWeights } from '../../Styling';
+import { getGlobalClassNames, FontWeights } from '../../Styling';
 import { IDocumentCardActivityStyleProps, IDocumentCardActivityStyles } from './DocumentCardActivity.types';
 
 const VERTICAL_PADDING = 8;
@@ -18,7 +18,7 @@ export const DocumentCardActivityGlobalClassNames = {
 
 export const getStyles = (props: IDocumentCardActivityStyleProps): IDocumentCardActivityStyles => {
   const { theme, className, multiplePeople } = props;
-  const { palette } = theme;
+  const { palette, fonts } = theme;
 
   const classNames = getGlobalClassNames(DocumentCardActivityGlobalClassNames, theme);
 
@@ -82,7 +82,7 @@ export const getStyles = (props: IDocumentCardActivityStyleProps): IDocumentCard
       classNames.name,
       {
         display: 'block',
-        fontSize: FontSizes.small,
+        fontSize: fonts.small.fontSize,
         lineHeight: '15px',
         height: '15px',
         overflow: 'hidden',
@@ -96,7 +96,7 @@ export const getStyles = (props: IDocumentCardActivityStyleProps): IDocumentCard
       classNames.activity,
       {
         display: 'block',
-        fontSize: FontSizes.small,
+        fontSize: fonts.small.fontSize,
         lineHeight: '15px',
         height: '15px',
         overflow: 'hidden',

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardLocation.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardLocation.styles.ts
@@ -1,4 +1,4 @@
-import { getGlobalClassNames, FontSizes } from '../../Styling';
+import { getGlobalClassNames } from '../../Styling';
 import { IDocumentCardLocationStyleProps, IDocumentCardLocationStyles } from './DocumentCardLocation.types';
 
 export const DocumentCardLocationGlobalClassNames = {
@@ -7,15 +7,15 @@ export const DocumentCardLocationGlobalClassNames = {
 
 export const getStyles = (props: IDocumentCardLocationStyleProps): IDocumentCardLocationStyles => {
   const { theme, className } = props;
-  const { palette } = theme;
+  const { palette, fonts } = theme;
 
   const classNames = getGlobalClassNames(DocumentCardLocationGlobalClassNames, theme);
 
   return {
     root: [
       classNames.root,
+      fonts.small,
       {
-        fontSize: FontSizes.small,
         color: palette.neutralPrimary,
         display: 'block',
         padding: '8px 16px',

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardLogo.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardLogo.styles.ts
@@ -7,7 +7,7 @@ const GlobalClassNames = {
 
 export const getStyles = (props: IDocumentCardLogoStyleProps): IDocumentCardLogoStyles => {
   const { theme, className } = props;
-  const { palette } = theme;
+  const { palette, fonts } = theme;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
@@ -15,7 +15,7 @@ export const getStyles = (props: IDocumentCardLogoStyleProps): IDocumentCardLogo
     root: [
       classNames.root,
       {
-        fontSize: '32px',
+        fontSize: fonts.xxLargePlus.fontSize,
         color: palette.themePrimary,
         display: 'block',
         padding: '16px 16px 0 16px'

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.styles.ts
@@ -1,4 +1,4 @@
-import { getGlobalClassNames, FontSizes } from '../../Styling';
+import { getGlobalClassNames } from '../../Styling';
 import { IDocumentCardPreviewStyleProps, IDocumentCardPreviewStyles } from './DocumentCardPreview.types';
 
 export const DocumentCardPreviewGlobalClassNames = {
@@ -9,13 +9,14 @@ export const DocumentCardPreviewGlobalClassNames = {
 
 export const getStyles = (props: IDocumentCardPreviewStyleProps): IDocumentCardPreviewStyles => {
   const { theme, className, isFileList } = props;
-  const { palette } = theme;
+  const { palette, fonts } = theme;
 
   const classNames = getGlobalClassNames(DocumentCardPreviewGlobalClassNames, theme);
 
   return {
     root: [
       classNames.root,
+      fonts.small,
       {
         borderBottom: `1px solid ${palette.neutralLight}`,
         position: 'relative',
@@ -57,7 +58,6 @@ export const getStyles = (props: IDocumentCardPreviewStyleProps): IDocumentCardP
           whiteSpace: 'nowrap'
         },
         a: {
-          fontSize: FontSizes.small,
           textDecoration: 'none',
           color: palette.neutralDark,
           selectors: {
@@ -75,8 +75,7 @@ export const getStyles = (props: IDocumentCardPreviewStyleProps): IDocumentCardP
     },
     fileListOverflowText: {
       padding: '0px 16px 8px 16px',
-      display: 'block',
-      fontSize: FontSizes.small
+      display: 'block'
     }
   };
 };

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
@@ -23,8 +23,13 @@ exports[`DocumentCard renders DocumentCard correctly 1`] = `
     className=
         ms-DocumentCardPreview
         {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
           background-color: #faf9f8;
           border-bottom: 1px solid #edebe9;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
           overflow: hidden;
           position: relative;
         }

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Compact.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Compact.Example.tsx
@@ -69,14 +69,16 @@ export class DocumentCardCompactExample extends React.PureComponent {
     };
 
     const theme = getTheme();
+    const { palette, fonts } = theme;
+
     const previewPropsUsingIcon: IDocumentCardPreviewProps = {
       previewImages: [
         {
-          previewIconProps: { iconName: 'OpenFile', styles: { root: { fontSize: 42, color: theme.palette.white } } },
+          previewIconProps: { iconName: 'OpenFile', styles: { root: { fontSize: fonts.superLarge.fontSize, color: palette.white } } },
           width: 144
         }
       ],
-      styles: { previewIcon: { backgroundColor: theme.palette.themePrimary } }
+      styles: { previewIcon: { backgroundColor: palette.themePrimary } }
     };
 
     const previewOutlookUsingIcon: IDocumentCardPreviewProps = {
@@ -86,9 +88,9 @@ export class DocumentCardCompactExample extends React.PureComponent {
             iconName: 'OutlookLogo',
             styles: {
               root: {
-                fontSize: 42,
+                fontSize: fonts.superLarge.fontSize,
                 color: '#0078d7',
-                backgroundColor: theme.palette.neutralLighterAlt
+                backgroundColor: palette.neutralLighterAlt
               }
             }
           },
@@ -96,7 +98,7 @@ export class DocumentCardCompactExample extends React.PureComponent {
         }
       ],
       styles: {
-        previewIcon: { backgroundColor: theme.palette.neutralLighterAlt }
+        previewIcon: { backgroundColor: palette.neutralLighterAlt }
       }
     };
 

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -2,7 +2,6 @@ import { IDropdownStyles, IDropdownStyleProps } from './Dropdown.types';
 import { IStyleFunction, IsFocusVisibleClassName } from '../../Utilities';
 import { RectangleEdge } from '../../utilities/positioning';
 import {
-  FontSizes,
   FontWeights,
   HighContrastSelector,
   IRawStyle,
@@ -87,7 +86,7 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
   }
 
   const globalClassnames = getGlobalClassNames(GlobalClassNames, theme);
-  const { palette, semanticColors, effects } = theme;
+  const { palette, semanticColors, effects, fonts } = theme;
 
   const rootHoverFocusActiveSelectorNeutralDarkMixin: IStyle = {
     color: semanticColors.menuItemTextHovered
@@ -294,7 +293,7 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
     ],
     caretDown: [
       globalClassnames.caretDown,
-      { color: palette.neutralSecondary, fontSize: FontSizes.small, pointerEvents: 'none' },
+      { color: palette.neutralSecondary, fontSize: fonts.small.fontSize, pointerEvents: 'none' },
       disabled && { color: semanticColors.disabledText, selectors: { [HighContrastSelector]: { color: 'GrayText' } } }
     ],
     errorMessage: { color: semanticColors.errorText, ...theme.fonts.small, paddingTop: 5 },
@@ -333,7 +332,7 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
     dropdownItemHeader: [
       globalClassnames.dropdownItemHeader,
       {
-        ...theme.fonts.medium,
+        ...fonts.medium,
         fontWeight: FontWeights.semibold,
         color: semanticColors.menuHeader,
         background: 'none',

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -183,8 +183,8 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
     dropdown: [
       globalClassnames.dropdown,
       normalize,
+      fonts.medium,
       {
-        ...theme.fonts.medium,
         color: palette.neutralPrimary,
         borderColor: palette.neutralSecondary,
         position: 'relative',

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.styles.ts
@@ -34,7 +34,7 @@ export const getStyles = (props: IGroupHeaderStyleProps): IGroupHeaderStyles => 
   const { cellLeftPadding } = DEFAULT_CELL_STYLE_PROPS; // padding from the source to align GroupHeader title with DetailsRow's first cell.
   const finalRowHeight = compact ? COMPACT_GROUP_HEADER_HEIGHT : DEFAULT_GROUP_HEADER_HEIGHT;
 
-  const { semanticColors, palette } = theme;
+  const { semanticColors, palette, fonts } = theme;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme!);
 
@@ -146,7 +146,7 @@ export const getStyles = (props: IGroupHeaderStyleProps): IGroupHeaderStyles => 
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        fontSize: 12, // TODO: after reconciling the fluent type ramp we need to change this to use theme values.
+        fontSize: fonts.small.fontSize,
         width: EXPAND_BUTTON_WIDTH,
         height: finalRowHeight,
         color: selected ? palette.neutralPrimary : palette.neutralSecondary,
@@ -180,7 +180,7 @@ export const getStyles = (props: IGroupHeaderStyleProps): IGroupHeaderStyles => 
       classNames.title,
       {
         paddingLeft: cellLeftPadding,
-        fontSize: compact ? 14 : 16, // TODO: after reconciling the fluent type ramp we need to change this to use theme values.
+        fontSize: compact ? fonts.medium.fontSize : fonts.mediumPlus.fontSize,
         fontWeight: isCollapsed ? FontWeights.regular : FontWeights.semibold,
         cursor: 'pointer',
         outline: 0,

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupShowAll.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupShowAll.styles.ts
@@ -1,5 +1,5 @@
 import { IGroupShowAllProps, IGroupShowAllStyleProps, IGroupShowAllStyles } from './GroupShowAll.types';
-import { getGlobalClassNames, FontSizes } from '../../Styling';
+import { getGlobalClassNames } from '../../Styling';
 
 export { IGroupShowAllProps };
 
@@ -10,19 +10,20 @@ const GlobalClassNames = {
 
 export const getStyles = (props: IGroupShowAllStyleProps): IGroupShowAllStyles => {
   const { theme } = props;
+  const { fonts } = theme;
+
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
   return {
     root: [
       classNames.root,
-      theme.fonts.medium,
       {
         position: 'relative',
         padding: '10px 84px',
         cursor: 'pointer',
         selectors: {
           [`.${classNames.link}`]: {
-            fontSize: FontSizes.small
+            fontSize: fonts.small.fontSize
           }
         }
       }

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.styles.ts
@@ -1,5 +1,5 @@
 import { IGroupedListStyleProps, IGroupedListStyles } from './GroupedList.types';
-import { getGlobalClassNames, FontSizes, AnimationVariables } from '../../Styling';
+import { getGlobalClassNames, AnimationVariables } from '../../Styling';
 
 const GlobalClassNames = {
   root: 'ms-GroupedList',
@@ -21,10 +21,9 @@ export const getStyles = (props: IGroupedListStyleProps): IGroupedListStyles => 
   return {
     root: [
       classNames.root,
-      theme.fonts.medium,
+      theme.fonts.small,
       {
         position: 'relative',
-        fontSize: FontSizes.small,
         selectors: {
           [`.${classNames.listCell}`]: {
             minHeight: 38 // be consistent with DetailsList styles
@@ -49,10 +48,8 @@ export const getStyles = (props: IGroupedListStyleProps): IGroupedListStyles => 
         transition: `background-color ${AnimationVariables.durationValue2} ${beziers.easeInOutSine}`
       }
     ],
-    groupIsDropping: [
-      {
-        backgroundColor: palette.neutralLight
-      }
-    ]
+    groupIsDropping: {
+      backgroundColor: palette.neutralLight
+    }
   };
 };

--- a/packages/office-ui-fabric-react/src/components/List/examples/List.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/examples/List.Basic.Example.tsx
@@ -5,7 +5,7 @@ import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { Image, ImageFit } from 'office-ui-fabric-react/lib/Image';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { List } from 'office-ui-fabric-react/lib/List';
-import { ITheme, mergeStyleSets, getTheme, getFocusStyle, DefaultFontStyles, FontSizes } from '@uifabric/styling';
+import { ITheme, mergeStyleSets, getTheme, getFocusStyle, FontSizes } from '@uifabric/styling';
 
 export type IExampleItem = { name: string; thumbnail: string; description: string };
 
@@ -52,7 +52,7 @@ const classNames: IListBasicExampleClassObject = mergeStyleSets({
     flexGrow: 1
   },
   itemName: [
-    DefaultFontStyles.xLarge,
+    theme.fonts.xLarge,
     {
       whiteSpace: 'nowrap',
       overflow: 'hidden',

--- a/packages/office-ui-fabric-react/src/components/List/examples/List.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/examples/List.Basic.Example.tsx
@@ -5,7 +5,7 @@ import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { Image, ImageFit } from 'office-ui-fabric-react/lib/Image';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { List } from 'office-ui-fabric-react/lib/List';
-import { ITheme, mergeStyleSets, getTheme, getFocusStyle, FontSizes } from '@uifabric/styling';
+import { ITheme, mergeStyleSets, getTheme, getFocusStyle } from '@uifabric/styling';
 
 export type IExampleItem = { name: string; thumbnail: string; description: string };
 
@@ -28,6 +28,7 @@ interface IListBasicExampleClassObject {
 }
 
 const theme: ITheme = getTheme();
+const { palette, semanticColors, fonts } = theme;
 
 const classNames: IListBasicExampleClassObject = mergeStyleSets({
   itemCell: [
@@ -36,10 +37,10 @@ const classNames: IListBasicExampleClassObject = mergeStyleSets({
       minHeight: 54,
       padding: 10,
       boxSizing: 'border-box',
-      borderBottom: `1px solid ${theme.semanticColors.bodyDivider}`,
+      borderBottom: `1px solid ${semanticColors.bodyDivider}`,
       display: 'flex',
       selectors: {
-        '&:hover': { background: theme.palette.neutralLight }
+        '&:hover': { background: palette.neutralLight }
       }
     }
   ],
@@ -52,7 +53,7 @@ const classNames: IListBasicExampleClassObject = mergeStyleSets({
     flexGrow: 1
   },
   itemName: [
-    theme.fonts.xLarge,
+    fonts.xLarge,
     {
       whiteSpace: 'nowrap',
       overflow: 'hidden',
@@ -60,15 +61,15 @@ const classNames: IListBasicExampleClassObject = mergeStyleSets({
     }
   ],
   itemIndex: {
-    fontSize: FontSizes.small,
-    color: theme.palette.neutralTertiary,
+    fontSize: fonts.small.fontSize,
+    color: palette.neutralTertiary,
     marginBottom: 10
   },
   chevron: {
     alignSelf: 'center',
     marginLeft: 10,
-    color: theme.palette.neutralTertiary,
-    fontSize: FontSizes.large,
+    color: palette.neutralTertiary,
+    fontSize: fonts.large.fontSize,
     flexShrink: 0
   }
 });

--- a/packages/office-ui-fabric-react/src/components/List/examples/List.Ghosting.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/examples/List.Ghosting.Example.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { FocusZone, FocusZoneDirection } from 'office-ui-fabric-react/lib/FocusZone';
 import { List } from 'office-ui-fabric-react/lib/List';
 import { Image, ImageFit } from 'office-ui-fabric-react/lib/Image';
-import { ITheme, mergeStyleSets, getTheme, DefaultFontStyles, FontSizes, getFocusStyle } from 'office-ui-fabric-react/lib/Styling';
+import { ITheme, mergeStyleSets, getTheme, FontSizes, getFocusStyle } from 'office-ui-fabric-react/lib/Styling';
 
 export type IExampleItem = { name: string; thumbnail: string };
 
@@ -48,7 +48,7 @@ const classNames: IListGhostingExampleClassObject = mergeStyleSets({
     flexGrow: 1
   },
   itemName: [
-    DefaultFontStyles.xLarge,
+    theme.fonts.xLarge,
     {
       whiteSpace: 'nowrap',
       overflow: 'hidden',

--- a/packages/office-ui-fabric-react/src/components/List/examples/List.Ghosting.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/examples/List.Ghosting.Example.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { FocusZone, FocusZoneDirection } from 'office-ui-fabric-react/lib/FocusZone';
 import { List } from 'office-ui-fabric-react/lib/List';
 import { Image, ImageFit } from 'office-ui-fabric-react/lib/Image';
-import { ITheme, mergeStyleSets, getTheme, FontSizes, getFocusStyle } from 'office-ui-fabric-react/lib/Styling';
+import { ITheme, mergeStyleSets, getTheme, getFocusStyle } from 'office-ui-fabric-react/lib/Styling';
 
 export type IExampleItem = { name: string; thumbnail: string };
 
@@ -21,6 +21,8 @@ interface IListGhostingExampleClassObject {
 }
 
 const theme: ITheme = getTheme();
+const { palette, semanticColors, fonts } = theme;
+
 const classNames: IListGhostingExampleClassObject = mergeStyleSets({
   container: {
     overflow: 'auto',
@@ -32,10 +34,10 @@ const classNames: IListGhostingExampleClassObject = mergeStyleSets({
       minHeight: 54,
       padding: 10,
       boxSizing: 'border-box',
-      borderBottom: `1px solid ${theme.semanticColors.bodyDivider}`,
+      borderBottom: `1px solid ${semanticColors.bodyDivider}`,
       display: 'flex',
       selectors: {
-        '&:hover': { background: theme.palette.neutralLight }
+        '&:hover': { background: palette.neutralLight }
       }
     }
   ],
@@ -48,7 +50,7 @@ const classNames: IListGhostingExampleClassObject = mergeStyleSets({
     flexGrow: 1
   },
   itemName: [
-    theme.fonts.xLarge,
+    fonts.xLarge,
     {
       whiteSpace: 'nowrap',
       overflow: 'hidden',
@@ -56,15 +58,15 @@ const classNames: IListGhostingExampleClassObject = mergeStyleSets({
     }
   ],
   itemIndex: {
-    fontSize: FontSizes.small,
-    color: theme.palette.neutralTertiary,
+    fontSize: fonts.small.fontSize,
+    color: palette.neutralTertiary,
     marginBottom: 10
   },
   chevron: {
     alignSelf: 'center',
     marginLeft: 10,
-    color: theme.palette.neutralTertiary,
-    fontSize: FontSizes.large,
+    color: palette.neutralTertiary,
+    fontSize: fonts.large.fontSize,
     flexShrink: 0
   }
 });

--- a/packages/office-ui-fabric-react/src/components/List/examples/List.Grid.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/examples/List.Grid.Example.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { FocusZone } from 'office-ui-fabric-react/lib/FocusZone';
 import { List } from 'office-ui-fabric-react/lib/List';
 import { IRectangle } from 'office-ui-fabric-react/lib/Utilities';
-import { ITheme, FontSizes, getTheme, mergeStyleSets } from '@uifabric/styling';
+import { ITheme, getTheme, mergeStyleSets } from '@uifabric/styling';
 
 export interface IListGridExampleProps {
   items: any[];
@@ -18,7 +18,8 @@ interface IListGridExampleClassObject {
 }
 
 const theme: ITheme = getTheme();
-const borderColour: string = '1px solid ' + theme.palette.white;
+const { palette, fonts } = theme;
+
 const classNames: IListGridExampleClassObject = mergeStyleSets({
   listGridExample: {
     overflow: 'hidden',
@@ -30,7 +31,7 @@ const classNames: IListGridExampleClassObject = mergeStyleSets({
     outline: 'none',
     position: 'relative',
     float: 'left',
-    background: theme.palette.neutralLighter,
+    background: palette.neutralLighter,
     selectors: {
       'focus:after': {
         content: '',
@@ -40,7 +41,7 @@ const classNames: IListGridExampleClassObject = mergeStyleSets({
         top: 2,
         bottom: 2,
         boxSizing: 'border-box',
-        border: borderColour
+        border: `1px solid ${palette.white}`
       }
     }
   },
@@ -62,7 +63,7 @@ const classNames: IListGridExampleClassObject = mergeStyleSets({
     bottom: 0,
     left: 0,
     width: '100%',
-    fontSize: FontSizes.small,
+    fontSize: fonts.small.fontSize,
     boxSizing: 'border-box'
   },
   listGridExampleImage: {

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
@@ -5,7 +5,8 @@ import {
   HighContrastSelector,
   ScreenWidthMaxSmall,
   getScreenSelector,
-  getGlobalClassNames
+  getGlobalClassNames,
+  IconFontSizes
 } from '../../Styling';
 import { IMessageBarStyleProps, IMessageBarStyles, MessageBarType } from './MessageBar.types';
 
@@ -72,7 +73,7 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
   const dismissalAndExpandIconStyle: IStyle = {
-    fontSize: 10,
+    fontSize: IconFontSizes.xSmall,
     height: 10,
     lineHeight: '10px',
     color: palette.neutralPrimary,
@@ -146,7 +147,7 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
     iconContainer: [
       classNames.iconContainer,
       {
-        fontSize: 16,
+        fontSize: IconFontSizes.medium,
         minWidth: 16,
         minHeight: 16,
         display: 'flex',

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.styles.ts
@@ -26,14 +26,14 @@ export const getStyles = (props: IModalStyleProps): IModalStyles => {
     layerClassName,
     isDefaultDragHandle
   } = props;
-  const { palette, effects } = theme;
+  const { palette, effects, fonts } = theme;
 
   const classNames = getGlobalClassNames(globalClassNames, theme);
 
   return {
     root: [
       classNames.root,
-      theme.fonts.medium,
+      fonts.medium,
       {
         backgroundColor: 'transparent',
         position: isModeless ? 'absolute' : 'fixed',
@@ -111,7 +111,7 @@ export const getStyles = (props: IModalStyleProps): IModalStyles => {
       padding: '3px 0px'
     },
     keyboardMoveIcon: {
-      fontSize: '24px',
+      fontSize: fonts.xLargePlus.fontSize,
       width: '24px'
     }
   };

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.styles.ts
@@ -45,7 +45,7 @@ export const getStyles = (props: INavStyleProps): INavStyles => {
     rightPadding = 20
   } = props;
 
-  const { palette, semanticColors } = theme;
+  const { palette, semanticColors, fonts } = theme;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
@@ -53,7 +53,7 @@ export const getStyles = (props: INavStyleProps): INavStyles => {
     root: [
       classNames.root,
       className,
-      theme.fonts.medium,
+      fonts.medium,
       {
         overflowY: 'auto',
         userSelect: 'none',
@@ -153,7 +153,7 @@ export const getStyles = (props: INavStyleProps): INavStyles => {
     chevronButton: [
       classNames.chevronButton,
       getFocusStyle(theme),
-      theme.fonts.small,
+      fonts.small,
       {
         display: 'block',
         textAlign: 'left',
@@ -182,7 +182,7 @@ export const getStyles = (props: INavStyleProps): INavStyles => {
         }
       },
       isGroup && {
-        fontSize: theme.fonts.large.fontSize,
+        fontSize: fonts.large.fontSize,
         width: '100%',
         height: `${navHeight}px`,
         borderBottom: `1px solid ${semanticColors.bodyDivider}`
@@ -222,7 +222,7 @@ export const getStyles = (props: INavStyleProps): INavStyles => {
         left: '8px',
         height: `${navHeight}px`,
         lineHeight: `${navHeight}px`,
-        fontSize: '12px',
+        fontSize: fonts.small.fontSize,
         transition: 'transform .1s linear'
       },
       isExpanded && {

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.styles.ts
@@ -1,15 +1,6 @@
 import { INavStyleProps, INavStyles } from './Nav.types';
 import { IButtonStyles } from '../../Button';
-import {
-  AnimationClassNames,
-  DefaultFontStyles,
-  getFocusStyle,
-  FontSizes,
-  FontWeights,
-  ZIndexes,
-  getGlobalClassNames,
-  HighContrastSelector
-} from '../../Styling';
+import { AnimationClassNames, getFocusStyle, ZIndexes, getGlobalClassNames, HighContrastSelector } from '../../Styling';
 
 const GlobalClassNames = {
   root: 'ms-Nav',
@@ -162,10 +153,9 @@ export const getStyles = (props: INavStyleProps): INavStyles => {
     chevronButton: [
       classNames.chevronButton,
       getFocusStyle(theme),
+      theme.fonts.small,
       {
         display: 'block',
-        fontWeight: FontWeights.regular,
-        fontSize: FontSizes.small,
         textAlign: 'left',
         lineHeight: `${navHeight}px`,
         margin: '5px 0',
@@ -191,27 +181,23 @@ export const getStyles = (props: INavStyleProps): INavStyles => {
           }
         }
       },
-      isGroup && [
-        {
-          width: '100%',
-          height: `${navHeight}px`,
-          borderBottom: `1px solid ${semanticColors.bodyDivider}`
-        },
-        DefaultFontStyles.large
-      ],
-      isLink && [
-        {
-          display: 'block',
-          width: `${leftPaddingExpanded - 2}px`,
-          height: `${navHeight - 2}px`,
-          position: 'absolute',
-          top: '1px',
-          left: `${position}px`,
-          zIndex: ZIndexes.Nav,
-          padding: 0,
-          margin: 0
-        }
-      ],
+      isGroup && {
+        fontSize: theme.fonts.large.fontSize,
+        width: '100%',
+        height: `${navHeight}px`,
+        borderBottom: `1px solid ${semanticColors.bodyDivider}`
+      },
+      isLink && {
+        display: 'block',
+        width: `${leftPaddingExpanded - 2}px`,
+        height: `${navHeight - 2}px`,
+        position: 'absolute',
+        top: '1px',
+        left: `${position}px`,
+        zIndex: ZIndexes.Nav,
+        padding: 0,
+        margin: 0
+      },
       isSelected && {
         color: palette.themePrimary,
         backgroundColor: palette.neutralLighterAlt,

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -2,7 +2,6 @@ import { IPanelStyleProps, IPanelStyles, PanelType } from './Panel.types';
 import {
   AnimationClassNames,
   AnimationVariables,
-  DefaultFontStyles,
   getGlobalClassNames,
   HighContrastSelector,
   ScreenWidthMinMedium,
@@ -12,7 +11,6 @@ import {
   ScreenWidthMinUhfMobile,
   IStyle
 } from '../../Styling';
-import { FontWeights } from '../../Styling';
 
 // TODO -Issue #5689: Comment in once Button is converted to mergeStyles
 // import { IStyleFunctionOrObject } from '../../Utilities';
@@ -190,7 +188,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
     theme,
     type = PanelType.smallFixedFar
   } = props;
-  const { palette, effects } = theme;
+  const { palette, effects, fonts } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
   const isCustomPanel = type === PanelType.custom || type === PanelType.customNear;
 
@@ -310,11 +308,9 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
     ],
     headerText: [
       classNames.headerText,
-      DefaultFontStyles.xLarge,
+      fonts.xLarge,
       {
         color: palette.neutralPrimary,
-        fontSize: 20, // TODO: after the type ramp gets reevaluated this needs to be changed
-        fontWeight: FontWeights.semibold,
         lineHeight: '27px',
         margin: 0,
         overflowWrap: 'break-word',

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.styles.ts
@@ -1,5 +1,5 @@
 import { IPersonaStyleProps, IPersonaStyles, PersonaPresence, PersonaSize } from './Persona.types';
-import { FontSizes, FontWeights, IStyle, normalize, noWrap, getGlobalClassNames } from '../../Styling';
+import { FontWeights, IStyle, normalize, noWrap, getGlobalClassNames } from '../../Styling';
 import { personaSize, presenceBoolean, sizeBoolean } from './PersonaConsts';
 
 const GlobalClassNames = {
@@ -32,7 +32,7 @@ const GlobalClassNames = {
 export const getStyles = (props: IPersonaStyleProps): IPersonaStyles => {
   const { className, showSecondaryText, theme } = props;
 
-  const { palette } = theme;
+  const { palette, fonts } = theme;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
@@ -44,7 +44,7 @@ export const getStyles = (props: IPersonaStyleProps): IPersonaStyles => {
   const sharedTextStyles: IStyle = {
     color: palette.neutralSecondary,
     fontWeight: FontWeights.regular,
-    fontSize: FontSizes.small
+    fontSize: fonts.small.fontSize
   };
 
   return {
@@ -54,8 +54,6 @@ export const getStyles = (props: IPersonaStyleProps): IPersonaStyles => {
       normalize,
       {
         color: palette.neutralPrimary,
-        fontSize: FontSizes.medium,
-        fontWeight: FontWeights.regular,
         position: 'relative',
         height: personaSize.size48,
         minWidth: personaSize.size48,
@@ -207,7 +205,7 @@ export const getStyles = (props: IPersonaStyleProps): IPersonaStyles => {
       {
         color: palette.neutralPrimary,
         fontWeight: FontWeights.regular,
-        fontSize: FontSizes.medium,
+        fontSize: fonts.medium.fontSize,
         selectors: {
           ':hover': {
             color: palette.neutralDark
@@ -222,7 +220,7 @@ export const getStyles = (props: IPersonaStyleProps): IPersonaStyles => {
       },
 
       (size.isSize8 || size.isSize10) && {
-        fontSize: FontSizes.small,
+        fontSize: fonts.small.fontSize,
         lineHeight: personaSize.size8
       },
 
@@ -236,7 +234,7 @@ export const getStyles = (props: IPersonaStyleProps): IPersonaStyles => {
         },
 
       (size.isSize56 || size.isSize72 || size.isSize100) && {
-        fontSize: 20 // TODO: after type ramp reconcile this needs to be replaced with a FontSize variable.
+        fontSize: fonts.xLarge.fontSize
       },
 
       (size.isSize56 || size.isSize72 || size.isSize100) &&
@@ -267,7 +265,7 @@ export const getStyles = (props: IPersonaStyleProps): IPersonaStyles => {
         },
 
       (size.isSize56 || size.isSize72 || size.isSize100) && {
-        fontSize: FontSizes.medium
+        fontSize: fonts.medium.fontSize
       },
 
       (size.isSize56 || size.isSize72 || size.isSize100) &&
@@ -282,7 +280,7 @@ export const getStyles = (props: IPersonaStyleProps): IPersonaStyles => {
       sharedTextStyles,
       {
         display: 'none',
-        fontSize: FontSizes.medium
+        fontSize: fonts.medium.fontSize
       },
 
       (size.isSize72 || size.isSize100) && {
@@ -296,7 +294,7 @@ export const getStyles = (props: IPersonaStyleProps): IPersonaStyles => {
       sharedTextStyles,
       {
         display: 'none',
-        fontSize: FontSizes.medium
+        fontSize: fonts.medium.fontSize
       },
 
       size.isSize100 && {

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.styles.ts
@@ -1,5 +1,5 @@
 import { IPersonaCoinStyleProps, IPersonaCoinStyles, PersonaSize } from '../Persona.types';
-import { HighContrastSelector, FontSizes, FontWeights, getGlobalClassNames } from '../../../Styling';
+import { HighContrastSelector, FontWeights, getGlobalClassNames } from '../../../Styling';
 import { sizeBoolean, sizeToPixels } from '../PersonaConsts';
 
 const GlobalClassNames = {
@@ -23,7 +23,7 @@ const GlobalClassNames = {
 export const getStyles = (props: IPersonaCoinStyleProps): IPersonaCoinStyles => {
   const { className, theme, coinSize } = props;
 
-  const { palette } = theme;
+  const { palette, fonts } = theme;
 
   const size = sizeBoolean(props.size as PersonaSize);
 
@@ -38,7 +38,7 @@ export const getStyles = (props: IPersonaCoinStyleProps): IPersonaCoinStyles => 
   return {
     coin: [
       classNames.coin,
-      theme.fonts.medium,
+      fonts.medium,
       size.isSize8 && classNames.size8,
       size.isSize10 && classNames.size10,
       size.isSize16 && classNames.size16,
@@ -54,7 +54,7 @@ export const getStyles = (props: IPersonaCoinStyleProps): IPersonaCoinStyles => 
     ],
 
     size10WithoutPresenceIcon: {
-      fontSize: '10px',
+      fontSize: fonts.xSmall.fontSize,
       position: 'absolute',
       top: '5px',
       right: 'auto',
@@ -111,7 +111,7 @@ export const getStyles = (props: IPersonaCoinStyleProps): IPersonaCoinStyles => 
       {
         borderRadius: '50%',
         color: props.showUnknownPersonaCoin ? unknownPersonaFontColor : palette.white,
-        fontSize: FontSizes.large,
+        fontSize: fonts.large.fontSize,
         fontWeight: FontWeights.semibold,
         lineHeight: dimension === 48 ? 46 : dimension, // copying the logic for the dimensions; defaulted to 46 for size48
         height: dimension,
@@ -135,31 +135,31 @@ export const getStyles = (props: IPersonaCoinStyleProps): IPersonaCoinStyles => 
       },
 
       dimension < 32 && {
-        fontSize: FontSizes.mini
+        fontSize: fonts.xSmall.fontSize
       },
 
       dimension >= 32 &&
         dimension < 40 && {
-          fontSize: FontSizes.medium
+          fontSize: fonts.medium.fontSize
         },
 
       dimension >= 40 &&
         dimension < 56 && {
-          fontSize: 16 // TODO needs to replaced after type ramp reconcile
+          fontSize: fonts.mediumPlus.fontSize
         },
 
       dimension >= 56 &&
         dimension < 72 && {
-          fontSize: 20 // TODO needs to replaced after type ramp reconcile
+          fontSize: fonts.xLarge.fontSize
         },
 
       dimension >= 72 &&
         dimension < 100 && {
-          fontSize: FontSizes.xxLarge
+          fontSize: fonts.xxLarge.fontSize
         },
 
       dimension >= 100 && {
-        fontSize: FontSizes.superLarge
+        fontSize: fonts.superLarge.fontSize
       }
     ]
   };

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaPresence/PersonaPresence.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaPresence/PersonaPresence.styles.ts
@@ -1,5 +1,5 @@
 import { IPersonaPresenceStyleProps, IPersonaPresenceStyles, PersonaPresence, PersonaSize } from '../Persona.types';
-import { FontSizes, HighContrastSelector, getGlobalClassNames, IRawStyle } from '../../../Styling';
+import { HighContrastSelector, getGlobalClassNames, IRawStyle } from '../../../Styling';
 import { personaPresenceSize, presenceBoolean, sizeBoolean } from '../PersonaConsts';
 
 const GlobalClassNames = {
@@ -9,7 +9,7 @@ const GlobalClassNames = {
 
 export const getStyles = (props: IPersonaPresenceStyleProps): IPersonaPresenceStyles => {
   const { theme } = props;
-  const { semanticColors } = theme;
+  const { semanticColors, fonts } = theme;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
@@ -184,7 +184,7 @@ export const getStyles = (props: IPersonaPresenceStyleProps): IPersonaPresenceSt
       classNames.presenceIcon,
       {
         color: semanticColors.bodyBackground,
-        fontSize: '6px',
+        fontSize: '6px', // exception case where we don't have an available theme.fonts variable to match it.
         lineHeight: personaPresenceSize.size12,
         verticalAlign: 'top',
 
@@ -196,17 +196,17 @@ export const getStyles = (props: IPersonaPresenceStyleProps): IPersonaPresenceSt
       },
 
       size.isSize56 && {
-        fontSize: '8px',
+        fontSize: '8px', // exception case where we don't have an available theme.fonts variable to match it.
         lineHeight: personaPresenceSize.size16
       },
 
       size.isSize72 && {
-        fontSize: FontSizes.small,
+        fontSize: fonts.small.fontSize,
         lineHeight: personaPresenceSize.size20
       },
 
       size.isSize100 && {
-        fontSize: FontSizes.medium,
+        fontSize: fonts.medium.fontSize,
         lineHeight: personaPresenceSize.size28
       },
 

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.styles.ts
@@ -1,5 +1,5 @@
 import { IPivotStyleProps, IPivotStyles } from './Pivot.types';
-import { AnimationVariables, getGlobalClassNames, HighContrastSelector, IStyle, normalize, FontSizes, FontWeights } from '../../Styling';
+import { AnimationVariables, getGlobalClassNames, HighContrastSelector, IStyle, normalize, FontWeights } from '../../Styling';
 import { IsFocusVisibleClassName } from '../../Utilities';
 
 const globalClassNames = {
@@ -16,13 +16,12 @@ const globalClassNames = {
 
 const linkStyles = (props: IPivotStyleProps): IStyle[] => {
   const { rootIsLarge, rootIsTabs } = props;
-  const { semanticColors } = props.theme;
+  const { semanticColors, fonts } = props.theme;
   return [
+    fonts.medium,
     {
       color: semanticColors.actionLink,
       display: 'inline-block',
-      fontSize: FontSizes.medium,
-      fontWeight: FontWeights.regular,
       lineHeight: 44,
       height: 44,
       marginRight: 8,
@@ -76,7 +75,7 @@ const linkStyles = (props: IPivotStyleProps): IStyle[] => {
       }
     },
     rootIsLarge && {
-      fontSize: FontSizes.large
+      fontSize: fonts.large.fontSize
     },
     rootIsTabs && [
       {
@@ -103,18 +102,16 @@ const linkStyles = (props: IPivotStyleProps): IStyle[] => {
 
 export const getStyles = (props: IPivotStyleProps): IPivotStyles => {
   const { className, rootIsLarge, rootIsTabs, theme } = props;
-  const { semanticColors } = theme;
+  const { semanticColors, fonts } = theme;
 
   const classNames = getGlobalClassNames(globalClassNames, theme);
 
   return {
     root: [
       classNames.root,
-      theme.fonts.medium,
+      fonts.medium,
       normalize,
       {
-        fontSize: FontSizes.medium,
-        fontWeight: FontWeights.regular,
         position: 'relative',
         color: semanticColors.link,
         whiteSpace: 'nowrap'

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.styles.ts
@@ -1,4 +1,4 @@
-import { FontSizes, FontWeights, HighContrastSelector, keyframes, noWrap, getGlobalClassNames, IRawStyle } from '../../Styling';
+import { HighContrastSelector, keyframes, noWrap, getGlobalClassNames, IRawStyle } from '../../Styling';
 import { getRTL } from '../../Utilities';
 import { IProgressIndicatorStyleProps, IProgressIndicatorStyles } from './ProgressIndicator.types';
 
@@ -32,7 +32,7 @@ export const getStyles = (props: IProgressIndicatorStyleProps): IProgressIndicat
   const isRTL = getRTL();
   const { className, indeterminate, theme, barHeight = 2 } = props;
 
-  const { palette, semanticColors } = theme;
+  const { palette, semanticColors, fonts } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
   const marginBetweenText = 8;
@@ -40,21 +40,13 @@ export const getStyles = (props: IProgressIndicatorStyleProps): IProgressIndicat
   const progressTrackColor = palette.neutralLight;
 
   return {
-    root: [
-      classNames.root,
-      theme.fonts.medium,
-      {
-        fontWeight: FontWeights.regular
-      },
-      className
-    ],
+    root: [classNames.root, fonts.medium, className],
 
     itemName: [
       classNames.itemName,
       noWrap,
       {
         color: semanticColors.bodyText,
-        fontSize: FontSizes.medium,
         paddingTop: marginBetweenText / 2,
         lineHeight: textHeight + 2
       }
@@ -64,7 +56,7 @@ export const getStyles = (props: IProgressIndicatorStyleProps): IProgressIndicat
       classNames.itemDescription,
       {
         color: semanticColors.bodySubtext,
-        fontSize: FontSizes.small,
+        fontSize: fonts.small.fontSize,
         lineHeight: textHeight
       }
     ],

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/__snapshots__/ProgressIndicator.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`ProgressIndicator renders ProgressIndicator correctly 1`] = `
         ms-ProgressIndicator-itemName
         {
           color: #323130;
-          font-size: 14px;
           line-height: 20px;
           overflow: hidden;
           padding-top: 4px;
@@ -109,7 +108,6 @@ exports[`ProgressIndicator renders React content 1`] = `
         ms-ProgressIndicator-itemName
         {
           color: #323130;
-          font-size: 14px;
           line-height: 20px;
           overflow: hidden;
           padding-top: 4px;
@@ -205,7 +203,6 @@ exports[`ProgressIndicator renders indeterminate ProgressIndicator correctly 1`]
         ms-ProgressIndicator-itemName
         {
           color: #323130;
-          font-size: 14px;
           line-height: 20px;
           overflow: hidden;
           padding-top: 4px;
@@ -363,7 +360,6 @@ exports[`ProgressIndicator renders with no progress 1`] = `
         ms-ProgressIndicator-itemName
         {
           color: #323130;
-          font-size: 14px;
           line-height: 20px;
           overflow: hidden;
           padding-top: 4px;

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.styles.ts
@@ -32,7 +32,7 @@ const _getDisabledStyles = memoizeFunction(
 
 export const getArrowButtonStyles = memoizeFunction(
   (theme: ITheme, isUpArrow: boolean, customSpecificArrowStyles?: Partial<IButtonStyles>): IButtonStyles => {
-    const { palette, effects, fonts } = theme;
+    const { palette, effects } = theme;
 
     // TODO: after updating the semanticColor slots all this need to be reevaluated.
     const ArrowButtonTextColor = palette.neutralSecondary;

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.styles.ts
@@ -1,9 +1,7 @@
-import { FontSizes, IRawStyle, ITheme, concatStyleSets, HighContrastSelector } from '../../Styling';
-
+import { IRawStyle, ITheme, concatStyleSets, HighContrastSelector, IconFontSizes } from '../../Styling';
 import { IButtonStyles } from '../../Button';
 import { ISpinButtonStyles } from './SpinButton.types';
 import { memoizeFunction } from '../../Utilities';
-import { IconFontSizes } from '../../Styling';
 
 const ARROW_BUTTON_WIDTH = 23;
 const ARROW_BUTTON_ICON_SIZE = 8;
@@ -34,7 +32,7 @@ const _getDisabledStyles = memoizeFunction(
 
 export const getArrowButtonStyles = memoizeFunction(
   (theme: ITheme, isUpArrow: boolean, customSpecificArrowStyles?: Partial<IButtonStyles>): IButtonStyles => {
-    const { palette, effects } = theme;
+    const { palette, effects, fonts } = theme;
 
     // TODO: after updating the semanticColor slots all this need to be reevaluated.
     const ArrowButtonTextColor = palette.neutralSecondary;
@@ -121,7 +119,7 @@ export const getArrowButtonStyles = memoizeFunction(
 
 export const getStyles = memoizeFunction(
   (theme: ITheme, customStyles?: Partial<ISpinButtonStyles>): ISpinButtonStyles => {
-    const { palette, semanticColors, effects } = theme;
+    const { palette, semanticColors, effects, fonts } = theme;
 
     const SpinButtonRootBorderColor = semanticColors.inputBorder;
     const SpinButtonRootBorderColorHovered = semanticColors.inputBorderHovered;
@@ -136,7 +134,7 @@ export const getStyles = memoizeFunction(
     const defaultStyles: ISpinButtonStyles = {
       root: {
         outline: 'none',
-        fontSize: FontSizes.medium,
+        fontSize: fonts.medium.fontSize,
         width: '100%',
         minWidth: 86
       },
@@ -209,7 +207,7 @@ export const getStyles = memoizeFunction(
         borderStyle: 'none',
         flex: 1,
         margin: 0,
-        fontSize: FontSizes.medium,
+        fontSize: fonts.medium.fontSize,
         color: SpinButtonInputTextColor,
         height: '100%',
         padding: '0 8px',

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
@@ -1,5 +1,5 @@
 import { ITeachingBubbleStyleProps, ITeachingBubbleStyles } from './TeachingBubble.types';
-import { AnimationVariables, FontSizes, FontWeights, getGlobalClassNames, GlobalClassNames, IStyle, keyframes } from '../../Styling';
+import { AnimationVariables, FontWeights, getGlobalClassNames, GlobalClassNames, IStyle, keyframes } from '../../Styling';
 
 const globalClassNames = {
   root: 'ms-TeachingBubble',
@@ -88,11 +88,11 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
     theme
   } = props;
   const hasLargeHeadline: boolean = !hasCondensedHeadline && !hasSmallHeadline;
-  const { palette } = theme;
+  const { palette, fonts } = theme;
   const classNames = getGlobalClassNames(globalClassNames, theme);
 
   return {
-    root: [classNames.root, theme.fonts.medium, calloutClassName],
+    root: [classNames.root, fonts.medium, calloutClassName],
     body: [
       classNames.body,
       {
@@ -120,7 +120,7 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
         top: 0,
         borderRadius: 0,
         color: palette.white,
-        fontSize: FontSizes.small,
+        fontSize: fonts.small.fontSize,
         selectors: {
           ':hover': {
             background: palette.themeDarkAlt,
@@ -158,7 +158,7 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
       classNames.header,
       ...headerStyle(classNames, hasCondensedHeadline, hasSmallHeadline),
       (hasCondensedHeadline || hasSmallHeadline) && [
-        theme.fonts.medium,
+        fonts.medium,
         {
           marginRight: 10,
           fontWeight: FontWeights.semibold
@@ -174,7 +174,7 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
       },
       hasLargeHeadline && [
         {
-          fontSize: 20 // TODO: reevaluate after type ramp changes for fluent
+          fontSize: fonts.xLarge.fontSize
         }
       ]
     ],
@@ -198,7 +198,7 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
         whiteSpace: 'nowrap',
         selectors: {
           // TODO: global class name usage should be converted to a button styles function once Button supports JS styling
-          [`.${classNames.buttonLabel}`]: theme.fonts.medium,
+          [`.${classNames.buttonLabel}`]: fonts.medium,
           ':hover': {
             backgroundColor: palette.themeLighter,
             borderColor: palette.themeLighter,
@@ -226,7 +226,7 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
         selectors: {
           // TODO: global class name usage should be converted to a button styles function once Button supports JS styling
           [`.${classNames.buttonLabel}`]: [
-            theme.fonts.medium,
+            fonts.medium,
             {
               color: palette.white
             }
@@ -246,14 +246,14 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
       classNames.subText,
       {
         margin: 0,
-        fontSize: FontSizes.medium,
+        fontSize: fonts.medium.fontSize,
         color: palette.white,
         fontWeight: FontWeights.semilight
       }
     ],
     subComponentStyles: {
       callout: {
-        root: [...rootStyle(isWide), theme.fonts.medium],
+        root: [...rootStyle(isWide), fonts.medium],
         beak: [
           {
             background: palette.themePrimary

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -1,11 +1,11 @@
 import {
   AnimationClassNames,
-  FontSizes,
   getGlobalClassNames,
   HighContrastSelector,
   IStyle,
   normalize,
-  getPlaceholderStyles
+  getPlaceholderStyles,
+  IconFontSizes
 } from '../../Styling';
 import { ILabelStyles, ILabelStyleProps } from '../../Label';
 import { ITextFieldStyleProps, ITextFieldStyles } from './TextField.types';
@@ -32,15 +32,17 @@ const globalClassNames = {
 };
 
 function getLabelStyles(props: ITextFieldStyleProps): IStyleFunctionOrObject<ILabelStyleProps, ILabelStyles> {
-  const { underlined, disabled, focused } = props;
+  const { underlined, disabled, focused, theme } = props;
+  const { palette, fonts } = theme;
+
   return () => ({
     root: [
       underlined &&
         disabled && {
-          color: props.theme.palette.neutralTertiary
+          color: palette.neutralTertiary
         },
       underlined && {
-        fontSize: FontSizes.medium,
+        fontSize: fonts.medium.fontSize,
         marginRight: 8,
         paddingLeft: 12,
         paddingRight: 0,
@@ -77,7 +79,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
     autoAdjustHeight
   } = props;
 
-  const { semanticColors, effects } = theme;
+  const { semanticColors, effects, fonts } = theme;
 
   const classNames = getGlobalClassNames(globalClassNames, theme);
 
@@ -94,7 +96,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
 
   // placeholder style constants
   const placeholderStyles: IStyle = [
-    theme.fonts.medium,
+    fonts.medium,
     {
       color: semanticColors.inputPlaceholderText,
       opacity: 1
@@ -108,7 +110,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
   return {
     root: [
       classNames.root,
-      theme.fonts.medium,
+      fonts.medium,
       required && classNames.required,
       disabled && classNames.disabled,
       focused && classNames.active,
@@ -278,11 +280,10 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
         }
     ],
     field: [
-      theme.fonts.medium,
+      fonts.medium,
       classNames.field,
       normalize,
       {
-        fontSize: FontSizes.medium,
         borderRadius: 0,
         border: 'none',
         background: 'none',
@@ -371,7 +372,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
         bottom: 5,
         right: 8,
         top: 'auto',
-        fontSize: 16,
+        fontSize: IconFontSizes.medium,
         lineHeight: 18
       },
       disabled && {
@@ -382,13 +383,13 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
       classNames.description,
       {
         color: semanticColors.bodySubtext,
-        fontSize: FontSizes.xSmall
+        fontSize: fonts.xSmall.fontSize
       }
     ],
     errorMessage: [
       classNames.errorMessage,
       AnimationClassNames.slideDownIn20,
-      theme.fonts.small,
+      fonts.small,
       {
         color: semanticColors.errorText,
         margin: 0,

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.LazyLoading.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.LazyLoading.Example.tsx.shot
@@ -170,7 +170,6 @@ exports[`Component Examples renders Announced.LazyLoading.Example.tsx correctly 
           ms-ProgressIndicator-itemName
           {
             color: #323130;
-            font-size: 14px;
             line-height: 20px;
             overflow: hidden;
             padding-top: 4px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
@@ -79,7 +79,6 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
               }
               & .ms-ChoiceFieldLabel {
                 display: inline-block;
-                font-size: 14px;
                 padding-left: 26px;
               }
         >
@@ -218,7 +217,6 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
               }
               & .ms-ChoiceFieldLabel {
                 display: inline-block;
-                font-size: 14px;
                 padding-left: 26px;
               }
         >
@@ -356,7 +354,6 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
               }
               & .ms-ChoiceFieldLabel {
                 display: inline-block;
-                font-size: 14px;
                 padding-left: 26px;
               }
         >
@@ -474,7 +471,6 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
               }
               & .ms-ChoiceFieldLabel {
                 display: inline-block;
-                font-size: 14px;
                 padding-left: 26px;
               }
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -79,7 +79,6 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
               }
               & .ms-ChoiceFieldLabel {
                 display: inline-block;
-                font-size: 14px;
                 padding-left: 26px;
               }
         >
@@ -388,7 +387,6 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
               }
               & .ms-ChoiceFieldLabel {
                 display: inline-block;
-                font-size: 14px;
                 padding-left: 26px;
               }
         >
@@ -526,7 +524,6 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
               }
               & .ms-ChoiceFieldLabel {
                 display: inline-block;
-                font-size: 14px;
                 padding-left: 26px;
               }
         >
@@ -644,7 +641,6 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
               }
               & .ms-ChoiceFieldLabel {
                 display: inline-block;
-                font-size: 14px;
                 padding-left: 26px;
               }
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
@@ -84,7 +84,6 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
             }
             & .ms-ChoiceFieldLabel {
               display: inline-block;
-              font-size: 14px;
             }
       >
         <div
@@ -258,7 +257,10 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
               className=
                   ms-ChoiceField-labelWrapper
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     display: block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
                     height: 30px;
@@ -311,7 +313,6 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
             }
             & .ms-ChoiceFieldLabel {
               display: inline-block;
-              font-size: 14px;
             }
       >
         <div
@@ -467,7 +468,10 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
               className=
                   ms-ChoiceField-labelWrapper
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     display: block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
                     height: 30px;
@@ -520,7 +524,6 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
             }
             & .ms-ChoiceFieldLabel {
               display: inline-block;
-              font-size: 14px;
             }
       >
         <div
@@ -671,7 +674,10 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
               className=
                   ms-ChoiceField-labelWrapper
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
                     display: block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
                     height: 30px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
@@ -85,7 +85,6 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
               }
               & .ms-ChoiceFieldLabel {
                 display: inline-block;
-                font-size: 14px;
               }
         >
           <div
@@ -343,7 +342,10 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                 className=
                     ms-ChoiceField-labelWrapper
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
                       display: block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                       font-size: 14px;
                       font-weight: 400;
                       height: 30px;
@@ -396,7 +398,6 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
               }
               & .ms-ChoiceFieldLabel {
                 display: inline-block;
-                font-size: 14px;
               }
         >
           <div
@@ -636,7 +637,10 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                 className=
                     ms-ChoiceField-labelWrapper
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
                       display: block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                       font-size: 14px;
                       font-weight: 400;
                       height: 30px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
@@ -79,7 +79,6 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
               }
               & .ms-ChoiceFieldLabel {
                 display: inline-block;
-                font-size: 14px;
                 padding-left: 26px;
               }
         >
@@ -218,7 +217,6 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
               }
               & .ms-ChoiceFieldLabel {
                 display: inline-block;
-                font-size: 14px;
                 padding-left: 26px;
               }
         >
@@ -356,7 +354,6 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
               }
               & .ms-ChoiceFieldLabel {
                 display: inline-block;
-                font-size: 14px;
                 padding-left: 26px;
               }
         >
@@ -474,7 +471,6 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
               }
               & .ms-ChoiceFieldLabel {
                 display: inline-block;
-                font-size: 14px;
                 padding-left: 26px;
               }
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Basic.Example.tsx.shot
@@ -42,8 +42,13 @@ exports[`Component Examples renders DocumentCard.Basic.Example.tsx correctly 1`]
     className=
         ms-DocumentCardPreview
         {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
           background-color: #faf9f8;
           border-bottom: 1px solid #edebe9;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
           overflow: hidden;
           position: relative;
         }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
@@ -84,8 +84,13 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
       className=
           ms-DocumentCardPreview
           {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
             background-color: #faf9f8;
             border-bottom: 1px solid #edebe9;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
             overflow: hidden;
             position: relative;
           }
@@ -416,8 +421,13 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
       className=
           ms-DocumentCardPreview
           {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
             background-color: #ffffff;
             border-bottom: 1px solid #edebe9;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
             overflow: hidden;
             position: relative;
           }
@@ -449,7 +459,6 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
               }
               & a {
                 color: #201f1e;
-                font-size: 12px;
                 text-decoration: none;
               }
               & a:hover {
@@ -690,7 +699,6 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
 
               {
                 display: block;
-                font-size: 12px;
                 padding-bottom: 8px;
                 padding-left: 16px;
                 padding-right: 16px;
@@ -972,8 +980,13 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
       className=
           ms-DocumentCardPreview
           {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
             background-color: #faf9f8;
             border-bottom: 1px solid #edebe9;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
             overflow: hidden;
             position: relative;
           }
@@ -1288,8 +1301,13 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
       className=
           ms-DocumentCardPreview
           {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
             background-color: #faf9f8;
             border-bottom: 1px solid #edebe9;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
             overflow: hidden;
             position: relative;
           }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
@@ -42,8 +42,13 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
     className=
         ms-DocumentCardPreview
         {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
           background-color: #ffffff;
           border-bottom: 1px solid #edebe9;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
           overflow: hidden;
           position: relative;
         }
@@ -75,7 +80,6 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
             }
             & a {
               color: #201f1e;
-              font-size: 12px;
               text-decoration: none;
             }
             & a:hover {
@@ -316,7 +320,6 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
 
             {
               display: block;
-              font-size: 12px;
               padding-bottom: 8px;
               padding-left: 16px;
               padding-right: 16px;
@@ -332,9 +335,13 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
     className=
         ms-DocumentCardLocation
         {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
           color: #323130;
           display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 12px;
+          font-weight: 400;
           overflow: hidden;
           padding-bottom: 8px;
           padding-left: 16px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
@@ -91,11 +91,14 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                 className=
                     ms-Nav-chevronButton
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       border: none;
                       color: #323130;
                       cursor: pointer;
                       display: block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                       font-size: 12px;
                       font-weight: 400;
                       height: 34px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Nested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Nested.Example.tsx.shot
@@ -86,11 +86,14 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
                 className=
                     ms-Nav-chevronButton
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       border: none;
                       color: #323130;
                       cursor: pointer;
                       display: block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                       font-size: 12px;
                       font-weight: 400;
                       height: 34px;
@@ -326,11 +329,14 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
                 className=
                     ms-Nav-chevronButton
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
                       background-color: transparent;
                       border: none;
                       color: #323130;
                       cursor: pointer;
                       display: block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                       font-size: 12px;
                       font-weight: 400;
                       height: 34px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ProgressIndicator.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ProgressIndicator.Basic.Example.tsx.shot
@@ -17,7 +17,6 @@ exports[`Component Examples renders ProgressIndicator.Basic.Example.tsx correctl
         ms-ProgressIndicator-itemName
         {
           color: #323130;
-          font-size: 14px;
           line-height: 20px;
           overflow: hidden;
           padding-top: 4px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ProgressIndicator.Indeterminate.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ProgressIndicator.Indeterminate.Example.tsx.shot
@@ -17,7 +17,6 @@ exports[`Component Examples renders ProgressIndicator.Indeterminate.Example.tsx 
         ms-ProgressIndicator-itemName
         {
           color: #323130;
-          font-size: 14px;
           line-height: 20px;
           overflow: hidden;
           padding-top: 4px;

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.styles.ts
@@ -15,7 +15,7 @@ const REMOVE_BUTTON_SIZE = 24;
 export function getStyles(props: IPeoplePickerItemSelectedStyleProps): IPeoplePickerItemSelectedStyles {
   const { className, theme, selected, invalid, disabled } = props;
 
-  const { palette, semanticColors } = theme;
+  const { palette, semanticColors, fonts } = theme;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
@@ -57,7 +57,7 @@ export function getStyles(props: IPeoplePickerItemSelectedStyleProps): IPeoplePi
 
   const personaCoinInitialsStyles: IStyle = [
     invalid && {
-      fontSize: 20 // does not exist on the FontSizes type ramp.
+      fontSize: fonts.xLarge.fontSize
     }
   ];
 

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.styles.ts
@@ -1,4 +1,4 @@
-import { getGlobalClassNames, FontSizes, IStyle, hiddenContentStyle } from '../../../Styling';
+import { getGlobalClassNames, IStyle, hiddenContentStyle } from '../../../Styling';
 import { ISuggestionsStyleProps, ISuggestionsStyles } from './Suggestions.types';
 
 const GlobalClassNames = {
@@ -16,7 +16,7 @@ const GlobalClassNames = {
 export function getStyles(props: ISuggestionsStyleProps): ISuggestionsStyles {
   const { className, suggestionsClassName, theme, forceResolveButtonSelected, searchForMoreButtonSelected } = props;
 
-  const { palette } = theme;
+  const { palette, fonts } = theme;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
@@ -32,7 +32,7 @@ export function getStyles(props: ISuggestionsStyleProps): ISuggestionsStyles {
     height: 40,
     textAlign: 'left',
     width: '100%',
-    fontSize: FontSizes.small,
+    fontSize: fonts.small.fontSize,
     selectors: {
       ':hover': {
         backgroundColor: palette.neutralLight,
@@ -42,7 +42,7 @@ export function getStyles(props: ISuggestionsStyleProps): ISuggestionsStyles {
         backgroundColor: palette.themeLight
       },
       '.ms-Button-icon': {
-        fontSize: FontSizes.icon,
+        fontSize: fonts.mediumPlus.fontSize,
         width: 25
       },
       '.ms-Button-label': {
@@ -76,7 +76,7 @@ export function getStyles(props: ISuggestionsStyleProps): ISuggestionsStyles {
       classNames.title,
       {
         padding: '0 12px',
-        fontSize: FontSizes.small,
+        fontSize: fonts.small.fontSize,
         color: palette.themePrimary,
         lineHeight: 40,
         borderBottom: `1px solid ${palette.neutralLight}`
@@ -97,7 +97,7 @@ export function getStyles(props: ISuggestionsStyleProps): ISuggestionsStyles {
       {
         textAlign: 'center',
         color: palette.neutralSecondary,
-        fontSize: FontSizes.small,
+        fontSize: fonts.small.fontSize,
         lineHeight: 30
       }
     ],
@@ -112,7 +112,7 @@ export function getStyles(props: ISuggestionsStyleProps): ISuggestionsStyles {
             textAlign: 'left',
             whiteSpace: 'nowrap',
             lineHeight: 20,
-            fontSize: FontSizes.small
+            fontSize: fonts.small.fontSize
           }
         ],
         circle: {

--- a/packages/office-ui-fabric-react/tslint.json
+++ b/packages/office-ui-fabric-react/tslint.json
@@ -4,6 +4,7 @@
     "deprecation": false,
     "jsx-ban-props": false,
     "no-any": false,
-    "typedef": [false]
+    "typedef": [false],
+    "import-blacklist": [true, { "../../Styling": ["FontSizes"] }]
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ yarn change`

#### Description of changes

Making sure most of the font styles related styling is pulling values from the theme object. All that’s left is `IconFontSizes` and `FontWeights` that are kind of necessary for some overrides.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10027)