### PR TITLE
PersonaCoin: Update colors to match v7

### DIFF
--- a/change/@uifabric-experiments-2019-08-16-16-56-03-fix-persona-coin.json
+++ b/change/@uifabric-experiments-2019-08-16-16-56-03-fix-persona-coin.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Persona types, updated snapshots.",
+  "packageName": "@uifabric/experiments",
+  "email": "jdh@microsoft.com",
+  "commit": "83e181410c1ce8511c411decfef2563e5b150248",
+  "date": "2019-08-16T23:56:02.981Z"
+}

--- a/change/office-ui-fabric-react-2019-08-15-17-37-47-6.0.json
+++ b/change/office-ui-fabric-react-2019-08-15-17-37-47-6.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "PersonaCoin: Update colors to match v7 and improve color contrast.",
+  "packageName": "office-ui-fabric-react",
+  "email": "jdh@microsoft.com",
+  "commit": "f31b6a30ff21317481f3bf12c1d7cd188c9ae703",
+  "date": "2019-08-16T00:37:47.917Z"
+}

--- a/packages/experiments/src/components/Persona/Vertical/__snapshots__/VerticalPersona.test.tsx.snap
+++ b/packages/experiments/src/components/Persona/Vertical/__snapshots__/VerticalPersona.test.tsx.snap
@@ -22,7 +22,7 @@ exports[`VerticalPersona renders correctly with a text and secondary text 1`] = 
 
         {
           align-items: center;
-          background-color: #5E4B8B;
+          background-color: #A4262C;
           border-radius: 50%;
           color: white;
           display: flex;
@@ -122,7 +122,7 @@ exports[`VerticalPersona renders correctly with only a text 1`] = `
 
         {
           align-items: center;
-          background-color: #5E4B8B;
+          background-color: #A4262C;
           border-radius: 50%;
           color: white;
           display: flex;

--- a/packages/experiments/src/components/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/experiments/src/components/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`PersonaCoin renders a coin with a contact icon 1`] = `
       test-cn-root
       {
         align-items: center;
-        background-color: #2D89EF;
+        background-color: #0078D4;
         border-radius: 50%;
         color: white;
         display: flex;
@@ -44,7 +44,7 @@ exports[`PersonaCoin renders a coin with a contact icon for a Chinese name 1`] =
       test-cn-root
       {
         align-items: center;
-        background-color: #00A300;
+        background-color: #69797E;
         border-radius: 50%;
         color: white;
         display: flex;
@@ -82,7 +82,7 @@ exports[`PersonaCoin renders a coin with the initials JB 1`] = `
       test-cn-root
       {
         align-items: center;
-        background-color: #2D89EF;
+        background-color: #0078D4;
         border-radius: 50%;
         color: white;
         display: flex;
@@ -118,7 +118,7 @@ exports[`PersonaCoin renders a correct persona 1`] = `
       test-cn-root
       {
         align-items: center;
-        background-color: #5E4B8B;
+        background-color: #A4262C;
         border-radius: 50%;
         color: white;
         display: flex;
@@ -190,7 +190,7 @@ exports[`PersonaCoin renders presence correctly when a very large coin is render
       test-cn-root
       {
         align-items: center;
-        background-color: #00A300;
+        background-color: #69797E;
         border-radius: 50%;
         color: white;
         display: flex;
@@ -289,7 +289,7 @@ exports[`PersonaCoin renders presence when it is passed 1`] = `
       test-cn-root
       {
         align-items: center;
-        background-color: #00A300;
+        background-color: #69797E;
         border-radius: 50%;
         color: white;
         display: flex;
@@ -388,7 +388,7 @@ exports[`PersonaCoin renders the coin with the provided image 1`] = `
       test-cn-root
       {
         align-items: center;
-        background-color: #00A300;
+        background-color: #69797E;
         border-radius: 50%;
         color: white;
         display: flex;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -8212,15 +8212,25 @@ export class PersonaCoinBase extends BaseComponent<IPersonaCoinProps, IPersonaSt
 
 // @public (undocumented)
 export enum PersonaInitialsColor {
+    // @deprecated
     black = 11,
     // (undocumented)
     blue = 1,
+    // (undocumented)
+    burgundy = 19,
+    // (undocumented)
+    coolGray = 21,
+    // (undocumented)
+    cyan = 23,
     // (undocumented)
     darkBlue = 2,
     // (undocumented)
     darkGreen = 6,
     // (undocumented)
     darkRed = 14,
+    // (undocumented)
+    gold = 18,
+    gray = 22,
     // (undocumented)
     green = 5,
     // (undocumented)
@@ -8230,6 +8240,8 @@ export enum PersonaInitialsColor {
     // (undocumented)
     lightPink = 7,
     // (undocumented)
+    lightRed = 17,
+    // (undocumented)
     magenta = 9,
     // (undocumented)
     orange = 12,
@@ -8237,12 +8249,17 @@ export enum PersonaInitialsColor {
     pink = 8,
     // (undocumented)
     purple = 10,
+    // @deprecated
     red = 13,
+    // (undocumented)
+    rust = 24,
     // (undocumented)
     teal = 3,
     transparent = 15,
     // (undocumented)
     violet = 16,
+    // (undocumented)
+    warmGray = 20,
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/ActivityItem/__snapshots__/ActivityItem.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ActivityItem/__snapshots__/ActivityItem.test.tsx.snap
@@ -102,7 +102,7 @@ exports[`ActivityItem renders compact with a single persona correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #2D89EF;
+                  background-color: #4F6BED;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 11px;
@@ -375,7 +375,7 @@ exports[`ActivityItem renders compact with animation correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #2D89EF;
+                  background-color: #4F6BED;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 11px;
@@ -533,7 +533,7 @@ exports[`ActivityItem renders compact with multiple personas correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #2D89EF;
+                  background-color: #4F6BED;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 11px;
@@ -686,7 +686,7 @@ exports[`ActivityItem renders compact with multiple personas correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #00ABA9;
+                  background-color: #D13438;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 11px;
@@ -807,7 +807,7 @@ exports[`ActivityItem renders with a single persona correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #2D89EF;
+                  background-color: #4F6BED;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 14px;
@@ -1045,7 +1045,7 @@ exports[`ActivityItem renders with multiple personas correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #2D89EF;
+                  background-color: #4F6BED;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 11px;
@@ -1176,7 +1176,7 @@ exports[`ActivityItem renders with multiple personas correctly 1`] = `
             className=
                 ms-Persona-initials
                 {
-                  background-color: #00ABA9;
+                  background-color: #D13438;
                   border-radius: 50%;
                   color: #ffffff;
                   font-size: 11px;

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
@@ -123,7 +123,7 @@ exports[`DocumentCard renders DocumentCard correctly 1`] = `
               className=
                   ms-Persona-initials
                   {
-                    background-color: #2D89EF;
+                    background-color: #0078D4;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
@@ -411,7 +411,7 @@ exports[`Facepile renders Facepile correctly 1`] = `
                   className=
                       ms-Persona-initials
                       {
-                        background-color: #D13438;
+                        background-color: #8E562E;
                         border-radius: 50%;
                         color: #ffffff;
                         font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
@@ -411,7 +411,7 @@ exports[`Facepile renders Facepile correctly 1`] = `
                   className=
                       ms-Persona-initials
                       {
-                        background-color: #1E7145;
+                        background-color: #D13438;
                         border-radius: 50%;
                         color: #ffffff;
                         font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.types.ts
@@ -418,12 +418,14 @@ export enum PersonaInitialsColor {
   magenta = 9,
   purple = 10,
   /**
-   * Black is a color that can result in offensive persona coins with some initials combinations, so it can only be set with overrides
+   * `black` is a color that can result in offensive persona coins with some initials combinations, so it can only be set with overrides.
+   * @deprecated will be removed in a future major release.
    */
   black = 11,
   orange = 12,
   /**
-   * Red is a color that often has a special meaning, so it is considered a reserved color and can only be set with overrides
+   * `red` is a color that often has a special meaning, so it is considered a reserved color and can only be set with overrides
+   * @deprecated will be removed in a future major release.
    */
   red = 13,
   darkRed = 14,
@@ -432,5 +434,16 @@ export enum PersonaInitialsColor {
    * Its primary use is for overflow buttons, so it is considered a reserved color and can only be set with overrides.
    */
   transparent = 15,
-  violet = 16
+  violet = 16,
+  lightRed = 17,
+  gold = 18,
+  burgundy = 19,
+  warmGray = 20,
+  coolGray = 21,
+  /**
+   * `gray` is a color that can result in offensive persona coins with some initials combinations, so it can only be set with overrides
+   */
+  gray = 22,
+  cyan = 23,
+  rust = 24
 }

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.deprecated.test.tsx.snap
@@ -29,7 +29,7 @@ exports[`PersonaCoin renders correctly 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #2D89EF;
+            background-color: #0078D4;
             border-radius: 50%;
             color: #ffffff;
             font-size: 17px;
@@ -177,7 +177,7 @@ exports[`PersonaCoin renders correctly with provided initials 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #2D89EF;
+            background-color: #0078D4;
             border-radius: 50%;
             color: #ffffff;
             font-size: 17px;
@@ -230,7 +230,7 @@ exports[`PersonaCoin renders correctly with text 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #5E4B8B;
+            background-color: #498205;
             border-radius: 50%;
             color: #ffffff;
             font-size: 17px;

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -975,7 +975,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         className=
             ms-Persona-initials
             {
-              background-color: #D13438;
+              background-color: #8E562E;
               border-radius: 50%;
               color: #ffffff;
               font-size: 42px;
@@ -1782,7 +1782,7 @@ exports[`PersonaCoin renders correctly with onRender callback 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #D13438;
+            background-color: #8E562E;
             border-radius: 50%;
             color: #ffffff;
             font-size: 42px;

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`Persona renders Persona children correctly 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #5E4B8B;
+              background-color: #498205;
               border-radius: 50%;
               color: #ffffff;
               font-size: 17px;
@@ -627,7 +627,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #5E4B8B;
+              background-color: #498205;
               border-radius: 50%;
               color: #ffffff;
               font-size: 17px;
@@ -800,7 +800,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #2D89EF;
+              background-color: #0078D4;
               border-radius: 50%;
               color: #ffffff;
               font-size: 17px;
@@ -975,7 +975,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         className=
             ms-Persona-initials
             {
-              background-color: #7E3878;
+              background-color: #D13438;
               border-radius: 50%;
               color: #ffffff;
               font-size: 42px;
@@ -1634,7 +1634,7 @@ exports[`PersonaCoin renders correctly 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #2D89EF;
+            background-color: #0078D4;
             border-radius: 50%;
             color: #ffffff;
             font-size: 17px;
@@ -1782,7 +1782,7 @@ exports[`PersonaCoin renders correctly with onRender callback 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #7E3878;
+            background-color: #D13438;
             border-radius: 50%;
             color: #ffffff;
             font-size: 42px;
@@ -1835,7 +1835,7 @@ exports[`PersonaCoin renders correctly with provided initials 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #2D89EF;
+            background-color: #0078D4;
             border-radius: 50%;
             color: #ffffff;
             font-size: 17px;
@@ -1888,7 +1888,7 @@ exports[`PersonaCoin renders correctly with text 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #5E4B8B;
+            background-color: #498205;
             border-radius: 50%;
             color: #ffffff;
             font-size: 17px;
@@ -1941,7 +1941,7 @@ exports[`PersonaCoin renders the initials before the image is loaded 1`] = `
       className=
           ms-Persona-initials
           {
-            background-color: #5E4B8B;
+            background-color: #498205;
             border-radius: 50%;
             color: #ffffff;
             font-size: 17px;

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.test.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.test.ts
@@ -4,10 +4,10 @@ import { PersonaInitialsColor } from './Persona.types';
 describe('PersonaInitialsColor tests', () => {
   it('renders gets the correct colors if none was provided', () => {
     const colorCode = getPersonaInitialsColor({ text: 'Kat Larrson' });
-    expect(colorCode).toEqual('#5E4B8B');
+    expect(colorCode).toEqual('#498205');
 
     const colorCode2 = getPersonaInitialsColor({ text: 'Annie Lindqvist' });
-    expect(colorCode2).toEqual('#00A300');
+    expect(colorCode2).toEqual('#038387');
   });
 
   it('uses provided enum initialsColor if one was specified', () => {

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaInitialsColor.ts
@@ -1,26 +1,34 @@
 import { PersonaInitialsColor, IPersonaProps } from './Persona.types';
 
 /**
- * These colors are considered reserved colors and can only be set with overrides:
- * - Red is a color that often has a special meaning.
- * - Transparent is not intended to be used with typical initials due to accessibility issues,
+ * Following colors are considered reserved colors and can only be set with overrides, so they are excluded from this set:
+ * - `gray` and `black` are colors that can result in offensive persona coins with some initials combinations,
+ *   so it can only be set with overrides.
+ * - `red` is a color that often has a special meaning, so it is considered a reserved color and can only be set with overrides.
+ * - `transparent` is not intended to be used with typical initials due to accessibility issues,
  *   its primary use is for Facepile overflow buttons.
  */
 const COLOR_SWATCHES_LOOKUP: PersonaInitialsColor[] = [
-  PersonaInitialsColor.lightGreen,
   PersonaInitialsColor.lightBlue,
-  PersonaInitialsColor.lightPink,
+  PersonaInitialsColor.blue,
+  PersonaInitialsColor.darkBlue,
+  PersonaInitialsColor.teal,
   PersonaInitialsColor.green,
   PersonaInitialsColor.darkGreen,
+  PersonaInitialsColor.lightPink,
   PersonaInitialsColor.pink,
   PersonaInitialsColor.magenta,
   PersonaInitialsColor.purple,
-  PersonaInitialsColor.violet,
-  PersonaInitialsColor.teal,
-  PersonaInitialsColor.blue,
-  PersonaInitialsColor.darkBlue,
   PersonaInitialsColor.orange,
-  PersonaInitialsColor.darkRed
+  PersonaInitialsColor.lightRed,
+  PersonaInitialsColor.darkRed,
+  PersonaInitialsColor.violet,
+  PersonaInitialsColor.gold,
+  PersonaInitialsColor.burgundy,
+  PersonaInitialsColor.warmGray,
+  PersonaInitialsColor.cyan,
+  PersonaInitialsColor.rust,
+  PersonaInitialsColor.coolGray
 ];
 
 const COLOR_SWATCHES_NUM_ENTRIES = COLOR_SWATCHES_LOOKUP.length;
@@ -47,39 +55,54 @@ function getInitialsColorFromName(displayName: string | undefined): PersonaIniti
 function personaInitialsColorToHexCode(personaInitialsColor: PersonaInitialsColor): string {
   switch (personaInitialsColor) {
     case PersonaInitialsColor.lightBlue:
-      return '#6BA5E7';
+      return '#4F6BED';
     case PersonaInitialsColor.blue:
-      return '#2D89EF';
+      return '#0078D4';
     case PersonaInitialsColor.darkBlue:
-      return '#2B5797';
+      return '#004E8C';
     case PersonaInitialsColor.teal:
-      return '#00ABA9';
+      return '#038387';
     case PersonaInitialsColor.lightGreen:
-      return '#99B433';
     case PersonaInitialsColor.green:
-      return '#00A300';
+      return '#498205';
     case PersonaInitialsColor.darkGreen:
-      return '#1E7145';
+      return '#0B6A0B';
     case PersonaInitialsColor.lightPink:
-      return '#E773BD';
+      return '#C239B3';
     case PersonaInitialsColor.pink:
-      return '#FF0097';
+      return '#E3008C';
     case PersonaInitialsColor.magenta:
-      return '#7E3878';
+      return '#881798';
     case PersonaInitialsColor.purple:
-      return '#603CBA';
-    case PersonaInitialsColor.black:
-      return '#1D1D1D';
+      return '#5C2E91';
     case PersonaInitialsColor.orange:
-      return '#DA532C';
+      return '#CA5010';
     case PersonaInitialsColor.red:
       return '#EE1111';
+    case PersonaInitialsColor.lightRed:
+      return '#D13438';
     case PersonaInitialsColor.darkRed:
-      return '#B91D47';
+      return '#A4262C';
     case PersonaInitialsColor.transparent:
       return 'transparent';
     case PersonaInitialsColor.violet:
-      return '#5E4B8B';
+      return '#8764B8';
+    case PersonaInitialsColor.gold:
+      return '#986F0B';
+    case PersonaInitialsColor.burgundy:
+      return '#750B1C';
+    case PersonaInitialsColor.warmGray:
+      return '#7A7574';
+    case PersonaInitialsColor.cyan:
+      return '#005B70';
+    case PersonaInitialsColor.rust:
+      return '#8E562E';
+    case PersonaInitialsColor.coolGray:
+      return '#69797E';
+    case PersonaInitialsColor.black:
+      return '#1D1D1D';
+    case PersonaInitialsColor.gray:
+      return '#393939';
   }
 }
 

--- a/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
@@ -263,7 +263,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #5E4B8B;
+              background-color: #498205;
               border-radius: 50%;
               color: #ffffff;
               font-size: 17px;
@@ -436,7 +436,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #2D89EF;
+              background-color: #0078D4;
               border-radius: 50%;
               color: #ffffff;
               font-size: 17px;

--- a/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
@@ -975,7 +975,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         className=
             ms-Persona-initials
             {
-              background-color: #D13438;
+              background-color: #8E562E;
               border-radius: 50%;
               color: #ffffff;
               font-size: 42px;

--- a/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
@@ -63,7 +63,7 @@ exports[`Persona renders Persona children correctly 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #5E4B8B;
+              background-color: #498205;
               border-radius: 50%;
               color: #ffffff;
               font-size: 17px;
@@ -627,7 +627,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #5E4B8B;
+              background-color: #498205;
               border-radius: 50%;
               color: #ffffff;
               font-size: 17px;
@@ -800,7 +800,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
         className=
             ms-Persona-initials
             {
-              background-color: #2D89EF;
+              background-color: #0078D4;
               border-radius: 50%;
               color: #ffffff;
               font-size: 17px;
@@ -975,7 +975,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
         className=
             ms-Persona-initials
             {
-              background-color: #7E3878;
+              background-color: #D13438;
               border-radius: 50%;
               color: #ffffff;
               font-size: 42px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Compact.Example.tsx.shot
@@ -293,7 +293,7 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
               className=
                   ms-Persona-initials
                   {
-                    background-color: #00A300;
+                    background-color: #5C2E91;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 11px;
@@ -446,7 +446,7 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
               className=
                   ms-Persona-initials
                   {
-                    background-color: #603CBA;
+                    background-color: #0B6A0B;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 11px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
@@ -306,7 +306,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               className=
                   ms-Persona-initials
                   {
-                    background-color: #B91D47;
+                    background-color: #E3008C;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 11px;
@@ -697,7 +697,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               className=
                   ms-Persona-initials
                   {
-                    background-color: #00A300;
+                    background-color: #5C2E91;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 11px;
@@ -1105,7 +1105,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               className=
                   ms-Persona-initials
                   {
-                    background-color: #1E7145;
+                    background-color: #4F6BED;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 11px;
@@ -1236,7 +1236,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               className=
                   ms-Persona-initials
                   {
-                    background-color: #00A300;
+                    background-color: #038387;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 11px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -4,7 +4,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
 <div
   className=
 
-      & .headerDivider-519:hover + .headerDividerBar-520 {
+      & .headerDivider-520:hover + .headerDividerBar-521 {
         display: inline;
       }
 >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
@@ -279,7 +279,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                   className=
                       ms-Persona-initials
                       {
-                        background-color: #00ABA9;
+                        background-color: #0B6A0B;
                         border-radius: 50%;
                         color: #ffffff;
                         font-size: 14px;
@@ -1447,7 +1447,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                   className=
                       ms-Persona-initials
                       {
-                        background-color: #7E3878;
+                        background-color: #A4262C;
                         border-radius: 50%;
                         color: #ffffff;
                         font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Conversation.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Conversation.Example.tsx.shot
@@ -1166,7 +1166,7 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #D13438;
+                      background-color: #005B70;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Conversation.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Conversation.Example.tsx.shot
@@ -256,7 +256,7 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #00ABA9;
+                      background-color: #0B6A0B;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;
@@ -779,7 +779,7 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #7E3878;
+                      background-color: #A4262C;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;
@@ -1166,7 +1166,7 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #6BA5E7;
+                      background-color: #D13438;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Image.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Image.Example.tsx.shot
@@ -241,7 +241,7 @@ exports[`Component Examples renders DocumentCard.Image.Example.tsx correctly 1`]
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #00ABA9;
+                      background-color: #0B6A0B;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;
@@ -617,7 +617,7 @@ exports[`Component Examples renders DocumentCard.Image.Example.tsx correctly 1`]
                 className=
                     ms-Persona-initials
                     {
-                      background-color: #7E3878;
+                      background-color: #A4262C;
                       border-radius: 50%;
                       color: #ffffff;
                       font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.AddFace.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.AddFace.Example.tsx.shot
@@ -168,7 +168,7 @@ exports[`Component Examples renders Facepile.AddFace.Example.tsx correctly 1`] =
               className=
                   ms-Persona-initials
                   {
-                    background-color: #2D89EF;
+                    background-color: #0078D4;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -436,7 +436,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                     className=
                         ms-Persona-initials
                         {
-                          background-color: #D13438;
+                          background-color: #8E562E;
                           border-radius: 50%;
                           color: #ffffff;
                           font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -436,7 +436,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                     className=
                         ms-Persona-initials
                         {
-                          background-color: #1E7145;
+                          background-color: #D13438;
                           border-radius: 50%;
                           color: #ffffff;
                           font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
@@ -436,7 +436,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                     className=
                         ms-Persona-initials
                         {
-                          background-color: #1E7145;
+                          background-color: #D13438;
                           border-radius: 50%;
                           color: #ffffff;
                           font-size: 14px;
@@ -532,7 +532,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                   className=
                       ms-Persona-initials
                       {
-                        background-color: #00ABA9;
+                        background-color: #0B6A0B;
                         border-radius: 50%;
                         color: #ffffff;
                         font-size: 14px;
@@ -627,7 +627,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                   className=
                       ms-Persona-initials
                       {
-                        background-color: #00A300;
+                        background-color: #498205;
                         border-radius: 50%;
                         color: #ffffff;
                         font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
@@ -436,7 +436,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                     className=
                         ms-Persona-initials
                         {
-                          background-color: #D13438;
+                          background-color: #8E562E;
                           border-radius: 50%;
                           color: #ffffff;
                           font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Initials.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Initials.Example.tsx.shot
@@ -1565,7 +1565,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #D13438;
+                background-color: #986F0B;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 17px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Initials.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Initials.Example.tsx.shot
@@ -66,7 +66,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #5E4B8B;
+                background-color: #498205;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 17px;
@@ -278,7 +278,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #00A300;
+                background-color: #0078D4;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 17px;
@@ -490,7 +490,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #00A300;
+                background-color: #038387;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 17px;
@@ -702,7 +702,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #00A300;
+                background-color: #8764B8;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 17px;
@@ -914,7 +914,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #B91D47;
+                background-color: #0078D4;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 17px;
@@ -1126,7 +1126,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #E773BD;
+                background-color: #C239B3;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 17px;
@@ -1353,7 +1353,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #E773BD;
+                background-color: #C239B3;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 17px;
@@ -1565,7 +1565,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #1E7145;
+                background-color: #D13438;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 17px;
@@ -1792,7 +1792,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #DA532C;
+                background-color: #881798;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 17px;
@@ -2019,7 +2019,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #2B5797;
+                background-color: #D13438;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 17px;
@@ -2246,7 +2246,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #6BA5E7;
+                background-color: #4F6BED;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 17px;
@@ -2458,7 +2458,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #00ABA9;
+                background-color: #038387;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 17px;
@@ -2682,7 +2682,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
           className=
               ms-Persona-initials
               {
-                background-color: #00ABA9;
+                background-color: #038387;
                 border-radius: 50%;
                 color: #ffffff;
                 font-size: 42px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SelectedPeopleList.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SelectedPeopleList.Controlled.Example.tsx.shot
@@ -383,7 +383,7 @@ exports[`Component Examples renders SelectedPeopleList.Controlled.Example.tsx co
                       className=
                           ms-Persona-initials
                           {
-                            background-color: #603CBA;
+                            background-color: #E3008C;
                             border-radius: 50%;
                             color: #ffffff;
                             font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
@@ -960,7 +960,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
               className=
                   ms-Persona-initials
                   {
-                    background-color: #2D89EF;
+                    background-color: #0078D4;
                     border-radius: 50%;
                     color: #ffffff;
                     font-size: 14px;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #10084
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Bring PersonaCoin colors from v7 into v6 to resolve accessibility warnings with contrast.

@Vitalius1 , @betrue-final-final -- can you please comment on if this is a good idea or not? Visually it looks fine, but not sure if there are design system concerns with MDL2.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10139)