### PR TITLE
Make Monaco work cross-domain

### DIFF
--- a/apps/fabric-website/homepage.htm
+++ b/apps/fabric-website/homepage.htm
@@ -34,23 +34,18 @@
   var entryPointFilename = 'fabric-sitev5';
   var appPath = '';
   var Flight = {};
-  // Suffix used on our built JS files. Starts out as .min.js, and if that fails to load,
-  // switches to .js (non-min). This helps us determine whether to load the min or non-min
-  // variants of the Monaco workers.
   var jsSuffix = '.min.js';
 
-  // Determine production or staging/dogfood
   if (location.hostname === 'developer.microsoft.com') {
     isProduction = true;
   } else if (location.hostname === 'developer.microsoft-tst.com') {
     isDogfood = true;
   }
 
-  // If the site is hosted, load the flight config script for production or dogfood
   if (devhost !== null) {
     if (devhost === '') {
       var loc = window.location;
-      devhost =  loc.protocol + '//' + loc.host + loc.pathname.replace('homepage.htm', '');
+      devhost = loc.protocol + '//' + loc.host + loc.pathname.replace('homepage.htm', '');
     }
     appPath = devhost;
     Flight.baseCDNUrl = devhost;
@@ -59,19 +54,16 @@
     // Update as new fabric versions and its documentation are supported
     var fabricVersions = [5, 6, 7];
 
-    // Get fabricVer from URL param, session value, or latest version in array
     var fabricVersion = Number(
       getParameterByName('fabricVer') || window.sessionStorage.getItem('fabricVer') || fabricVersions[fabricVersions.length - 1]
     );
 
-    // Set session value if it's in array
     if (fabricVersions.indexOf(fabricVersion) > -1) {
       window.sessionStorage.setItem('fabricVer', fabricVersion);
     }
 
     var prefixVer =
       fabricVersions.indexOf(fabricVersion) > -1 && fabricVersion !== fabricVersions.slice(-1)[0] ? 'v' + fabricVersion + '-' : '';
-    // If a devhost is provided, override the config app path
 
     var configPrefix = 'fabric-website-' + prefixVer + (isProduction ? 'prod' : 'df');
 
@@ -85,7 +77,6 @@
     });
   }
 
-  // Simple synchronous script loader with callback. Adapted from https://stackoverflow.com/questions/1866717
   function loadScripts(array, callback) {
     var loader = function(src, handler, failHandler) {
       var script = document.createElement('script');
@@ -109,8 +100,6 @@
       if (array.length != 0) {
         const scriptName = array.shift();
         loader(scriptName, run, function() {
-          // Load failures may occur because the min version of the script doesn't exist.
-          // Try loading the non-min version instead.
           jsSuffix = '.js';
           loader(scriptName.replace('.min.js', '.js'), run);
         });
@@ -120,23 +109,22 @@
     })();
   }
 
