### PR TITLE
Callout: allow reposition after position prop is passed in

### DIFF
--- a/change/office-ui-fabric-react-2019-08-08-13-06-17-callout-reposition.json
+++ b/change/office-ui-fabric-react-2019-08-08-13-06-17-callout-reposition.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Allow callout to reposition after position prop is passed in",
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com",
+  "commit": "529fc8885913c2f188c9a3710b7c857a0d56a1c5",
+  "date": "2019-08-08T20:06:17.443Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -366,7 +366,6 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
 
   private _updatePosition(): void {
     // Try to update the target, page might have changed
-    console.log('here');
     this._setTargetWindowAndElement(this._getTarget());
 
     const { positions } = this.state;

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -149,7 +149,7 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
     }
 
     // Ensure positioning is recalculated when we are about to show a persisted menu.
-    if (this._didPositionPropsChanges(newProps, this.props)) {
+    if (this._didPositionPropsChange(newProps, this.props)) {
       this._maxHeight = undefined;
       // Target might have been updated while hidden.
       this._setTargetWindowAndElement(newTarget);
@@ -527,8 +527,8 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
   }
 
   // Whether or not the current positions should be reset
-  private _didPositionPropsChanges(newProps: ICalloutProps, oldProps: ICalloutProps): boolean {
-    return (!newProps.hidden && newProps.hidden !== this.props.hidden) || newProps.directionalHint !== this.props.directionalHint;
+  private _didPositionPropsChange(newProps: ICalloutProps, oldProps: ICalloutProps): boolean {
+    return (!newProps.hidden && newProps.hidden !== oldProps.hidden) || newProps.directionalHint !== oldProps.directionalHint;
   }
 
   private _getTarget(props: ICalloutProps = this.props): Target {

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -149,7 +149,7 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
     }
 
     // Ensure positioning is recalculated when we are about to show a persisted menu.
-    if (!newProps.hidden && newProps.hidden !== this.props.hidden) {
+    if (this._didPositionPropsChanges(newProps, this.props)) {
       this._maxHeight = undefined;
       // Target might have been updated while hidden.
       this._setTargetWindowAndElement(newTarget);
@@ -366,6 +366,7 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
 
   private _updatePosition(): void {
     // Try to update the target, page might have changed
+    console.log('here');
     this._setTargetWindowAndElement(this._getTarget());
 
     const { positions } = this.state;
@@ -524,6 +525,11 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
         }
       });
     }
+  }
+
+  // Whether or not the current positions should be reset
+  private _didPositionPropsChanges(newProps: ICalloutProps, oldProps: ICalloutProps): boolean {
+    return (!newProps.hidden && newProps.hidden !== this.props.hidden) || newProps.directionalHint !== this.props.directionalHint;
   }
 
   private _getTarget(props: ICalloutProps = this.props): Target {


### PR DESCRIPTION
- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

   Allow callout to reposition after position prop is passed in

#### Focus areas to test

(optional)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10100)