### PR TITLE
Fix generated font theme tokens for legacy

### DIFF
--- a/change/@uifabric-styling-2019-08-16-15-18-00-phkuo-fixThemingAgain6.0.json
+++ b/change/@uifabric-styling-2019-08-16-15-18-00-phkuo-fixThemingAgain6.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix generated font theme tokens for legacy theming",
+  "packageName": "@uifabric/styling",
+  "email": "phkuo@microsoft.com",
+  "commit": "8fed2cf839a7f27ae8f64126069e7dc013c6982c",
+  "date": "2019-08-16T22:18:00.898Z"
+}

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -101,8 +101,8 @@ function _loadFonts(theme: ITheme): { [name: string]: string } {
     for (const propName of Object.keys(font)) {
       const name = fontName + propName.charAt(0).toUpperCase() + propName.slice(1);
       let value = font[propName];
-      if (propName === 'fontSize' && value && value.indexOf && value.indexOf('px') < 0) {
-        value += 'px';
+      if (propName === 'fontSize' && typeof value === 'number') {
+        value = value + 'px';
       }
       lines[name] = value;
     }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Fix generated font theme tokens for legacy. I got a little confused with the previous change (which does fix the crash, but doesn't solve the underlying problem).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10176)