### PR TITLE
Drop hint's icon and position, for column drag-drop in DetailsList updated

### DIFF
--- a/change/office-ui-fabric-react-2019-08-12-00-07-38-fabric-7.0.json
+++ b/change/office-ui-fabric-react-2019-08-12-00-07-38-fabric-7.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Moving the drag-drop caret icon on top of column divider to make if compatible with Sticky header",
+  "packageName": "office-ui-fabric-react",
+  "email": "svaibhav@microsoft.com",
+  "commit": "f92b1ee8a21054d1f57d0277d3fd0010d9d1b124",
+  "date": "2019-08-11T18:37:38.361Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -586,7 +586,7 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
           data-is-focusable={false}
           data-sizer-index={dropHintIndex}
           className={classNames.dropHintCaretStyle}
-          iconName={'CaretUpSolid8'}
+          iconName={'CaretDownSolid8'}
         />
         <div
           key={`dropHintLineKey`}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
@@ -307,7 +307,7 @@ export const getStyles = (props: IDetailsHeaderStyleProps): IDetailsHeaderStyles
       {
         display: 'none',
         position: 'absolute',
-        top: 22,
+        top: -18,
         left: -7.5,
         fontSize: fonts.mediumPlus.fontSize,
         color: palette.themePrimary,
@@ -322,7 +322,7 @@ export const getStyles = (props: IDetailsHeaderStyleProps): IDetailsHeaderStyles
         display: 'none',
         position: 'absolute',
         bottom: 0,
-        top: -3,
+        top: 6,
         overflow: 'hidden',
         height: 37,
         width: 1,

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -1087,10 +1087,10 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                         background: #0078d4;
                         bottom: 0px;
                         display: none;
-                        height: 33px;
+                        height: 37px;
                         overflow: hidden;
                         position: absolute;
-                        top: 0px;
+                        top: 6px;
                         width: 1px;
                         z-index: 10;
                       }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -1069,15 +1069,15 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                         overflow: visible;
                         position: absolute;
                         speak: none;
-                        top: 22px;
+                        top: -18px;
                         z-index: 10;
                       }
-                  data-icon-name="CaretUpSolid8"
+                  data-icon-name="CaretDownSolid8"
                   data-is-focusable={false}
                   data-sizer-index={1}
                   role="presentation"
                 >
-                  
+                  
                 </i>
                 <div
                   aria-hidden={true}
@@ -1087,10 +1087,10 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                         background: #0078d4;
                         bottom: 0px;
                         display: none;
-                        height: 37px;
+                        height: 33px;
                         overflow: hidden;
                         position: absolute;
-                        top: -3px;
+                        top: 0px;
                         width: 1px;
                         z-index: 10;
                       }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Changing the drop hint icon and it's position for list's column drag-drop
With reference of [**PR for Fabric 6.0**](https://github.com/OfficeDev/office-ui-fabric-react/pull/10086), this is to make the latest version same as that of earlier so that bumping fabric from 6.x to 7.x do not regress the drag-drop feature

#### Focus areas to test

Details list: drag drop a column to a new position. The drop hint will now appear above

**CC:** @KevinTCoughlin , @arkogupta  kindly have a look at the change. The impact can be seen in the DetailsList's drag-drop example in the demo app.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10120)