### PR TITLE
Theming: fix font variables passed to legacyLoadTheme

### DIFF
--- a/change/@uifabric-styling-2019-08-08-18-10-45-phkuo-fontSassFix6.json
+++ b/change/@uifabric-styling-2019-08-08-18-10-45-phkuo-fontSassFix6.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix font SASS variables passed to legacyLoadTheme",
+  "packageName": "@uifabric/styling",
+  "email": "phkuo@microsoft.com",
+  "commit": "a088ce0ca3e156fc8d833479ae04823b4b834eea",
+  "date": "2019-08-09T01:10:45.537Z"
+}

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -99,8 +99,12 @@ function _loadFonts(theme: ITheme): { [name: string]: string } {
   for (const fontName of Object.keys(theme.fonts)) {
     const font = theme.fonts[fontName];
     for (const propName of Object.keys(font)) {
-      const name = 'ms-font-' + fontName + '-' + propName;
-      lines[name] = `"[theme:${name}, default: ${font[propName]}]"`;
+      const name = fontName + propName.charAt(0).toUpperCase() + propName.slice(1);
+      let value = font[propName];
+      if (propName === 'fontSize' && value.indexOf('px') < 0) {
+        value += 'px';
+      }
+      lines[name] = value;
     }
   }
   return lines;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Fix font variables passed to legacyLoadTheme so that they actually work.
Backport of #10106


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10107)