### PR TITLE
Command Bar: Far items directly into onRenderData

### DIFF
--- a/change/office-ui-fabric-react-2019-08-06-14-40-09-farItems.json
+++ b/change/office-ui-fabric-react-2019-08-06-14-40-09-farItems.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fillin",
+  "comment": "Passing farItems directly to _onRenderData instead of including it in commandBarData. This fixes a bug in Microsoft's BAF version of CommandBar where its searchBox far item would lose characters when the user types fast, except in cases where we force the farItems array to never change. The rationale for fixing this way: Resizing does not affect farItems, so we shouldn't need to supply farItems data to the ResizeGroup, nor to its cacheKey.",
   "packageName": "office-ui-fabric-react",
   "email": "email not defined",
   "commit": "be86439717e210486c5e5dc814c424cbeb0297da",

--- a/change/office-ui-fabric-react-2019-08-06-14-40-09-farItems.json
+++ b/change/office-ui-fabric-react-2019-08-06-14-40-09-farItems.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fillin",
+  "packageName": "office-ui-fabric-react",
+  "email": "email not defined",
+  "commit": "be86439717e210486c5e5dc814c424cbeb0297da",
+  "date": "2019-08-06T21:40:09.748Z"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -21,10 +21,6 @@ export interface ICommandBarData {
    */
   overflowItems: ICommandBarItemProps[];
   /**
-   * Items being rendered on the far side
-   */
-  farItems: ICommandBarItemProps[] | undefined;
-  /**
    * Length of original overflowItems to ensure that they are not moved into primary region on resize
    */
   minimumOverflowItems: number;
@@ -61,7 +57,6 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
       primaryItems: [...items],
       overflowItems: [...overflowItems!],
       minimumOverflowItems: [...overflowItems!].length, // for tracking
-      farItems,
       cacheKey: ''
     };
 
@@ -74,7 +69,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
         data={commandBarData}
         onReduceData={onReduceData}
         onGrowData={onGrowData}
-        onRenderData={this._onRenderData}
+        onRenderData={this._onRenderData(farItems)}
         dataDidRender={dataDidRender}
       />
     );
@@ -90,7 +85,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
     this._resizeGroup.current && this._resizeGroup.current.remeasure();
   }
 
-  private _onRenderData = (data: ICommandBarData): JSX.Element => {
+  private _onRenderData = (farItems: ICommandBarItemProps[] | undefined) => (data: ICommandBarData): JSX.Element => {
     return (
       <FocusZone
         className={css(this._classNames.root)}
@@ -111,12 +106,12 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
         />
 
         {/*Secondary Items*/}
-        {data.farItems && (
+        {farItems && (
           <OverflowSet
             className={css(this._classNames.secondarySet)}
             doNotContainWithinFocusZone={true}
             role={'presentation'}
-            items={data.farItems}
+            items={farItems}
             onRenderItem={this._onRenderItem}
             onRenderOverflowButton={nullRender}
           />
@@ -202,17 +197,16 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
   };
 
   private _computeCacheKey(data: ICommandBarData): string {
-    const { primaryItems, farItems = [], overflowItems } = data;
+    const { primaryItems, overflowItems } = data;
     const returnKey = (acc: string, current: ICommandBarItemProps): string => {
       const { cacheKey = current.key } = current;
       return acc + cacheKey;
     };
 
     const primaryKey = primaryItems.reduce(returnKey, '');
-    const farKey = farItems.reduce(returnKey, '');
     const overflowKey = !!overflowItems.length ? 'overflow' : '';
 
-    return [primaryKey, farKey, overflowKey].join(' ');
+    return [primaryKey, overflowKey].join(' ');
   }
 
   private _onReduceData = (data: ICommandBarData): ICommandBarData | undefined => {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Passing farItems directly to _onRenderData instead of including it in commandBarData.

This fixes a bug in Microsoft's BAF version of CommandBar where its searchBox far item would lose characters when the user types fast, except in cases where we force the farItems array to never change.
(I abandoned a band-aid fix in the following PR, which gives more context:
https://msazure.visualstudio.com/DefaultCollection/One/_git/BusinessApp-Fabric/pullrequest/1920638?_a=overview)

The rationale for fixing this way: Resizing does not affect farItems, so we shouldn't need to supply farItems data to the ResizeGroup, nor to its cacheKey.

#### Focus areas to test

CommandBar with a SearchBox as a far item, where you use both the `value` and `onChange` props of SearchBox to control it.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10077)