### PR TITLE
Teachingbubble - right align the action buttons

### DIFF
--- a/change/office-ui-fabric-react-2019-08-20-11-05-04-teachingbubble.json
+++ b/change/office-ui-fabric-react-2019-08-20-11-05-04-teachingbubble.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "right align the action buttons per new design",
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com",
+  "commit": "a68fcab8e5e63d8e659249ecac327edae68ca7ff",
+  "date": "2019-08-20T18:05:04.921Z"
+}

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
@@ -144,6 +144,7 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
       classNames.footer,
       {
         display: 'flex',
+        justifyContent: 'flex-end',
         alignItems: 'center',
         color: palette.white,
         selectors: {

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -295,6 +295,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
             align-items: center;
             color: #ffffff;
             display: flex;
+            justify-content: flex-end;
           }
           & .ms-Button:not(:first-child) {
             margin-left: 16px;
@@ -845,6 +846,7 @@ exports[`TeachingBubble renders TeachingBubbleContent with custom footer text 1`
             align-items: center;
             color: #ffffff;
             display: flex;
+            justify-content: flex-end;
           }
           & .ms-Button:not(:first-child) {
             margin-left: 16px;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10193
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Per new designs in #10193, we are moving all the actions buttons of teaching bubbles to the right.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10206)