### PR TITLE
Theming: fix legacyLoadTheme's font variables

### DIFF
--- a/change/@uifabric-styling-2019-08-08-17-44-55-phkuo-fontSassFix.json
+++ b/change/@uifabric-styling-2019-08-08-17-44-55-phkuo-fontSassFix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix font theme variable values for legacy-load-theme",
+  "packageName": "@uifabric/styling",
+  "email": "phkuo@microsoft.com",
+  "commit": "321af43b33cab1c3111bdddcf4b008a872d84f95",
+  "date": "2019-08-09T00:44:55.664Z"
+}

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -14,6 +14,7 @@ let _theme: ITheme = createTheme({
   disableGlobalClassNames: false
 });
 let _onThemeChangeCallbacks: Array<(theme: ITheme) => void> = [];
+loadTheme(_theme);
 
 export const ThemeSettingName = 'theme';
 
@@ -99,7 +100,7 @@ function _loadFonts(theme: ITheme): { [name: string]: string } {
   for (const fontName of Object.keys(theme.fonts)) {
     const font = theme.fonts[fontName];
     for (const propName of Object.keys(font)) {
-      const name = 'ms-font-' + fontName + '-' + propName;
+      const name = fontName + propName.charAt(0).toUpperCase() + propName.slice(1);
       let value = font[propName];
       if (propName === 'fontSize' && value.indexOf('px') < 0) {
         value += 'px';

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -72,6 +72,7 @@ export function removeOnThemeChangeCallback(callback: (theme: ITheme) => void): 
  */
 export function loadTheme(theme: IPartialTheme, depComments: boolean = false): ITheme {
   _theme = createTheme(theme, depComments);
+
   // Invoke the legacy method of theming the page as well.
   legacyLoadTheme({ ..._theme.palette, ..._theme.semanticColors, ..._theme.effects, ..._loadFonts(_theme) });
 

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -14,7 +14,6 @@ let _theme: ITheme = createTheme({
   disableGlobalClassNames: false
 });
 let _onThemeChangeCallbacks: Array<(theme: ITheme) => void> = [];
-loadTheme(_theme);
 
 export const ThemeSettingName = 'theme';
 

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -72,7 +72,6 @@ export function removeOnThemeChangeCallback(callback: (theme: ITheme) => void): 
  */
 export function loadTheme(theme: IPartialTheme, depComments: boolean = false): ITheme {
   _theme = createTheme(theme, depComments);
-
   // Invoke the legacy method of theming the page as well.
   legacyLoadTheme({ ..._theme.palette, ..._theme.semanticColors, ..._theme.effects, ..._loadFonts(_theme) });
 
@@ -100,7 +99,11 @@ function _loadFonts(theme: ITheme): { [name: string]: string } {
     const font = theme.fonts[fontName];
     for (const propName of Object.keys(font)) {
       const name = 'ms-font-' + fontName + '-' + propName;
-      lines[name] = `"[theme:${name}, default: ${font[propName]}]"`;
+      let value = font[propName];
+      if (propName === 'fontSize' && value.indexOf('px') < 0) {
+        value += 'px';
+      }
+      lines[name] = value;
     }
   }
   return lines;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The values passed to legacyLoadTheme were the unprocessed theme variable strings instead of the values. The variable names should match those in _themeVariables.scss, such as:
```
$ms-font-mediumPlusFontSize: "[theme:mediumPlusFontSize, default: 15px]";
$ms-font-mediumPlusFontWeight: "[theme:mediumPlusFontWeight, default: 400]";
```

Old:
![image](https://user-images.githubusercontent.com/20691641/62746443-79f14000-ba04-11e9-8cf3-ebb10121eb2d.png)

New:
![image](https://user-images.githubusercontent.com/20691641/62746819-5e873480-ba06-11e9-9b05-d308177f824a.png)




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10106)