### PR TITLE
Publish tsx-editor

### DIFF
--- a/change/@uifabric-tsx-editor-2019-08-02-02-04-48-tsx-fix.json
+++ b/change/@uifabric-tsx-editor-2019-08-02-02-04-48-tsx-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Publish tsx-editor",
+  "packageName": "@uifabric/tsx-editor",
+  "email": "elcraig@microsoft.com",
+  "commit": "e3369223a335f8d0f71b5f18579a2d9704ad4cb0",
+  "date": "2019-08-02T09:04:48.311Z"
+}

--- a/packages/tsx-editor/package.json
+++ b/packages/tsx-editor/package.json
@@ -5,7 +5,6 @@
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
   "typings": "lib/index.d.ts",
-  "private": true,
   "sideEffects": [
     "lib/version.js"
   ],


### PR DESCRIPTION
Now that example-app-base depends on tsx-editor, we have to publish tsx-editor. (beachball feature request for @kenotron -- detect this situation automatically?)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10033)