### PR TITLE
MessageBar: fix colors in dark themed context

### DIFF
--- a/change/office-ui-fabric-react-2019-08-18-23-11-20-vibraga-message-bar-theme-fix.json
+++ b/change/office-ui-fabric-react-2019-08-18-23-11-20-vibraga-message-bar-theme-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "MessageBar: use global theme instead of context one to work same in a dark theme.",
+  "packageName": "office-ui-fabric-react",
+  "email": "vibraga@microsoft.com",
+  "commit": "1bcecaee3c69f091f0e07e13597d2e364ed1107a",
+  "date": "2019-08-19T06:11:20.723Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -8031,7 +8031,6 @@ export class MessageBarBase extends BaseComponent<IMessageBarProps, IMessageBarS
 
 // @public (undocumented)
 export class MessageBarButton extends BaseComponent<IButtonProps, {}> {
-    constructor(props: IButtonProps);
     // (undocumented)
     render(): JSX.Element;
 }

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -8031,6 +8031,7 @@ export class MessageBarBase extends BaseComponent<IMessageBarProps, IMessageBarS
 
 // @public (undocumented)
 export class MessageBarButton extends BaseComponent<IButtonProps, {}> {
+    constructor(props: IButtonProps);
     // (undocumented)
     render(): JSX.Element;
 }

