### PR TITLE
OUFR: add custom tslint rule to disallow certain imports from specified modules

### DIFF
--- a/change/office-ui-fabric-react-2019-08-05-22-36-46-vibraga-custom-tslint.json
+++ b/change/office-ui-fabric-react-2019-08-05-22-36-46-vibraga-custom-tslint.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Custom tslint rule to disallow certain imports from specified modules through regex patterns.",
+  "packageName": "office-ui-fabric-react",
+  "email": "vibraga@microsoft.com",
+  "commit": "70a94f596d95fb9a5215c217965714ceca5150c5",
+  "date": "2019-08-06T05:36:46.207Z"
+}

--- a/packages/office-ui-fabric-react/lintCustom/customImportBlacklistRule.js
+++ b/packages/office-ui-fabric-react/lintCustom/customImportBlacklistRule.js
@@ -1,0 +1,161 @@
+'use strict';
+var __extends =
+  (this && this.__extends) ||
+  (function() {
+    var extendStatics = function(d, b) {
+      extendStatics =
+        Object.setPrototypeOf ||
+        ({ __proto__: [] } instanceof Array &&
+          function(d, b) {
+            d.__proto__ = b;
+          }) ||
+        function(d, b) {
+          for (var p in b) if (b.hasOwnProperty(p)) d[p] = b[p];
+        };
+      return extendStatics(d, b);
+    };
+    return function(d, b) {
+      extendStatics(d, b);
+      function __() {
+        this.constructor = d;
+      }
+      d.prototype = b === null ? Object.create(b) : ((__.prototype = b.prototype), new __());
+    };
+  })();
+var __makeTemplateObject =
+  (this && this.__makeTemplateObject) ||
+  function(cooked, raw) {
+    if (Object.defineProperty) {
+      Object.defineProperty(cooked, 'raw', { value: raw });
+    } else {
+      cooked.raw = raw;
+    }
+    return cooked;
+  };
+exports.__esModule = true;
+var Lint = require('tslint');
+var ts = require('typescript');
+var Rule = /** @class */ (function(_super) {
+  __extends(Rule, _super);
+  function Rule() {
+    return (_super !== null && _super.apply(this, arguments)) || this;
+  }
+  Rule.prototype.isEnabled = function() {
+    return _super.prototype.isEnabled.call(this) && this.ruleArguments.length > 0;
+  };
+  Rule.prototype.apply = function(sourceFile) {
+    return this.applyWithWalker(
+      new CustomImportBlacklistWalker(sourceFile, this.ruleName, {
+        modulesWithBannedImports: this.ruleArguments[0].modulesWithBannedImports
+      })
+    );
+  };
+  Rule.metadata = {
+    ruleName: 'custom-import-blacklist',
+    description: 'Disallows imports that were blacklisted from specific modules.',
+    optionsDescription: Lint.Utils.dedent(
+      templateObject_1 ||
+        (templateObject_1 = __makeTemplateObject(
+          [
+            "\n        'modulesWithBannedImports': a list of arrays where in each array the first item is a regex pattern\n        for the module that is imported from and the rest of the elements are regex patterns of the imports\n        to forbid importing from the matched module. If only the module element is provided, then the whole\n        import statement is disallowed."
+          ],
+          [
+            "\n        'modulesWithBannedImports': a list of arrays where in each array the first item is a regex pattern\n        for the module that is imported from and the rest of the elements are regex patterns of the imports\n        to forbid importing from the matched module. If only the module element is provided, then the whole\n        import statement is disallowed."
+          ]
+        ))
+    ),
+    options: {
+      type: 'object',
+      properties: {
+        modulesWithBannedImports: {
+          type: 'array',
+          items: {
+            type: 'array',
+            items: {
+              type: 'string'
+            },
+            minLength: 1
+          },
+          minLength: 1
+        }
+      },
+      additionalProperties: false
+    },
+    optionExamples: [[true, { modulesWithBannedImports: [['lodash', 'pull'], ['lodash', 'pullAll']] }]],
+    type: 'functionality',
+    typescriptOnly: true
+  };
+  Rule.FAILURE_STRING = 'Import statement forbidden';
+  return Rule;
+})(Lint.Rules.AbstractRule);
+exports.Rule = Rule;
+// The walker takes care of all the work.
+var CustomImportBlacklistWalker = /** @class */ (function(_super) {
+  __extends(CustomImportBlacklistWalker, _super);
+  function CustomImportBlacklistWalker() {
+    return (_super !== null && _super.apply(this, arguments)) || this;
+  }
+  CustomImportBlacklistWalker.prototype.walk = function(sourceFile) {
+    var _this = this;
+    // create a failure at the current position
+    var cb = function(node) {
+      if (node.kind === ts.SyntaxKind.ImportDeclaration) {
+        var bannedModuleIndex = _this._bannedModuleIndex(node);
+        if (bannedModuleIndex !== undefined) {
+          var options = _this.options.modulesWithBannedImports;
+          var bannedModule = options && options[bannedModuleIndex];
+          if (bannedModule && bannedModule.length > 1) {
+            var namedBindings = node.importClause && node.importClause.namedBindings;
+            var bannedImportsOfBannedModule = _this._bannedImportsOfBannedModule(namedBindings, bannedModuleIndex);
+            if (bannedImportsOfBannedModule.length) {
+              _this.addFailureAtNode(node, Rule.FAILURE_STRING + ': ' + bannedImportsOfBannedModule.join(', '));
+            }
+          } else {
+            _this.addFailureAtNode(node, Rule.FAILURE_STRING + ' from ' + node.moduleSpecifier.getText() + '.');
+          }
+        }
+      } else {
+        // Continue rescursion: call function `cb` for all children of the current node.
+        return ts.forEachChild(node, cb);
+      }
+    };
+    return ts.forEachChild(sourceFile, cb); // start recursion with children of sourceFile
+  };
+  CustomImportBlacklistWalker.prototype._bannedModuleIndex = function(node) {
+    var options = this.options.modulesWithBannedImports;
+    if (!options) {
+      return;
+    }
+    var nodeText = node.moduleSpecifier.getText();
+    for (var i = 0, l = options.length; i < l; i++) {
+      var option = options[i];
+      if (RegExp(option[0], 'gi').test(nodeText)) {
+        return i;
+      }
+    }
+  };
+  CustomImportBlacklistWalker.prototype._bannedImportsOfBannedModule = function(namedImports, bannedModuleIndex) {
+    var _this = this;
+    var bannedImports = [];
+    namedImports.elements.forEach(function(element) {
+      var importText = element.name.text;
+      if (_this._checkImport(importText, bannedModuleIndex)) {
+        bannedImports.push(importText);
+      }
+    });
+    return bannedImports;
+  };
+  CustomImportBlacklistWalker.prototype._checkImport = function(importText, bannedModuleIndex) {
+    var options = this.options.modulesWithBannedImports;
+    var bannedModule = options[bannedModuleIndex];
+    for (var i = 1, l = bannedModule.length; i < l; i++) {
+      var importPattern = bannedModule[i];
+      if (RegExp(importPattern, 'gi').test(importText)) {
+        return true;
+      }
+    }
+    return false;
+  };
+  return CustomImportBlacklistWalker;
+})(Lint.AbstractWalker);
+var templateObject_1;

