### PR TITLE
Checkbox: Fix for an accessibility bug where checkbox labels were read at two different locations in Narrator's scan mode

### DIFF
--- a/change/office-ui-fabric-react-2019-08-05-12-11-50-kisiebel-checkbox-accessibility.json
+++ b/change/office-ui-fabric-react-2019-08-05-12-11-50-kisiebel-checkbox-accessibility.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Checkbox: Fix for an accessibility bug where checkbox labels were read at two different locations in Narrator's scan mode",
+  "packageName": "office-ui-fabric-react",
+  "email": "kisiebel@microsoft.com",
+  "commit": "7f603fcee030101df5460919af34b01c19ac6421",
+  "date": "2019-08-05T19:11:50.956Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.base.tsx
@@ -116,7 +116,7 @@ export class CheckboxBase extends React.Component<ICheckboxProps, ICheckboxState
               aria-posinset={ariaPositionInSet}
               aria-setsize={ariaSetSize}
             />
-            <label aria-hidden="true" className={this._classNames.label} htmlFor={this._id}>
+            <label className={this._classNames.label} htmlFor={this._id}>
               <div className={this._classNames.checkbox} data-ktp-target={keytipAttributes['data-ktp-target']}>
                 <Icon iconName="CheckMark" {...checkmarkIconProps} className={this._classNames.checkmark} />
               </div>
@@ -172,6 +172,10 @@ export class CheckboxBase extends React.Component<ICheckboxProps, ICheckboxState
   private _onRenderLabel = (props: ICheckboxProps): JSX.Element | null => {
     const { label } = props;
 
-    return label ? <span className={this._classNames.text}>{label}</span> : null;
+    return label ? (
+      <span aria-hidden="true" className={this._classNames.text}>
+        {label}
+      </span>
+    ) : null;
   };
 }

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.base.tsx
@@ -74,7 +74,8 @@ export class CheckboxBase extends React.Component<ICheckboxProps, ICheckboxState
       ariaPositionInSet,
       ariaSetSize,
       keytipProps,
-      title
+      title,
+      label
     } = this.props;
 
     const isChecked = checked === undefined ? this.state.isChecked : checked;
@@ -109,13 +110,13 @@ export class CheckboxBase extends React.Component<ICheckboxProps, ICheckboxState
               onFocus={this._onFocus}
               onBlur={this._onBlur}
               aria-disabled={disabled}
-              aria-label={ariaLabel}
+              aria-label={ariaLabel || label}
               aria-labelledby={ariaLabelledBy}
               aria-describedby={mergeAriaAttributeValues(ariaDescribedBy, keytipAttributes['aria-describedby'])}
               aria-posinset={ariaPositionInSet}
               aria-setsize={ariaSetSize}
             />
-            <label className={this._classNames.label} htmlFor={this._id}>
+            <label aria-hidden="true" className={this._classNames.label} htmlFor={this._id}>
               <div className={this._classNames.checkbox} data-ktp-target={keytipAttributes['data-ktp-target']}>
                 <Icon iconName="CheckMark" {...checkmarkIconProps} className={this._classNames.checkmark} />
               </div>

--- a/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -55,7 +55,6 @@ exports[`Checkbox renders Checkbox correctly 1`] = `
     type="checkbox"
   />
   <label
-    aria-hidden="true"
     className=
         ms-Checkbox-label
         {
@@ -128,6 +127,7 @@ exports[`Checkbox renders Checkbox correctly 1`] = `
       </i>
     </div>
     <span