--- a/packages/office-ui-fabric-react/src/components/Button/MessageBarButton/MessageBarButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/MessageBarButton/MessageBarButton.tsx
@@ -10,24 +10,10 @@ import { ITheme, getTheme } from '../../../Styling';
  */
 @customizable('MessageBarButton', ['theme', 'styles'], true)
 export class MessageBarButton extends BaseComponent<IButtonProps, {}> {
-  private _globalTheme: ITheme;
-
-  constructor(props: IButtonProps) {
-    super(props);
-
-    this._globalTheme = getTheme();
-  }
-
   public render(): JSX.Element {
     const { styles } = this.props;
+    const theme: ITheme = getTheme();
 
-    return (
-      <DefaultButton
-        {...this.props}
-        styles={getStyles(this._globalTheme, styles)}
-        theme={this._globalTheme}
-        onRenderDescription={nullRender}
-      />
-    );
+    return <DefaultButton {...this.props} styles={getStyles(theme, styles)} theme={theme} onRenderDescription={nullRender} />;
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Button/MessageBarButton/MessageBarButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/MessageBarButton/MessageBarButton.tsx
@@ -3,15 +3,31 @@ import { DefaultButton } from '../DefaultButton/DefaultButton';
 import { BaseComponent, customizable, nullRender } from '../../../Utilities';
 import { IButtonProps } from '../Button.types';
 import { getStyles } from './MessageBarButton.styles';
+import { ITheme, getTheme } from '../../../Styling';
 
 /**
  * {@docCategory MessageBar}
  */
 @customizable('MessageBarButton', ['theme', 'styles'], true)
 export class MessageBarButton extends BaseComponent<IButtonProps, {}> {
-  public render(): JSX.Element {
-    const { styles, theme } = this.props;
+  private _globalTheme: ITheme;
 
-    return <DefaultButton {...this.props} styles={getStyles(theme!, styles)} onRenderDescription={nullRender} />;
+  constructor(props: IButtonProps) {
+    super(props);
+
+    this._globalTheme = getTheme();
+  }
+
+  public render(): JSX.Element {
+    const { styles } = this.props;
+
+    return (
+      <DefaultButton
+        {...this.props}
+        styles={getStyles(this._globalTheme, styles)}
+        theme={this._globalTheme}
+        onRenderDescription={nullRender}
+      />
+    );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.base.tsx
@@ -31,7 +31,6 @@ export class MessageBarBase extends BaseComponent<IMessageBarProps, IMessageBarS
   };
 
   private _classNames: { [key in keyof IMessageBarStyles]: string };
-  private _globalTheme: ITheme;
 
   constructor(props: IMessageBarProps) {
     super(props);
@@ -41,8 +40,6 @@ export class MessageBarBase extends BaseComponent<IMessageBarProps, IMessageBarS
       showContent: false,
       expandSingleLine: false
     };
-
-    this._globalTheme = getTheme();
   }
 
   public render(): JSX.Element {
@@ -110,7 +107,7 @@ export class MessageBarBase extends BaseComponent<IMessageBarProps, IMessageBarS
   }
 
   private _renderMultiLine(): React.ReactElement<React.HTMLAttributes<HTMLAreaElement>> {
-    const theme = this._globalTheme;
+    const theme: ITheme = getTheme();
     return (
       <div style={{ background: theme.semanticColors.bodyBackground }}>
         <div className={this._classNames.root}>
@@ -126,7 +123,7 @@ export class MessageBarBase extends BaseComponent<IMessageBarProps, IMessageBarS
   }
 
   private _renderSingleLine(): React.ReactElement<React.HTMLAttributes<HTMLAreaElement>> {
-    const theme = this._globalTheme;
+    const theme: ITheme = getTheme();
     return (
       <div style={{ background: theme.semanticColors.bodyBackground }}>
         <div className={this._classNames.root}>
@@ -161,7 +158,7 @@ export class MessageBarBase extends BaseComponent<IMessageBarProps, IMessageBarS
     const { expandSingleLine } = this.state;
 
     return getClassNames(this.props.styles!, {
-      theme: this._globalTheme,
+      theme: getTheme(),
       messageBarType: messageBarType || MessageBarType.info,
       onDismiss: onDismiss !== undefined,
       actions: actions !== undefined,

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.base.tsx
@@ -3,6 +3,7 @@ import { BaseComponent, DelayedRender, getId, classNamesFunction, getNativeProps
 import { IconButton } from '../../Button';
 import { Icon } from '../../Icon';
 import { IMessageBarProps, IMessageBarStyleProps, IMessageBarStyles, MessageBarType } from './MessageBar.types';
+import { ITheme, getTheme } from '../../Styling';
 
 const getClassNames = classNamesFunction<IMessageBarStyleProps, IMessageBarStyles>();
 
@@ -30,6 +31,7 @@ export class MessageBarBase extends BaseComponent<IMessageBarProps, IMessageBarS
   };
 
   private _classNames: { [key in keyof IMessageBarStyles]: string };
+  private _globalTheme: ITheme;
 
   constructor(props: IMessageBarProps) {
     super(props);
@@ -39,6 +41,8 @@ export class MessageBarBase extends BaseComponent<IMessageBarProps, IMessageBarS
       showContent: false,
       expandSingleLine: false
     };
+
+    this._globalTheme = getTheme();
   }
 
   public render(): JSX.Element {
@@ -106,9 +110,9 @@ export class MessageBarBase extends BaseComponent<IMessageBarProps, IMessageBarS
   }
 
   private _renderMultiLine(): React.ReactElement<React.HTMLAttributes<HTMLAreaElement>> {
-    const { theme } = this.props;
+    const theme = this._globalTheme;
     return (
-      <div style={{ background: theme!.semanticColors.bodyBackground }}>
+      <div style={{ background: theme.semanticColors.bodyBackground }}>
         <div className={this._classNames.root}>
           <div className={this._classNames.content}>
             {this._getIconSpan()}
@@ -122,9 +126,9 @@ export class MessageBarBase extends BaseComponent<IMessageBarProps, IMessageBarS
   }
 
   private _renderSingleLine(): React.ReactElement<React.HTMLAttributes<HTMLAreaElement>> {
-    const { theme } = this.props;
+    const theme = this._globalTheme;
     return (
-      <div style={{ background: theme!.semanticColors.bodyBackground }}>
+      <div style={{ background: theme.semanticColors.bodyBackground }}>
         <div className={this._classNames.root}>
           <div className={this._classNames.content}>
             {this._getIconSpan()}
@@ -153,11 +157,11 @@ export class MessageBarBase extends BaseComponent<IMessageBarProps, IMessageBarS
   }
 
   private _getClassNames(): { [key in keyof IMessageBarStyles]: string } {
-    const { theme, className, messageBarType, onDismiss, actions, truncated, isMultiline } = this.props;
+    const { className, messageBarType, onDismiss, actions, truncated, isMultiline } = this.props;
     const { expandSingleLine } = this.state;
 
     return getClassNames(this.props.styles!, {
-      theme: theme!,
+      theme: this._globalTheme,
       messageBarType: messageBarType || MessageBarType.info,
       onDismiss: onDismiss !== undefined,
       actions: actions !== undefined,


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #9613
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Fixing how MessageBar looks on dark theme:

# Before
<img width="1265" alt="Screen Shot 2019-08-18 at 23 19 08" src="https://user-images.githubusercontent.com/29514833/63243394-43d76b80-c20f-11e9-9548-103bef628067.png">

# After:
<img width="1267" alt="Screen Shot 2019-08-18 at 23 09 47" src="https://user-images.githubusercontent.com/29514833/63243412-4c2fa680-c20f-11e9-8bc4-2736cf663522.png">



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10184)