### PR TITLE
TSX Editor: Fetching Fabric typings for IntelliSense support

### DIFF
--- a/change/@uifabric-tsx-editor-2019-08-08-19-21-54-fetch.json
+++ b/change/@uifabric-tsx-editor-2019-08-08-19-21-54-fetch.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "using fetch API to bring in fabric typings to editor",
+  "packageName": "@uifabric/tsx-editor",
+  "email": "nishikaza@berkeley.edu",
+  "commit": "3f8cf613cae2fcf9892fbd338869932c1fea450a",
+  "date": "2019-08-09T02:21:54.663Z"
+}

--- a/packages/tsx-editor/src/components/Editor.tsx
+++ b/packages/tsx-editor/src/components/Editor.tsx
@@ -21,6 +21,16 @@ export const Editor: React.FunctionComponent<IEditorProps> = (props: IEditorProp
       lib: ['es5', 'dom']
     });
 
+    fetch('https://unpkg.com/office-ui-fabric-react/dist/office-ui-fabric-react.d.ts').then(response => {
+      response.text().then(fabricTypings => {
+        console.log(fabricTypings);
+        monaco.languages.typescript.typescriptDefaults.addExtraLib(
+          fabricTypings,
+          'node_modules/@types/external/office-ui-fabric-react.d.ts'
+        );
+      });
+    });
+
     monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({ noSemanticValidation: true });
 
     // Creating proxy URL for JSX support since HTML5 does not allow pages loaded on file:// to create web workers

--- a/packages/tsx-editor/src/components/Editor.tsx
+++ b/packages/tsx-editor/src/components/Editor.tsx
@@ -21,20 +21,19 @@ export const Editor: React.FunctionComponent<IEditorProps> = (props: IEditorProp
       lib: ['es5', 'dom']
     });
 
+    // Fetching Fabric typings to allow for intellisense in editor
     fetch('https://unpkg.com/office-ui-fabric-react/dist/office-ui-fabric-react.d.ts').then(response => {
       response.text().then(fabricTypings => {
-        console.log(fabricTypings);
         monaco.languages.typescript.typescriptDefaults.addExtraLib(
           fabricTypings,
-          'node_modules/@types/external/office-ui-fabric-react.d.ts'
+          'file:///node_modules/@types/office-ui-fabric-react/index.d.ts'
         );
       });
     });
 
     monaco.languages.typescript.typescriptDefaults.setDiagnosticsOptions({ noSemanticValidation: true });
 
-    // Creating proxy URL for JSX support since HTML5 does not allow pages loaded on file:// to create web workers
-    const model = monaco.editor.createModel(code, 'typescript', monaco.Uri.parse('https://developer.microsoft.com/main.tsx'));
+    const model = monaco.editor.createModel(code, 'typescript', monaco.Uri.parse('file:///main.tsx'));
 
     onChange(model);
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Fetch API used to get typings from unpkg link and add library to monaco editor for intellisense support.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10109)