### PR TITLE
Teaching bubble: update examples to have aria labels for close icons

### DIFF
--- a/change/office-ui-fabric-react-2019-08-08-15-38-01-teachingBubbleExamples.json
+++ b/change/office-ui-fabric-react-2019-08-08-15-38-01-teachingBubbleExamples.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "TeachingBubble: Added aria labels to examples with close icons",
+  "packageName": "office-ui-fabric-react",
+  "email": "marygans@microsoft.com",
+  "commit": "806584e1347d8a4a428f5e9727a1d842002c7a58",
+  "date": "2019-08-08T22:38:01.255Z"
+}

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/examples/TeachingBubble.Condensed.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/examples/TeachingBubble.Condensed.Example.tsx
@@ -37,6 +37,7 @@ export class TeachingBubbleCondensedExample extends React.Component<{}, ITeachin
               hasCondensedHeadline={true}
               onDismiss={this._onDismiss}
               hasCloseIcon={true}
+              closeButtonAriaLabel="Close"
               headline="Discover what’s trending around you"
             >
               Lorem ipsum dolor sit amet, consectetur adipisicing elit. Facere, nulla, ipsum? Molestiae quis aliquam magni harum non?

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/examples/TeachingBubble.SmallHeadline.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/examples/TeachingBubble.SmallHeadline.Example.tsx
@@ -41,6 +41,7 @@ export class TeachingBubbleSmallHeadlineExample extends React.Component<{}, ITea
               hasSmallHeadline={true}
               onDismiss={this._onDismiss}
               hasCloseIcon={true}
+              closeButtonAriaLabel="Close"
               primaryButtonProps={examplePrimaryButton}
               headline="Discover what’s trending around you"
             >

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/examples/TeachingBubble.WideIllustration.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/examples/TeachingBubble.WideIllustration.Example.tsx
@@ -50,6 +50,7 @@ export class TeachingBubbleWideIllustrationExample extends React.Component<{}, I
               isWide={true}
               hasSmallHeadline={true}
               hasCloseIcon={true}
+              closeButtonAriaLabel="Close"
               target={this._menuButtonElement}
               primaryButtonProps={examplePrimaryButton}
               secondaryButtonProps={exampleSecondaryButtonProps}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #10010
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

update teaching bubble examples to have aria labels and aria tooltip for close icons


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10104)