+      aria-hidden="true"
       className=
           ms-Checkbox-text
           {

--- a/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -33,6 +33,7 @@ exports[`Checkbox renders Checkbox correctly 1`] = `
       }
 >
   <input
+    aria-label="Standard checkbox"
     className=
 
         {
@@ -54,6 +55,7 @@ exports[`Checkbox renders Checkbox correctly 1`] = `
     type="checkbox"
   />
   <label
+    aria-hidden="true"
     className=
         ms-Checkbox-label
         {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
@@ -52,6 +52,7 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
           }
     >
       <input
+        aria-label="Show beak"
         checked={true}
         className=
 
@@ -74,6 +75,7 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
         type="checkbox"
       />
       <label
+        aria-hidden="true"
         className=
             ms-Checkbox-label
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
@@ -75,7 +75,6 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
         type="checkbox"
       />
       <label
-        aria-hidden="true"
         className=
             ms-Checkbox-label
             {
@@ -154,6 +153,7 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
           </i>
         </div>
         <span
+          aria-hidden="true"
           className=
               ms-Checkbox-text
               {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Basic.Example.tsx.shot
@@ -56,7 +56,6 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
       type="checkbox"
     />
     <label
-      aria-hidden="true"
       className=
           ms-Checkbox-label
           {
@@ -129,6 +128,7 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span
+        aria-hidden="true"
         className=
             ms-Checkbox-text
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Basic.Example.tsx.shot
@@ -34,6 +34,7 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
         }
   >
     <input
+      aria-label="Standard checkbox"
       className=
 
           {
@@ -55,6 +56,7 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
       type="checkbox"
     />
     <label
+      aria-hidden="true"
       className=
           ms-Checkbox-label
           {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Other.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Other.Example.tsx.shot
@@ -35,6 +35,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         }
   >
     <input
+      aria-label="Uncontrolled checkbox"
       className=
 
           {
@@ -56,6 +57,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
       type="checkbox"
     />
     <label
+      aria-hidden="true"
       className=
           ms-Checkbox-label
           {
@@ -183,6 +185,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         }
   >
     <input
+      aria-label="Uncontrolled checkbox with defaultChecked true"
       className=
 
           {
@@ -205,6 +208,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
       type="checkbox"
     />
     <label
+      aria-hidden="true"
       className=
           ms-Checkbox-label
           {
@@ -308,6 +312,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
   >
     <input
       aria-disabled={true}
+      aria-label="Disabled uncontrolled checkbox"
       className=
 
           {
@@ -330,6 +335,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
       type="checkbox"
     />
     <label
+      aria-hidden="true"
       className=
           ms-Checkbox-label
           {
@@ -435,6 +441,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
   >
     <input
       aria-disabled={true}
+      aria-label="Disabled uncontrolled checkbox with defaultChecked true"
       className=
 
           {
@@ -458,6 +465,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
       type="checkbox"
     />
     <label
+      aria-hidden="true"
       className=
           ms-Checkbox-label
           {
@@ -584,6 +592,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         }
   >
     <input
+      aria-label="Controlled checkbox"
       checked={false}
       className=
 
@@ -606,6 +615,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
       type="checkbox"
     />
     <label
+      aria-hidden="true"
       className=
           ms-Checkbox-label
           {
@@ -725,6 +735,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         }
   >
     <input
+      aria-label="Checkbox rendered with boxSide \\"end\\" test"
       className=
 
           {
@@ -746,6 +757,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
       type="checkbox"
     />
     <label
+      aria-hidden="true"
       className=
           ms-Checkbox-label
           {
@@ -866,6 +878,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         }
   >
     <input
+      aria-label="Persona Checkbox"
       className=
 
           {
@@ -887,6 +900,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
       type="checkbox"
     />
     <label
+      aria-hidden="true"
       className=
           ms-Checkbox-label
           {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Other.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Other.Example.tsx.shot
@@ -57,7 +57,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
       type="checkbox"
     />
     <label
-      aria-hidden="true"
       className=
           ms-Checkbox-label
           {
@@ -130,6 +129,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span
+        aria-hidden="true"
         className=
             ms-Checkbox-text
             {
@@ -208,7 +208,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
       type="checkbox"
     />
     <label
-      aria-hidden="true"
       className=
           ms-Checkbox-label
           {
@@ -287,6 +286,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span
+        aria-hidden="true"
         className=
             ms-Checkbox-text
             {
@@ -335,7 +335,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
       type="checkbox"
     />
     <label
-      aria-hidden="true"
       className=
           ms-Checkbox-label
           {
@@ -412,6 +411,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span
+        aria-hidden="true"
         className=
             ms-Checkbox-text
             {
@@ -465,7 +465,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
       type="checkbox"
     />
     <label
-      aria-hidden="true"
       className=
           ms-Checkbox-label
           {
@@ -543,6 +542,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span
+        aria-hidden="true"
         className=
             ms-Checkbox-text
             {
@@ -615,7 +615,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
       type="checkbox"
     />
     <label
-      aria-hidden="true"
       className=
           ms-Checkbox-label
           {
@@ -688,6 +687,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span
+        aria-hidden="true"
         className=
             ms-Checkbox-text
             {
@@ -757,7 +757,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
       type="checkbox"
     />
     <label
-      aria-hidden="true"
       className=
           ms-Checkbox-label
           {
@@ -832,6 +831,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span
+        aria-hidden="true"
         className=
             ms-Checkbox-text
             {
@@ -900,7 +900,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
       type="checkbox"
     />
     <label
-      aria-hidden="true"
       className=
           ms-Checkbox-label
           {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
@@ -66,7 +66,6 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
         type="checkbox"
       />
       <label
-        aria-hidden="true"
         className=
             ms-Checkbox-label
             {
@@ -139,6 +138,7 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
           </i>
         </div>
         <span
+          aria-hidden="true"
           className=
               ms-Checkbox-text
               {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
@@ -43,6 +43,7 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
           }
     >
       <input
+        aria-label="Show beak"
         checked={false}
         className=
 
@@ -65,6 +66,7 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
         type="checkbox"
       />
       <label
+        aria-hidden="true"
         className=
             ms-Checkbox-label
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Basic.Example.tsx.shot
@@ -34,6 +34,7 @@ exports[`Component Examples renders Dialog.Basic.Example.tsx correctly 1`] = `
         }
   >
     <input
+      aria-label="Is draggable"
       checked={false}
       className=
 
@@ -56,6 +57,7 @@ exports[`Component Examples renders Dialog.Basic.Example.tsx correctly 1`] = `
       type="checkbox"
     />
     <label
+      aria-hidden="true"
       className=
           ms-Checkbox-label
           {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Basic.Example.tsx.shot
@@ -57,7 +57,6 @@ exports[`Component Examples renders Dialog.Basic.Example.tsx correctly 1`] = `
       type="checkbox"
     />
     <label
-      aria-hidden="true"
       className=
           ms-Checkbox-label
           {
@@ -130,6 +129,7 @@ exports[`Component Examples renders Dialog.Basic.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span
+        aria-hidden="true"
         className=
             ms-Checkbox-text
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Modeless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Modeless.Example.tsx.shot
@@ -64,7 +64,6 @@ exports[`Component Examples renders Dialog.Modeless.Example.tsx correctly 1`] = 
         type="checkbox"
       />
       <label
-        aria-hidden="true"
         className=
             ms-Checkbox-label
             {
@@ -137,6 +136,7 @@ exports[`Component Examples renders Dialog.Modeless.Example.tsx correctly 1`] = 
           </i>
         </div>
         <span
+          aria-hidden="true"
           className=
               ms-Checkbox-text
               {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Modeless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Modeless.Example.tsx.shot
@@ -40,6 +40,7 @@ exports[`Component Examples renders Dialog.Modeless.Example.tsx correctly 1`] = 
     >
       <input
         aria-disabled={false}
+        aria-label="Is draggable"
         checked={false}
         className=
 
@@ -63,6 +64,7 @@ exports[`Component Examples renders Dialog.Modeless.Example.tsx correctly 1`] = 
         type="checkbox"
       />
       <label
+        aria-hidden="true"
         className=
             ms-Checkbox-label
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -1007,7 +1007,6 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
         type="checkbox"
       />
       <label
-        aria-hidden="true"
         className=
             ms-Checkbox-label
             {
@@ -1086,6 +1085,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
           </i>
         </div>
         <span
+          aria-hidden="true"
           className=
               ms-Checkbox-text
               {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -984,6 +984,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
           }
     >
       <input
+        aria-label="Fade In"
         checked={true}
         className=
 
@@ -1006,6 +1007,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
         type="checkbox"
       />
       <label
+        aria-hidden="true"
         className=
             ms-Checkbox-label
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/MarqueeSelection.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/MarqueeSelection.Basic.Example.tsx.shot
@@ -54,6 +54,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
         }
   >
     <input
+      aria-label="Is marquee enabled"
       className=
 
           {
@@ -76,6 +77,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       type="checkbox"
     />
     <label
+      aria-hidden="true"
       className=
           ms-Checkbox-label
           {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/MarqueeSelection.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/MarqueeSelection.Basic.Example.tsx.shot
@@ -77,7 +77,6 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
       type="checkbox"
     />
     <label
-      aria-hidden="true"
       className=
           ms-Checkbox-label
           {
@@ -156,6 +155,7 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
         </i>
       </div>
       <span
+        aria-hidden="true"
         className=
             ms-Checkbox-text
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Basic.Example.tsx.shot
@@ -57,7 +57,6 @@ exports[`Component Examples renders Modal.Basic.Example.tsx correctly 1`] = `
       type="checkbox"
     />
     <label
-      aria-hidden="true"
       className=
           ms-Checkbox-label
           {
@@ -130,6 +129,7 @@ exports[`Component Examples renders Modal.Basic.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span
+        aria-hidden="true"
         className=
             ms-Checkbox-text
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Basic.Example.tsx.shot
@@ -34,6 +34,7 @@ exports[`Component Examples renders Modal.Basic.Example.tsx correctly 1`] = `
         }
   >
     <input
+      aria-label="Is draggable"
       checked={false}
       className=
 
@@ -56,6 +57,7 @@ exports[`Component Examples renders Modal.Basic.Example.tsx correctly 1`] = `
       type="checkbox"
     />
     <label
+      aria-hidden="true"
       className=
           ms-Checkbox-label
           {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Modeless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Modeless.Example.tsx.shot
@@ -35,6 +35,7 @@ exports[`Component Examples renders Modal.Modeless.Example.tsx correctly 1`] = `
   >
     <input
       aria-disabled={false}
+      aria-label="Is draggable"
       checked={false}
       className=
 
@@ -58,6 +59,7 @@ exports[`Component Examples renders Modal.Modeless.Example.tsx correctly 1`] = `
       type="checkbox"
     />
     <label
+      aria-hidden="true"
       className=
           ms-Checkbox-label
           {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Modeless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Modeless.Example.tsx.shot
@@ -59,7 +59,6 @@ exports[`Component Examples renders Modal.Modeless.Example.tsx correctly 1`] = `
       type="checkbox"
     />
     <label
-      aria-hidden="true"
       className=
           ms-Checkbox-label
           {
@@ -132,6 +131,7 @@ exports[`Component Examples renders Modal.Modeless.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span
+        aria-hidden="true"
         className=
             ms-Checkbox-text
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
@@ -345,6 +345,7 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
           }
     >
       <input
+        aria-label="Disable People Picker"
         checked={false}
         className=
 
@@ -367,6 +368,7 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
         type="checkbox"
       />
       <label
+        aria-hidden="true"
         className=
             ms-Checkbox-label
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
@@ -368,7 +368,6 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
         type="checkbox"
       />
       <label
-        aria-hidden="true"
         className=
             ms-Checkbox-label
             {
@@ -441,6 +440,7 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
           </i>
         </div>
         <span
+          aria-hidden="true"
           className=
               ms-Checkbox-text
               {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Basic.Example.tsx.shot
@@ -86,7 +86,6 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
       type="checkbox"
     />
     <label
-      aria-hidden="true"
       className=
           ms-Checkbox-label
           {
@@ -165,6 +164,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         </i>
       </div>
       <span
+        aria-hidden="true"
         className=
             ms-Checkbox-text
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Basic.Example.tsx.shot
@@ -63,6 +63,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         }
   >
     <input
+      aria-label="Include persona details"
       checked={true}
       className=
 
@@ -85,6 +86,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
       type="checkbox"
     />
     <label
+      aria-hidden="true"
       className=
           ms-Checkbox-label
           {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -3380,6 +3380,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
           }
     >
       <input
+        aria-label="Enable caching"
         checked={false}
         className=
 
@@ -3402,6 +3403,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
         type="checkbox"
       />
       <label
+        aria-hidden="true"
         className=
             ms-Checkbox-label
             {
@@ -3519,6 +3521,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
           }
     >
       <input
+        aria-label="Set onGrowData"
         checked={false}
         className=
 
@@ -3541,6 +3544,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
         type="checkbox"
       />
       <label
+        aria-hidden="true"
         className=
             ms-Checkbox-label
             {
@@ -3658,6 +3662,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
           }
     >
       <input
+        aria-label="Buttons checked"
         checked={false}
         className=
 
@@ -3680,6 +3685,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
         type="checkbox"
       />
       <label
+        aria-hidden="true"
         className=
             ms-Checkbox-label
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -3403,7 +3403,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
         type="checkbox"
       />
       <label
-        aria-hidden="true"
         className=
             ms-Checkbox-label
             {
@@ -3476,6 +3475,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
           </i>
         </div>
         <span
+          aria-hidden="true"
           className=
               ms-Checkbox-text
               {
@@ -3544,7 +3544,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
         type="checkbox"
       />
       <label
-        aria-hidden="true"
         className=
             ms-Checkbox-label
             {
@@ -3617,6 +3616,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
           </i>
         </div>
         <span
+          aria-hidden="true"
           className=
               ms-Checkbox-text
               {
@@ -3685,7 +3685,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
         type="checkbox"
       />
       <label
-        aria-hidden="true"
         className=
             ms-Checkbox-label
             {
@@ -3758,6 +3757,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
           </i>
         </div>
         <span
+          aria-hidden="true"
           className=
               ms-Checkbox-text
               {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
@@ -411,7 +411,6 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
               type="checkbox"
             />
             <label
-              aria-hidden="true"
               className=
                   ms-Checkbox-label
                   {
@@ -484,6 +483,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 </i>
               </div>
               <span
+                aria-hidden="true"
                 className=
                     ms-Checkbox-text
                     {
@@ -551,7 +551,6 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
               type="checkbox"
             />
             <label
-              aria-hidden="true"
               className=
                   ms-Checkbox-label
                   {
@@ -624,6 +623,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 </i>
               </div>
               <span
+                aria-hidden="true"
                 className=
                     ms-Checkbox-text
                     {
@@ -751,7 +751,6 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
               type="checkbox"
             />
             <label
-              aria-hidden="true"
               className=
                   ms-Checkbox-label
                   {
@@ -824,6 +823,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 </i>
               </div>
               <span
+                aria-hidden="true"
                 className=
                     ms-Checkbox-text
                     {
@@ -891,7 +891,6 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
               type="checkbox"
             />
             <label
-              aria-hidden="true"
               className=
                   ms-Checkbox-label
                   {
@@ -964,6 +963,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 </i>
               </div>
               <span
+                aria-hidden="true"
                 className=
                     ms-Checkbox-text
                     {
@@ -3474,7 +3474,6 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
           type="checkbox"
         />
         <label
-          aria-hidden="true"
           className=
               ms-Checkbox-label
               {
@@ -3547,6 +3546,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
             </i>
           </div>
           <span
+            aria-hidden="true"
             className=
                 ms-Checkbox-text
                 {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
@@ -389,6 +389,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 }
           >
             <input
+              aria-label="Shadow around items"
               className=
 
                   {
@@ -410,6 +411,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
               type="checkbox"
             />
             <label
+              aria-hidden="true"
               className=
                   ms-Checkbox-label
                   {
@@ -527,6 +529,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 }
           >
             <input
+              aria-label="Prevent item overflow"
               className=
 
                   {
@@ -548,6 +551,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
               type="checkbox"
             />
             <label
+              aria-hidden="true"
               className=
                   ms-Checkbox-label
                   {
@@ -725,6 +729,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 }
           >
             <input
+              aria-label="Wrap items"
               className=
 
                   {
@@ -746,6 +751,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
               type="checkbox"
             />
             <label
+              aria-hidden="true"
               className=
                   ms-Checkbox-label
                   {
@@ -863,6 +869,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 }
           >
             <input
+              aria-label="Shrink items"
               className=
 
                   {
@@ -884,6 +891,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
               type="checkbox"
             />
             <label
+              aria-hidden="true"
               className=
                   ms-Checkbox-label
                   {
@@ -3444,6 +3452,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
             }
       >
         <input
+          aria-label="Hide empty children"
           className=
 
               {
@@ -3465,6 +3474,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
           type="checkbox"
         />
         <label
+          aria-hidden="true"
           className=
               ms-Checkbox-label
               {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
@@ -390,6 +390,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 }
           >
             <input
+              aria-label="Shadow around items"
               className=
 
                   {
@@ -411,6 +412,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
               type="checkbox"
             />
             <label
+              aria-hidden="true"
               className=
                   ms-Checkbox-label
                   {
@@ -529,6 +531,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 }
           >
             <input
+              aria-label="Prevent item overflow"
               className=
 
                   {
@@ -550,6 +553,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
               type="checkbox"
             />
             <label
+              aria-hidden="true"
               className=
                   ms-Checkbox-label
                   {
@@ -668,6 +672,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 }
           >
             <input
+              aria-label="Shrink items"
               className=
 
                   {
@@ -689,6 +694,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
               type="checkbox"
             />
             <label
+              aria-hidden="true"
               className=
                   ms-Checkbox-label
                   {
@@ -806,6 +812,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 }
           >
             <input
+              aria-label="Wrap items"
               className=
 
                   {
@@ -827,6 +834,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
               type="checkbox"
             />
             <label
+              aria-hidden="true"
               className=
                   ms-Checkbox-label
                   {
@@ -1208,6 +1216,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
               }
         >
           <input
+            aria-label="Automatic height (based on items)"
             className=
 
                 {
@@ -1230,6 +1239,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
             type="checkbox"
           />
           <label
+            aria-hidden="true"
             className=
                 ms-Checkbox-label
                 {
@@ -2164,6 +2174,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   }
             >
               <input
+                aria-label="Hide empty children"
                 className=
 
                     {
@@ -2185,6 +2196,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 type="checkbox"
               />
               <label
+                aria-hidden="true"
                 className=
                     ms-Checkbox-label
                     {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
@@ -412,7 +412,6 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
               type="checkbox"
             />
             <label
-              aria-hidden="true"
               className=
                   ms-Checkbox-label
                   {
@@ -485,6 +484,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 </i>
               </div>
               <span
+                aria-hidden="true"
                 className=
                     ms-Checkbox-text
                     {
@@ -553,7 +553,6 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
               type="checkbox"
             />
             <label
-              aria-hidden="true"
               className=
                   ms-Checkbox-label
                   {
@@ -626,6 +625,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 </i>
               </div>
               <span
+                aria-hidden="true"
                 className=
                     ms-Checkbox-text
                     {
@@ -694,7 +694,6 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
               type="checkbox"
             />
             <label
-              aria-hidden="true"
               className=
                   ms-Checkbox-label
                   {
@@ -767,6 +766,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 </i>
               </div>
               <span
+                aria-hidden="true"
                 className=
                     ms-Checkbox-text
                     {
@@ -834,7 +834,6 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
               type="checkbox"
             />
             <label
-              aria-hidden="true"
               className=
                   ms-Checkbox-label
                   {
@@ -907,6 +906,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 </i>
               </div>
               <span
+                aria-hidden="true"
                 className=
                     ms-Checkbox-text
                     {
@@ -1239,7 +1239,6 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
             type="checkbox"
           />
           <label
-            aria-hidden="true"
             className=
                 ms-Checkbox-label
                 {
@@ -1318,6 +1317,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
               </i>
             </div>
             <span
+              aria-hidden="true"
               className=
                   ms-Checkbox-text
                   {
@@ -2196,7 +2196,6 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 type="checkbox"
               />
               <label
-                aria-hidden="true"
                 className=
                     ms-Checkbox-label
                     {
@@ -2269,6 +2268,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   </i>
                 </div>
                 <span
+                  aria-hidden="true"
                   className=
                       ms-Checkbox-text
                       {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -67,7 +67,6 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
       type="checkbox"
     />
     <label
-      aria-hidden="true"
       className=
           ms-Checkbox-label
           {
@@ -140,6 +139,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
         </i>
       </div>
       <span
+        aria-hidden="true"
         className=
             ms-Checkbox-text
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -44,6 +44,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
         }
   >
     <input
+      aria-label="Disable Tag Picker"
       checked={false}
       className=
 
@@ -66,6 +67,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
       type="checkbox"
     />
     <label
+      aria-hidden="true"
       className=
           ms-Checkbox-label
           {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10014
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Fixes an accessibility bug where, when using scan mode in Narrator on Edge, focus would stop twice per checkbox.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10059)