-  function loadAppScripts() {
-    var version = isLocal ? '.development.js' : '.production.min.js';
-    var reactPath = '//cdnjs.cloudflare.com/ajax/libs/react/16.8.6/umd/react' + version;
-    var reactDomPath = '//cdnjs.cloudflare.com/ajax/libs/react-dom/16.8.6/umd/react-dom' + version;
+  function loadAppScripts(appPath) {
+    var scripts = [appPath + entryPointFilename + '.min.js'];
 
-    var scripts = [reactPath, reactDomPath, appPath + entryPointFilename + jsSuffix];
+    if (!window.React) {
+      // Only needed for Fabric 5 and 6 (7 bundles React)
+      // DO NOT replace 16.3.2 with a newer version!
+      var reactPath = '//cdnjs.cloudflare.com/ajax/libs/react/16.3.2/umd/react.production.min.js';
+      var reactDomPath = '//cdnjs.cloudflare.com/ajax/libs/react-dom/16.3.2/umd/react-dom.production.min.js';
 
-    // Load React and app scripts
+      scripts.unshift(reactDomPath);
+      scripts.unshift(reactPath);
+    }
+
     loadScripts(scripts);
 
-    // Required configuration to make Monaco work
     window.MonacoEnvironment = {
-      // This is needed for cases where the JS files will be on a different domain (the CDN)
-      // instead of the domain the HTML is running on. Web workers (used by Monaco) can't be
-      // loaded by script residing on a different domain, so we use this proxy script on the
-      // main domain to load the worker script. (Also do this with localhost/devhost for testing.)
-      // https://github.com/microsoft/monaco-editor/blob/master/docs/integrate-amd-cross.md
       getWorkerUrl: function(workerId, label) {
         var workerName = label === 'typescript' || label === 'javascript' ? 'ts.worker' : 'editor.worker';
         return (

--- a/apps/fabric-website/homepage.htm
+++ b/apps/fabric-website/homepage.htm
@@ -28,30 +28,21 @@
 </div>
 
 <script type="text/javascript">
-  var isDogfood = false;
-  var isProduction = false;
+  var isProduction = location.hostname === 'developer.microsoft.com';
   var devhost = getParameterByName('devhost');
   var entryPointFilename = 'fabric-sitev5';
   var appPath = '';
   var Flight = {};
   var jsSuffix = '.min.js';
 
-  if (location.hostname === 'developer.microsoft.com') {
-    isProduction = true;
-  } else if (location.hostname === 'developer.microsoft-tst.com') {
-    isDogfood = true;
-  }
-
   if (devhost !== null) {
     if (devhost === '') {
-      var loc = window.location;
-      devhost = loc.protocol + '//' + loc.host + loc.pathname.replace('homepage.htm', '');
+      devhost = location.origin + location.pathname.replace('homepage.htm', '');
     }
     appPath = devhost;
     Flight.baseCDNUrl = devhost;
     loadAppScripts();
   } else {
-    // Update as new fabric versions and its documentation are supported
     var fabricVersions = [5, 6, 7];
 
     var fabricVersion = Number(
@@ -139,7 +130,7 @@
 
   function getParameterByName(name, url) {
     if (!url) {
-      url = window.location.href;
+      url = location.href;
     }
     name = name.replace(/[\[\]]/g, '\\$&');
     var regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)'),

--- a/apps/fabric-website/homepage.htm
+++ b/apps/fabric-website/homepage.htm
@@ -28,49 +28,59 @@
 </div>
 
 <script type="text/javascript">
+  var isDogfood = false;
+  var isProduction = false;
   var devhost = getParameterByName('devhost');
   var entryPointFilename = 'fabric-sitev5';
   var appPath = '';
   var Flight = {};
+  // Suffix used on our built JS files. Starts out as .min.js, and if that fails to load,
+  // switches to .js (non-min). This helps us determine whether to load the min or non-min
+  // variants of the Monaco workers.
+  var jsSuffix = '.min.js';
 
-  // Update as new fabric versions and its documentation are supported
-  var fabricVersions = [5, 6, 7];
-
-  // Get fabricVer from URL param, session value, or latest version in array
-  var fabricVersion = Number(
-    getParameterByName('fabricVer') || window.sessionStorage.getItem('fabricVer') || fabricVersions[fabricVersions.length - 1]
-  );
-
-  // Set session value if it's in array
-  if (fabricVersions.indexOf(fabricVersion) > -1) {
-    window.sessionStorage.setItem('fabricVer', fabricVersion);
+  // Determine production or staging/dogfood
+  if (location.hostname === 'developer.microsoft.com') {
+    isProduction = true;
+  } else if (location.hostname === 'developer.microsoft-tst.com') {
+    isDogfood = true;
   }
 
+  // If the site is hosted, load the flight config script for production or dogfood
   if (devhost !== null) {
     if (devhost === '') {
       var loc = window.location;
-      devhost = loc.protocol + '//' + loc.host + loc.pathname.replace('homepage.htm', '');
+      devhost =  loc.protocol + '//' + loc.host + loc.pathname.replace('homepage.htm', '');
     }
     appPath = devhost;
     Flight.baseCDNUrl = devhost;
-    loadAppScripts(appPath);
+    loadAppScripts();
   } else {
+    // Update as new fabric versions and its documentation are supported
+    var fabricVersions = [5, 6, 7];
+
+    // Get fabricVer from URL param, session value, or latest version in array
+    var fabricVersion = Number(
+      getParameterByName('fabricVer') || window.sessionStorage.getItem('fabricVer') || fabricVersions[fabricVersions.length - 1]
+    );
+
+    // Set session value if it's in array
+    if (fabricVersions.indexOf(fabricVersion) > -1) {
+      window.sessionStorage.setItem('fabricVer', fabricVersion);
+    }
+
     var prefixVer =
       fabricVersions.indexOf(fabricVersion) > -1 && fabricVersion !== fabricVersions.slice(-1)[0] ? 'v' + fabricVersion + '-' : '';
+    // If a devhost is provided, override the config app path
 
-    var configPrefix = 'fabric-website-' + prefixVer + 'df';
-
-    if (location.hostname === 'developer.microsoft.com') {
-      configPrefix = 'fabric-website-' + prefixVer + 'prod';
-    }
+    var configPrefix = 'fabric-website-' + prefixVer + (isProduction ? 'prod' : 'df');
 
     var configScript = ['https://fabricweb.azureedge.net/fabric-website/manifests/' + configPrefix + '.js'];
 
     loadScripts(configScript, function() {
       if (window.Flight) {
-        appPath += window.Flight.baseCDNUrl;
-
-        loadAppScripts(appPath);
+        appPath = window.Flight.baseCDNUrl;
+        loadAppScripts();
       }
     });
   }
@@ -99,6 +109,9 @@
       if (array.length != 0) {
         const scriptName = array.shift();
         loader(scriptName, run, function() {
+          // Load failures may occur because the min version of the script doesn't exist.
+          // Try loading the non-min version instead.
+          jsSuffix = '.js';
           loader(scriptName.replace('.min.js', '.js'), run);
         });
       } else {
@@ -107,23 +120,33 @@
     })();
   }
 
-  function loadAppScripts(appPath) {
-    var scripts = [appPath + entryPointFilename + '.min.js'];
+  function loadAppScripts() {
+    var version = isLocal ? '.development.js' : '.production.min.js';
+    var reactPath = '//cdnjs.cloudflare.com/ajax/libs/react/16.8.6/umd/react' + version;
+    var reactDomPath = '//cdnjs.cloudflare.com/ajax/libs/react-dom/16.8.6/umd/react-dom' + version;
 
-    if (!window.React) {
-      // Only needed for Fabric 5 and 6 (7 bundles React)
-      // DO NOT replace 16.3.2 with a newer version!
-      var reactPath = '//cdnjs.cloudflare.com/ajax/libs/react/16.3.2/umd/react';
-      var reactDomPath = '//cdnjs.cloudflare.com/ajax/libs/react-dom/16.3.2/umd/react-dom';
+    var scripts = [reactPath, reactDomPath, appPath + entryPointFilename + jsSuffix];
 
-      reactPath = reactPath + '.production.min.js';
-      reactDomPath = reactDomPath + '.production.min.js';
-
-      scripts.unshift(reactDomPath);
-      scripts.unshift(reactPath);
-    }
-
+    // Load React and app scripts
     loadScripts(scripts);
+
+    // Required configuration to make Monaco work
+    window.MonacoEnvironment = {
+      // This is needed for cases where the JS files will be on a different domain (the CDN)
+      // instead of the domain the HTML is running on. Web workers (used by Monaco) can't be
+      // loaded by script residing on a different domain, so we use this proxy script on the
+      // main domain to load the worker script. (Also do this with localhost/devhost for testing.)
+      // https://github.com/microsoft/monaco-editor/blob/master/docs/integrate-amd-cross.md
+      getWorkerUrl: function(workerId, label) {
+        var workerName = label === 'typescript' || label === 'javascript' ? 'ts.worker' : 'editor.worker';
+        return (
+          'data:text/javascript;charset=utf-8,' +
+          encodeURIComponent(
+            'self.MonacoEnvironment = { baseUrl: "' + appPath + '" }; ' + 'importScripts("' + appPath + workerName + jsSuffix + '");'
+          )
+        );
+      }
+    };
   }
 
   function getParameterByName(name, url) {

--- a/apps/fabric-website/index.html
+++ b/apps/fabric-website/index.html
@@ -21,58 +21,6 @@
         justify-content: center;
       }
     </style>
-    <!--
-      <script type="text/javascript">
-        var appInsights =
-          window.appInsights ||
-          (function(a) {
-            function b(a) {
-              c[a] = function() {
-                var b = arguments;
-                c.queue.push(function() {
-                  c[a].apply(c, b);
-                });
-              };
-            }
-            var c = { config: a },
-              d = document,
-              e = window;
-            setTimeout(function() {
-              var b = d.createElement('script');
-              (b.src = a.url || 'https://az416426.vo.msecnd.net/scripts/a/ai.0.js'),
-                d.getElementsByTagName('script')[0].parentNode.appendChild(b);
-            });
-            try {
-              c.cookie = d.cookie;
-            } catch (a) {}
-            c.queue = [];
-            for (var f = ['Event', 'Exception', 'Metric', 'PageView', 'Trace', 'Dependency']; f.length; ) b('track' + f.pop());
-            if (
-              (b('setAuthenticatedUserContext'),
-              b('clearAuthenticatedUserContext'),
-              b('startTrackEvent'),
-              b('stopTrackEvent'),
-              b('startTrackPage'),
-              b('stopTrackPage'),
-              b('flush'),
-              !a.disableExceptionTracking)
-            ) {
-              (f = 'onerror'), b('_' + f);
-              var g = e[f];
-              e[f] = function(a, b, d, e, h) {
-                var i = g && g(a, b, d, e, h);
-                return !0 !== i && c['_' + f](a, b, d, e, h), i;
-              };
-            }
-            return c;
-          })({
-            instrumentationKey: '18e07455-6fee-47f7-ab59-8dbf99a31d23'
-          });
-
-        // @TODO: Add custom referrer tracking here. https://stackoverflow.com/questions/5097808/is-document-referrer-cross-browser-compatible
-        (window.appInsights = appInsights), appInsights.queue && 0 === appInsights.queue.length && appInsights.trackPageView();
-      </script>
-    -->
   </head>
 
   <body>
@@ -101,11 +49,15 @@
       var entryPointFilename = 'fabric-sitev5';
       var appPath = '';
       var Flight = {};
+      // Suffix used on our built JS files. Starts out as .min.js, and if that fails to load,
+      // switches to .js (non-min). This helps us determine whether to load the min or non-min
+      // variants of the Monaco workers.
+      var jsSuffix = '.min.js';
 
       // Determine production or staging/dogfood
       if (location.hostname === 'developer.microsoft.com' || productionParam) {
         isProduction = true;
-      } else if (location.hostname === 'uifabric-tst.azurewebsites.net' || dogfoodParam) {
+      } else if (location.hostname === 'developer.microsoft-tst.com' || dogfoodParam) {
         isDogfood = true;
       }
 
@@ -117,7 +69,7 @@
         }
         appPath = devhost;
         Flight.baseCDNUrl = devhost;
-        loadAppScripts(appPath);
+        loadAppScripts();
       } else if (!isLocal) {
         // Update as new fabric versions and its documentation are supported
         var fabricVersions = [5, 6, 7];
@@ -142,13 +94,13 @@
 
         loadScripts(configScript, function() {
           if (window.Flight) {
-            appPath += window.Flight.baseCDNUrl;
-
-            loadAppScripts(appPath);
+            appPath = window.Flight.baseCDNUrl;
+            loadAppScripts();
           }
         });
       } else {
-        loadAppScripts(appPath);
+        appPath = window.location.origin + '/';
+        loadAppScripts();
       }
 
       // Simple synchronous script loader with callback. Adapted from https://stackoverflow.com/questions/1866717
@@ -175,6 +127,9 @@
           if (array.length != 0) {
             const scriptName = array.shift();
             loader(scriptName, run, function() {
+              // Load failures may occur because the min version of the script doesn't exist.
+              // Try loading the non-min version instead.
+              jsSuffix = '.js';
               loader(scriptName.replace('.min.js', '.js'), run);
             });
           } else {
@@ -183,15 +138,33 @@
         })();
       }
 
-      function loadAppScripts(appPath) {
+      function loadAppScripts() {
         var version = isLocal ? '.development.js' : '.production.min.js';
         var reactPath = '//cdnjs.cloudflare.com/ajax/libs/react/16.8.6/umd/react' + version;
         var reactDomPath = '//cdnjs.cloudflare.com/ajax/libs/react-dom/16.8.6/umd/react-dom' + version;
 
-        var scripts = [reactPath, reactDomPath, appPath + entryPointFilename + '.min.js'];
+        var scripts = [reactPath, reactDomPath, appPath + entryPointFilename + jsSuffix];
 
         // Load React and app scripts
         loadScripts(scripts);
+
+        // Required configuration to make Monaco work
+        window.MonacoEnvironment = {
+          // This is needed for cases where the JS files will be on a different domain (the CDN)
+          // instead of the domain the HTML is running on. Web workers (used by Monaco) can't be
+          // loaded by script residing on a different domain, so we use this proxy script on the
+          // main domain to load the worker script. (Also do this with localhost/devhost for testing.)
+          // https://github.com/microsoft/monaco-editor/blob/master/docs/integrate-amd-cross.md
+          getWorkerUrl: function(workerId, label) {
+            var workerName = label === 'typescript' || label === 'javascript' ? 'ts.worker' : 'editor.worker';
+            return (
+              'data:text/javascript;charset=utf-8,' +
+              encodeURIComponent(
+                'self.MonacoEnvironment = { baseUrl: "' + appPath + '" }; importScripts("' + appPath + workerName + jsSuffix + '");'
+              )
+            );
+          }
+        };
       }
 
       function getParameterByName(name, url) {

--- a/apps/fabric-website/index.html
+++ b/apps/fabric-website/index.html
@@ -37,15 +37,9 @@
     </div>
 
     <script type="text/javascript">
-      var isLocal = window.location.hostname === 'localhost' || window.location.hostname.indexOf('ngrok.io') > -1;
-      var isDogfood = false;
-      var isProduction = false;
-
-      // Query params
-      var dogfoodParam = getParameterByName('isDogfood');
-      var productionParam = getParameterByName('isProduction');
+      var isLocal = location.hostname === 'localhost' || location.hostname.indexOf('ngrok.io') > -1;
+      var isProduction = location.hostname === 'developer.microsoft.com' || getParameterByName('isProduction');
       var devhost = getParameterByName('devhost');
-
       var entryPointFilename = 'fabric-sitev5';
       var appPath = '';
       var Flight = {};
@@ -54,18 +48,10 @@
       // variants of the Monaco workers.
       var jsSuffix = '.min.js';
 
-      // Determine production or staging/dogfood
-      if (location.hostname === 'developer.microsoft.com' || productionParam) {
-        isProduction = true;
-      } else if (location.hostname === 'developer.microsoft-tst.com' || dogfoodParam) {
-        isDogfood = true;
-      }
-
       // If the site is hosted, load the flight config script for production or dogfood
       if (devhost !== null) {
         if (devhost === '') {
-          var loc = window.location;
-          devhost = loc.protocol + '//' + loc.host + loc.pathname.replace('index.html', '');
+          devhost = location.origin + location.pathname.replace('homepage.htm', '');
         }
         appPath = devhost;
         Flight.baseCDNUrl = devhost;
@@ -99,7 +85,7 @@
           }
         });
       } else {
-        appPath = window.location.origin + '/';
+        appPath = location.origin + '/';
         loadAppScripts();
       }
 
@@ -169,7 +155,7 @@
 
       function getParameterByName(name, url) {
         if (!url) {
-          url = window.location.href;
+          url = location.href;
         }
         name = name.replace(/[\[\]]/g, '\\$&');
         var regex = new RegExp('[?&]' + name + '(=([^&#]*)|&|#|$)'),

--- a/apps/fabric-website/index.html
+++ b/apps/fabric-website/index.html
@@ -51,7 +51,7 @@
       // If the site is hosted, load the flight config script for production or dogfood
       if (devhost !== null) {
         if (devhost === '') {
-          devhost = location.origin + location.pathname.replace('homepage.htm', '');
+          devhost = location.origin + location.pathname.replace('index.html', '');
         }
         appPath = devhost;
         Flight.baseCDNUrl = devhost;

--- a/apps/fabric-website/jsconfig.json
+++ b/apps/fabric-website/jsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "target": "ES6",
-    "module": "commonjs"
+    "module": "commonjs",
+    "resolveJsonModule": true
   }
 }

--- a/apps/fabric-website/jsconfig.json
+++ b/apps/fabric-website/jsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "target": "ES6",
-    "module": "commonjs",
-    "resolveJsonModule": true
+    "module": "commonjs"
   }
 }

