### PR TITLE
Add optional parameter to DocumentCardPreview

### DIFF
--- a/change/office-ui-fabric-react-2019-08-08-16-32-26-master.json
+++ b/change/office-ui-fabric-react-2019-08-08-16-32-26-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Adding Optional parameter to DocumentCardPreview for managing the item limit",
+  "packageName": "office-ui-fabric-react",
+  "email": "cimon.tremblay@osedea.com",
+  "commit": "0e02b9f982ea0772317a9b87d7bc7b66d572d052",
+  "date": "2019-08-08T20:32:26.477Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -494,7 +494,7 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> impl
 }
 
 // Warning: (ae-forgotten-export) The symbol "ICalloutState" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export class Callout extends React.Component<ICalloutProps, ICalloutState> {
     // (undocumented)
@@ -652,7 +652,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     static defaultProps: IComboBoxProps;
     dismissMenu: () => void;
     // Warning: (ae-unresolved-inheritdoc-base) The @inheritDoc tag needs a TSDoc declaration reference; signature matching is not supported yet
-    //
+    // 
     // (undocumented)
     focus: (shouldOpenOnFocus?: boolean | undefined, useFocusAsync?: boolean | undefined) => void;
     // (undocumented)
@@ -2858,7 +2858,7 @@ export interface IContextualMenuItem {
     data?: any;
     disabled?: boolean;
     // Warning: (ae-forgotten-export) The symbol "IMenuItemClassNames" needs to be exported by the entry point index.d.ts
-    //
+    // 
     // @deprecated
     getItemClassNames?: (theme: ITheme, disabled: boolean, expanded: boolean, checked: boolean, isAnchorLink: boolean, knownIcon: boolean, itemClassName?: string, dividerClassName?: string, iconClassName?: string, subMenuClassName?: string, primaryDisabled?: boolean) => IMenuItemClassNames;
     getSplitButtonVerticalDividerClassNames?: (theme: ITheme) => IVerticalDividerClassNames;
@@ -2958,7 +2958,7 @@ export interface IContextualMenuListProps {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IWithResponsiveModeState" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public
 export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWithResponsiveModeState {
     alignTargetEdge?: boolean;
@@ -2978,7 +2978,7 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
     focusZoneProps?: IFocusZoneProps;
     gapSpace?: number;
     // Warning: (ae-forgotten-export) The symbol "IContextualMenuClassNames" needs to be exported by the entry point index.d.ts
-    //
+    // 
     // @deprecated
     getMenuClassNames?: (theme: ITheme, className?: string) => IContextualMenuClassNames;
     hidden?: boolean;
@@ -3727,7 +3727,7 @@ export interface IDialogFooterStyles {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IAccessiblePopupProps" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IDialogProps extends React.ClassAttributes<DialogBase>, IWithResponsiveModeState, IAccessiblePopupProps {
     // @deprecated
@@ -3831,7 +3831,7 @@ export interface IDocumentCardActions {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardActionsBase" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IDocumentCardActionsProps extends React.ClassAttributes<DocumentCardActionsBase> {
     actions: IButtonProps[];
@@ -3874,7 +3874,7 @@ export interface IDocumentCardActivityPerson {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardActivityBase" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IDocumentCardActivityProps extends React.ClassAttributes<DocumentCardActivityBase> {
     activity: string;
@@ -3913,7 +3913,7 @@ export interface IDocumentCardDetails {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardDetailsBase" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IDocumentCardDetailsProps extends React.Props<DocumentCardDetailsBase> {
     className?: string;
@@ -3972,7 +3972,7 @@ export interface IDocumentCardLocation {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardLocationBase" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IDocumentCardLocationProps extends React.ClassAttributes<DocumentCardLocationBase> {
     ariaLabel?: string;
@@ -4002,7 +4002,7 @@ export interface IDocumentCardLogo {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardLogoBase" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IDocumentCardLogoProps extends React.ClassAttributes<DocumentCardLogoBase> {
     className?: string;
@@ -4054,6 +4054,7 @@ export interface IDocumentCardPreviewProps extends IBaseProps<{}> {
     className?: string;
     componentRef?: IRefObject<IDocumentCardPreview>;
     getOverflowDocumentCountText?: (overflowCount: number) => string;
+    previewDocumentsToDisplayNumber?: number;
     previewImages: IDocumentCardPreviewImage[];
     styles?: IStyleFunctionOrObject<IDocumentCardPreviewStyleProps, IDocumentCardPreviewStyles>;
     theme?: ITheme;
@@ -4102,7 +4103,7 @@ export interface IDocumentCardStatus {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardStatusBase" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IDocumentCardStatusProps extends React.Props<DocumentCardStatusBase> {
     className?: string;
@@ -4144,7 +4145,7 @@ export interface IDocumentCardTitle {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardTitleBase" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IDocumentCardTitleProps extends React.ClassAttributes<DocumentCardTitleBase> {
     className?: string;
@@ -4347,7 +4348,7 @@ export interface IExpandingCard {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IBaseCardProps" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public
 export interface IExpandingCardProps extends IBaseCardProps<IExpandingCard, IExpandingCardStyles, IExpandingCardStyleProps> {
     compactCardHeight?: number;
@@ -4366,7 +4367,7 @@ export interface IExpandingCardState {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IBaseCardStyleProps" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IExpandingCardStyleProps extends IBaseCardStyleProps {
     compactCardHeight?: number;
@@ -4376,7 +4377,7 @@ export interface IExpandingCardStyleProps extends IBaseCardStyleProps {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IBaseCardStyles" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IExpandingCardStyles extends IBaseCardStyles {
     compactCard?: IStyle;
@@ -5700,7 +5701,7 @@ export interface IPanelHeaderRenderer extends IRenderFunction<IPanelProps> {
 }
 
 // Warning: (ae-forgotten-export) The symbol "PanelBase" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
     className?: string;
@@ -6858,7 +6859,7 @@ export interface ISpinButtonProps {
     keytipProps?: IKeytipProps;
     label?: string;
     // Warning: (ae-forgotten-export) The symbol "Position" needs to be exported by the entry point index.d.ts
-    //
+    // 
     // (undocumented)
     labelPosition?: Position;
     max?: number;
@@ -7474,14 +7475,14 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
 }
 
 // Warning: (ae-internal-missing-underscore) The name "ITextFieldSnapshot" should be prefixed with an underscore because the declaration is marked as @internal
-//
+// 
 // @internal (undocumented)
 export interface ITextFieldSnapshot {
     selection?: [number | null, number | null];
 }
 
 // Warning: (ae-internal-missing-underscore) The name "ITextFieldState" should be prefixed with an underscore because the declaration is marked as @internal
-//
+// 
 // @internal (undocumented)
 export interface ITextFieldState {
     errorMessage: string | JSX.Element;
@@ -7758,7 +7759,7 @@ export class Keytip extends React.Component<IKeytipProps, {}> {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IKeytipDataProps" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public
 export class KeytipData extends React.Component<IKeytipDataProps & IRenderComponent<{}>, {}> {
     // (undocumented)
@@ -7786,7 +7787,7 @@ export class KeytipLayerBase extends BaseComponent<IKeytipLayerProps, IKeytipLay
     // (undocumented)
     getCurrentSequence(): string;
     // Warning: (ae-forgotten-export) The symbol "KeytipTree" needs to be exported by the entry point index.d.ts
-    //
+    // 
     // (undocumented)
     getKeytipTree(): KeytipTree;
     processInput(key: string, ev?: React.KeyboardEvent<HTMLElement>): void;
@@ -7828,7 +7829,7 @@ export class LayerBase extends React.Component<ILayerProps, ILayerBaseState> {
     }
 
 // Warning: (ae-forgotten-export) The symbol "ILayerHostProps" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export class LayerHost extends React.Component<ILayerHostProps> {
     // (undocumented)
@@ -9191,7 +9192,7 @@ export const TextField: React.StatelessComponent<ITextFieldProps>;
 
 // Warning: (ae-incompatible-release-tags) The symbol "TextFieldBase" is marked as @public, but its signature references "ITextFieldState" which is marked as @internal
 // Warning: (ae-incompatible-release-tags) The symbol "TextFieldBase" is marked as @public, but its signature references "ITextFieldSnapshot" which is marked as @internal
-//
+// 
 // @public (undocumented)
 export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldState, ITextFieldSnapshot> implements ITextField {
     constructor(props: ITextFieldProps);
@@ -9348,7 +9349,7 @@ export * from "@uifabric/styling";
 export * from "@uifabric/utilities";
 
 // Warnings were encountered during analysis:
-//
+// 
 // lib/components/ColorPicker/ColorPicker.base.d.ts:8:9 - (ae-forgotten-export) The symbol "IRGBHex" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.base.tsx
@@ -12,7 +12,7 @@ import {
 } from './DocumentCardPreview.types';
 
 // Constant for how many documents to show
-const PREVIEW_DOCUMENTS_TO_DISPLAY_NUMBER = 3;
+const PREVIEW_DOCUMENTS_TO_DISPLAY_DEFAULT_NUMBER = 3;
 const getClassNames = classNamesFunction<IDocumentCardPreviewStyleProps, IDocumentCardPreviewStyles>();
 
 /**
@@ -81,17 +81,18 @@ export class DocumentCardPreviewBase extends BaseComponent<IDocumentCardPreviewP
   }
 
   private _renderPreviewList = (previewImages: IDocumentCardPreviewImage[]): React.ReactElement<React.HTMLAttributes<HTMLDivElement>> => {
-    const { getOverflowDocumentCountText, previewDocumentsToDisplayNumber = PREVIEW_DOCUMENTS_TO_DISPLAY_NUMBER } = this.props;
+    const { getOverflowDocumentCountText, previewDocumentsToDisplayNumber = PREVIEW_DOCUMENTS_TO_DISPLAY_DEFAULT_NUMBER } = this.props;
 
     // Determine how many documents we won't be showing
     const overflowDocumentCount = previewImages.length - previewDocumentsToDisplayNumber;
 
     // Determine the overflow text that will be rendered after the preview list.
-    const overflowText = overflowDocumentCount
-      ? getOverflowDocumentCountText
-        ? getOverflowDocumentCountText(overflowDocumentCount)
-        : '+' + overflowDocumentCount
-      : null;
+    const overflowText =
+      overflowDocumentCount > 0
+        ? getOverflowDocumentCountText
+          ? getOverflowDocumentCountText(overflowDocumentCount)
+          : '+' + overflowDocumentCount
+        : null;
 
     // Create list items for the documents to be shown
     const fileListItems = previewImages.slice(0, previewDocumentsToDisplayNumber).map((file, fileIndex) => (

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.base.tsx
@@ -19,13 +19,12 @@ const getClassNames = classNamesFunction<IDocumentCardPreviewStyleProps, IDocume
  * {@docCategory DocumentCard}
  */
 export class DocumentCardPreviewBase extends BaseComponent<IDocumentCardPreviewProps, any> {
-  private _classNames: IProcessedStyleSet<IDocumentCardPreviewStyles>;
-
   // Set default property to previewDocumentsToDisplayNumber.
   // Currently not visible by Typescript because of HOC wrapper used to display this component
   public static defaultProps: Partial<IDocumentCardPreviewProps> = {
     previewDocumentsToDisplayNumber: PREVIEW_DOCUMENTS_TO_DISPLAY_DEFAULT_NUMBER
   };
+  private _classNames: IProcessedStyleSet<IDocumentCardPreviewStyles>;
 
   public render(): JSX.Element {
     const { previewImages, styles, theme, className } = this.props;

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.base.tsx
@@ -11,7 +11,8 @@ import {
   IDocumentCardPreviewStyles
 } from './DocumentCardPreview.types';
 
-const LIST_ITEM_COUNT = 3;
+// Constant for how many documents to show
+const PREVIEW_DOCUMENTS_TO_DISPLAY_NUMBER = 3;
 const getClassNames = classNamesFunction<IDocumentCardPreviewStyleProps, IDocumentCardPreviewStyles>();
 
 /**
@@ -80,10 +81,10 @@ export class DocumentCardPreviewBase extends BaseComponent<IDocumentCardPreviewP
   }
 
   private _renderPreviewList = (previewImages: IDocumentCardPreviewImage[]): React.ReactElement<React.HTMLAttributes<HTMLDivElement>> => {
-    const { getOverflowDocumentCountText } = this.props;
+    const { getOverflowDocumentCountText, previewDocumentsToDisplayNumber = PREVIEW_DOCUMENTS_TO_DISPLAY_NUMBER } = this.props;
 
     // Determine how many documents we won't be showing
-    const overflowDocumentCount = previewImages.length - LIST_ITEM_COUNT;
+    const overflowDocumentCount = previewImages.length - previewDocumentsToDisplayNumber;
 
     // Determine the overflow text that will be rendered after the preview list.
     const overflowText = overflowDocumentCount
@@ -93,7 +94,7 @@ export class DocumentCardPreviewBase extends BaseComponent<IDocumentCardPreviewP
       : null;
 
     // Create list items for the documents to be shown
-    const fileListItems = previewImages.slice(0, LIST_ITEM_COUNT).map((file, fileIndex) => (
+    const fileListItems = previewImages.slice(0, previewDocumentsToDisplayNumber).map((file, fileIndex) => (
       <li key={fileIndex}>
         <Image className={this._classNames.fileListIcon} src={file.iconSrc} role="presentation" alt="" width="16px" height="16px" />
         <Link {...(file.linkProps, { href: file.url || (file.linkProps && file.linkProps.href) })}>{file.name}</Link>

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.base.tsx
@@ -21,6 +21,12 @@ const getClassNames = classNamesFunction<IDocumentCardPreviewStyleProps, IDocume
 export class DocumentCardPreviewBase extends BaseComponent<IDocumentCardPreviewProps, any> {
   private _classNames: IProcessedStyleSet<IDocumentCardPreviewStyles>;
 
+  // Set default property to previewDocumentsToDisplayNumber.
+  // Currently not visible by Typescript because of HOC wrapper used to display this component
+  public static defaultProps: Partial<IDocumentCardPreviewProps> = {
+    previewDocumentsToDisplayNumber: PREVIEW_DOCUMENTS_TO_DISPLAY_DEFAULT_NUMBER
+  };
+
   public render(): JSX.Element {
     const { previewImages, styles, theme, className } = this.props;
     let style, preview;

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.types.ts
@@ -45,7 +45,8 @@ export interface IDocumentCardPreviewProps extends IBaseProps<{}> {
   className?: string;
 
   /**
-   * Minimum number of documents to display before adding the overflow text
+   * Maximum number of documents to display before adding the overflow text
+   * @DefaultValue 3
    */
   previewDocumentsToDisplayNumber?: number;
 }

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardPreview.types.ts
@@ -43,6 +43,11 @@ export interface IDocumentCardPreviewProps extends IBaseProps<{}> {
    * Optional override class name
    */
   className?: string;
+
+  /**
+   * Minimum number of documents to display before adding the overflow text
+   */
+  previewDocumentsToDisplayNumber?: number;
 }
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9991
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Adding an optional parameter to the DocumentCardPreview component to manage the limit of items to see of the list.  If no value is entered for this parameter, the default value a 3 will be assigned.  

I am using a props default value assignation inside the _renderPreviewList and a optional parameter inside the component props interface.  I tried to use Typescript 3.0 feature that detects "defaultProps" inside a component, but it's hard with the HOC wrapper.

#### Focus areas to test

DocumentCardCompleteExample component, we can set the parameter to the DocumentCardPreview

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10101)