### PR TITLE
Fix async patterns in tests

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -25,7 +25,7 @@
       "program": "${workspaceRoot}/scripts/debug-test.js",
       "cwd": "${fileDirname}",
       "stopOnEntry": false,
-      "args": ["-i", "--testPathPattern=${fileBasenameNoExtension}", "--watch"],
+      "args": ["-i", "--testPathPattern=\\b${fileBasenameNoExtension}", "--watch"],
       "runtimeExecutable": null,
       "runtimeArgs": ["--nolazy", "--debug"],
       "env": {

--- a/change/office-ui-fabric-react-2019-08-13-17-47-43-async-tests.json
+++ b/change/office-ui-fabric-react-2019-08-13-17-47-43-async-tests.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix async patterns in tests",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "commit": "09a0bbca1887a3a4695306ef64abf97986efbd1e",
+  "date": "2019-08-14T00:47:43.645Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Autofill/Autofill.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Autofill/Autofill.test.tsx
@@ -3,8 +3,7 @@ import * as React from 'react';
 import * as ReactTestUtils from 'react-dom/test-utils';
 
 import { IRefObject, KeyCodes } from '../../Utilities';
-import { Autofill, IAutofillState } from './Autofill';
-import { IAutofill, IAutofillProps } from '../pickers';
+import { Autofill, IAutofillState, IAutofill, IAutofillProps } from './index';
 import { ReactWrapper, mount } from 'enzyme';
 import { mockEvent } from 'office-ui-fabric-react/lib/common/testUtilities';
 

--- a/packages/office-ui-fabric-react/src/components/Autofill/Autofill.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Autofill/Autofill.test.tsx
@@ -16,7 +16,6 @@ describe('Autofill', () => {
   let component: ReactWrapper<IAutofillProps, IAutofillState, Autofill>;
 
   afterEach(() => {
-    jest.useRealTimers();
     component.unmount();
   });
 

--- a/packages/office-ui-fabric-react/src/components/Autofill/Autofill.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Autofill/Autofill.test.tsx
@@ -1,99 +1,90 @@
 import * as React from 'react';
 
-import * as ReactDOM from 'react-dom';
 import * as ReactTestUtils from 'react-dom/test-utils';
 
-import { KeyCodes } from '../../Utilities';
-import { Autofill } from './Autofill';
+import { IRefObject, KeyCodes } from '../../Utilities';
+import { Autofill, IAutofillState } from './Autofill';
+import { IAutofill, IAutofillProps } from '../pickers';
+import { ReactWrapper, mount } from 'enzyme';
+import { mockEvent } from 'office-ui-fabric-react/lib/common/testUtilities';
 
 describe('Autofill', () => {
-  let autoFill: Autofill;
-  let autoFillInput: HTMLInputElement;
-  const baseNode = document.createElement('div');
-  document.body.appendChild(baseNode);
-  beforeEach(() => {
-    const component = ReactDOM.render(
-      <Autofill ref={(c: Autofill | null) => c && (autoFill = c)} suggestedDisplayValue="hello" />,
-      baseNode
-    );
-    autoFillInput = ReactDOM.findDOMNode((component as unknown) as React.ReactInstance) as HTMLInputElement;
+  let autofill: Autofill;
+  const autofillRef: IRefObject<IAutofill> = (ref: IAutofill | null) => {
+    autofill = ref as Autofill;
+  };
+  let component: ReactWrapper<IAutofillProps, IAutofillState, Autofill>;
+
+  afterEach(() => {
+    jest.useRealTimers();
+    component.unmount();
   });
 
-  it('correctly autofills', (done: (error?: Error) => void) => {
+  it('correctly autofills', () => {
+    let updatedText: string | undefined;
     const onInputValueChange = (text: string | undefined): void => {
-      expect(text).toBe('hel');
-      expect(autoFill.value).toBe('hel');
-      done();
+      updatedText = text;
     };
 
-    ReactDOM.render(
-      <Autofill ref={(c: Autofill | null) => c && (autoFill = c)} onInputValueChange={onInputValueChange} suggestedDisplayValue="hello" />,
-      baseNode
-    );
-    autoFillInput.value = 'hel';
-    ReactTestUtils.Simulate.input(autoFillInput);
-    ReactDOM.render(
-      <Autofill ref={(c: Autofill | null) => c && (autoFill = c)} onInputValueChange={onInputValueChange} suggestedDisplayValue="hello" />,
-      baseNode
-    );
-    expect(autoFill.inputElement && autoFill.inputElement.value).toBe('hello');
+    component = mount(<Autofill componentRef={autofillRef} onInputValueChange={onInputValueChange} suggestedDisplayValue="hello" />);
+
+    ReactTestUtils.Simulate.input(autofill.inputElement!, mockEvent('hel'));
+    expect(updatedText).toBe('hel');
+    expect(autofill.value).toBe('hel');
+    expect(autofill.inputElement!.value).toBe('hello');
   });
 
-  it('does not autofill if suggestedDisplayValue does not match input', (done: (error?: Error) => void) => {
+  it('does not autofill if suggestedDisplayValue does not match input', () => {
+    let updatedText: string | undefined;
     const onInputValueChange = (text: string | undefined): void => {
-      expect(text).toBe('hep');
-      expect(autoFill.value).toBe('hep');
-      expect(autoFill.inputElement && autoFill.inputElement.value).toBe('hep');
-      done();
+      updatedText = text;
     };
 
-    autoFillInput.value = 'hep';
-    ReactTestUtils.Simulate.input(autoFillInput);
-    ReactDOM.render(
-      <Autofill ref={(c: Autofill | null) => c && (autoFill = c)} onInputValueChange={onInputValueChange} suggestedDisplayValue="hello" />,
-      baseNode
-    );
-    ReactTestUtils.Simulate.input(autoFillInput);
+    component = mount(<Autofill componentRef={autofillRef} onInputValueChange={onInputValueChange} suggestedDisplayValue="hello" />);
+    ReactTestUtils.Simulate.input(autofill.inputElement!, mockEvent('hep'));
+
+    expect(updatedText).toBe('hep');
+    expect(autofill.value).toBe('hep');
+    expect(autofill.inputElement!.value).toBe('hep');
   });
 
-  it('does not autofill if left or right arrow has been pressed', () => {
-    autoFillInput.value = 'hel';
-    ReactTestUtils.Simulate.input(autoFillInput);
+  it('autofills if left arrow is pressed', () => {
+    component = mount(<Autofill componentRef={autofillRef} suggestedDisplayValue="hello" />);
 
-    ReactDOM.render(<Autofill ref={(c: Autofill | null) => c && (autoFill = c)} suggestedDisplayValue="hello" />, baseNode);
+    ReactTestUtils.Simulate.input(autofill.inputElement!, mockEvent('hel'));
+    expect(autofill.value).toBe('hel');
+    expect(autofill.inputElement!.value).toBe('hello');
 
-    ReactTestUtils.Simulate.keyDown(autoFillInput, { keyCode: KeyCodes.left, which: KeyCodes.left });
-
-    // Because reacttestutils doesn't allow you to enter text normally we need to reset the autofillinput value to hel.
-    // If we don't the change event will cause the current input value, 'hello', to be set.
-    autoFillInput.value = 'hel';
-
-    ReactTestUtils.Simulate.input(autoFillInput);
-
-    expect(autoFill.value).toBe('hel');
-    expect(autoFill.inputElement && autoFill.inputElement.value).toBe('hel');
+    ReactTestUtils.Simulate.keyDown(autofill.inputElement!, { keyCode: KeyCodes.left, which: KeyCodes.left });
+    expect(autofill.value).toBe('hello');
+    expect(autofill.inputElement!.value).toBe('hello');
   });
 
-  it('will autofill if keyCode up or down is pressed', () => {
-    autoFillInput.value = 'hel';
-    ReactTestUtils.Simulate.input(autoFillInput);
+  it('autofills if right arrow is pressed', () => {
+    component = mount(<Autofill componentRef={autofillRef} suggestedDisplayValue="hello" />);
 
-    ReactDOM.render(<Autofill ref={(c: Autofill | null) => c && (autoFill = c)} suggestedDisplayValue="hello" />, baseNode);
+    ReactTestUtils.Simulate.input(autofill.inputElement!, mockEvent('hel'));
+    expect(autofill.value).toBe('hel');
+    expect(autofill.inputElement!.value).toBe('hello');
 
-    expect(autoFill.value).toBe('hel');
-    expect(autoFill.inputElement && autoFill.inputElement.value).toBe('hel');
+    ReactTestUtils.Simulate.keyDown(autofill.inputElement!, { keyCode: KeyCodes.right, which: KeyCodes.right });
+    expect(autofill.value).toBe('hello');
+    expect(autofill.inputElement!.value).toBe('hello');
+  });
 
-    ReactTestUtils.Simulate.keyDown(autoFillInput, { keyCode: KeyCodes.left, which: KeyCodes.left });
+  it('does not autofill if up or down is pressed', () => {
+    component = mount(<Autofill componentRef={autofillRef} suggestedDisplayValue="hello" />);
 
-    autoFillInput.value = 'hel';
+    ReactTestUtils.Simulate.input(autofill.inputElement!, mockEvent('hel'));
+    expect(autofill.value).toBe('hel');
+    expect(autofill.inputElement!.value).toBe('hello');
 
-    ReactTestUtils.Simulate.keyDown(autoFillInput, { keyCode: KeyCodes.up, which: KeyCodes.up });
-    autoFillInput.value = 'hel';
-    ReactTestUtils.Simulate.input(autoFillInput);
+    ReactTestUtils.Simulate.keyDown(autofill.inputElement!, { keyCode: KeyCodes.up, which: KeyCodes.up });
+    expect(autofill.value).toBe('hel');
+    expect(autofill.inputElement!.value).toBe('hello');
 
-    ReactDOM.render(<Autofill ref={(c: Autofill | null) => c && (autoFill = c)} suggestedDisplayValue="hello" />, baseNode);
-
-    expect(autoFill.value).toBe('hel');
-    expect(autoFill.inputElement && autoFill.inputElement.value).toBe('hello');
+    ReactTestUtils.Simulate.keyDown(autofill.inputElement!, { keyCode: KeyCodes.down, which: KeyCodes.down });
+    expect(autofill.value).toBe('hel');
+    expect(autofill.inputElement!.value).toBe('hello');
   });
 });

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.test.tsx
@@ -1,7 +1,5 @@
-/* tslint:disable:no-unused-variable */
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
-/* tslint:enable:no-unused-variable */
 
 import * as ReactTestUtils from 'react-dom/test-utils';
 import * as renderer from 'react-test-renderer';
@@ -17,6 +15,10 @@ class CalloutContentWrapper extends React.Component<ICalloutProps, {}> {
 }
 
 describe('Callout', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('renders Callout correctly', () => {
     const createNodeMock = (el: React.ReactElement<{}>) => {
       return {
@@ -110,7 +112,8 @@ describe('Callout', () => {
     expect(threwException).toEqual(false);
   });
 
-  it('passes event to onDismiss prop', done => {
+  it('passes event to onDismiss prop', () => {
+    jest.useFakeTimers();
     let threwException = false;
     let gotEvent = false;
     const onDismiss = (ev?: any) => {
@@ -145,15 +148,8 @@ describe('Callout', () => {
     const focusTarget = document.querySelector('#focustarget') as HTMLButtonElement;
 
     // Move focus
-    setTimeout(() => {
-      try {
-        focusTarget.focus();
-        expect(gotEvent).toEqual(true);
-      } catch (e) {
-        done(e);
-      }
-
-      done();
-    }, 100);
+    jest.runAllTimers();
+    focusTarget.focus();
+    expect(gotEvent).toEqual(true);
   });
 });

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.test.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { Promise } from 'es6-promise';
 import * as ReactTestUtils from 'react-dom/test-utils';
 import { KeyCodes } from '../../Utilities';
 import { FocusZoneDirection } from '../../FocusZone';
 import * as renderer from 'react-test-renderer';
+// Have to import this separately for mock purposes
+import * as Utilities from '../../Utilities';
 
 import { IContextualMenuProps, IContextualMenuStyles, IContextualMenu } from './ContextualMenu.types';
 import { ContextualMenu } from './ContextualMenu';
@@ -20,7 +21,29 @@ describe('ContextualMenu', () => {
         i--;
       }
     }
+    jest.useRealTimers();
+    jest.restoreAllMocks();
   });
+
+  /**
+   * Needed to make initial focus work: mock focusFirstChild to mark all child elements as visible,
+   * then call the real version.
+   */
+  function mockFocusFirstChild() {
+    const realFocusFirstChild = Utilities.focusFirstChild;
+    jest.spyOn(Utilities, 'focusFirstChild').mockImplementation((rootElement: HTMLElement) => {
+      function markAllVisible(element: Element) {
+        (element as any).isVisible = true;
+        if (element.children.length) {
+          for (let i = 0; i < element.children.length; i++) {
+            markAllVisible(element.children[i]);
+          }
+        }
+      }
+      markAllVisible(rootElement);
+      return realFocusFirstChild(rootElement);
+    });
+  }
 
   it('allows setting aria-label per ContextualMenuItem', () => {
     const items: IContextualMenuItem[] = [{ text: 'Later Today', key: 'Today', secondaryText: '7:00 PM', ariaLabel: 'foo' }];
@@ -713,16 +736,12 @@ describe('ContextualMenu', () => {
         expect(linkSelfTarget.getAttribute('rel')).toBeNull();
       });
 
-      describe('when the target is _blank and there is no rel specified', () => {
-        it('should default a rel to prevent clickjacking', () => {
-          expect(linkBlankTarget.getAttribute('rel')).toEqual('nofollow noopener noreferrer');
-        });
+      it('when the target is _blank and no rel is specified, defaults a rel to prevent clickjacking', () => {
+        expect(linkBlankTarget.getAttribute('rel')).toEqual('nofollow noopener noreferrer');
       });
 
-      describe('when the target is _blank and there is a rel specified', () => {
-        it('should use the specified rel', () => {
-          expect(linkBlankTargetAndRel.getAttribute('rel')).toEqual('test');
-        });
+      it('when the target is _blank and rel is specified, uses the specified rel', () => {
+        expect(linkBlankTargetAndRel.getAttribute('rel')).toEqual('test');
       });
     });
 
@@ -740,7 +759,9 @@ describe('ContextualMenu', () => {
     expect(menuList).toBeNull();
   });
 
-  it('correctly focuses the first element', done => {
+  it('correctly focuses the first element', () => {
+    jest.useFakeTimers();
+    mockFocusFirstChild();
     const items: IContextualMenuItem[] = [
       {
         text: 'TestText 1',
@@ -753,23 +774,16 @@ describe('ContextualMenu', () => {
       }
     ];
 
-    ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
+    ReactTestUtils.renderIntoDocument(<ContextualMenu items={items} />);
+    jest.runAllTimers();
 
-    new Promise<any>(resolve => {
-      let focusedItem;
-      for (let i = 0; i < 20; i++) {
-        focusedItem = document.querySelector('.testkey1')!.firstChild;
-        if (focusedItem === document.activeElement) {
-          break;
-        }
-      }
-      expect(document.activeElement).toEqual(focusedItem);
-      done();
-      resolve();
-    }).catch(done());
+    const focusedItem = document.querySelector('.testkey1')!.firstChild;
+    expect(document.activeElement).toEqual(focusedItem);
   });
 
-  it('will not focus the first element when shouldFocusOnMount is false', done => {
+  it('will not focus the first element when shouldFocusOnMount is false', () => {
+    jest.useFakeTimers();
+    mockFocusFirstChild();
     const items: IContextualMenuItem[] = [
       {
         text: 'TestText 1',
@@ -783,21 +797,14 @@ describe('ContextualMenu', () => {
     ];
 
     ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} shouldFocusOnMount={true} />);
-    new Promise(resolve => {
-      let focusedItem;
-      for (let i = 0; i < 20; i++) {
-        focusedItem = document.querySelector('.testkey1')!.firstChild;
-        if (focusedItem === document.activeElement) {
-          break;
-        }
-      }
-      expect(document.activeElement).not.toEqual(focusedItem);
-      done();
-      resolve();
-    }).catch(done);
+    jest.runAllTimers();
+
+    const focusedItem = document.querySelector('.testkey1')!.firstChild;
+    expect(document.activeElement).toEqual(focusedItem);
   });
 
-  it('Hover correctly focuses the second element', done => {
+  it('Correctly focuses the second element on hover', () => {
+    jest.useFakeTimers();
     const items: IContextualMenuItem[] = [
       {
         text: 'TestText 1',
@@ -812,26 +819,13 @@ describe('ContextualMenu', () => {
     ];
 
     ReactTestUtils.renderIntoDocument<IContextualMenuProps>(<ContextualMenu items={items} />);
+    jest.runAllTimers();
 
-    new Promise<any>(resolve => {
-      let focusedItem;
-      for (let i = 0; i < 20; i++) {
-        focusedItem = document.querySelector('.testkey2')!.firstChild;
-
-        if (focusedItem) {
-          const focusedItemElement = focusedItem as HTMLElement;
-          const eventObject = document.createEvent('Events');
-          eventObject.initEvent('mouseenter', true, false);
-          focusedItemElement.dispatchEvent(eventObject);
-        }
-        if (focusedItem === document.activeElement) {
-          break;
-        }
-      }
-      expect(document.activeElement).toEqual(focusedItem);
-      done();
-      resolve();
-    }).catch(done());
+    const itemToFocus = document.querySelector('.testkey2')!.firstChild as HTMLElement;
+    ReactTestUtils.Simulate.mouseMove(itemToFocus);
+    ReactTestUtils.Simulate.mouseEnter(itemToFocus);
+    jest.runAllTimers();
+    expect(document.activeElement).toEqual(itemToFocus);
   });
 
   it('merges callout classNames', () => {

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.test.tsx
@@ -6,7 +6,11 @@ import { DialogBase } from './Dialog.base';
 import { DialogContent } from './DialogContent';
 import { DialogType } from './DialogContent.types'; // for express fluent assertions
 
-/* tslint:disable:no-unused-expression */ describe('Dialog', () => {
+describe('Dialog', () => {
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
   it('renders Dialog correctly', () => {
     const component = renderer.create(<DialogContent />);
     const tree = component.toJSON();
@@ -29,7 +33,8 @@ import { DialogType } from './DialogContent.types'; // for express fluent assert
     expect(tree).toMatchSnapshot();
   });
 
-  it('Fires dismissed after closing', done => {
+  it('Fires dismissed after closing', () => {
+    jest.useFakeTimers();
     let dismissedCalled = false;
 
     const handleDismissed = () => {
@@ -42,17 +47,10 @@ import { DialogType } from './DialogContent.types'; // for express fluent assert
     wrapper.setProps({ hidden: true });
     wrapper.update();
 
-    // give time for update to complete
-    setTimeout(() => {
-      try {
-        expect(document.querySelector('[role="dialog"]')).toBeNull();
-        expect(dismissedCalled).toEqual(true);
-      } catch (e) {
-        done(e);
-      }
-      wrapper.unmount();
-      done();
-    }, 300);
+    jest.runAllTimers();
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+    expect(dismissedCalled).toEqual(true);
+    wrapper.unmount();
   });
 
   it('Properly attaches auto-generated aria attributes IDs', () => {

--- a/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/KeytipLayer/KeytipLayer.test.tsx
@@ -56,10 +56,6 @@ describe('KeytipLayer', () => {
     keySequences: ['g']
   };
 
-  function delay(millisecond: number): Promise<void> {
-    return new Promise<void>(resolve => setTimeout(resolve, millisecond));
-  }
-
   function getKeytip(keytips: IKeytipProps[], content: string): IKeytipProps | undefined {
     return find(keytips, (keytip: IKeytipProps) => {
       return keytip.content === content;
@@ -342,6 +338,8 @@ describe('KeytipLayer', () => {
 
   describe('event listeners', () => {
     beforeEach(() => {
+      jest.useFakeTimers();
+
       // Add keytips to the manager
       ktpMgr.keytips = [
         { keytip: keytipB, uniqueID: uniqueIdB },
@@ -357,6 +355,10 @@ describe('KeytipLayer', () => {
       ktpTree = layerRef.current!.getKeytipTree();
     });
 
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
     it('keytipAdded event delay-shows a keytip if the current keytip is its parent', () => {
       ktpTree.currentKeytip = ktpTree.getNode(keytipIdB);
       // Add a child under B
@@ -364,11 +366,11 @@ describe('KeytipLayer', () => {
         content: 'X',
         keySequences: ['b', 'x']
       });
-      return delay(750).then(() => {
-        const visibleKeytips: IKeytipProps[] = ktpLayer.state('visibleKeytips');
-        expect(visibleKeytips).toHaveLength(1);
-        expect(getKeytip(visibleKeytips, 'X')).toBeDefined();
-      });
+      jest.runAllTimers();
+
+      const visibleKeytips: IKeytipProps[] = ktpLayer.state('visibleKeytips');
+      expect(visibleKeytips).toHaveLength(1);
+      expect(getKeytip(visibleKeytips, 'X')).toBeDefined();
     });
   });
 });

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.test.tsx
@@ -73,10 +73,6 @@ describe('OverflowSet', () => {
     expect(onRenderOverflowButton.called).toEqual(false);
   });
 
-  function delay(millisecond: number): Promise<void> {
-    return new Promise<void>(resolve => setTimeout(resolve, millisecond));
-  }
-
   describe('keytip tests', () => {
     let overflowSet: ReactWrapper;
     let overflowKeytips: any;
@@ -175,6 +171,8 @@ describe('OverflowSet', () => {
     });
 
     afterEach(() => {
+      jest.useRealTimers();
+
       // Clean up the keytip items
       keytipManager.keytips = [];
       keytipManager.persistedKeytips = [];
@@ -243,6 +241,8 @@ describe('OverflowSet', () => {
       });
 
       it('triggering the overflow button keytip should register the menu item keytips with their modified sequence', () => {
+        jest.useFakeTimers();
+
         overflowSet = mount(
           <div>
             <OverflowSet
@@ -261,26 +261,27 @@ describe('OverflowSet', () => {
         keytipTree.currentKeytip = keytipTree.root;
         // Open the overflow menu
         layerRef.current!.processInput('x');
+        jest.runAllTimers();
 
-        return delay(750).then(() => {
-          // Opening the submenu should register the two keytips for those items
-          const keytip3 = getKeytip(keytipManager, ['c']);
-          expect(keytip3).toBeDefined();
-          expect(keytip3!.overflowSetSequence).toBeDefined();
-          expect(keytip3!.overflowSetSequence![0]).toEqual('x');
-          const keytip4 = getKeytip(keytipManager, ['d']);
-          expect(keytip4).toBeDefined();
-          expect(keytip4!.overflowSetSequence).toBeDefined();
-          expect(keytip4!.overflowSetSequence![0]).toEqual('x');
+        // Opening the submenu should register the two keytips for those items
+        const keytip3 = getKeytip(keytipManager, ['c']);
+        expect(keytip3).toBeDefined();
+        expect(keytip3!.overflowSetSequence).toBeDefined();
+        expect(keytip3!.overflowSetSequence![0]).toEqual('x');
+        const keytip4 = getKeytip(keytipManager, ['d']);
+        expect(keytip4).toBeDefined();
+        expect(keytip4!.overflowSetSequence).toBeDefined();
+        expect(keytip4!.overflowSetSequence![0]).toEqual('x');
 
-          // Those two keytips should now be visible in the Layer
-          layerRef.current!.state.keytips;
-          const visibleKeytips = layerRef.current!.state.visibleKeytips;
-          expect(visibleKeytips).toHaveLength(2);
-        });
+        // Those two keytips should now be visible in the Layer
+        layerRef.current!.state.keytips;
+        const visibleKeytips = layerRef.current!.state.visibleKeytips;
+        expect(visibleKeytips).toHaveLength(2);
       });
 
       it('overflowSetSequence gets set correctly on overflowItems keytipProps when the overflow menu is opened', () => {
+        jest.useFakeTimers();
+
         // Set current keytip at root, like we've entered keytip mode
         overflowSet = mount(
           <div>
@@ -300,18 +301,17 @@ describe('OverflowSet', () => {
         keytipTree.currentKeytip = keytipTree.root;
         // Open the overflow menu
         layerRef.current!.processInput('x');
+        jest.runAllTimers();
 
-        return delay(750).then(() => {
-          // item3
-          const item3Keytip = getKeytip(keytipManager, overflowKeytips.overflowItemKeytip3.keySequences);
-          expect(arraysEqual(item3Keytip!.overflowSetSequence!, overflowKeytips.overflowButtonKeytip.keySequences)).toEqual(true);
-          // item4
-          const item4Keytip = getKeytip(keytipManager, overflowKeytips.overflowItemKeytip4.keySequences);
-          expect(arraysEqual(item4Keytip!.overflowSetSequence!, overflowKeytips.overflowButtonKeytip.keySequences)).toEqual(true);
-        });
+        // item3
+        const item3Keytip = getKeytip(keytipManager, overflowKeytips.overflowItemKeytip3.keySequences);
+        expect(arraysEqual(item3Keytip!.overflowSetSequence!, overflowKeytips.overflowButtonKeytip.keySequences)).toEqual(true);
+        // item4
+        const item4Keytip = getKeytip(keytipManager, overflowKeytips.overflowItemKeytip4.keySequences);
+        expect(arraysEqual(item4Keytip!.overflowSetSequence!, overflowKeytips.overflowButtonKeytip.keySequences)).toEqual(true);
       });
 
-      it('correctly picks up a disabled keytip and doesn`t call it', () => {
+      it("correctly picks up a disabled keytip and doesn't call it", () => {
         overflowItems = [
           {
             key: 'item3',
@@ -409,6 +409,8 @@ describe('OverflowSet', () => {
 
       describe('with children keytips', () => {
         it('should open the overflow and submenu when the persisted keytip is triggered', () => {
+          jest.useFakeTimers();
+
           const overflowItemsWithSubMenuAndKeytips = [
             item3,
             {
@@ -476,18 +478,19 @@ describe('OverflowSet', () => {
           const subMenu6Keytip = getKeytip(keytipManager, modifiedKeytip6Sequence);
           expect(subMenu6Keytip).toBeDefined();
           expect(subMenu6Keytip!.overflowSetSequence![0]).toEqual('x');
+          jest.runAllTimers();
 
-          return delay(750).then(() => {
-            // Those two keytips should now be visible in the Layer and have overflowSetSequence set
-            const submenuKeytips = layerRef.current!.state.visibleKeytips;
-            submenuKeytips.forEach((submenuKeytip: IKeytipProps) => {
-              expect(submenuKeytip.visible).toEqual(true);
-              expect(arraysEqual(submenuKeytip.overflowSetSequence!, overflowKeytips.overflowButtonKeytip.keySequences)).toEqual(true);
-            });
+          // Those two keytips should now be visible in the Layer and have overflowSetSequence set
+          const submenuKeytips = layerRef.current!.state.visibleKeytips;
+          submenuKeytips.forEach((submenuKeytip: IKeytipProps) => {
+            expect(submenuKeytip.visible).toEqual(true);
+            expect(arraysEqual(submenuKeytip.overflowSetSequence!, overflowKeytips.overflowButtonKeytip.keySequences)).toEqual(true);
           });
         });
 
         it('should behave correctly when the persisted keytip execute is delayed', () => {
+          jest.useFakeTimers();
+
           const overflowItemsWithSubMenuAndKeytips = [
             item3,
             {
@@ -532,6 +535,7 @@ describe('OverflowSet', () => {
           const delayedOverflowButton = (overflowElements: any[] | undefined): JSX.Element => {
             // Overflow button which delays 2s before opening the menu
             // This simulates latency when opening the menu
+            // (note that we'll actually skip through this latency with jest.runAllTimers())
             return (
               <CommandBarButton
                 menuIconProps={{ iconName: 'More' }}
@@ -540,10 +544,10 @@ describe('OverflowSet', () => {
                   content: 'X',
                   keySequences: ['x'],
                   onExecute: (el: HTMLElement) => {
-                    delay(2000).then(() => {
+                    setTimeout(() => {
                       // Find the overflow button and manually click it to open the overflow menu
                       overflowSet.find(ktpTargetFromId('ktp-x')).simulate('click');
-                    });
+                    }, 2000);
                   }
                 }}
               />
@@ -567,21 +571,22 @@ describe('OverflowSet', () => {
           const keytipTree = layerRef.current!.getKeytipTree();
           keytipTree.currentKeytip = keytipTree.root;
           layerRef.current!.processInput('d');
+          // Wait for the menu to open
+          jest.runAllTimers();
 
-          // Delay to wait for the menu to open
-          return delay(3000).then(() => {
-            // Those two keytips should now be visible in the Layer and have overflowSetSequence set
-            const submenuKeytips = layerRef.current!.state.visibleKeytips;
-            submenuKeytips.forEach((submenuKeytip: IKeytipProps) => {
-              expect(submenuKeytip.visible).toEqual(true);
-              expect(arraysEqual(submenuKeytip.overflowSetSequence!, overflowKeytips.overflowButtonKeytip.keySequences)).toEqual(true);
-            });
+          // Those two keytips should now be visible in the Layer and have overflowSetSequence set
+          const submenuKeytips = layerRef.current!.state.visibleKeytips;
+          submenuKeytips.forEach((submenuKeytip: IKeytipProps) => {
+            expect(submenuKeytip.visible).toEqual(true);
+            expect(arraysEqual(submenuKeytip.overflowSetSequence!, overflowKeytips.overflowButtonKeytip.keySequences)).toEqual(true);
           });
         });
       });
 
       describe('with non-standard children keytips', () => {
         it('should respect itemSubMenuProvider when setting overflowSetSequence', () => {
+          jest.useFakeTimers();
+
           const overflowItemsWithSubMenuAndKeytips = [
             item3,
             {
@@ -648,14 +653,13 @@ describe('OverflowSet', () => {
           keytipTree.currentKeytip = keytipTree.root;
 
           layerRef.current!.processInput('d');
+          jest.runAllTimers();
 
-          return delay(750).then(() => {
-            // Those two keytips should now be visible in the Layer and have overflowSetSequence set
-            const submenuKeytips = layerRef.current!.state.visibleKeytips;
-            submenuKeytips.forEach((submenuKeytip: IKeytipProps) => {
-              expect(submenuKeytip.visible).toEqual(true);
-              expect(arraysEqual(submenuKeytip.overflowSetSequence!, overflowKeytips.overflowButtonKeytip.keySequences)).toEqual(true);
-            });
+          // Those two keytips should now be visible in the Layer and have overflowSetSequence set
+          const submenuKeytips = layerRef.current!.state.visibleKeytips;
+          submenuKeytips.forEach((submenuKeytip: IKeytipProps) => {
+            expect(submenuKeytip.visible).toEqual(true);
+            expect(arraysEqual(submenuKeytip.overflowSetSequence!, overflowKeytips.overflowButtonKeytip.keySequences)).toEqual(true);
           });
         });
       });

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.test.tsx
@@ -1,4 +1,3 @@
-import { Promise } from 'es6-promise';
 import * as React from 'react';
 import * as ReactTestUtils from 'react-dom/test-utils';
 import * as renderer from 'react-test-renderer';
@@ -10,6 +9,12 @@ import { mockEvent, renderIntoDocument } from '../../common/testUtilities';
 describe('SpinButton', () => {
   beforeEach(() => {
     resetIds();
+  });
+
+  afterEach(() => {
+    if ((setTimeout as any).mock) {
+      jest.useRealTimers();
+    }
   });
 
   it('renders SpinButton correctly', () => {
@@ -520,14 +525,12 @@ describe('SpinButton', () => {
   });
 
   it('should stop spinning if text field is focused while actively spinning', () => {
+    jest.useFakeTimers();
+
     const exampleLabelValue = 'SpinButton';
     const exampleMinValue = 2;
     const exampleMaxValue = 22;
     const exampleDefaultValue = '12';
-
-    function delay(millisecond: number): Promise<string> {
-      return new Promise<string>(resolve => setTimeout(resolve, millisecond));
-    }
 
     const renderedDOM: HTMLElement = renderIntoDocument(
       <SpinButton label={exampleLabelValue} min={exampleMinValue} max={exampleMaxValue} defaultValue={exampleDefaultValue} />
@@ -537,15 +540,21 @@ describe('SpinButton', () => {
     const inputDOM: HTMLInputElement = renderedDOM.getElementsByTagName('input')[0];
     const buttonDOM: Element = renderedDOM.getElementsByClassName('ms-UpButton')[0];
 
-    expect(buttonDOM.tagName).toEqual('BUTTON');
+    expect(buttonDOM).toBeTruthy();
 
+    // start spinning
     ReactTestUtils.Simulate.mouseDown(buttonDOM, {
       type: 'mousedown',
       clientX: 0,
       clientY: 0
     });
+    // spin again
+    jest.runOnlyPendingTimers();
+    // spin again
+    jest.runOnlyPendingTimers();
 
-    delay(500).then(() => ReactTestUtils.Simulate.focus(inputDOM));
+    ReactTestUtils.Simulate.focus(inputDOM);
+    jest.runAllTimers();
 
     const currentValue = inputDOM.value;
     expect(currentValue).not.toEqual('2');


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

While working on the TextField tests in #10016, I learned about patterns for testing async code using [Jest's fake timers](https://jestjs.io/docs/en/timer-mocks.html) instead of real timeouts. So this PR applies that knowledge to some other tests, replacing actual timeouts (sometimes up to 3s) with fake timers. This will make the tests run a bit faster.

Also noticed (while working on some TextField changes I later reverted) that the Autofill tests weren't actually testing anything, and sometimes the actual behavior was the exact opposite of what the test was claiming to verify. So I fixed that too.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10140)