### PR TITLE
6.0

### DIFF
--- a/common/changes/office-ui-fabric-react/6.0_2019-08-07-10-27.json
+++ b/common/changes/office-ui-fabric-react/6.0_2019-08-07-10-27.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Changing the drop hint icon and it's position for list's column drag-drop",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "svaibhav@microsoft.com"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -215,58 +215,58 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
       >
         {showCheckbox
           ? [
-              <div
-                key="__checkbox"
-                className={classNames.cellIsCheck}
-                aria-labelledby={`${this._id}-check`}
-                onClick={!isCheckboxHidden ? this._onSelectAllClicked : undefined}
-                aria-colindex={1}
-                role={'columnheader'}
-              >
-                {onRenderColumnHeaderTooltip(
-                  {
-                    hostClassName: classNames.checkTooltip,
-                    id: `${this._id}-checkTooltip`,
-                    setAriaDescribedBy: false,
-                    content: ariaLabelForSelectAllCheckbox,
-                    children: (
-                      <DetailsRowCheck
-                        id={`${this._id}-check`}
-                        aria-label={ariaLabelForSelectionColumn}
-                        aria-describedby={
-                          !isCheckboxHidden
-                            ? ariaLabelForSelectAllCheckbox && !this.props.onRenderColumnHeaderTooltip
-                              ? `${this._id}-checkTooltip`
-                              : undefined
-                            : ariaLabelForSelectionColumn && !this.props.onRenderColumnHeaderTooltip
+            <div
+              key="__checkbox"
+              className={classNames.cellIsCheck}
+              aria-labelledby={`${this._id}-check`}
+              onClick={!isCheckboxHidden ? this._onSelectAllClicked : undefined}
+              aria-colindex={1}
+              role={'columnheader'}
+            >
+              {onRenderColumnHeaderTooltip(
+                {
+                  hostClassName: classNames.checkTooltip,
+                  id: `${this._id}-checkTooltip`,
+                  setAriaDescribedBy: false,
+                  content: ariaLabelForSelectAllCheckbox,
+                  children: (
+                    <DetailsRowCheck
+                      id={`${this._id}-check`}
+                      aria-label={ariaLabelForSelectionColumn}
+                      aria-describedby={
+                        !isCheckboxHidden
+                          ? ariaLabelForSelectAllCheckbox && !this.props.onRenderColumnHeaderTooltip
                             ? `${this._id}-checkTooltip`
                             : undefined
-                        }
-                        data-is-focusable={!isCheckboxHidden || undefined}
-                        isHeader={true}
-                        selected={isAllSelected}
-                        anySelected={false}
-                        canSelect={!isCheckboxHidden}
-                        className={classNames.check}
-                        onRenderDetailsCheckbox={onRenderDetailsCheckbox}
-                      />
-                    )
-                  },
-                  this._onRenderColumnHeaderTooltip
-                )}
-              </div>,
-              !this.props.onRenderColumnHeaderTooltip ? (
-                ariaLabelForSelectAllCheckbox && !isCheckboxHidden ? (
-                  <label key="__checkboxLabel" id={`${this._id}-checkTooltip`} className={classNames.accessibleLabel}>
-                    {ariaLabelForSelectAllCheckbox}
-                  </label>
-                ) : ariaLabelForSelectionColumn && isCheckboxHidden ? (
-                  <label key="__checkboxLabel" id={`${this._id}-checkTooltip`} className={classNames.accessibleLabel}>
-                    {ariaLabelForSelectionColumn}
-                  </label>
-                ) : null
+                          : ariaLabelForSelectionColumn && !this.props.onRenderColumnHeaderTooltip
+                            ? `${this._id}-checkTooltip`
+                            : undefined
+                      }
+                      data-is-focusable={!isCheckboxHidden || undefined}
+                      isHeader={true}
+                      selected={isAllSelected}
+                      anySelected={false}
+                      canSelect={!isCheckboxHidden}
+                      className={classNames.check}
+                      onRenderDetailsCheckbox={onRenderDetailsCheckbox}
+                    />
+                  )
+                },
+                this._onRenderColumnHeaderTooltip
+              )}
+            </div>,
+            !this.props.onRenderColumnHeaderTooltip ? (
+              ariaLabelForSelectAllCheckbox && !isCheckboxHidden ? (
+                <label key="__checkboxLabel" id={`${this._id}-checkTooltip`} className={classNames.accessibleLabel}>
+                  {ariaLabelForSelectAllCheckbox}
+                </label>
+              ) : ariaLabelForSelectionColumn && isCheckboxHidden ? (
+                <label key="__checkboxLabel" id={`${this._id}-checkTooltip`} className={classNames.accessibleLabel}>
+                  {ariaLabelForSelectionColumn}
+                </label>
               ) : null
-            ]
+            ) : null
+          ]
           : null}
         {groupNestingDepth! > 0 && this.props.collapseAllVisibility === CollapseAllVisibility.visible ? (
           <div
@@ -286,8 +286,8 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
             : false;
           return [
             columnReorderProps &&
-              (_isDraggable || columnIndex === columns.length - frozenColumnCountFromEnd) &&
-              this._renderDropHint(columnIndex),
+            (_isDraggable || columnIndex === columns.length - frozenColumnCountFromEnd) &&
+            this._renderDropHint(columnIndex),
             <DetailsColumn
               column={column}
               key={column.key}
@@ -623,7 +623,7 @@ export class DetailsHeaderBase extends BaseComponent<IDetailsHeaderBaseProps, ID
           data-is-focusable={false}
           data-sizer-index={dropHintIndex}
           className={classNames.dropHintCaretStyle}
-          iconName={'CaretUpSolid8'}
+          iconName={'CaretDownSolid8'}
         />
         <div
           key={`dropHintLineKey`}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
@@ -265,18 +265,18 @@ export const getStyles = (props: IDetailsHeaderStyleProps): IDetailsHeaderStyles
       classNames.collapseButton,
       isAllCollapsed
         ? [
-            classNames.isCollapsed,
-            {
-              transform: 'rotate(0deg)',
-              transformOrigin: '50% 50%',
-              transition: 'transform .1s linear'
-            }
-          ]
-        : {
-            transform: 'rotate(90deg)',
+          classNames.isCollapsed,
+          {
+            transform: 'rotate(0deg)',
             transformOrigin: '50% 50%',
             transition: 'transform .1s linear'
           }
+        ]
+        : {
+          transform: 'rotate(90deg)',
+          transformOrigin: '50% 50%',
+          transition: 'transform .1s linear'
+        }
     ],
 
     checkTooltip: [],
@@ -325,7 +325,7 @@ export const getStyles = (props: IDetailsHeaderStyleProps): IDetailsHeaderStyles
       {
         display: 'none',
         position: 'absolute',
-        top: 22,
+        top: -13,
         left: -7.5,
         fontSize: 16,
         color: palette.themePrimary,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Changing the drop hint icon and it's position for list's column drag-drop

Old drop hint:
![old_drop_hint](https://user-images.githubusercontent.com/6286818/62616586-92daf200-b92d-11e9-88e9-538ee901d343.png)

New drop hint:
![new_drop_hint](https://user-images.githubusercontent.com/6286818/62616599-9b332d00-b92d-11e9-8178-841de65451b5.png)


#### Focus areas to test

Details list: drag drop a column to a new position. The drop hint will now appear above


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10085)