### PR TITLE
Fix tooltip examples

### DIFF
--- a/change/office-ui-fabric-react-2019-08-16-15-39-36-master.json
+++ b/change/office-ui-fabric-react-2019-08-16-15-39-36-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Tooltip: Fix examples to pass correct root display styling.",
+  "packageName": "office-ui-fabric-react",
+  "email": "email not defined",
+  "commit": "e3b482b0d2587e7a56b2717a27454688fece8197",
+  "date": "2019-08-16T22:39:36.332Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Basic.Example.tsx
@@ -11,7 +11,12 @@ export class TooltipBasicExample extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
       <div>
-        <TooltipHost content="This is the tooltip" id={this._hostId} calloutProps={{ gapSpace: 0 }}>
+        <TooltipHost
+          content="This is the tooltip"
+          id={this._hostId}
+          calloutProps={{ gapSpace: 0 }}
+          styles={{ root: { display: 'inline-block' } }}
+        >
           <DefaultButton aria-labelledby={this._hostId}>Hover Over Me</DefaultButton>
         </TooltipHost>
       </div>

--- a/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Custom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Custom.Example.tsx
@@ -11,7 +11,6 @@ export class TooltipCustomExample extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
       <TooltipHost
-        calloutProps={{ gapSpace: 20 }}
         tooltipProps={{
           onRenderContent: () => {
             return (
@@ -27,6 +26,7 @@ export class TooltipCustomExample extends React.Component<any, any> {
         delay={TooltipDelay.zero}
         id={this._hostId}
         directionalHint={DirectionalHint.bottomCenter}
+        styles={{ root: { display: 'inline-block' } }}
       >
         <DefaultButton aria-labelledby={this._hostId} text="Hover Over Me" />
       </TooltipHost>

--- a/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Interactive.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Interactive.Example.tsx
@@ -11,7 +11,13 @@ export class TooltipInteractiveExample extends React.Component<any, any> {
   public render() {
     return (
       <div>
-        <TooltipHost content="This is the tooltip" id={this._hostId} calloutProps={{ gapSpace: 0 }} closeDelay={500}>
+        <TooltipHost
+          content="This is the tooltip"
+          id={this._hostId}
+          calloutProps={{ gapSpace: 0 }}
+          closeDelay={500}
+          styles={{ root: { display: 'inline-block' } }}
+        >
           <DefaultButton aria-labelledby={this._hostId}>Interact with my tooltip</DefaultButton>
         </TooltipHost>
       </div>

--- a/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.NoScroll.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.NoScroll.Example.tsx
@@ -8,7 +8,12 @@ export class TooltipNoScrollExample extends BaseComponent<{}> {
 
   public render(): JSX.Element {
     return (
-      <TooltipHost content="This is the tooltip" id={this.tooltipId} tooltipProps={{ style: { overflowY: 'auto' } }}>
+      <TooltipHost
+        content="This is the tooltip"
+        id={this.tooltipId}
+        tooltipProps={{ style: { overflowY: 'auto' } }}
+        styles={{ root: { display: 'inline-block' } }}
+      >
         <DefaultButton aria-labelledby={this.tooltipId}>Tooltip without scroll</DefaultButton>
       </TooltipHost>
     );

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Basic.Example.tsx.shot
@@ -6,7 +6,7 @@ exports[`Component Examples renders Tooltip.Basic.Example.tsx correctly 1`] = `
     className=
         ms-TooltipHost
         {
-          display: inline;
+          display: inline-block;
         }
     onBlurCapture={[Function]}
     onFocusCapture={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Custom.Example.tsx.shot
@@ -5,7 +5,7 @@ exports[`Component Examples renders Tooltip.Custom.Example.tsx correctly 1`] = `
   className=
       ms-TooltipHost
       {
-        display: inline;
+        display: inline-block;
       }
   onBlurCapture={[Function]}
   onFocusCapture={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Interactive.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Interactive.Example.tsx.shot
@@ -6,7 +6,7 @@ exports[`Component Examples renders Tooltip.Interactive.Example.tsx correctly 1`
     className=
         ms-TooltipHost
         {
-          display: inline;
+          display: inline-block;
         }
     onBlurCapture={[Function]}
     onFocusCapture={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.NoScroll.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.NoScroll.Example.tsx.shot
@@ -5,7 +5,7 @@ exports[`Component Examples renders Tooltip.NoScroll.Example.tsx correctly 1`] =
   className=
       ms-TooltipHost
       {
-        display: inline;
+        display: inline-block;
       }
   onBlurCapture={[Function]}
   onFocusCapture={[Function]}


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #10050
- [X] Include a change request file using `$ yarn change`

#### Description of changes

`TooltipHost` examples did not follow correct practices of passing in `display` attribute when wrapping `inline-block` children.

#### Aside

Seems like this might be a reasonable default. What other cases are common for `TooltipHost` ?

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10178)