### PR TITLE
a11y-tests: Temporarily Disable

### DIFF
--- a/apps/a11y-tests/just.config.js
+++ b/apps/a11y-tests/just.config.js
@@ -1,6 +1,7 @@
-const { preset, just } = require('@uifabric/build');
-const { task, series, condition, argv } = just;
+// a11y-tests disabled until occasional local and CI timeout issue can be resolved.
+// const { preset, just } = require('@uifabric/build');
+// const { task, series, condition, argv } = just;
 
-preset();
+// preset();
 
-task('build', series('clean', 'ts:commonjs-only', condition('jest', () => !argv().min))).cached();
+// task('build', series('clean', 'ts:commonjs-only', condition('jest', () => !argv().min))).cached();

--- a/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
+++ b/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
@@ -55,7 +55,6 @@ Array [
 - Element has a value attribute and the value attribute is empty.
 - Element has no value attribute or the value attribute is empty.
 - Element does not have inner text that is visible to screen readers.
-- aria-label attribute does not exist or is empty.
 - aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
 - Element's default semantics were not overridden with role=\\"presentation\\".
 - Element's default semantics were not overridden with role=\\"none\\".

--- a/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
+++ b/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
@@ -55,6 +55,7 @@ Array [
 - Element has a value attribute and the value attribute is empty.
 - Element has no value attribute or the value attribute is empty.
 - Element does not have inner text that is visible to screen readers.
+- aria-label attribute does not exist or is empty.
 - aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty.
 - Element's default semantics were not overridden with role=\\"presentation\\".
 - Element's default semantics were not overridden with role=\\"none\\".

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,11 +69,12 @@ steps:
       githubDescription: 'Click "Details" to go to the Deployed Site'
       githubTargetLink: 'http://fabricweb.z5.web.core.windows.net/pr-deploy-site/$(Build.SourceBranch)/'
 
-  - task: PublishBuildArtifacts@1
-    inputs:
-      pathtoPublish: './apps/a11y-tests/dist/reports'
-      artifactName: 'CodeAnalysisLogs'
-    displayName: publish sarif a11y reports
+  # a11y-tests disabled until occasional local and CI timeout issue can be resolved.
+  #- task: PublishBuildArtifacts@1
+  #  inputs:
+  #    pathtoPublish: './apps/a11y-tests/dist/reports'
+  #    artifactName: 'CodeAnalysisLogs'
+  #  displayName: publish sarif a11y reports
 
   - script: |
       git config --global user.email "fabrictactical@microsoft.com"


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

a11-test package is having occasional timeouts locally and in CI, resulting in build failures. Disabling a11y-tests temporarily until root cause can be addressed.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10091)