### PR TITLE
CollapsibleSection:  Ignore left/right keypress from inner text input/textarea

### DIFF
--- a/change/@uifabric-experiments-2019-08-03-17-25-20-collapse-section-focus.json
+++ b/change/@uifabric-experiments-2019-08-03-17-25-20-collapse-section-focus.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Ignore left/right keypress from inner text input/textarea",
+  "packageName": "@uifabric/experiments",
+  "email": "rezha@microsoft.com",
+  "commit": "1bf48c5c0a3e3e9ee566d4f5df2253bbeab0dec9",
+  "date": "2019-08-04T00:25:20.493Z"
+}

--- a/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.state.tsx
+++ b/packages/experiments/src/components/CollapsibleSection/CollapsibleSection.state.tsx
@@ -48,7 +48,16 @@ export const useCollapsibleSectionState: ICollapsibleSectionComponent['state'] =
 
   const _onRootKeyDown = useCallback((ev: React.KeyboardEvent<Element>) => {
     const rootKey = getRTL() ? KeyCodes.right : KeyCodes.left;
-    if (ev.which === rootKey && ev.target !== titleElementRef.current && titleElementRef.current) {
+
+    // If left/right keypress originates from text input or text area inside collapsible section,
+    // ignore the event.
+    if (
+      ev.which === rootKey &&
+      ev.target !== titleElementRef.current &&
+      titleElementRef.current &&
+      !(ev.target instanceof HTMLTextAreaElement) &&
+      !(ev.target instanceof HTMLInputElement && ev.target.type === 'text')
+    ) {
       titleElementRef.current.focus();
       ev.preventDefault();
       ev.stopPropagation();


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10047
- [x] Include a change request file using `$ yarn change`

#### Description of changes

If left/right keypress originates from text input or text area inside collapsible section, ignore the event (i.e. don't move focus to the section title).

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10048)