### PR TITLE
Add space functionality to split button with tests

### DIFF
--- a/change/office-ui-fabric-react-2019-08-19-18-29-41-chiechan-splitButton.json
+++ b/change/office-ui-fabric-react-2019-08-19-18-29-41-chiechan-splitButton.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add space functionality to split button with tests",
+  "packageName": "office-ui-fabric-react",
+  "email": "chiechan@microsoft.com",
+  "commit": "2d36be7008d746555faf1570d5541f8e74ea31c8",
+  "date": "2019-08-20T01:29:40.953Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -673,7 +673,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
   };
 
   private _onSplitButtonContainerKeyDown = (ev: React.KeyboardEvent<HTMLDivElement>) => {
-    if (ev.which === KeyCodes.enter) {
+    if (ev.which === KeyCodes.enter || ev.which === KeyCodes.space) {
       if (this._buttonElement.current) {
         this._buttonElement.current.click();
         ev.preventDefault();

--- a/packages/office-ui-fabric-react/src/components/Button/Button.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.test.tsx
@@ -456,6 +456,38 @@ describe('Button', () => {
       expect(keyDownSpy).toHaveBeenCalled();
     });
 
+    it('Space keydown in a splitButton will fire onClick', () => {
+      const onClickSpy = jest.fn();
+
+      const button = render(
+        <DefaultButton
+          data-automation-id="test"
+          text="Create account"
+          split={true}
+          onClick={onClickSpy}
+          menuProps={{
+            items: [
+              {
+                key: 'emailMessage',
+                text: 'Email message',
+                iconProps: { iconName: 'Mail' }
+              },
+              {
+                key: 'calendarEvent',
+                text: 'Calendar event',
+                iconProps: { iconName: 'Calendar' }
+              }
+            ]
+          }}
+        />
+      );
+      const buttonContainer: HTMLDivElement = button.getElementsByTagName('div')[0] as HTMLDivElement;
+
+      ReactTestUtils.Simulate.keyDown(buttonContainer, { which: KeyCodes.space });
+
+      expect(onClickSpy).toHaveBeenCalled();
+    });
+
     it('Providing onClick, menuProps and setting splitButton to true renders a SplitButton', () => {
       const button = render(
         <DefaultButton


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ yarn change`

#### Description of changes

For SplitButtons we want to be able to execute the onClick action when the user presses Space, which is similar to what other buttons currently do.

#### Focus areas to test

I tested in the button demo page. When focus is on a split button and space is pressed, the action will now be executed. The other button's behavior remain the same.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10198)