### PR TITLE
React: Rename deprecated lifecycle methods

### DIFF
--- a/apps/fabric-website/src/components/Site/Site.tsx
+++ b/apps/fabric-website/src/components/Site/Site.tsx
@@ -113,7 +113,8 @@ export class Site<TPlatforms extends string = string> extends React.Component<IS
     window.removeEventListener('hashchange', this._handleRouteChange);
   }
 
-  public componentWillReceiveProps(nextProps: ISiteProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(nextProps: ISiteProps): void {
     if (nextProps && nextProps.children !== this.props.children) {
       document.body.scrollTop = document.documentElement.scrollTop = 0;
     }

--- a/change/@uifabric-date-time-2019-08-13-12-50-31-jg-rename-lifecycle-functions.json
+++ b/change/@uifabric-date-time-2019-08-13-12-50-31-jg-rename-lifecycle-functions.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Rename deprecated React lifecycle functions to prevent development mode warnings in React 16.9.",
+  "packageName": "@uifabric/date-time",
+  "email": "jagore@microsoft.com",
+  "commit": "ce48383da2d27474122aef769af0c313e29281d0",
+  "date": "2019-08-13T19:50:20.872Z"
+}

--- a/change/@uifabric-example-app-base-2019-08-13-12-50-31-jg-rename-lifecycle-functions.json
+++ b/change/@uifabric-example-app-base-2019-08-13-12-50-31-jg-rename-lifecycle-functions.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Rename deprecated React lifecycle functions to prevent development mode warnings in React 16.9.",
+  "packageName": "@uifabric/example-app-base",
+  "email": "jagore@microsoft.com",
+  "commit": "ce48383da2d27474122aef769af0c313e29281d0",
+  "date": "2019-08-13T19:50:24.363Z"
+}

--- a/change/@uifabric-experiments-2019-08-13-12-50-31-jg-rename-lifecycle-functions.json
+++ b/change/@uifabric-experiments-2019-08-13-12-50-31-jg-rename-lifecycle-functions.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Rename deprecated React lifecycle functions to prevent development mode warnings in React 16.9.",
+  "packageName": "@uifabric/experiments",
+  "email": "jagore@microsoft.com",
+  "commit": "ce48383da2d27474122aef769af0c313e29281d0",
+  "date": "2019-08-13T19:50:28.268Z"
+}

--- a/change/@uifabric-fabric-website-2019-08-13-12-50-31-jg-rename-lifecycle-functions.json
+++ b/change/@uifabric-fabric-website-2019-08-13-12-50-31-jg-rename-lifecycle-functions.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Rename deprecated React lifecycle functions to prevent development mode warnings in React 16.9.",
+  "packageName": "@uifabric/fabric-website",
+  "email": "jagore@microsoft.com",
+  "commit": "ce48383da2d27474122aef769af0c313e29281d0",
+  "date": "2019-08-13T19:50:13.950Z"
+}

--- a/change/office-ui-fabric-react-2019-08-13-12-50-31-jg-rename-lifecycle-functions.json
+++ b/change/office-ui-fabric-react-2019-08-13-12-50-31-jg-rename-lifecycle-functions.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Rename deprecated React lifecycle functions to prevent development mode warnings in React 16.9.",
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com",
+  "commit": "ce48383da2d27474122aef769af0c313e29281d0",
+  "date": "2019-08-13T19:50:31.600Z"
+}

--- a/packages/date-time/etc/date-time.api.md
+++ b/packages/date-time/etc/date-time.api.md
@@ -40,8 +40,6 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
     // (undocumented)
     componentDidUpdate(prevProps: IDatePickerProps, prevState: IDatePickerState): void;
     // (undocumented)
-    componentWillReceiveProps(nextProps: IDatePickerProps): void;
-    // (undocumented)
     static defaultProps: IDatePickerProps;
     // (undocumented)
     focus(): void;
@@ -49,6 +47,8 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
     render(): JSX.Element;
     // (undocumented)
     reset(): void;
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(nextProps: IDatePickerProps): void;
     }
 
 export { DateRangeType }

--- a/packages/date-time/src/components/Calendar/Calendar.base.tsx
+++ b/packages/date-time/src/components/Calendar/Calendar.base.tsx
@@ -124,7 +124,8 @@ export class CalendarBase extends BaseComponent<ICalendarProps, ICalendarState> 
     this._focusOnUpdate = false;
   }
 
