### PR TITLE
Spinbutton: Update top Label styling inconsistencies

### DIFF
--- a/change/office-ui-fabric-react-2019-08-07-16-29-27-spinButtonLabelFix.json
+++ b/change/office-ui-fabric-react-2019-08-07-16-29-27-spinButtonLabelFix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Spinbutton: removed additional top and bottom margin styling overriding Label's styling and causes alignment inconsistencies with textbox, combobox, etc.",
+  "packageName": "office-ui-fabric-react",
+  "email": "marygans@microsoft.com",
+  "commit": "7b9e8d198b5a8d0808916bda2ffc47287b752dd9",
+  "date": "2019-08-07T23:29:27.819Z"
+}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.styles.ts
@@ -153,12 +153,6 @@ export const getStyles = memoizeFunction(
         float: 'right',
         marginLeft: LABEL_MARGIN
       },
-      labelWrapperTop: {
-        marginBottom: LABEL_MARGIN
-      },
-      labelWrapperBottom: {
-        marginTop: LABEL_MARGIN
-      },
       icon: {
         padding: '0 5px',
         fontSize: IconFontSizes.large
@@ -168,7 +162,6 @@ export const getStyles = memoizeFunction(
       },
       label: {
         pointerEvents: 'none',
-        padding: 0,
         // centering the label with the icon by forcing the exact same height as the icon.
         lineHeight: IconFontSizes.large
       },

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.styles.ts
@@ -153,6 +153,8 @@ export const getStyles = memoizeFunction(
         float: 'right',
         marginLeft: LABEL_MARGIN
       },
+      labelWrapperTop: {},
+      labelWrapperBottom: {},
       icon: {
         padding: '0 5px',
         fontSize: IconFontSizes.large

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
@@ -273,6 +273,16 @@ export interface ISpinButtonStyles {
   labelWrapperEnd: IStyle;
 
   /**
+   * Style override when the label is positioned at the top.
+   */
+  labelWrapperTop: IStyle;
+
+  /**
+   * Style override when the label is positioned at the bottom.
+   */
+  labelWrapperBottom: IStyle;
+
+  /**
    * Style for the icon.
    */
   icon: IStyle;

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
@@ -273,16 +273,6 @@ export interface ISpinButtonStyles {
   labelWrapperEnd: IStyle;
 
   /**
-   * Style override when the label is positioned at the top.
-   */
-  labelWrapperTop: IStyle;
-
-  /**
-   * Style override when the label is positioned at the bottom.
-   */
-  labelWrapperBottom: IStyle;
-
-  /**
    * Style for the icon.
    */
   icon: IStyle;

--- a/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
@@ -41,10 +41,10 @@ exports[`SpinButton renders SpinButton correctly 1`] = `
             margin-right: 0px;
             margin-top: 0px;
             overflow-wrap: break-word;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
             pointer-events: none;
             word-wrap: break-word;
           }
@@ -448,10 +448,10 @@ exports[`SpinButton renders SpinButton correctly with values that the user passe
             margin-right: 0px;
             margin-top: 0px;
             overflow-wrap: break-word;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
             pointer-events: none;
             word-wrap: break-word;
           }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -592,10 +592,10 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                       margin-right: 0px;
                       margin-top: 0px;
                       overflow-wrap: break-word;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
+                      padding-bottom: 5px;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 5px;
                       pointer-events: none;
                       word-wrap: break-word;
                     }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Basic.Example.tsx.shot
@@ -71,10 +71,10 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
               margin-right: 0px;
               margin-top: 0px;
               overflow-wrap: break-word;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
               pointer-events: none;
               word-wrap: break-word;
             }
@@ -477,10 +477,10 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
               margin-right: 0px;
               margin-top: 0px;
               overflow-wrap: break-word;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
               pointer-events: none;
               word-wrap: break-word;
             }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
@@ -48,10 +48,10 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
               margin-right: 0px;
               margin-top: 0px;
               overflow-wrap: break-word;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
               pointer-events: none;
               word-wrap: break-word;
             }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithEndPosition.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithEndPosition.Example.tsx.shot
@@ -71,10 +71,10 @@ exports[`Component Examples renders SpinButton.BasicWithEndPosition.Example.tsx 
               margin-right: 0px;
               margin-top: 0px;
               overflow-wrap: break-word;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
               pointer-events: none;
               word-wrap: break-word;
             }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIcon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIcon.Example.tsx.shot
@@ -71,10 +71,10 @@ exports[`Component Examples renders SpinButton.BasicWithIcon.Example.tsx correct
               margin-right: 0px;
               margin-top: 0px;
               overflow-wrap: break-word;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
               pointer-events: none;
               word-wrap: break-word;
             }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
@@ -72,10 +72,10 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
               margin-right: 0px;
               margin-top: 0px;
               overflow-wrap: break-word;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
               pointer-events: none;
               word-wrap: break-word;
             }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.CustomStyled.Example.tsx.shot
@@ -42,10 +42,10 @@ exports[`Component Examples renders SpinButton.CustomStyled.Example.tsx correctl
               margin-right: 0px;
               margin-top: 0px;
               overflow-wrap: break-word;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
               pointer-events: none;
               word-wrap: break-word;
             }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Stateful.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Stateful.Example.tsx.shot
@@ -48,10 +48,10 @@ exports[`Component Examples renders SpinButton.Stateful.Example.tsx correctly 1`
               margin-right: 0px;
               margin-top: 0px;
               overflow-wrap: break-word;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
               pointer-events: none;
               word-wrap: break-word;
             }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #10015
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

`Spinbutton` top label alignment did not match similar components such as `ComboBox` and `Textbox`. `Label` padding attributes were overridden by `SpinButton` margins in`spinbutton.styles.ts`. Removing these references to the margins allows the `spinbutton `component to inherit top/bottom padding from `Label` and achieve consistency.

**Before** 
<img width="448" alt="Screen Shot 2019-08-07 at 3 51 02 PM" src="https://user-images.githubusercontent.com/38991459/62663989-9a4ecb00-b92e-11e9-92c7-4c1575cca759.png">

**After**
<img width="440" alt="Screen Shot 2019-08-07 at 3 37 48 PM" src="https://user-images.githubusercontent.com/38991459/62664022-bfdbd480-b92e-11e9-827c-ea3bf18f4106.png">

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10096)