--- a/apps/fabric-website/webpack.config.js
+++ b/apps/fabric-website/webpack.config.js
@@ -5,7 +5,6 @@ module.exports = function(env) {
   const isDogfoodArg = env && !env.production;
   const isProductionArg = env && env.production;
   const now = Date.now();
-  const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
 
   // Production defaults
   let minFileNamePart = '';
@@ -19,25 +18,19 @@ module.exports = function(env) {
     minFileNamePart = '.min';
   }
 
-  return resources.createConfig(
-    entryPointName,
-    isProductionArg,
-    {
+  return (
+    resources.createConfig(entryPointName, isProductionArg, {
       entry: {
-        [entryPointName]: './lib/root.js'
+        [entryPointName]: './lib/root.js',
+        'editor.worker': 'monaco-editor/esm/vs/editor/editor.worker.js',
+        'ts.worker': 'monaco-editor/esm/vs/language/typescript/ts.worker.js'
       },
 
       output: {
         publicPath: publicPath,
+        globalObject: 'self', // required for monaco--see https://github.com/webpack/webpack/issues/6642
         chunkFilename: `${entryPointName}-${version}-[name]-${now}${minFileNamePart}.js`
       },
-
-      plugins: [
-        new MonacoWebpackPlugin({
-          // available options are documented at https://github.com/Microsoft/monaco-editor-webpack-plugin#options
-          languages: ['typescript']
-        })
-      ],
 
       resolve: {
         alias: {
@@ -49,7 +42,7 @@ module.exports = function(env) {
           '@uifabric/api-docs/lib': path.join(__dirname, '../../packages/api-docs/lib')
         }
       }
-    },
-    isProductionArg /* only production */
-  );
+    }),
+    isProductionArg
+  ); /* only production */
 };

--- a/apps/fabric-website/webpack.config.js
+++ b/apps/fabric-website/webpack.config.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 module.exports = function(env) {
   const path = require('path');
   const resources = require('@uifabric/build/webpack/webpack-resources');
@@ -9,7 +11,7 @@ module.exports = function(env) {
   // Production defaults
   let minFileNamePart = '';
   const entryPointName = 'fabric-sitev5';
-  const publicPath = 'https://static2.sharepointonline.com/files/fabric/fabric-website/dist/';
+  let publicPath = 'https://static2.sharepointonline.com/files/fabric/fabric-website/dist/';
 
   // Dogfood overrides
   if (!isProductionArg) {

--- a/apps/fabric-website/webpack.config.js
+++ b/apps/fabric-website/webpack.config.js
@@ -1,15 +1,15 @@
 module.exports = function(env) {
   const path = require('path');
-  const resources = require('../../scripts/webpack/webpack-resources');
+  const resources = require('@uifabric/build/webpack/webpack-resources');
+  const { addMonacoConfig } = require('@uifabric/tsx-editor/scripts/monaco-webpack');
   const version = require('./package.json').version;
-  const isDogfoodArg = env && !env.production;
   const isProductionArg = env && env.production;
   const now = Date.now();
 
   // Production defaults
   let minFileNamePart = '';
-  let entryPointName = 'fabric-sitev5';
-  let publicPath = 'https://static2.sharepointonline.com/files/fabric/fabric-website/dist/';
+  const entryPointName = 'fabric-sitev5';
+  const publicPath = 'https://static2.sharepointonline.com/files/fabric/fabric-website/dist/';
 
   // Dogfood overrides
   if (!isProductionArg) {
@@ -18,8 +18,10 @@ module.exports = function(env) {
     minFileNamePart = '.min';
   }
 
-  return (
-    resources.createConfig(entryPointName, isProductionArg, {
+  return resources.createConfig(
+    entryPointName,
+    isProductionArg,
+    addMonacoConfig({
       entry: {
         [entryPointName]: './lib/root.js',
         'editor.worker': 'monaco-editor/esm/vs/editor/editor.worker.js',
@@ -36,10 +38,10 @@ module.exports = function(env) {
         alias: {
           '@uifabric/fabric-website/src': path.join(__dirname, 'src'),
           '@uifabric/fabric-website/lib': path.join(__dirname, 'lib'),
-          'office-ui-fabric-react$': path.join(__dirname, '../../packages/office-ui-fabric-react/lib'),
-          'office-ui-fabric-react/src': path.join(__dirname, '../../packages/office-ui-fabric-react/src'),
-          'office-ui-fabric-react/lib': path.join(__dirname, '../../packages/office-ui-fabric-react/lib'),
-          '@uifabric/api-docs/lib': path.join(__dirname, '../../packages/api-docs/lib')
+          'office-ui-fabric-react$': path.resolve(__dirname, '../../packages/office-ui-fabric-react/lib'),
+          'office-ui-fabric-react/src': path.resolve(__dirname, '../../packages/office-ui-fabric-react/src'),
+          'office-ui-fabric-react/lib': path.resolve(__dirname, '../../packages/office-ui-fabric-react/lib'),
+          '@uifabric/api-docs/lib': path.resolve(__dirname, '../../packages/api-docs/lib')
         }
       }
     }),

--- a/apps/fabric-website/webpack.config.js
+++ b/apps/fabric-website/webpack.config.js
@@ -4,6 +4,7 @@ module.exports = function(env) {
   const path = require('path');
   const resources = require('@uifabric/build/webpack/webpack-resources');
   const { addMonacoConfig } = require('@uifabric/tsx-editor/scripts/monaco-webpack');
+  // @ts-ignore
   const version = require('./package.json').version;
   const isProductionArg = env && env.production;
   const now = Date.now();
@@ -25,14 +26,11 @@ module.exports = function(env) {
     isProductionArg,
     addMonacoConfig({
       entry: {
-        [entryPointName]: './lib/root.js',
-        'editor.worker': 'monaco-editor/esm/vs/editor/editor.worker.js',
-        'ts.worker': 'monaco-editor/esm/vs/language/typescript/ts.worker.js'
+        [entryPointName]: './lib/root.js'
       },
 
       output: {
         publicPath: publicPath,
-        globalObject: 'self', // required for monaco--see https://github.com/webpack/webpack/issues/6642
         chunkFilename: `${entryPointName}-${version}-[name]-${now}${minFileNamePart}.js`
       },
 
@@ -47,6 +45,6 @@ module.exports = function(env) {
         }
       }
     }),
-    isProductionArg
-  ); /* only production */
+    /* only production */ isProductionArg
+  );
 };

--- a/apps/fabric-website/webpack.serve.config.js
+++ b/apps/fabric-website/webpack.serve.config.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 const path = require('path');
 const resources = require('@uifabric/build/webpack/webpack-resources');
 const { addMonacoConfig } = require('@uifabric/tsx-editor/scripts/monaco-webpack');
@@ -27,7 +29,6 @@ module.exports = resources.createServeConfig(
         'office-ui-fabric-react$': path.resolve(__dirname, '../../packages/office-ui-fabric-react/lib'),
         'office-ui-fabric-react/src': path.resolve(__dirname, '../../packages/office-ui-fabric-react/src'),
         'office-ui-fabric-react/lib': path.resolve(__dirname, '../../packages/office-ui-fabric-react/lib'),
-        '@uifabric/example-app-base$': path.resolve(__dirname, '../../packages/example-app-base/src'),
         'Props.ts.js': 'Props',
         'Example.tsx.js': 'Example'
       }

--- a/apps/fabric-website/webpack.serve.config.js
+++ b/apps/fabric-website/webpack.serve.config.js
@@ -1,36 +1,36 @@
-let path = require('path');
-let resources = require('../../scripts/webpack/webpack-resources');
+const path = require('path');
+const resources = require('@uifabric/build/webpack/webpack-resources');
+const { addMonacoConfig } = require('@uifabric/tsx-editor/scripts/monaco-webpack');
 
-let entryPointName = 'fabric-sitev5';
+const entryPointName = 'fabric-sitev5';
 
-module.exports = resources.createServeConfig({
-  entry: {
-    [entryPointName]: './src/root.tsx',
-    'editor.worker': 'monaco-editor/esm/vs/editor/editor.worker.js',
-    'ts.worker': 'monaco-editor/esm/vs/language/typescript/ts.worker.js'
-  },
+module.exports = resources.createServeConfig(
+  addMonacoConfig({
+    entry: {
+      [entryPointName]: './src/root.tsx'
+    },
 
-  output: {
-    globalObject: 'self', // required for monaco--see https://github.com/webpack/webpack/issues/6642
-    chunkFilename: `${entryPointName}-[name].js`
-  },
+    output: {
+      chunkFilename: `${entryPointName}-[name].js`
+    },
 
-  externals: {
-    react: 'React',
-    'react-dom': 'ReactDOM'
-  },
+    externals: {
+      react: 'React',
+      'react-dom': 'ReactDOM'
+    },
 
-  resolve: {
-    alias: {
-      '@uifabric/fabric-website/src': path.join(__dirname, 'src'),
-      '@uifabric/fabric-website/lib': path.join(__dirname, 'lib'),
-      '@uifabric/example-app-base$': path.resolve(__dirname, '../../packages/example-app-base/src'),
-      'office-ui-fabric-react$': path.join(__dirname, '../../packages/office-ui-fabric-react/lib'),
-      'office-ui-fabric-react/src': path.join(__dirname, '../../packages/office-ui-fabric-react/src'),
-      'office-ui-fabric-react/lib': path.join(__dirname, '../../packages/office-ui-fabric-react/lib'),
-      '@uifabric/example-app-base$': path.join(__dirname, '../../packages/example-app-base/src'),
-      'Props.ts.js': 'Props',
-      'Example.tsx.js': 'Example'
+    resolve: {
+      alias: {
+        '@uifabric/fabric-website/src': path.join(__dirname, 'src'),
+        '@uifabric/fabric-website/lib': path.join(__dirname, 'lib'),
+        '@uifabric/example-app-base$': path.resolve(__dirname, '../../packages/example-app-base/src'),
+        'office-ui-fabric-react$': path.resolve(__dirname, '../../packages/office-ui-fabric-react/lib'),
+        'office-ui-fabric-react/src': path.resolve(__dirname, '../../packages/office-ui-fabric-react/src'),
+        'office-ui-fabric-react/lib': path.resolve(__dirname, '../../packages/office-ui-fabric-react/lib'),
+        '@uifabric/example-app-base$': path.resolve(__dirname, '../../packages/example-app-base/src'),
+        'Props.ts.js': 'Props',
+        'Example.tsx.js': 'Example'
+      }
     }
-  }
-});
+  })
+);

--- a/apps/fabric-website/webpack.serve.config.js
+++ b/apps/fabric-website/webpack.serve.config.js
@@ -1,34 +1,24 @@
 let path = require('path');
 let resources = require('../../scripts/webpack/webpack-resources');
-const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
 
-const devServerConfig = {
-  inline: true,
-  port: 4321
-};
-
-const outputConfig = {
-  filename: 'fabric-sitev5.js'
-};
+let entryPointName = 'fabric-sitev5';
 
 module.exports = resources.createServeConfig({
-  entry: './src/root.tsx',
+  entry: {
+    [entryPointName]: './src/root.tsx',
+    'editor.worker': 'monaco-editor/esm/vs/editor/editor.worker.js',
+    'ts.worker': 'monaco-editor/esm/vs/language/typescript/ts.worker.js'
+  },
 
-  output: outputConfig,
-
-  devServer: devServerConfig,
+  output: {
+    globalObject: 'self', // required for monaco--see https://github.com/webpack/webpack/issues/6642
+    chunkFilename: `${entryPointName}-[name].js`
+  },
 
   externals: {
     react: 'React',
     'react-dom': 'ReactDOM'
   },
-
-  plugins: [
-    new MonacoWebpackPlugin({
-      // available options are documented at https://github.com/Microsoft/monaco-editor-webpack-plugin#options
-      languages: ['typescript']
-    })
-  ],
 
   resolve: {
     alias: {

--- a/change/@uifabric-example-app-base-2019-08-07-13-53-42-editor-webpack.json
+++ b/change/@uifabric-example-app-base-2019-08-07-13-53-42-editor-webpack.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add check for monaco global in example card",
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com",
+  "commit": "b36b034d883fb1e85b9e3da13eb87f281b3262e3",
+  "date": "2019-08-07T20:51:06.452Z"
+}

--- a/change/@uifabric-fabric-website-2019-08-06-18-27-01-editor-webpack.json
+++ b/change/@uifabric-fabric-website-2019-08-06-18-27-01-editor-webpack.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update webpack configs to make Monaco work cross-domain",
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com",
+  "commit": "3e6d5375a58386bc28819855d98c0c1a6b2d790f",
+  "date": "2019-08-07T01:27:01.417Z"
+}

--- a/change/@uifabric-tsx-editor-2019-08-07-13-53-42-editor-webpack.json
+++ b/change/@uifabric-tsx-editor-2019-08-07-13-53-42-editor-webpack.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "add editor config helper",
+  "packageName": "@uifabric/tsx-editor",
+  "email": "elcraig@microsoft.com",
+  "commit": "b36b034d883fb1e85b9e3da13eb87f281b3262e3",
+  "date": "2019-08-07T20:53:42.786Z"
+}

--- a/packages/example-app-base/src/components/ExampleCard/ExampleCard.tsx
+++ b/packages/example-app-base/src/components/ExampleCard/ExampleCard.tsx
@@ -2,7 +2,16 @@ import * as React from 'react';
 import { CommandButton } from 'office-ui-fabric-react/lib/Button';
 import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import { ThemeProvider } from 'office-ui-fabric-react/lib/Foundation';
-import { styled, Customizer, classNamesFunction, css, isIE11, CustomizerContext, warn } from 'office-ui-fabric-react/lib/Utilities';
+import {
+  styled,
+  Customizer,
+  classNamesFunction,
+  css,
+  isIE11,
+  CustomizerContext,
+  warn,
+  getWindow
+} from 'office-ui-fabric-react/lib/Utilities';
 import { ISchemeNames, IProcessedStyleSet } from 'office-ui-fabric-react/lib/Styling';
 import { IStackComponent, Stack } from 'office-ui-fabric-react/lib/Stack';
 import { AppCustomizationsContext, IAppCustomizations, IExampleCardCustomizations } from '../../utilities/customizations';
@@ -18,7 +27,8 @@ import { getSetting } from '../../index2';
 import { Spinner, SpinnerSize } from 'office-ui-fabric-react';
 
 export interface IExampleCardState {
-  isCodeVisible?: boolean; // only used if props.isCodeVisible and props.onToggleEditor are undefined
+  /** only used if props.isCodeVisible and props.onToggleEditor are undefined */
+  isCodeVisible?: boolean;
   schemeIndex: number;
   themeIndex: number;
   error?: string;
@@ -51,8 +61,12 @@ export class ExampleCardBase extends React.Component<IExampleCardProps, IExample
       schemeIndex: 0,
       themeIndex: 0
     };
+    const win = getWindow();
     this.canRenderLiveEditor =
-      getSetting('useEditor') === '1' && !isIE11() && transformExample(props.code!, 'placeholder').error === undefined;
+      !!(win && (win as any).MonacoEnvironment) && // tslint:disable-line:no-any
+      getSetting('useEditor') === '1' &&
+      !isIE11() &&
+      transformExample(props.code!, 'placeholder').error === undefined;
 
     if (this.canRenderLiveEditor) {
       import('office-ui-fabric-react').then(Fabric => {

--- a/packages/tsx-editor/scripts/monaco-webpack.js
+++ b/packages/tsx-editor/scripts/monaco-webpack.js
@@ -1,4 +1,6 @@
-const { merge } = require('@uifabric/build/tasks/merge');
+// @ts-check
+
+const merge = require('@uifabric/build/tasks/merge');
 
 function addMonacoConfig(config) {
   return merge(

--- a/packages/tsx-editor/scripts/monaco-webpack.js
+++ b/packages/tsx-editor/scripts/monaco-webpack.js
@@ -1,0 +1,18 @@
+const { merge } = require('@uifabric/build/tasks/merge');
+
+function addMonacoConfig(config) {
+  return merge(
+    {
+      entry: {
+        'editor.worker': 'monaco-editor/esm/vs/editor/editor.worker.js',
+        'ts.worker': 'monaco-editor/esm/vs/language/typescript/ts.worker.js'
+      },
+      output: {
+        globalObject: 'self' // required for monaco--see https://github.com/webpack/webpack/issues/6642
+      }
+    },
+    config
+  );
+}
+
+module.exports = { addMonacoConfig };

--- a/packages/tsx-editor/webpack.config.js
+++ b/packages/tsx-editor/webpack.config.js
@@ -1,5 +1,5 @@
 const path = require('path');
-const resources = require('../../scripts/webpack/webpack-resources');
+const resources = require('@uifabric/build/webpack/webpack-resources');
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
 
 const BUNDLE_NAME = 'tsx-editor';

--- a/scripts/webpack/webpack-resources.js
+++ b/scripts/webpack/webpack-resources.js
@@ -8,6 +8,12 @@ const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const webpackVersion = require('webpack/package.json').version;
 console.log(`Webpack version: ${webpackVersion}`);
 
+const cssRule = {
+  test: /\.css$/,
+  include: /node_modules/,
+  use: ['style-loader', 'css-loader']
+};
+
 let isValidEnv = false;
 
 function validateEnv() {
@@ -61,22 +67,26 @@ function createEntryWithPolyfill(entry, config) {
 module.exports = {
   webpack,
 
+  /**
+   * @param packageName {string} - name of the package
+   * @param isProduction {boolean} - whether it's a production build
+   * @param customConfig {Partial<webpack.Configuration>} - partial custom webpack config, merged into each full config object
+   * @param [onlyProduction] {boolean} - whether to only generate the production config
+   * @param [excludeSourceMaps] {boolean} - whether to skip generating source maps
+   * @returns {webpack.Configuration[]} array of configs
+   */
   createConfig(packageName, isProduction, customConfig, onlyProduction, excludeSourceMaps) {
     const module = {
       noParse: [/autoit.js/],
       rules: excludeSourceMaps
-        ? []
+        ? [cssRule]
         : [
             {
               test: /\.js$/,
               use: 'source-map-loader',
               enforce: 'pre'
             },
-            {
-              test: /\.css$/,
-              include: /node_modules/,
-              use: ['style-loader', 'css-loader']
-            }
+            cssRule
           ]
     };
 
@@ -147,11 +157,7 @@ module.exports = {
 
         module: {
           rules: [
-            {
-              test: /\.css$/,
-              include: /node_modules/,
-              use: ['style-loader', 'css-loader']
-            },
+            cssRule,
             {
               test: [/\.tsx?$/],
               use: {


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Update the fabric-website webpack configs and index.html to make loading Monaco's workers cross-domain work. Use a similar config on localhost/devhost for testing.

(Note that the real homepage.htm will need to be updated too before this will work on the live site.)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10081)