### PR TITLE
[date-time] fixing animations, fixing IE11

### DIFF
--- a/change/@uifabric-date-time-2019-08-05-12-12-13-lorejoh12-fixingAnimations.json
+++ b/change/@uifabric-date-time-2019-08-05-12-12-13-lorejoh12-fixingAnimations.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fixing broken IE11 by removing findIndex call, fixing the weeklydaypicker not rerendering when passed new initial date",
+  "packageName": "@uifabric/date-time",
+  "email": "jolore@microsoft.com",
+  "commit": "3e3a88e08225630c5e19cf648610ff7f85e5cf1f",
+  "date": "2019-08-05T19:12:13.555Z"
+}

--- a/packages/date-time/src/components/WeeklyDayPicker/WeeklyDayPicker.base.tsx
+++ b/packages/date-time/src/components/WeeklyDayPicker/WeeklyDayPicker.base.tsx
@@ -13,7 +13,7 @@ import {
 } from '../Calendar/Calendar.types';
 import { CalendarDayGrid } from '../CalendarDayGrid/CalendarDayGrid';
 import { ICalendarDayGrid } from '../CalendarDayGrid/CalendarDayGrid.types';
-import { compareDatePart, getStartDateOfWeek, addDays } from '../../utilities/dateMath/DateMath';
+import { compareDatePart, getStartDateOfWeek, addDays, compareDates } from '../../utilities/dateMath/DateMath';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 
 const getClassNames = classNamesFunction<IWeeklyDayPickerStyleProps, IWeeklyDayPickerStyles>();
@@ -73,7 +73,23 @@ export class WeeklyDayPickerBase extends BaseComponent<IWeeklyDayPickerProps, IW
   private _focusOnUpdate: boolean;
   private _initialTouchX: number | undefined;
 
-  constructor(props: IWeeklyDayPickerProps) {
+  public static getDerivedStateFromProps(props: IWeeklyDayPickerProps, state: IWeeklyDayPickerState): IWeeklyDayPickerState {
+    const currentDate = props.initialDate && !isNaN(props.initialDate.getTime()) ? props.initialDate : props.today || new Date();
+
+    if (!compareDates(currentDate, state.selectedDate)) {
+      return {
+        selectedDate: currentDate,
+        navigatedDate: currentDate
+      };
+    }
+
+    return {
+      selectedDate: currentDate,
+      navigatedDate: state.navigatedDate
+    };
+  }
+
+  public constructor(props: IWeeklyDayPickerProps) {
     super(props);
     const currentDate = props.initialDate && !isNaN(props.initialDate.getTime()) ? props.initialDate : props.today || new Date();
 

--- a/packages/date-time/src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Example.scss
+++ b/packages/date-time/src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Example.scss
@@ -1,3 +1,7 @@
 .wrapper {
   height: 340px;
 }
+
+.button {
+  margin: 17px 10px 0 0;
+}

--- a/packages/date-time/src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Example.tsx
+++ b/packages/date-time/src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Example.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { WeeklyDayPicker, DateRangeType, DayOfWeek } from '@uifabric/date-time';
+import { WeeklyDayPicker, DateRangeType, DayOfWeek, addDays } from '@uifabric/date-time';
 
 import * as styles from './WeeklyDayPicker.Example.scss';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 
 const DayPickerStrings = {
   months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
@@ -20,7 +21,7 @@ const DayPickerStrings = {
 };
 
 export interface IWeeklyDayPickerInlineExampleState {
-  selectedDate?: Date | null;
+  selectedDate?: Date;
 }
 
 export interface IWeeklyDayPickerInlineExampleProps {
@@ -47,7 +48,7 @@ export class WeeklyDayPickerInlineExample extends React.Component<IWeeklyDayPick
     super(props);
 
     this.state = {
-      selectedDate: null
+      selectedDate: new Date()
     };
 
     this._onSelectDate = this._onSelectDate.bind(this);
@@ -89,7 +90,14 @@ export class WeeklyDayPickerInlineExample extends React.Component<IWeeklyDayPick
           minDate={this.props.minDate}
           maxDate={this.props.maxDate}
           restrictedDates={this.props.restrictedDates}
+          initialDate={this.state.selectedDate}
         />
+        {this.props.showNavigateButtons && (
+          <div>
+            <DefaultButton className={styles.button} onClick={this._goPrevious} text="Previous" />
+            <DefaultButton className={styles.button} onClick={this._goNext} text="Next" />
+          </div>
+        )}
       </div>
     );
   }
@@ -101,4 +109,16 @@ export class WeeklyDayPickerInlineExample extends React.Component<IWeeklyDayPick
       };
     });
   }
+
+  private _goPrevious = () => {
+    if (this.state && this.state.selectedDate) {
+      this._onSelectDate(addDays(this.state.selectedDate, -1));
+    }
+  };
+
+  private _goNext = () => {
+    if (this.state && this.state.selectedDate) {
+      this._onSelectDate(addDays(this.state.selectedDate, 1));
+    }
+  };
 }

--- a/packages/date-time/src/components/pages/WeeklyDayPickerPage.tsx
+++ b/packages/date-time/src/components/pages/WeeklyDayPickerPage.tsx
@@ -26,6 +26,19 @@ export class WeeklyDayPickerPage extends React.Component<{}, {}> {
                 showGoToToday={true}
               />
             </ExampleCard>
+            <ExampleCard
+              title="Inline WeeklyDayPicker with externally controlled date"
+              code={WeeklyDayPickerInlineExampleCode}
+              codepenJS={WeeklyDayPickerInlineExampleCodepen}
+            >
+              <WeeklyDayPickerInlineExample
+                isMonthPickerVisible={false}
+                dateRangeType={DateRangeType.Day}
+                autoNavigateOnSelection={false}
+                showGoToToday={true}
+                showNavigateButtons={true}
+              />
+            </ExampleCard>
           </div>
         }
         propertiesTables={


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- findIndex is not supported in IE11, change to use the findIndex call in uifabric/utilities
   - broken link from previous commit in IE: http://fabricweb.z5.web.core.windows.net/pr-deploy-site/refs/pull/9862/merge/date-time/dist/index.html#/examples/weeklydaypicker (open in IE11, nothing renders)
- arrow navigation in calendar broken by the fake rows added from animations, mark those as non-tabbable and aria-hidden
- weeklydaypicker was not rerendering when initialDate prop changed- fixed by adding computation of state from props, added example to show it working now

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10058)