### PR TITLE
Fix TextField onChange bug

### DIFF
--- a/change/@uifabric-tslint-rules-2019-08-19-17-11-32-textfield-onchange2.json
+++ b/change/@uifabric-tslint-rules-2019-08-19-17-11-32-textfield-onchange2.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add lint rule banning describe/it.only",
+  "packageName": "@uifabric/tslint-rules",
+  "email": "elcraig@microsoft.com",
+  "commit": "adc0f263cc2c85ea2ff6ef9d44b2b3e3bc52139a",
+  "date": "2019-08-20T00:11:32.150Z"
+}

--- a/change/office-ui-fabric-react-2019-08-19-17-11-32-textfield-onchange2.json
+++ b/change/office-ui-fabric-react-2019-08-19-17-11-32-textfield-onchange2.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix TextField onChange bug",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "commit": "adc0f263cc2c85ea2ff6ef9d44b2b3e3bc52139a",
+  "date": "2019-08-20T00:11:28.647Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
@@ -33,7 +33,7 @@ const createNodeMock = (el: React.ReactElement<{}>) => {
   };
 };
 
-describe.only('ComboBox', () => {
+describe('ComboBox', () => {
   afterEach(() => {
     if (wrapper) {
       wrapper.unmount();

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -156,11 +156,14 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
       // Adjust height if needed based on new value
       this._adjustInputHeight();
 
+      // Reset the record of the last value seen by a change/input event
+      this._lastChangeValue = undefined;
+
       // TODO: #5875 added logic to trigger validation in componentWillReceiveProps and other places.
       // This seems a bit odd and hard to integrate with the new approach.
       // (Starting to think we should just put the validation logic in a separate wrapper component...?)
       if (_shouldValidateAllChanges(props)) {
-        this._delayedValidate(this.value);
+        this._delayedValidate(value);
       }
     }
   }

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -307,23 +307,9 @@ describe('TextField with error message', () => {
   it('should render error message when onGetErrorMessage returns a string', () => {
     const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
 
-    // function onNotifyResult(errorMessage: string | JSX.Element, value: string | undefined) {
-    //   try {
-    //     expect(validator).toHaveBeenCalledTimes(1);
-    //     assertErrorMessage(wrapper!.getDOMNode(), errorMessage);
-    //     done();
-    //   } catch (ex) {
-    //     done(ex);
-    //   }
-    // }
-
     wrapper = mount(<TextField onGetErrorMessage={validator} validateOnLoad={false} />);
 
     wrapper.find('input').simulate('input', mockEvent('also invalid'));
-    // // run the validation debounce timer
-    // jest.runOnlyPendingTimers();
-    // // // error message is inside a DelayedRender, so run that timer
-    // jest.runOnlyPendingTimers();
     jest.runAllTimers();
 
     expect(validator).toHaveBeenCalledTimes(1);
@@ -336,11 +322,6 @@ describe('TextField with error message', () => {
     wrapper = mount(<TextField onGetErrorMessage={validator} validateOnLoad={false} />);
 
     wrapper.find('input').simulate('input', mockEvent('also invalid'));
-    // // run the validation debounce timer
-    // jest.runOnlyPendingTimers();
-    // // error message is inside a DelayedRender, so run that timer
-    // jest.runOnlyPendingTimers();
-
     jest.runAllTimers();
 
     expect(validator).toHaveBeenCalledTimes(1);

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.test.tsx
@@ -32,12 +32,17 @@ function sharedBeforeEach() {
 }
 
 function sharedAfterEach() {
-  jest.useRealTimers();
   if (wrapper) {
     wrapper.unmount();
     wrapper = undefined;
   }
   textField = undefined;
+
+  // Do this after umounting the wrapper to make sure any timers cleaned up on unmount are
+  // cleaned up in fake timers world
+  if ((global.setTimeout as any).mock) {
+    jest.useRealTimers();
+  }
 }
 
 describe('TextField snapshots', () => {
@@ -273,11 +278,14 @@ describe('TextField with error message', () => {
 
     if (expectedErrorMessage === false) {
       expect(errorMessageDOM).toBeNull(); // element not exists
-    } else if (typeof expectedErrorMessage === 'string') {
-      expect(errorMessageDOM!.textContent).toEqual(expectedErrorMessage);
-    } else if (typeof expectedErrorMessage !== 'boolean') {
-      const xhtml = errorMessageDOM!.innerHTML.replace(/<br>/g, '<br/>');
-      expect(xhtml).toEqual(renderToStaticMarkup(expectedErrorMessage));
+    } else {
+      expect(errorMessageDOM).not.toBeNull();
+      if (typeof expectedErrorMessage === 'string') {
+        expect(errorMessageDOM!.textContent).toEqual(expectedErrorMessage);
+      } else if (typeof expectedErrorMessage !== 'boolean') {
+        const xhtml = errorMessageDOM!.innerHTML.replace(/<br>/g, '<br/>');
+        expect(xhtml).toEqual(renderToStaticMarkup(expectedErrorMessage));
+      }
     }
   }
 
@@ -299,9 +307,23 @@ describe('TextField with error message', () => {
   it('should render error message when onGetErrorMessage returns a string', () => {
     const validator = jest.fn((value: string) => (value.length > 3 ? errorMessage : ''));
 
+    // function onNotifyResult(errorMessage: string | JSX.Element, value: string | undefined) {
+    //   try {
+    //     expect(validator).toHaveBeenCalledTimes(1);
+    //     assertErrorMessage(wrapper!.getDOMNode(), errorMessage);
+    //     done();
+    //   } catch (ex) {
+    //     done(ex);
+    //   }
+    // }
+
     wrapper = mount(<TextField onGetErrorMessage={validator} validateOnLoad={false} />);
 
     wrapper.find('input').simulate('input', mockEvent('also invalid'));
+    // // run the validation debounce timer
+    // jest.runOnlyPendingTimers();
+    // // // error message is inside a DelayedRender, so run that timer
+    // jest.runOnlyPendingTimers();
     jest.runAllTimers();
 
     expect(validator).toHaveBeenCalledTimes(1);
@@ -314,6 +336,11 @@ describe('TextField with error message', () => {
     wrapper = mount(<TextField onGetErrorMessage={validator} validateOnLoad={false} />);
 
     wrapper.find('input').simulate('input', mockEvent('also invalid'));
+    // // run the validation debounce timer
+    // jest.runOnlyPendingTimers();
+    // // error message is inside a DelayedRender, so run that timer
+    // jest.runOnlyPendingTimers();
+
     jest.runAllTimers();
 
     expect(validator).toHaveBeenCalledTimes(1);
@@ -637,14 +664,14 @@ describe('TextField onChange', () => {
   function simulateAndVerifyChange(changeValue: string, calls: number, expectedValue?: string) {
     expectedValue = typeof expectedValue === 'string' ? expectedValue : changeValue;
 
-    const inputDOM = wrapper!.getDOMNode().querySelector('input')!;
+    const input = wrapper!.find('input');
     // Fire input AND change events to more realistically test
-    ReactTestUtils.Simulate.input(inputDOM, mockEvent(changeValue));
-    ReactTestUtils.Simulate.change(inputDOM, mockEvent(changeValue));
+    input.simulate('input', mockEvent(changeValue));
+    input.simulate('change', mockEvent(changeValue));
 
     expect(onChange).toHaveBeenCalledTimes(calls);
     expect(textField!.value).toEqual(expectedValue);
-    expect(inputDOM.value).toEqual(expectedValue);
+    expect((input.getDOMNode() as HTMLInputElement).value).toEqual(expectedValue);
   }
 
   beforeEach(() => {
@@ -677,6 +704,33 @@ describe('TextField onChange', () => {
 
     expect(onChange).toHaveBeenCalledTimes(0);
     simulateAndVerifyChange('value change', 1, initialValue);
+  });
+
+  it('should not apply edits if controlled (empty initial value)', () => {
+    wrapper = mount(<TextField componentRef={textFieldRef} value="" onChange={onChange} />);
+
+    expect(onChange).toHaveBeenCalledTimes(0);
+    simulateAndVerifyChange('value change', 1, '');
+  });
+
+  it('respects prop updates in response to onChange', () => {
+    onChange = jest.fn((ev: any, value?: string) => wrapper!.setProps({ value }));
+    wrapper = mount(<TextField componentRef={textFieldRef} value="" onChange={onChange} />);
+
+    simulateAndVerifyChange('a', 1);
+  });
+
+  it('should apply edits after clearing field', () => {
+    onChange = jest.fn((ev: any, value?: string) => wrapper!.setProps({ value }));
+    wrapper = mount(<TextField componentRef={textFieldRef} value="" onChange={onChange} />);
+
+    simulateAndVerifyChange('a', 1);
+
+    // clear the value manually (not via a change event)
+    wrapper.setProps({ value: '' });
+
+    // updating to the same value as before should be respected
+    simulateAndVerifyChange('a', 2);
   });
 }); // end on change
 

--- a/packages/tslint-rules/tslint.json
+++ b/packages/tslint-rules/tslint.json
@@ -180,6 +180,11 @@
       }
     ],
     "use-named-parameter": true,
+    "ban": [
+      true,
+      { "name": ["describe", "only"], "message": "describe.only should only be used during test development" },
+      { "name": ["it", "only"], "message": "it.only should only be used during test development" }
+    ],
     "react-a11y-tabindex-no-positive": true
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10182
- [x] Include a change request file using `$ yarn change`

#### Description of changes

TextField should reset the cached `_lastChangeValue` when the `value` prop changes. See #10182 for details on the scenario this fixes. 

Also added a lint rule banning `describe.only` and `it.only` from being checked in by accident.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10194)