### PR TITLE
Create component style memoization - Prototype 2

### DIFF
--- a/change/@uifabric-experiments-2019-08-14-14-18-18-createComponentMemoization2.json
+++ b/change/@uifabric-experiments-2019-08-14-14-18-18-createComponentMemoization2.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Memoizing styling in createComponent for components that have their default styling determined entirely by tokens.",
+  "packageName": "@uifabric/experiments",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "8507da7511cf1a7dd1c9de98568fc5c48fe22ba5",
+  "date": "2019-08-14T21:18:11.759Z"
+}

--- a/change/@uifabric-foundation-2019-08-14-14-18-18-createComponentMemoization2.json
+++ b/change/@uifabric-foundation-2019-08-14-14-18-18-createComponentMemoization2.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Memoizing styling in createComponent for components that have their default styling determined entirely by tokens.",
+  "packageName": "@uifabric/foundation",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "8507da7511cf1a7dd1c9de98568fc5c48fe22ba5",
+  "date": "2019-08-14T21:18:15.435Z"
+}

--- a/change/office-ui-fabric-react-2019-08-14-14-18-18-createComponentMemoization2.json
+++ b/change/office-ui-fabric-react-2019-08-14-14-18-18-createComponentMemoization2.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Memoizing styling in createComponent for components that have their default styling determined entirely by tokens.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "8507da7511cf1a7dd1c9de98568fc5c48fe22ba5",
+  "date": "2019-08-14T21:18:18.616Z"
+}

--- a/packages/experiments/src/components/Button/MenuButton/MenuButton.view.tsx
+++ b/packages/experiments/src/components/Button/MenuButton/MenuButton.view.tsx
@@ -17,6 +17,7 @@ export const MenuButtonView: IMenuButtonComponent['view'] = props => {
     expanded,
     onMenuDismiss,
     menuButtonRef,
+    styles,
     ...rest
   } = props;
   let { keytipProps } = props;

--- a/packages/experiments/src/components/Button/examples/Button.Slots.Example.tsx
+++ b/packages/experiments/src/components/Button/examples/Button.Slots.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Stack, IStackProps, IStackTokens } from 'office-ui-fabric-react/lib/Stack';
+import { Stack, IStackTokens } from 'office-ui-fabric-react/lib/Stack';
 import { Text } from 'office-ui-fabric-react/lib/Text';
 import { IMenuButtonProps, IMenuButtonStyles, IMenuButtonTokens, MenuButton } from '@uifabric/experiments/lib/MenuButton';
 import { ISplitButtonProps, ISplitButtonTokens, SplitButton } from '@uifabric/experiments/lib/SplitButton';
