### PR TITLE
Fix color picker's channel text display when a channel being zero

### DIFF
--- a/change/office-ui-fabric-react-2019-08-19-18-03-07-reli-color-picker-zero-fix-1.json
+++ b/change/office-ui-fabric-react-2019-08-19-18-03-07-reli-color-picker-zero-fix-1.json
@@ -2,7 +2,7 @@
   "type": "patch",
   "comment": "Fix empty text box when a color component being zero",
   "packageName": "office-ui-fabric-react",
-  "email": "email not defined",
+  "email": "reli@microsoft.com",
   "commit": "f389783057c0ba7f32c5a00c38840bec07125cb8",
   "date": "2019-08-20T01:03:07.503Z"
 }

--- a/change/office-ui-fabric-react-2019-08-19-18-03-07-reli-color-picker-zero-fix-1.json
+++ b/change/office-ui-fabric-react-2019-08-19-18-03-07-reli-color-picker-zero-fix-1.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix empty text box when a color component being zero",
+  "packageName": "office-ui-fabric-react",
+  "email": "email not defined",
+  "commit": "f389783057c0ba7f32c5a00c38840bec07125cb8",
+  "date": "2019-08-20T01:03:07.503Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
@@ -157,7 +157,11 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
     if (editingColor && editingColor.component === component) {
       return editingColor.value;
     }
-    return String(color[component] || '');
+    if (color[component] == null) {
+      return '';
+    } else {
+      return String(color[component]);
+    }
   }
 
   private _onSVChanged = (ev: React.MouseEvent<HTMLElement>, color: IColor): void => {

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorPicker.base.tsx
@@ -157,7 +157,7 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
     if (editingColor && editingColor.component === component) {
       return editingColor.value;
     }
-    if (color[component] == null) {
+    if (color[component] === null || color[component] === undefined) {
       return '';
     } else {
       return String(color[component]);


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #10195
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Corrected string formatting for `0` values in color channels.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10197)