--- a/packages/office-ui-fabric-react/lintCustom/customImportBlacklistRule.ts
+++ b/packages/office-ui-fabric-react/lintCustom/customImportBlacklistRule.ts
@@ -33,7 +33,7 @@ export class Rule extends Lint.Rules.AbstractRule {
     },
     optionExamples: [[true, { modulesWithBannedImports: [['lodash', 'pull'], ['lodash', 'pullAll']] }]],
     type: 'functionality',
-    typescriptOnly: true
+    typescriptOnly: false
   };
 
   public static FAILURE_STRING = 'Import statement forbidden';

--- a/packages/office-ui-fabric-react/lintCustom/customImportBlacklistRule.ts
+++ b/packages/office-ui-fabric-react/lintCustom/customImportBlacklistRule.ts
@@ -1,0 +1,129 @@
+import * as Lint from 'tslint';
+import * as ts from 'typescript';
+
+interface ICustomImportBlacklistOptions {
+  modulesWithBannedImports: Array<string[]>;
+}
+
+export class Rule extends Lint.Rules.AbstractRule {
+  public static metadata: Lint.IRuleMetadata = {
+    ruleName: 'custom-import-blacklist',
+    description: 'Disallows imports that were blacklisted from specific modules.',
+    optionsDescription: Lint.Utils.dedent`
+        'modulesWithBannedImports': a list of arrays where in each array the first item is a regex pattern
+        for the module that is imported from and the rest of the elements are regex patterns of the imports
+        to forbid importing from the matched module. If only the module element is provided, then the whole
+        import statement is disallowed.`,
+    options: {
+      type: 'object',
+      properties: {
+        modulesWithBannedImports: {
+          type: 'array',
+          items: {
+            type: 'array',
+            items: {
+              type: 'string'
+            },
+            minLength: 1
+          },
+          minLength: 1
+        }
+      },
+      additionalProperties: false
+    },
+    optionExamples: [[true, { modulesWithBannedImports: [['lodash', 'pull'], ['lodash', 'pullAll']] }]],
+    type: 'functionality',
+    typescriptOnly: true
+  };
+
+  public static FAILURE_STRING = 'Import statement forbidden';
+
+  public isEnabled(): boolean {
+    return super.isEnabled() && this.ruleArguments.length > 0;
+  }
+
+  public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+    return this.applyWithWalker(
+      new CustomImportBlacklistWalker(sourceFile, this.ruleName, {
+        modulesWithBannedImports: this.ruleArguments[0].modulesWithBannedImports
+      })
+    );
+  }
+}
+
+// The walker takes care of all the work.
+class CustomImportBlacklistWalker extends Lint.AbstractWalker<ICustomImportBlacklistOptions> {
+  public walk(sourceFile: ts.SourceFile) {
+    // create a failure at the current position
+    const cb = (node: ts.Node): void => {
+      if (node.kind === ts.SyntaxKind.ImportDeclaration) {
+        const bannedModuleIndex = this._bannedModuleIndex(node as ts.ImportDeclaration);
+
+        if (bannedModuleIndex !== undefined) {
+          const options = this.options.modulesWithBannedImports;
+          const bannedModule = options && options[bannedModuleIndex];
+
+          if (bannedModule && bannedModule.length > 1) {
+            const namedBindings =
+              (node as ts.ImportDeclaration).importClause && ((node as ts.ImportDeclaration).importClause.namedBindings as ts.NamedImports);
+            const bannedImportsOfBannedModule = this._bannedImportsOfBannedModule(namedBindings, bannedModuleIndex);
+
+            if (bannedImportsOfBannedModule.length) {
+              this.addFailureAtNode(node, `${Rule.FAILURE_STRING}: ${bannedImportsOfBannedModule.join(', ')}`);
+            }
+          } else {
+            this.addFailureAtNode(node, `${Rule.FAILURE_STRING} from ${(node as ts.ImportDeclaration).moduleSpecifier.getText()}.`);
+          }
+        }
+      } else {
+        // Continue rescursion: call function `cb` for all children of the current node.
+        return ts.forEachChild(node, cb);
+      }
+    };
+    return ts.forEachChild(sourceFile, cb); // start recursion with children of sourceFile
+  }
+
+  private _bannedModuleIndex(node: ts.ImportDeclaration): number | undefined {
+    const options = this.options.modulesWithBannedImports;
+
+    if (!options) {
+      return;
+    }
+
+    const nodeText = node.moduleSpecifier.getText();
+
+    for (let i = 0, l = options.length; i < l; i++) {
+      const option = options[i];
+      if (RegExp(option[0], 'gi').test(nodeText)) {
+        return i;
+      }
+    }
+  }
+
+  private _bannedImportsOfBannedModule(namedImports: ts.NamedImports, bannedModuleIndex: number): string[] {
+    const bannedImports: string[] = [];
+
+    namedImports.elements.forEach((element: ts.ImportSpecifier) => {
+      const importText = element.name.text;
+      if (this._checkImport(importText, bannedModuleIndex)) {
+        bannedImports.push(importText);
+      }
+    });
+
+    return bannedImports;
+  }
+
+  private _checkImport(importText: string, bannedModuleIndex: number): boolean {
+    const options = this.options.modulesWithBannedImports;
+    const bannedModule = options[bannedModuleIndex];
+
+    for (let i = 1, l = bannedModule.length; i < l; i++) {
+      const importPattern = bannedModule[i];
+      if (RegExp(importPattern, 'gi').test(importText)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+}

--- a/packages/office-ui-fabric-react/tslint.json
+++ b/packages/office-ui-fabric-react/tslint.json
@@ -1,10 +1,16 @@
 {
   "extends": ["@uifabric/tslint-rules"],
+  "rulesDirectory": "lintCustom",
   "rules": {
     "deprecation": false,
     "jsx-ban-props": false,
     "no-any": false,
     "typedef": [false],
-    "import-blacklist": [true, { "../../Styling": ["FontSizes"] }]
+    "custom-import-blacklist": [
+      true,
+      {
+        "modulesWithBannedImports": [[".*styling.*", "^FontSizes$", "DefaultFontStyles"]]
+      }
+    ]
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ yarn change`

#### Description of changes

Adding a custom tslint rule to forbid `FontSizes` and `DefaultFontStyles` directly from Styling package as discussed in [PR 10027 comment](https://github.com/OfficeDev/office-ui-fabric-react/pull/10027#discussion_r310332433). The built-in `import-blacklist` in tslint is not allowing to flag only certain imports from certain modules. With this rule we can now provide regex patterns for module paths along with only certain imports filtered by regex patterns provided.
Also, added to the failure message what specific import is flagged in the entire import declaration because there is no possibility to underline only the banned import and tslint underlines the whole line thus making impossible to tell what import is banned. Here what it looks like:

<img width="764" alt="Screen Shot 2019-08-05 at 22 56 29" src="https://user-images.githubusercontent.com/29514833/62514519-4c25b480-b7d4-11e9-8d2c-b9d788fa5b52.png">


Based on the example of `FontSizes` and the options provided the rule will flag all possible variations of the styling package. (p.s.: I am not an expert in regex patterns so any feedback is welcome)

```tsx
import { FontSizes, DefaultFontStyles } from ‘../../Styling’; // any level deep
import { FontSizes, DefaultFontStyles } from ‘office-ui-fabric-react/lib/Styling’;
import { FontSizes, DefaultFontStyles } from ‘@uifabric/styling’;
```
#### Focus areas to test

Test if there are any false positives flagged by the rule. Regex patterns need to be written correctly for this.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10067)