### PR TITLE
[6.0] Cherry-pick PR #10080 - DetailsRow useReducedRowRenderer shallow prop comparison fix

### DIFF
--- a/change/office-ui-fabric-react-2019-08-06-16-50-53-DetailsRowShouldUpdateFix.json
+++ b/change/office-ui-fabric-react-2019-08-06-16-50-53-DetailsRowShouldUpdateFix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "DetailsRow should only re-render if a prop is detected to have changed.",
+  "packageName": "office-ui-fabric-react",
+  "email": "megreid115@gmail.com",
+  "commit": "00bda91a359c9efbefd855bcf2bfaa09a031536e",
+  "date": "2019-08-06T23:50:53.659Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
@@ -150,7 +150,7 @@ export class DetailsRowBase extends BaseComponent<IDetailsRowBaseProps, IDetails
           return true;
         }
       }
-      return shallowCompare(this.props, nextProps);
+      return !shallowCompare(this.props, nextProps);
     } else {
       return true;
     }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10079
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This is a `6.0` cherry-pick of https://github.com/OfficeDev/office-ui-fabric-react/pull/10080 that fixes incorrect shallow prop comparison logic introduced in https://github.com/OfficeDev/office-ui-fabric-react/pull/5571.

Original PR description:

>The negation of shallowCompare should be used to ensure that the component updates when a prop has changed. This change only affects DetailsList when useReducedRowRenderer is set to true.

#### Focus areas to test

- CI passes

cc: @XpRv


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10171)