### PR TITLE
[Shimmer] moving clearTimeout inside diff check

### DIFF
--- a/change/office-ui-fabric-react-2019-08-06-16-08-26-lorejoh12-fixShimmer.json
+++ b/change/office-ui-fabric-react-2019-08-06-16-08-26-lorejoh12-fixShimmer.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "moving the async clearTimeout call inside the if check to prevent accidentally clearing the timeout unless we're going to be making a new one",
+  "packageName": "office-ui-fabric-react",
+  "email": "jolore@microsoft.com",
+  "commit": "3d86fbe7148e6cf4722d12aeb85ae113263efa32",
+  "date": "2019-08-06T23:08:26.938Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.base.tsx
@@ -41,9 +41,9 @@ export class ShimmerBase extends React.Component<IShimmerProps, IShimmerState> {
   public componentDidUpdate(prevProps: IShimmerProps): void {
     const { isDataLoaded } = this.props;
 
-    this._async.clearTimeout(this._lastTimeoutId);
-
     if (isDataLoaded !== prevProps.isDataLoaded) {
+      this._async.clearTimeout(this._lastTimeoutId);
+
       // Removing the shimmerWrapper div from the DOM only after the fade out animation completed.
       if (isDataLoaded) {
         this._lastTimeoutId = this._async.setTimeout(() => {


### PR DESCRIPTION
Moving the clearTimeout async call inside the if check

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10072 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Moves the clearTimeout async call inside the if check to see if the props changed. This prevents the issue where multiple props changing in quick succession cause the timeout to get cleared but never recreated, we only clear when the prop itself changed.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10076)