@@ -119,9 +119,11 @@ const SplitMenuButtonVerticalSlots: ISplitRibbonMenuButtonProps['slots'] = {
 export const RibbonSplitMenuButton: React.SFC<ISplitRibbonMenuButtonProps> = props => {
   const { content, vertical, ...rest } = props;
 
-  const rootProps: IStackProps = {
-    horizontal: false,
-    horizontalAlign: 'center'
+  const rootProps: React.DetailedHTMLProps<React.HtmlHTMLAttributes<any>, any> = {
+    style: {
+      alignItems: 'center',
+      flexDirection: 'column'
+    }
   };
 
   // TODO: This cast is required because menu is required in IMenuButtonSlots.

--- a/packages/experiments/src/components/PersonaCoin/PersonaCoin.ts
+++ b/packages/experiments/src/components/PersonaCoin/PersonaCoin.ts
@@ -5,6 +5,7 @@ import { IPersonaCoinProps } from './PersonaCoin.types';
 import { PersonaCoinView } from './PersonaCoin.view';
 
 export const PersonaCoin: React.StatelessComponent<IPersonaCoinProps> = createComponent(PersonaCoinView, {
+  disableCaching: true,
   displayName: 'PersonaCoin',
   styles: PersonaCoinStyles,
   state: usePersonaCoinState

--- a/packages/foundation/src/IComponent.ts
+++ b/packages/foundation/src/IComponent.ts
@@ -104,6 +104,11 @@ export interface IComponentOptions<
   TStatics = {}
 > {
   /**
+   * Boolean prop that determines whether style memoization should be disabled or not.
+   * @defaultvalue false
+   */
+  disableCaching?: boolean;
+  /**
    * Display name to identify component in React hierarchy. This parameter is required for targeted component styling via theming.
    */
   displayName?: string;

--- a/packages/foundation/src/createComponent.tsx
+++ b/packages/foundation/src/createComponent.tsx
@@ -14,6 +14,18 @@ import {
   IViewComponent
 } from './IComponent';
 import { IDefaultSlotProps, ISlotCreator, ValidProps } from './ISlots';
+import { mergeStyles } from '@uifabric/merge-styles';
+
+interface IClassNamesMapNode {
+  className?: string;
+  map: IClassNamesMap;
+}
+
+interface IClassNamesMap {
+  [key: string]: IClassNamesMapNode;
+}
+
+const memoizedClassNamesMap: IClassNamesMap = {};
 
 /**
  * Assembles a higher order component based on the following: styles, theme, view, and state.
@@ -63,15 +75,69 @@ export function createComponent<
     }
 
     const theme = componentProps.theme || settings.theme;
+    const tokens = _resolveTokens(componentProps, theme, options.tokens, settings.tokens, componentProps.tokens) as any;
+    let styles;
 
-    const tokens = _resolveTokens(componentProps, theme, options.tokens, settings.tokens, componentProps.tokens);
-    const styles = _resolveStyles(componentProps, theme, tokens, options.styles, settings.styles, componentProps.styles);
+    const finalStyles: { [key: string]: string | undefined } = {};
+
+    if (!options.disableCaching) {
+      // We get the entry in the memoized classNamesMap for the current component or create one if it doesn't exist.
+      const displayName = options.displayName || view.name;
+      if (!memoizedClassNamesMap.hasOwnProperty(displayName)) {
+        memoizedClassNamesMap[displayName] = { map: {} };
+      }
+
+      // Memoize based on the tokens definition.
+      let current = memoizedClassNamesMap[displayName];
+      const tokenKeys = Object.keys(tokens).sort();
+      for (const key of tokenKeys) {
+        let nextToken = tokens[key];
+        if (nextToken === undefined) {
+          nextToken = '__undefined__';
+        }
+        if (!current.map.hasOwnProperty(nextToken)) {
+          current.map[nextToken] = { map: {} };
+        }
+        current = current.map[nextToken];
+      }
+
+      // Memoize based on the base styling of the component (i.e. without user specified props).
+      const defaultStyles = _resolveStyles(componentProps, theme, tokens, options.styles, settings.styles) as any;
+      styles = defaultStyles;
+      const defaultStyleKeys = Object.keys(defaultStyles).sort();
+      for (const key of defaultStyleKeys) {
+        if (!current.map.hasOwnProperty(key)) {
+          current.map[key] = { className: mergeStyles(defaultStyles[key]), map: {} };
+        }
+        finalStyles[key] = current.map[key].className;
+      }
+
+      if (componentProps.styles) {
+        const userStyles: any =
+          typeof componentProps.styles === 'function'
+            ? componentProps.styles(componentProps as TViewProps, theme, tokens)
+            : componentProps.styles;
+        styles = concatStyleSets(styles, userStyles);
+        if (userStyles) {
+          const userStyleKeys = Object.keys(userStyles).sort();
+          for (const key of userStyleKeys) {
+            if (finalStyles.hasOwnProperty(key)) {
+              finalStyles[key] = mergeStyles([current.map[key].className], userStyles[key]);
+            } else {
+              finalStyles[key] = mergeStyles(userStyles[key]);
+            }
+          }
+        }
+      }
+    } else {
+      styles = _resolveStyles(componentProps, theme, tokens, options.styles, settings.styles, componentProps.styles);
+    }
 
     const viewProps = {
       ...componentProps,
       styles,
       tokens,
-      _defaultStyles: styles
+      _defaultStyles: options.disableCaching ? styles : finalStyles
     } as TViewProps & IDefaultSlotProps<any>;
 
     return view(viewProps);

--- a/packages/foundation/src/slots.tsx
+++ b/packages/foundation/src/slots.tsx
@@ -191,7 +191,16 @@ function _constructFinalProps<TProps extends IProcessedSlotProps>(defaultStyles:
     assign(finalProps, ...(props as any));
   }
 
-  finalProps.className = mergeStyles(defaultStyles, classNames);
+  if (typeof defaultStyles === 'string') {
+    finalProps.className = defaultStyles;
+    for (const className of classNames) {
+      if (className) {
+        finalProps.className += ' ' + className;
+      }
+    }
+  } else {
+    finalProps.className = mergeStyles([defaultStyles], classNames);
+  }
 
   return finalProps;
 }

--- a/packages/office-ui-fabric-react/src/components/Stack/Stack.tsx
+++ b/packages/office-ui-fabric-react/src/components/Stack/Stack.tsx
@@ -66,9 +66,10 @@ const StackStatics = {
 export const Stack: React.StatelessComponent<IStackProps> & {
   Item: React.StatelessComponent<IStackItemProps>;
 } = createComponent(StackView, {
+  disableCaching: true,
   displayName: 'Stack',
-  styles,
-  statics: StackStatics
+  statics: StackStatics,
+  styles
 });
 
 export default Stack;

--- a/packages/office-ui-fabric-react/src/components/Stack/StackItem/StackItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/Stack/StackItem/StackItem.tsx
@@ -18,6 +18,7 @@ const StackItemView: IStackItemComponent['view'] = props => {
 };
 
 export const StackItem: React.StatelessComponent<IStackItemProps> = createComponent(StackItemView, {
+  disableCaching: true,
   displayName: 'StackItem',
   styles
 });

--- a/packages/office-ui-fabric-react/src/components/Text/Text.ts
+++ b/packages/office-ui-fabric-react/src/components/Text/Text.ts
@@ -5,6 +5,7 @@ import { TextView } from './Text.view';
 import { TextStyles as styles } from './Text.styles';
 
 export const Text: React.StatelessComponent<ITextProps> = createComponent(TextView, {
+  disableCaching: true,
   displayName: 'Text',
   styles
 });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR introduces a second approach to style memoization at the `createComponent` layer using tokens to create a mapping from style to classname and thus reduce the amount of times that mergeStyles has to be called. This results in a performance gain for components where styling plays a big part of their rendering time, such as Button and its variants.

One thing to note is that the approach presented in this PR works if the component's default style depends just on the tokens defined and not on the props passed in (user provided styles as a prop still works). This makes components like `Button` work with this approach while components like `Stack` break if this approach is used (component props such as `horizontal`, `verticalAlign`, etc modify its styles). Given that, this PR also adds a `disableCaching` option to `createComponent` that is `false` by default but that has been turned on for `Stack`, `StackItem` and `Text` so they are not broken until we change them so that styling depends entirely on tokens (if we decide to).

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10151)