-  public componentWillReceiveProps(nextProps: ICalendarProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(nextProps: ICalendarProps): void {
     const { value, today = new Date() } = nextProps;
 
     this.setState({

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -72,7 +72,8 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
     this._onClose = this._onClose.bind(this);
   }
 
-  public componentWillReceiveProps(nextProps: ICalendarDayGridProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(nextProps: ICalendarDayGridProps): void {
     const weeks = this._getWeeks(nextProps);
     let isBackwards = undefined;
 

--- a/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
@@ -86,7 +86,8 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
     this._preventFocusOpeningPicker = false;
   }
 
-  public componentWillReceiveProps(nextProps: IDatePickerProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(nextProps: IDatePickerProps): void {
     const { formatDate, isRequired, strings, value, minDate, maxDate } = nextProps;
 
     if (

--- a/packages/example-app-base/src/components/LoadingComponent/LoadingComponent.tsx
+++ b/packages/example-app-base/src/components/LoadingComponent/LoadingComponent.tsx
@@ -114,7 +114,8 @@ export class LoadingComponent extends React.PureComponent<ILoadingComponentProps
   private readonly _async: Async = new Async();
   private _otherSections: IPageSectionProps[];
 
-  public componentWillMount(): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillMount(): void {
     this._otherSections = shimmerSections();
   }
 

--- a/packages/experiments/src/components/FloatingSuggestions/FloatingSuggestions.tsx
+++ b/packages/experiments/src/components/FloatingSuggestions/FloatingSuggestions.tsx
@@ -113,7 +113,8 @@ export class FloatingSuggestions<TItem> extends BaseComponent<IFloatingSuggestio
     this.isComponentMounted = false;
   }
 
-  public componentWillReceiveProps(newProps: IFloatingSuggestionsProps<TItem>): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(newProps: IFloatingSuggestionsProps<TItem>): void {
     if (newProps.suggestionItems) {
       this.updateSuggestions(newProps.suggestionItems);
     }

--- a/packages/experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsControl.tsx
+++ b/packages/experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsControl.tsx
@@ -68,7 +68,8 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
     this.scrollSelected();
   }
 
-  public componentWillReceiveProps(newProps: ISuggestionsControlProps<T>): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(newProps: ISuggestionsControlProps<T>): void {
     if (newProps.suggestions) {
       this.setState({ suggestions: newProps.suggestions }, () => {
         this._resetSelectedItem();

--- a/packages/experiments/src/components/Tile/Tile.tsx
+++ b/packages/experiments/src/components/Tile/Tile.tsx
@@ -93,7 +93,8 @@ export class Tile extends React.Component<ITileProps, ITileState> {
     this._events = new EventGroup(this);
   }
 
-  public componentWillReceiveProps(nextProps: ITileProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(nextProps: ITileProps): void {
     const { selection, selectionIndex } = this.props;
 
     const { selection: nextSelection, selectionIndex: nextSelectionIndex = -1 } = nextProps;

--- a/packages/experiments/src/components/TilesList/TilesList.tsx
+++ b/packages/experiments/src/components/TilesList/TilesList.tsx
@@ -94,7 +94,8 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
     initializeFocusRects();
   }
 
-  public componentWillReceiveProps(nextProps: ITilesListProps<TItem>): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(nextProps: ITilesListProps<TItem>): void {
     if (nextProps.items !== this.props.items) {
       this.setState({
         cells: this._getCells(nextProps.items)
@@ -102,7 +103,8 @@ export class TilesList<TItem> extends React.Component<ITilesListProps<TItem>, IT
     }
   }
 
-  public componentWillUpdate(nextProps: ITilesListProps<TItem>, nextState: ITilesListState<TItem>): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillUpdate(nextProps: ITilesListProps<TItem>, nextState: ITilesListState<TItem>): void {
     if (nextState.cells !== this.state.cells) {
       this._pageSpecificationCache = undefined;
     }

--- a/packages/experiments/src/components/VirtualizedList/VirtualizedList.tsx
+++ b/packages/experiments/src/components/VirtualizedList/VirtualizedList.tsx
@@ -63,7 +63,8 @@ export class VirtualizedList<TItem extends IObjectWithKey> extends BaseComponent
     this._updateObservedElements();
   }
 
-  public componentWillUpdate(): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillUpdate(): void {
     for (const key of Object.keys(this._spacerElements)) {
       const ref = this._spacerElements[key];
       this.context.scrollContainer.unobserve(ref);

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -549,8 +549,6 @@ export class ChoiceGroupBase extends React.Component<IChoiceGroupProps, IChoiceG
     focus(): void;
     // (undocumented)
     render(): JSX.Element;
-    // (undocumented)
-    UNSAFE_componentWillReceiveProps(newProps: IChoiceGroupProps): void;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -76,8 +76,6 @@ export class Autofill extends BaseComponent<IAutofillProps, IAutofillState> impl
     // (undocumented)
     componentDidUpdate(): void;
     // (undocumented)
-    componentWillReceiveProps(nextProps: IAutofillProps): void;
-    // (undocumented)
     readonly cursorLocation: number | null;
     // (undocumented)
     static defaultProps: {
@@ -95,6 +93,8 @@ export class Autofill extends BaseComponent<IAutofillProps, IAutofillState> impl
     readonly selectionEnd: number | null;
     // (undocumented)
     readonly selectionStart: number | null;
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(nextProps: IAutofillProps): void;
     // (undocumented)
     readonly value: string;
     }
@@ -135,8 +135,6 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extend
     clearInput(): void;
     // (undocumented)
     componentDidMount(): void;
-    // (undocumented)
-    componentWillReceiveProps(newProps: P): void;
     // (undocumented)
     floatingPicker: React.RefObject<BaseFloatingPicker<T, IBaseFloatingPickerProps<T>>>;
     // (undocumented)
@@ -183,6 +181,8 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extend
     protected selectedItemsListProps: IBaseSelectedItemsListProps<T>;
     // (undocumented)
     protected selection: Selection;
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(newProps: P): void;
 }
 
 // @public (undocumented)
@@ -198,8 +198,6 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extend
     componentDidMount(): void;
     // (undocumented)
     componentDidUpdate(): void;
-    // (undocumented)
-    componentWillReceiveProps(newProps: IBaseFloatingPickerProps<T>): void;
     // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
@@ -247,6 +245,8 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extend
     // (undocumented)
     protected suggestionStore: SuggestionsStore<T>;
     // (undocumented)
+    UNSAFE_componentWillReceiveProps(newProps: IBaseFloatingPickerProps<T>): void;
+    // (undocumented)
     updateSuggestions(suggestions: T[], forceUpdate?: boolean): void;
     // (undocumented)
     protected updateSuggestionsList(suggestions: T[] | PromiseLike<T[]>): void;
@@ -280,11 +280,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
     // (undocumented)
     componentDidMount(): void;
     // (undocumented)
-    componentWillReceiveProps(newProps: P): void;
-    // (undocumented)
     componentWillUnmount(): void;
-    // (undocumented)
-    componentWillUpdate(newProps: P, newState: IBasePickerState): void;
     // (undocumented)
     protected currentPromise: PromiseLike<any> | undefined;
     // (undocumented)
@@ -361,6 +357,10 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
     // (undocumented)
     protected suggestionStore: SuggestionsController<T>;
     // (undocumented)
+    UNSAFE_componentWillReceiveProps(newProps: P): void;
+    // (undocumented)
+    UNSAFE_componentWillUpdate(newProps: P, newState: IBasePickerState): void;
+    // (undocumented)
     protected updateSuggestions(suggestions: any[]): void;
     // (undocumented)
     protected updateSuggestionsList(suggestions: T[] | PromiseLike<T[]>, updatedValue?: string): void;
@@ -383,10 +383,6 @@ export class BaseSelectedItemsList<T, P extends IBaseSelectedItemsListProps<T>> 
     addItems: (items: T[]) => void;
     // (undocumented)
     componentDidMount(): void;
-    // (undocumented)
-    componentWillReceiveProps(newProps: P): void;
-    // (undocumented)
-    componentWillUpdate(newProps: P, newState: IBaseSelectedItemsListState): void;
     // (undocumented)
     protected copyItems(items: T[]): void;
     // (undocumented)
@@ -421,6 +417,10 @@ export class BaseSelectedItemsList<T, P extends IBaseSelectedItemsListProps<T>> 
     protected root: HTMLElement;
     // (undocumented)
     protected selection: Selection;
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(newProps: P): void;
+    // (undocumented)
+    UNSAFE_componentWillUpdate(newProps: P, newState: IBaseSelectedItemsListState): void;
     // (undocumented)
     unselectAll(): void;
     updateItems(items: T[], focusIndex?: number): void;
@@ -484,17 +484,17 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> impl
     // (undocumented)
     componentDidUpdate(): void;
     // (undocumented)
-    componentWillReceiveProps(nextProps: ICalendarProps): void;
-    // (undocumented)
     static defaultProps: ICalendarProps;
     // (undocumented)
     focus(): void;
     // (undocumented)
     render(): JSX.Element;
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(nextProps: ICalendarProps): void;
 }
 
 // Warning: (ae-forgotten-export) The symbol "ICalloutState" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export class Callout extends React.Component<ICalloutProps, ICalloutState> {
     // (undocumented)
@@ -544,13 +544,13 @@ export class ChoiceGroupBase extends React.Component<IChoiceGroupProps, IChoiceG
     constructor(props: IChoiceGroupProps);
     readonly checkedOption: IChoiceGroupOption | undefined;
     // (undocumented)
-    componentWillReceiveProps(newProps: IChoiceGroupProps): void;
-    // (undocumented)
     static defaultProps: IChoiceGroupProps;
     // (undocumented)
     focus(): void;
     // (undocumented)
     render(): JSX.Element;
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(newProps: IChoiceGroupProps): void;
 }
 
 // @public (undocumented)
@@ -573,8 +573,6 @@ export class CoachmarkBase extends BaseComponent<ICoachmarkProps, ICoachmarkStat
     // (undocumented)
     componentDidUpdate(prevProps: ICoachmarkProps, prevState: ICoachmarkState): void;
     // (undocumented)
-    componentWillReceiveProps(newProps: ICoachmarkProps): void;
-    // (undocumented)
     static defaultProps: Partial<ICoachmarkProps>;
     // (undocumented)
     dismiss: (ev?: Event | React.KeyboardEvent<HTMLElement> | React.MouseEvent<HTMLElement, MouseEvent> | undefined) => void;
@@ -582,7 +580,9 @@ export class CoachmarkBase extends BaseComponent<ICoachmarkProps, ICoachmarkStat
     render(): JSX.Element;
     // (undocumented)
     shouldComponentUpdate(newProps: ICoachmarkProps, newState: ICoachmarkState): boolean;
-    }
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(newProps: ICoachmarkProps): void;
+}
 
 // @public (undocumented)
 export enum CollapseAllVisibility {
@@ -601,8 +601,6 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
     // (undocumented)
     readonly color: IColor;
     // (undocumented)
-    componentWillReceiveProps(newProps: IColorPickerProps): void;
-    // (undocumented)
     static defaultProps: {
         hexLabel: string;
         redLabel: string;
@@ -612,6 +610,8 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
     };
     // (undocumented)
     render(): JSX.Element;
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(newProps: IColorPickerProps): void;
     }
 
 // @public (undocumented)
@@ -647,20 +647,20 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     // (undocumented)
     componentDidUpdate(prevProps: IComboBoxProps, prevState: IComboBoxState): void;
     // (undocumented)
-    componentWillReceiveProps(newProps: IComboBoxProps): void;
-    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     static defaultProps: IComboBoxProps;
     dismissMenu: () => void;
     // Warning: (ae-unresolved-inheritdoc-base) The @inheritDoc tag needs a TSDoc declaration reference; signature matching is not supported yet
-    //
+    // 
     // (undocumented)
     focus: (shouldOpenOnFocus?: boolean | undefined, useFocusAsync?: boolean | undefined) => void;
     // (undocumented)
     render(): JSX.Element;
     readonly selectedOptions: IComboBoxOption[];
-    }
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(newProps: IComboBoxProps): void;
+}
 
 // @public (undocumented)
 export const CommandBar: React.StatelessComponent<ICommandBarProps>;
@@ -721,11 +721,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
     // (undocumented)
     componentDidMount(): void;
     // (undocumented)
-    componentWillMount(): void;
-    // (undocumented)
     componentWillUnmount(): void;
-    // (undocumented)
-    componentWillUpdate(newProps: IContextualMenuProps): void;
     // (undocumented)
     static defaultProps: IContextualMenuProps;
     // (undocumented)
@@ -734,6 +730,10 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
     render(): JSX.Element | null;
     // (undocumented)
     shouldComponentUpdate(newProps: IContextualMenuProps, newState: IContextualMenuState): boolean;
+    // (undocumented)
+    UNSAFE_componentWillMount(): void;
+    // (undocumented)
+    UNSAFE_componentWillUpdate(newProps: IContextualMenuProps): void;
     }
 
 // @public
@@ -792,8 +792,6 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
     // (undocumented)
     componentDidUpdate(prevProps: IDatePickerProps, prevState: IDatePickerState): void;
     // (undocumented)
-    componentWillReceiveProps(nextProps: IDatePickerProps): void;
-    // (undocumented)
     static defaultProps: IDatePickerProps;
     // (undocumented)
     focus(): void;
@@ -801,6 +799,8 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
     render(): JSX.Element;
     // (undocumented)
     reset(): void;
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(nextProps: IDatePickerProps): void;
     }
 
 // @public
@@ -890,11 +890,7 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
     // (undocumented)
     componentDidUpdate(prevProps: IDetailsListProps, prevState: IDetailsListState): void;
     // (undocumented)
-    componentWillReceiveProps(newProps: IDetailsListProps): void;
-    // (undocumented)
     componentWillUnmount(): void;
-    // (undocumented)
-    componentWillUpdate(): void;
     // (undocumented)
     static defaultProps: {
         layoutMode: DetailsListLayoutMode;
@@ -916,7 +912,11 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
     render(): JSX.Element;
     // (undocumented)
     scrollToIndex(index: number, measureItem?: (itemIndex: number) => number, scrollToMode?: ScrollToMode): void;
-    }
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(newProps: IDetailsListProps): void;
+    // (undocumented)
+    UNSAFE_componentWillUpdate(): void;
+}
 
 // @public (undocumented)
 export enum DetailsListLayoutMode {
@@ -935,8 +935,6 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
     // (undocumented)
     componentDidUpdate(previousProps: IDetailsRowBaseProps): void;
     // (undocumented)
-    componentWillReceiveProps(newProps: IDetailsRowBaseProps): void;
-    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     focus(forceIntoFirstElement?: boolean): boolean;
@@ -947,6 +945,8 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
     render(): JSX.Element;
     // (undocumented)
     shouldComponentUpdate(nextProps: IDetailsRowBaseProps, nextState: IDetailsRowState): boolean;
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(newProps: IDetailsRowBaseProps): void;
     }
 
 // @public (undocumented)
@@ -1075,8 +1075,6 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
     // (undocumented)
     componentDidUpdate(prevProps: IDropdownProps, prevState: IDropdownState): void;
     // (undocumented)
-    componentWillReceiveProps(newProps: IDropdownProps): void;
-    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     static defaultProps: {
@@ -1089,7 +1087,9 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
     readonly selectedOptions: IDropdownOption[];
     // (undocumented)
     setSelectedIndex(event: React.FormEvent<HTMLDivElement>, index: number): void;
-    }
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(newProps: IDropdownProps): void;
+}
 
 // @public (undocumented)
 export enum ElementType {
@@ -1241,13 +1241,13 @@ export class FocusTrapZone extends React.Component<IFocusTrapZoneProps, {}> impl
     // (undocumented)
     componentDidUpdate(prevProps: IFocusTrapZoneProps): void;
     // (undocumented)
-    componentWillReceiveProps(nextProps: IFocusTrapZoneProps): void;
-    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     focus(): void;
     // (undocumented)
     render(): JSX.Element;
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(nextProps: IFocusTrapZoneProps): void;
     }
 
 // @public (undocumented)
@@ -1355,8 +1355,6 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
     // (undocumented)
     componentDidMount(): void;
     // (undocumented)
-    componentWillReceiveProps(newProps: IGroupedListProps): void;
-    // (undocumented)
     static defaultProps: {
         selectionMode: SelectionMode;
         isHeaderVisible: boolean;
@@ -1377,6 +1375,8 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
     scrollToIndex(index: number, measureItem?: (itemIndex: number) => number, scrollToMode?: ScrollToMode): void;
     // (undocumented)
     toggleCollapseAll(allCollapsed: boolean): void;
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(newProps: IGroupedListProps): void;
     }
 
 // @public (undocumented)
@@ -2867,7 +2867,7 @@ export interface IContextualMenuItem {
     data?: any;
     disabled?: boolean;
     // Warning: (ae-forgotten-export) The symbol "IMenuItemClassNames" needs to be exported by the entry point index.d.ts
-    //
+    // 
     // @deprecated
     getItemClassNames?: (theme: ITheme, disabled: boolean, expanded: boolean, checked: boolean, isAnchorLink: boolean, knownIcon: boolean, itemClassName?: string, dividerClassName?: string, iconClassName?: string, subMenuClassName?: string, primaryDisabled?: boolean) => IMenuItemClassNames;
     getSplitButtonVerticalDividerClassNames?: (theme: ITheme) => IVerticalDividerClassNames;
@@ -2967,7 +2967,7 @@ export interface IContextualMenuListProps {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IWithResponsiveModeState" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public
 export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWithResponsiveModeState {
     alignTargetEdge?: boolean;
@@ -2987,7 +2987,7 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
     focusZoneProps?: IFocusZoneProps;
     gapSpace?: number;
     // Warning: (ae-forgotten-export) The symbol "IContextualMenuClassNames" needs to be exported by the entry point index.d.ts
-    //
+    // 
     // @deprecated
     getMenuClassNames?: (theme: ITheme, className?: string) => IContextualMenuClassNames;
     hidden?: boolean;
@@ -3736,7 +3736,7 @@ export interface IDialogFooterStyles {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IAccessiblePopupProps" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IDialogProps extends React.ClassAttributes<DialogBase>, IWithResponsiveModeState, IAccessiblePopupProps {
     // @deprecated
@@ -3840,7 +3840,7 @@ export interface IDocumentCardActions {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardActionsBase" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IDocumentCardActionsProps extends React.ClassAttributes<DocumentCardActionsBase> {
     actions: IButtonProps[];
@@ -3883,7 +3883,7 @@ export interface IDocumentCardActivityPerson {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardActivityBase" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IDocumentCardActivityProps extends React.ClassAttributes<DocumentCardActivityBase> {
     activity: string;
@@ -3922,7 +3922,7 @@ export interface IDocumentCardDetails {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardDetailsBase" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IDocumentCardDetailsProps extends React.Props<DocumentCardDetailsBase> {
     className?: string;
@@ -3981,7 +3981,7 @@ export interface IDocumentCardLocation {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardLocationBase" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IDocumentCardLocationProps extends React.ClassAttributes<DocumentCardLocationBase> {
     ariaLabel?: string;
@@ -4011,7 +4011,7 @@ export interface IDocumentCardLogo {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardLogoBase" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IDocumentCardLogoProps extends React.ClassAttributes<DocumentCardLogoBase> {
     className?: string;
@@ -4111,7 +4111,7 @@ export interface IDocumentCardStatus {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardStatusBase" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IDocumentCardStatusProps extends React.Props<DocumentCardStatusBase> {
     className?: string;
@@ -4153,7 +4153,7 @@ export interface IDocumentCardTitle {
 }
 
 // Warning: (ae-forgotten-export) The symbol "DocumentCardTitleBase" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IDocumentCardTitleProps extends React.ClassAttributes<DocumentCardTitleBase> {
     className?: string;
@@ -4356,7 +4356,7 @@ export interface IExpandingCard {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IBaseCardProps" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public
 export interface IExpandingCardProps extends IBaseCardProps<IExpandingCard, IExpandingCardStyles, IExpandingCardStyleProps> {
     compactCardHeight?: number;
@@ -4375,7 +4375,7 @@ export interface IExpandingCardState {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IBaseCardStyleProps" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IExpandingCardStyleProps extends IBaseCardStyleProps {
     compactCardHeight?: number;
@@ -4385,7 +4385,7 @@ export interface IExpandingCardStyleProps extends IBaseCardStyleProps {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IBaseCardStyles" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IExpandingCardStyles extends IBaseCardStyles {
     compactCard?: IStyle;
@@ -5284,14 +5284,14 @@ export class ImageBase extends React.Component<IImageProps, IImageState> {
     // (undocumented)
     componentDidUpdate(prevProps: IImageProps, prevState: IImageState): void;
     // (undocumented)
-    componentWillReceiveProps(nextProps: IImageProps): void;
-    // (undocumented)
     static defaultProps: {
         shouldFadeIn: boolean;
     };
     // (undocumented)
     render(): JSX.Element;
-    }
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(nextProps: IImageProps): void;
+}
 
 // @public
 export enum ImageCoverStyle {
@@ -5709,7 +5709,7 @@ export interface IPanelHeaderRenderer extends IRenderFunction<IPanelProps> {
 }
 
 // Warning: (ae-forgotten-export) The symbol "PanelBase" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
     className?: string;
@@ -6867,7 +6867,7 @@ export interface ISpinButtonProps {
     keytipProps?: IKeytipProps;
     label?: string;
     // Warning: (ae-forgotten-export) The symbol "Position" needs to be exported by the entry point index.d.ts
-    //
+    // 
     // (undocumented)
     labelPosition?: Position;
     max?: number;
@@ -7483,14 +7483,14 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
 }
 
 // Warning: (ae-internal-missing-underscore) The name "ITextFieldSnapshot" should be prefixed with an underscore because the declaration is marked as @internal
-//
+// 
 // @internal (undocumented)
 export interface ITextFieldSnapshot {
     selection?: [number | null, number | null];
 }
 
 // Warning: (ae-internal-missing-underscore) The name "ITextFieldState" should be prefixed with an underscore because the declaration is marked as @internal
-//
+// 
 // @internal (undocumented)
 export interface ITextFieldState {
     errorMessage: string | JSX.Element;
@@ -7767,7 +7767,7 @@ export class Keytip extends React.Component<IKeytipProps, {}> {
 }
 
 // Warning: (ae-forgotten-export) The symbol "IKeytipDataProps" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public
 export class KeytipData extends React.Component<IKeytipDataProps & IRenderComponent<{}>, {}> {
     // (undocumented)
@@ -7795,7 +7795,7 @@ export class KeytipLayerBase extends BaseComponent<IKeytipLayerProps, IKeytipLay
     // (undocumented)
     getCurrentSequence(): string;
     // Warning: (ae-forgotten-export) The symbol "KeytipTree" needs to be exported by the entry point index.d.ts
-    //
+    // 
     // (undocumented)
     getKeytipTree(): KeytipTree;
     processInput(key: string, ev?: React.KeyboardEvent<HTMLElement>): void;
@@ -7825,19 +7825,19 @@ export class LayerBase extends React.Component<ILayerProps, ILayerBaseState> {
     // (undocumented)
     componentDidUpdate(): void;
     // (undocumented)
-    componentWillMount(): void;
-    // (undocumented)
     componentWillUnmount(): void;
-    // (undocumented)
-    componentWillUpdate(): void;
     // (undocumented)
     static defaultProps: ILayerProps;
     // (undocumented)
     render(): React.ReactNode;
-    }
+    // (undocumented)
+    UNSAFE_componentWillMount(): void;
+    // (undocumented)
+    UNSAFE_componentWillUpdate(): void;
+}
 
 // Warning: (ae-forgotten-export) The symbol "ILayerHostProps" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export class LayerHost extends React.Component<ILayerHostProps> {
     // (undocumented)
@@ -7867,8 +7867,6 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     // (undocumented)
     componentDidMount(): void;
     // (undocumented)
-    componentWillReceiveProps(newProps: IListProps<T>): void;
-    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     static defaultProps: {
@@ -7891,6 +7889,8 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     scrollToIndex(index: number, measureItem?: (itemIndex: number) => number, scrollToMode?: ScrollToMode): void;
     // (undocumented)
     shouldComponentUpdate(newProps: IListProps<T>, newState: IListState<T>): boolean;
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(newProps: IListProps<T>): void;
     }
 
 // @public (undocumented)
@@ -7916,8 +7916,6 @@ export class MaskedTextField extends React.Component<ITextFieldProps, IMaskedTex
     // (undocumented)
     componentDidUpdate(): void;
     // (undocumented)
-    componentWillReceiveProps(newProps: ITextFieldProps): void;
-    // (undocumented)
     static defaultProps: ITextFieldProps;
     // (undocumented)
     focus(): void;
@@ -7938,6 +7936,8 @@ export class MaskedTextField extends React.Component<ITextFieldProps, IMaskedTex
     // (undocumented)
     setValue(newValue: string): void;
     protected _skipComponentRefResolution: boolean;
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(newProps: ITextFieldProps): void;
     // (undocumented)
     readonly value: string | undefined;
 }
@@ -8020,14 +8020,14 @@ export class ModalBase extends BaseComponent<IModalProps, IDialogState> implemen
     // (undocumented)
     componentDidUpdate(prevProps: IModalProps, prevState: IDialogState): void;
     // (undocumented)
-    componentWillReceiveProps(newProps: IModalProps): void;
-    // (undocumented)
     static defaultProps: IModalProps;
     // (undocumented)
     focus(): void;
     // (undocumented)
     render(): JSX.Element | null;
-    }
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(newProps: IModalProps): void;
+}
 
 // @public (undocumented)
 export const mru: IExtendedPersonaProps[];
@@ -8094,14 +8094,14 @@ export class OverflowSetBase extends BaseComponent<IOverflowSetProps, {}> implem
     // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
-    componentWillUpdate(): void;
-    // (undocumented)
     static defaultProps: Pick<IOverflowSetProps, 'vertical' | 'role'>;
     focus(forceIntoFirstElement?: boolean): boolean;
     focusElement(childElement?: HTMLElement): boolean;
     // (undocumented)
     render(): JSX.Element;
-    }
+    // (undocumented)
+    UNSAFE_componentWillUpdate(): void;
+}
 
 // @public (undocumented)
 export const Overlay: React.StatelessComponent<IOverlayProps>;
@@ -8168,11 +8168,11 @@ export const PersonaCoin: React.StatelessComponent<IPersonaCoinProps>;
 export class PersonaCoinBase extends BaseComponent<IPersonaCoinProps, IPersonaState> {
     constructor(props: IPersonaCoinProps);
     // (undocumented)
-    componentWillReceiveProps(nextProps: IPersonaCoinProps): void;
-    // (undocumented)
     static defaultProps: IPersonaCoinProps;
     // (undocumented)
     render(): JSX.Element | null;
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(nextProps: IPersonaCoinProps): void;
 }
 
 // @public (undocumented)
@@ -8368,8 +8368,6 @@ export class Popup extends React.Component<IPopupProps, IPopupState> {
     // (undocumented)
     componentDidUpdate(): void;
     // (undocumented)
-    componentWillMount(): void;
-    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     static defaultProps: IPopupProps;
@@ -8377,6 +8375,8 @@ export class Popup extends React.Component<IPopupProps, IPopupState> {
     render(): JSX.Element;
     // (undocumented)
     _root: React.RefObject<HTMLDivElement>;
+    // (undocumented)
+    UNSAFE_componentWillMount(): void;
     }
 
 // @public (undocumented)
@@ -8386,10 +8386,6 @@ export class PositioningContainer extends BaseComponent<IPositioningContainerPro
     componentDidMount(): void;
     // (undocumented)
     componentDidUpdate(): void;
-    // (undocumented)
-    componentWillMount(): void;
-    // (undocumented)
-    componentWillUpdate(newProps: IPositioningContainerProps): void;
     // (undocumented)
     static defaultProps: IPositioningContainerProps;
     // @deprecated
@@ -8406,6 +8402,10 @@ export class PositioningContainer extends BaseComponent<IPositioningContainerPro
     render(): JSX.Element | null;
     // (undocumented)
     protected _setInitialFocus: () => void;
+    // (undocumented)
+    UNSAFE_componentWillMount(): void;
+    // (undocumented)
+    UNSAFE_componentWillUpdate(newProps: IPositioningContainerProps): void;
     }
 
 // @public (undocumented)
@@ -8471,11 +8471,11 @@ export class ResizeGroupBase extends BaseComponent<IResizeGroupProps, IResizeGro
     // (undocumented)
     componentDidUpdate(prevProps: IResizeGroupProps): void;
     // (undocumented)
-    componentWillReceiveProps(nextProps: IResizeGroupProps): void;
-    // (undocumented)
     remeasure(): void;
     // (undocumented)
     render(): JSX.Element;
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(nextProps: IResizeGroupProps): void;
     }
 
 // @public (undocumented)
@@ -8589,16 +8589,16 @@ export const SearchBox: React.StatelessComponent<ISearchBoxProps>;
 export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxState> {
     constructor(props: ISearchBoxProps);
     // (undocumented)
-    componentWillMount(): void;
-    // (undocumented)
-    componentWillReceiveProps(newProps: ISearchBoxProps): void;
-    // (undocumented)
     static defaultProps: Pick<ISearchBoxProps, 'disableAnimation' | 'clearButtonProps'>;
     focus(): void;
     hasFocus(): boolean;
     // (undocumented)
     render(): JSX.Element;
-    }
+    // (undocumented)
+    UNSAFE_componentWillMount(): void;
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(newProps: ISearchBoxProps): void;
+}
 
 // @public (undocumented)
 enum SelectableOptionMenuItemType {
@@ -8797,7 +8797,6 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
 // @public (undocumented)
 export class SpinButton extends React.Component<ISpinButtonProps, ISpinButtonState> implements ISpinButton {
     constructor(props: ISpinButtonProps);
-    componentWillReceiveProps(newProps: ISpinButtonProps): void;
     // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
@@ -8806,6 +8805,7 @@ export class SpinButton extends React.Component<ISpinButtonProps, ISpinButtonSta
     focus(): void;
     // (undocumented)
     render(): JSX.Element;
+    UNSAFE_componentWillReceiveProps(newProps: ISpinButtonProps): void;
     readonly value: string | undefined;
     }
 
@@ -8955,8 +8955,6 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
     // (undocumented)
     componentDidUpdate(): void;
     // (undocumented)
-    componentWillReceiveProps(newProps: ISuggestionsControlProps<T>): void;
-    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     readonly currentSuggestion: ISuggestionModel<T>;
@@ -8996,7 +8994,9 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
     protected selectPreviousItem(itemType: SuggestionItemType, originalItemType?: SuggestionItemType): void;
     // (undocumented)
     protected _suggestions: SuggestionsCore<T>;
-    }
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(newProps: ISuggestionsControlProps<T>): void;
+}
 
 // @public (undocumented)
 export class SuggestionsController<T> {
@@ -9105,14 +9105,14 @@ export const SwatchColorPicker: React.StatelessComponent<ISwatchColorPickerProps
 export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerProps, ISwatchColorPickerState> {
     constructor(props: ISwatchColorPickerProps);
     // (undocumented)
-    componentWillReceiveProps(newProps: ISwatchColorPickerProps): void;
-    // (undocumented)
     componentWillUnmount(): void;
     // (undocumented)
     static defaultProps: ISwatchColorPickerProps;
     // (undocumented)
     render(): JSX.Element | null;
-    }
+    // (undocumented)
+    UNSAFE_componentWillReceiveProps(newProps: ISwatchColorPickerProps): void;
+}
 
 // @public (undocumented)
 export const TagItem: React.FunctionComponent<ITagItemProps>;
@@ -9200,7 +9200,7 @@ export const TextField: React.StatelessComponent<ITextFieldProps>;
 
 // Warning: (ae-incompatible-release-tags) The symbol "TextFieldBase" is marked as @public, but its signature references "ITextFieldState" which is marked as @internal
 // Warning: (ae-incompatible-release-tags) The symbol "TextFieldBase" is marked as @public, but its signature references "ITextFieldSnapshot" which is marked as @internal
-//
+// 
 // @public (undocumented)
 export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldState, ITextFieldSnapshot> implements ITextField {
     constructor(props: ITextFieldProps);
@@ -9357,7 +9357,7 @@ export * from "@uifabric/styling";
 export * from "@uifabric/utilities";
 
 // Warnings were encountered during analysis:
-//
+// 
 // lib/components/ColorPicker/ColorPicker.base.d.ts:8:9 - (ae-forgotten-export) The symbol "IRGBHex" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
+++ b/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
@@ -62,7 +62,8 @@ export class Autofill extends BaseComponent<IAutofillProps, IAutofillState> impl
     return this._inputElement.current;
   }
 
-  public componentWillReceiveProps(nextProps: IAutofillProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(nextProps: IAutofillProps): void {
     let newValue;
 
     if (this.props.updateValueInWillReceiveProps) {

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
@@ -92,7 +92,8 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> impl
     this._focusOnUpdate = false;
   }
 
-  public componentWillReceiveProps(nextProps: ICalendarProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(nextProps: ICalendarProps): void {
     const { autoNavigateOnSelection, value, today = new Date() } = nextProps;
 
     // Make sure auto-navigation is supported for programmatic changes to selected date, i.e.,

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -90,7 +90,8 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
     this._onClose = this._onClose.bind(this);
   }
 
-  public componentWillReceiveProps(nextProps: ICalendarDayProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(nextProps: ICalendarDayProps): void {
     this.setState({
       weeks: this._getWeeks(nextProps)
     });

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -122,7 +122,8 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
     return !shallowCompare(this.props, newProps) || !shallowCompare(this.state, newState);
   }
 
-  public componentWillMount() {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillMount() {
     this._setTargetWindowAndElement(this._getTarget());
   }
 
@@ -131,7 +132,8 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
     this._disposables.forEach((dispose: () => void) => dispose());
   }
 
-  public componentWillUpdate(newProps: ICalloutProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillUpdate(newProps: ICalloutProps): void {
     // If the target element changed, find the new one. If we are tracking target with class name, always find element because we
     // do not know if fabric has rendered a new element and disposed the old element.
     const newTarget = this._getTarget(newProps);

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.base.tsx
@@ -70,7 +70,8 @@ export class ChoiceGroupBase extends React.Component<IChoiceGroupProps, IChoiceG
     return find(options, (value: IChoiceGroupOption) => value.key === key);
   }
 
-  public componentWillReceiveProps(newProps: IChoiceGroupProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(newProps: IChoiceGroupProps): void {
     const newKeyChecked = this._getKeyChecked(newProps);
     const oldKeyChecked = this._getKeyChecked(this.props);
 

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.base.tsx
@@ -299,7 +299,8 @@ export class CoachmarkBase extends BaseComponent<ICoachmarkProps, ICoachmarkStat
     );
   }
 
-  public componentWillReceiveProps(newProps: ICoachmarkProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(newProps: ICoachmarkProps): void {
     if (this.props.isCollapsed && !newProps.isCollapsed) {
       // The coachmark is about to open
       this._openCoachmark();

--- a/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.tsx
@@ -97,7 +97,8 @@ export class PositioningContainer extends BaseComponent<IPositioningContainerPro
     this._positionAttempts = 0;
   }
 
-  public componentWillMount(): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillMount(): void {
     this._setTargetWindowAndElement(this._getTarget());
   }
 
@@ -110,7 +111,8 @@ export class PositioningContainer extends BaseComponent<IPositioningContainerPro
     this._updateAsyncPosition();
   }
 
-  public componentWillUpdate(newProps: IPositioningContainerProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillUpdate(newProps: IPositioningContainerProps): void {
     // If the target element changed, find the new one. If we are tracking
     // target with class name, always find element because we do not know if
     // fabric has rendered a new element and disposed the old element.

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
@@ -81,7 +81,8 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
     return this.state.color;
   }
 
-  public componentWillReceiveProps(newProps: IColorPickerProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(newProps: IColorPickerProps): void {
     const color = _getColorFromProps(newProps);
     if (color) {
       this._updateColor(undefined, color);

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle/ColorRectangle.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle/ColorRectangle.base.tsx
@@ -41,7 +41,8 @@ export class ColorRectangleBase extends React.Component<IColorRectangleProps, IC
     return this.state.color;
   }
 
-  public componentWillReceiveProps(newProps: IColorRectangleProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(newProps: IColorRectangleProps): void {
     const { color } = newProps;
 
     this.setState({

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/ColorSlider.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/ColorSlider.base.tsx
@@ -35,7 +35,8 @@ export class ColorSliderBase extends React.Component<IColorSliderProps, IColorSl
     };
   }
 
-  public componentWillReceiveProps(newProps: IColorSliderProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(newProps: IColorSliderProps): void {
     if (newProps && newProps.value) {
       this.setState({ currentValue: newProps.value });
     }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -222,7 +222,8 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     }
   }
 
-  public componentWillReceiveProps(newProps: IComboBoxProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(newProps: IComboBoxProps): void {
     // Update the selectedIndex and currentOptions state if
     // the selectedKey, value, or options have changed
     if (newProps.selectedKey !== this.props.selectedKey || newProps.text !== this.props.text || newProps.options !== this.props.options) {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -150,7 +150,8 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
     return !shallowCompare(this.props, newProps) || !shallowCompare(this.state, newState);
   }
 
-  public componentWillUpdate(newProps: IContextualMenuProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillUpdate(newProps: IContextualMenuProps): void {
     if (newProps.target !== this.props.target) {
       const newTarget = newProps.target;
       this._setTargetWindowAndElement(newTarget!);
@@ -173,7 +174,8 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
   }
 
   // Invoked once, both on the client and server, immediately before the initial rendering occurs.
-  public componentWillMount() {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillMount() {
     const target = this.props.target;
     this._setTargetWindowAndElement(target!);
     if (!this.props.hidden) {

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -86,7 +86,8 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
     this._preventFocusOpeningPicker = false;
   }
 
-  public componentWillReceiveProps(nextProps: IDatePickerProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(nextProps: IDatePickerProps): void {
     const { formatDate, value } = nextProps;
 
     if (

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -210,7 +210,8 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
     }
   }
 
-  public componentWillReceiveProps(newProps: IDetailsListProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(newProps: IDetailsListProps): void {
     const {
       checkboxVisibility,
       items,
@@ -281,7 +282,8 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
     }
   }
 
-  public componentWillUpdate(): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillUpdate(): void {
     if (this._pendingForceUpdate) {
       this._forceListUpdates();
     }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
@@ -137,7 +137,8 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
     this._events.dispose();
   }
 
-  public componentWillReceiveProps(newProps: IDetailsRowBaseProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(newProps: IDetailsRowBaseProps): void {
     this.setState({
       selectionState: this._getSelectionState(newProps)
     });

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -130,7 +130,8 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
     clearTimeout(this._scrollIdleTimeoutId);
   }
 
-  public componentWillReceiveProps(newProps: IDropdownProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(newProps: IDropdownProps): void {
     // In controlled component usage where selectedKey is provided, update the selectedIndex
     // state if the key or options change.
     let selectedKeyProp: 'defaultSelectedKeys' | 'selectedKeys' | 'defaultSelectedKey' | 'selectedKey';

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -60,7 +60,8 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extend
     this.forceUpdate();
   }
 
-  public componentWillReceiveProps(newProps: P): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(newProps: P): void {
     if (newProps.floatingPickerProps) {
       this.floatingPickerProps = newProps.floatingPickerProps;
     }

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
@@ -120,7 +120,8 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extend
     this.isComponentMounted = false;
   }
 
-  public componentWillReceiveProps(newProps: IBaseFloatingPickerProps<T>): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(newProps: IBaseFloatingPickerProps<T>): void {
     if (newProps.suggestionItems) {
       this.updateSuggestions(newProps.suggestionItems);
     }

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/Suggestions/SuggestionsControl.tsx
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/Suggestions/SuggestionsControl.tsx
@@ -77,7 +77,8 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
     this.scrollSelected();
   }
 
-  public componentWillReceiveProps(newProps: ISuggestionsControlProps<T>): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(newProps: ISuggestionsControlProps<T>): void {
     if (newProps.suggestions) {
       this.setState({ suggestions: newProps.suggestions }, () => {
         this.resetSelectedItem();

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
@@ -35,7 +35,8 @@ export class FocusTrapZone extends React.Component<IFocusTrapZoneProps, {}> impl
     this._updateEventHandlers(this.props);
   }
 
-  public componentWillReceiveProps(nextProps: IFocusTrapZoneProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(nextProps: IFocusTrapZoneProps): void {
     const { elementToFocusOnDismiss } = nextProps;
     if (elementToFocusOnDismiss && this._previouslyFocusedElementOutsideTrapZone !== elementToFocusOnDismiss) {
       this._previouslyFocusedElementOutsideTrapZone = elementToFocusOnDismiss;

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
@@ -31,7 +31,8 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
     };
   }
 
-  public componentWillReceiveProps(newProps: IGroupHeaderProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(newProps: IGroupHeaderProps): void {
     if (newProps.group) {
       const newCollapsed = newProps.group.isCollapsed;
       const isGroupLoading = newProps.isGroupLoading;

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -60,7 +60,8 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
     return this._list.current!.getStartItemIndexInView() || 0;
   }
 
-  public componentWillReceiveProps(newProps: IGroupedListProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(newProps: IGroupedListProps): void {
     const { groups, selectionMode, compact } = this.props;
     let shouldForceUpdates = false;
 

--- a/packages/office-ui-fabric-react/src/components/Image/Image.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Image/Image.base.tsx
@@ -32,7 +32,8 @@ export class ImageBase extends React.Component<IImageProps, IImageState> {
     };
   }
 
-  public componentWillReceiveProps(nextProps: IImageProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(nextProps: IImageProps): void {
     if (nextProps.src !== this.props.src) {
       this.setState({
         loadState: ImageLoadState.notLoaded

--- a/packages/office-ui-fabric-react/src/components/Layer/Layer.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Layer/Layer.base.tsx
@@ -41,11 +41,13 @@ export class LayerBase extends React.Component<ILayerProps, ILayerBaseState> {
     }
   }
 
-  public componentWillMount(): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillMount(): void {
     this._layerElement = this._getLayerElement();
   }
 
-  public componentWillUpdate(): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillUpdate(): void {
     if (!this._layerElement) {
       this._layerElement = this._getLayerElement();
     }

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -319,7 +319,8 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     this._events.dispose();
   }
 
-  public componentWillReceiveProps(newProps: IListProps<T>): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(newProps: IListProps<T>): void {
     if (
       newProps.items !== this.props.items ||
       newProps.renderCount !== this.props.renderCount ||

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
@@ -67,7 +67,8 @@ export class ModalBase extends BaseComponent<IModalProps, IDialogState> implemen
     });
   }
 
-  public componentWillReceiveProps(newProps: IModalProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(newProps: IModalProps): void {
     clearTimeout(this._onModalCloseTimer);
 
     // Opening the dialog

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.base.tsx
@@ -116,7 +116,8 @@ export class OverflowSetBase extends BaseComponent<IOverflowSetProps, {}> implem
     this._unregisterPersistedKeytips();
   }
 
-  public componentWillUpdate() {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillUpdate() {
     this._unregisterPersistedKeytips();
   }
 

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
@@ -44,7 +44,8 @@ export class PersonaCoinBase extends BaseComponent<IPersonaCoinProps, IPersonaSt
     };
   }
 
-  public componentWillReceiveProps(nextProps: IPersonaCoinProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(nextProps: IPersonaCoinProps): void {
     if (nextProps.imageUrl !== this.props.imageUrl) {
       this.setState({
         isImageLoaded: false,

--- a/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
+++ b/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
@@ -26,7 +26,8 @@ export class Popup extends React.Component<IPopupProps, IPopupState> {
     this.state = { needsVerticalScrollBar: false };
   }
 
-  public componentWillMount(): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillMount(): void {
     this._originalFocusedElement = getDocument()!.activeElement as HTMLElement;
   }
 

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.base.tsx
@@ -360,7 +360,8 @@ export class ResizeGroupBase extends BaseComponent<IResizeGroupProps, IResizeGro
     this._events.on(window, 'resize', this._async.debounce(this._onResize, RESIZE_DELAY, { leading: true }));
   }
 
-  public componentWillReceiveProps(nextProps: IResizeGroupProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(nextProps: IResizeGroupProps): void {
     this.setState({
       dataToMeasure: { ...nextProps.data },
       resizeDirection: 'grow',

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -53,7 +53,8 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
     };
   }
 
-  public componentWillReceiveProps(newProps: ISearchBoxProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(newProps: ISearchBoxProps): void {
     if (newProps.value !== undefined) {
       this._latestValue = newProps.value;
       // If the user passes in null, substitute an empty string
@@ -64,7 +65,8 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
     }
   }
 
-  public componentWillMount() {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillMount() {
     if (this._events) {
       this._events.dispose();
     }

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/BaseSelectedItemsList.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/BaseSelectedItemsList.tsx
@@ -140,7 +140,8 @@ export class BaseSelectedItemsList<T, P extends IBaseSelectedItemsListProps<T>> 
     return this.selection.getSelection() as T[];
   }
 
-  public componentWillUpdate(newProps: P, newState: IBaseSelectedItemsListState): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillUpdate(newProps: P, newState: IBaseSelectedItemsListState): void {
     if (newState.items && newState.items !== this.state.items) {
       this.selection.setItems(newState.items);
     }
@@ -150,7 +151,8 @@ export class BaseSelectedItemsList<T, P extends IBaseSelectedItemsListProps<T>> 
     this.selection.setItems(this.state.items);
   }
 
-  public componentWillReceiveProps(newProps: P): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(newProps: P): void {
     const newItems = newProps.selectedItems;
 
     if (newItems) {

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -114,7 +114,8 @@ export class SpinButton extends React.Component<ISpinButtonProps, ISpinButtonSta
   /**
    * Invoked when a component is receiving new props. This method is not called for the initial render.
    */
-  public componentWillReceiveProps(newProps: ISpinButtonProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(newProps: ISpinButtonProps): void {
     this._lastValidValue = this.state.value;
     let value: string = newProps.value ? newProps.value : String(newProps.min);
     if (newProps.defaultValue) {

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
@@ -67,7 +67,8 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
     };
   }
 
-  public componentWillReceiveProps(newProps: ISwatchColorPickerProps): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(newProps: ISwatchColorPickerProps): void {
     if (newProps.selectedId !== undefined) {
       this.setState({
         selectedIndex: this._getSelectedIndex(newProps.colorCells, newProps.selectedId)

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/MaskedTextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/MaskedTextField.tsx
@@ -92,7 +92,8 @@ export class MaskedTextField extends React.Component<ITextFieldProps, IMaskedTex
     };
   }
 
-  public componentWillReceiveProps(newProps: ITextFieldProps) {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(newProps: ITextFieldProps) {
     if (newProps.mask !== this.props.mask || newProps.value !== this.props.value) {
       this._maskCharData = parseMask(newProps.mask, newProps.maskFormat);
       newProps.value !== undefined && this.setValue(newProps.value);

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -108,7 +108,8 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
     return this.state.items;
   }
 
-  public componentWillUpdate(newProps: P, newState: IBasePickerState): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillUpdate(newProps: P, newState: IBasePickerState): void {
     if (newState.items && newState.items !== this.state.items) {
       this.selection.setItems(newState.items);
     }
@@ -119,7 +120,8 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
     this._onResolveSuggestions = this._async.debounce(this._onResolveSuggestions, this.props.resolveDelay);
   }
 
-  public componentWillReceiveProps(newProps: P): void {
+  // tslint:disable-next-line function-name
+  public UNSAFE_componentWillReceiveProps(newProps: P): void {
     const newItems = newProps.selectedItems;
 
     if (newItems) {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10128
- [x] Include a change request file using `$ yarn change`

#### Description of changes

[React 16.9+ generates development mode warnings](https://reactjs.org/blog/2019/08/08/react-v16.9.0.html) for any of the deprecated lifecycle methods. This can make it hard for consumers of Fabric to distinguish development mode warnings related to their code. 

This PR simply renames the deprecated lifecycle methods as an interim solution until #4613 is resolved.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10137)