### PR TITLE
MessageBarButton: Remove Fixed Width Styling

### DIFF
--- a/change/office-ui-fabric-react-2019-08-14-11-23-34-jg-10134-messagebarbutton-width.json
+++ b/change/office-ui-fabric-react-2019-08-14-11-23-34-jg-10134-messagebarbutton-width.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "MessageBarButton: Remove the fixed width added in #8779.",
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com",
+  "commit": "c5882425313e25e68c419613f46c660e4e605d6e",
+  "date": "2019-08-14T18:23:34.026Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/MessageBarButton/MessageBarButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/MessageBarButton/MessageBarButton.styles.ts
@@ -9,7 +9,6 @@ export const getStyles = memoizeFunction(
     const messageBarButtonStyles: IButtonStyles = {
       root: {
         height: 24,
-        width: 84,
         borderColor: theme.palette.neutralTertiaryAlt
       }
     };

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Basic.Example.tsx.shot
@@ -1167,7 +1167,6 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
-                    width: 84px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -1283,7 +1282,6 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
-                    width: 84px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -1594,7 +1592,6 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                       text-decoration: none;
                       user-select: none;
                       vertical-align: top;
-                      width: 84px;
                     }
                     &::-moz-focus-inner {
                       border: 0;
@@ -1710,7 +1707,6 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                       text-decoration: none;
                       user-select: none;
                       vertical-align: top;
-                      width: 84px;
                     }
                     &::-moz-focus-inner {
                       border: 0;
@@ -2023,7 +2019,6 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                       text-decoration: none;
                       user-select: none;
                       vertical-align: top;
-                      width: 84px;
                     }
                     &::-moz-focus-inner {
                       border: 0;
@@ -2600,7 +2595,6 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
-                    width: 84px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -2716,7 +2710,6 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
-                    width: 84px;
                   }
                   &::-moz-focus-inner {
                     border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Styled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Styled.Example.tsx.shot
@@ -1175,7 +1175,6 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
-                    width: 84px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -1291,7 +1290,6 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
-                    width: 84px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -1604,7 +1602,6 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                       text-decoration: none;
                       user-select: none;
                       vertical-align: top;
-                      width: 84px;
                     }
                     &::-moz-focus-inner {
                       border: 0;
@@ -1720,7 +1717,6 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                       text-decoration: none;
                       user-select: none;
                       vertical-align: top;
-                      width: 84px;
                     }
                     &::-moz-focus-inner {
                       border: 0;
@@ -2035,7 +2031,6 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                       text-decoration: none;
                       user-select: none;
                       vertical-align: top;
-                      width: 84px;
                     }
                     &::-moz-focus-inner {
                       border: 0;
@@ -2615,7 +2610,6 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
-                    width: 84px;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -2731,7 +2725,6 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                     text-decoration: none;
                     user-select: none;
                     vertical-align: top;
-                    width: 84px;
                   }
                   &::-moz-focus-inner {
                     border: 0;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10134
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Remove the fixed width added in #8779 to allow `MessageBarButton` to adapt to user content by default.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10149)