### PR TITLE
New drop hint icon for drag-drop and corresponding padding on top

### DIFF
--- a/change/office-ui-fabric-react-2019-08-21-16-29-55-new-drop-hint.json
+++ b/change/office-ui-fabric-react-2019-08-21-16-29-55-new-drop-hint.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "New drop hint icon for drag-drop and corresponding padding space on top",
+  "packageName": "office-ui-fabric-react",
+  "email": "svaibhav@microsoft.com",
+  "commit": "c327dbc79097a670aa17b939f87295a59fbe1281",
+  "date": "2019-08-21T10:59:55.411Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -587,12 +587,12 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
     return (
       <div key={'dropHintKey'} className={classNames.dropHintStyle} id={`columnDropHint_${dropHintIndex}`}>
         <IconComponent
-          key={`dropHintCaretKey`}
+          key={`dropHintCircleKey`}
           aria-hidden={true}
           data-is-focusable={false}
           data-sizer-index={dropHintIndex}
           className={classNames.dropHintCaretStyle}
-          iconName={'CaretDownSolid8'}
+          iconName={'CircleShapeSolid'}
         />
         <div
           key={`dropHintLineKey`}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
@@ -101,7 +101,7 @@ export const getStyles = (props: IDetailsHeaderStyleProps): IDetailsHeaderStyles
         whiteSpace: 'nowrap',
         boxSizing: 'content-box',
         paddingBottom: '1px',
-        paddingTop: '1px',
+        paddingTop: '16px',
         borderBottom: `1px solid ${semanticColors.bodyDivider}`,
         cursor: 'default',
         userSelect: 'none',
@@ -307,9 +307,9 @@ export const getStyles = (props: IDetailsHeaderStyleProps): IDetailsHeaderStyles
       {
         display: 'none',
         position: 'absolute',
-        top: -18,
-        left: -7.5,
-        fontSize: fonts.mediumPlus.fontSize,
+        top: -28,
+        left: -6.5,
+        fontSize: fonts.medium.fontSize,
         color: palette.themePrimary,
         overflow: 'visible',
         zIndex: 10
@@ -322,9 +322,9 @@ export const getStyles = (props: IDetailsHeaderStyleProps): IDetailsHeaderStyles
         display: 'none',
         position: 'absolute',
         bottom: 0,
-        top: 6,
+        top: 0,
         overflow: 'hidden',
-        height: 37,
+        height: 42,
         width: 1,
         background: palette.themePrimary,
         zIndex: 10

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`DetailsHeader can render 1`] = `
         line-height: 42px;
         min-width: 100%;
         padding-bottom: 1px;
-        padding-top: 1px;
+        padding-top: 16px;
         position: relative;
         user-select: none;
         vertical-align: top;
@@ -922,7 +922,7 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
         line-height: 42px;
         min-width: 100%;
         padding-bottom: 1px;
-        padding-top: 1px;
+        padding-top: 16px;
         position: relative;
         user-select: none;
         vertical-align: top;
@@ -1712,7 +1712,7 @@ exports[`DetailsHeader renders accessible labels 1`] = `
         line-height: 42px;
         min-width: 100%;
         padding-bottom: 1px;
-        padding-top: 1px;
+        padding-top: 16px;
         position: relative;
         user-select: none;
         vertical-align: top;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -69,7 +69,7 @@ exports[`DetailsList renders List correctly 1`] = `
                 line-height: 42px;
                 min-width: 100%;
                 padding-bottom: 1px;
-                padding-top: 1px;
+                padding-top: 16px;
                 position: relative;
                 user-select: none;
                 vertical-align: top;
@@ -667,7 +667,7 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                 line-height: 42px;
                 min-width: 100%;
                 padding-bottom: 1px;
-                padding-top: 1px;
+                padding-top: 16px;
                 position: relative;
                 user-select: none;
                 vertical-align: top;
@@ -1861,7 +1861,7 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
                 line-height: 42px;
                 min-width: 100%;
                 padding-bottom: 1px;
-                padding-top: 1px;
+                padding-top: 16px;
                 position: relative;
                 user-select: none;
                 vertical-align: top;
@@ -2460,7 +2460,7 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                 line-height: 42px;
                 min-width: 100%;
                 padding-bottom: 1px;
-                padding-top: 1px;
+                padding-top: 16px;
                 position: relative;
                 user-select: none;
                 vertical-align: top;
@@ -3438,7 +3438,7 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                 line-height: 42px;
                 min-width: 100%;
                 padding-bottom: 1px;
-                padding-top: 1px;
+                padding-top: 16px;
                 position: relative;
                 user-select: none;
                 vertical-align: top;
@@ -4646,7 +4646,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                 line-height: 42px;
                 min-width: 100%;
                 padding-bottom: 1px;
-                padding-top: 1px;
+                padding-top: 16px;
                 position: relative;
                 user-select: none;
                 vertical-align: top;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -69,7 +69,7 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                 line-height: 42px;
                 min-width: 100%;
                 padding-bottom: 1px;
-                padding-top: 1px;
+                padding-top: 16px;
                 position: relative;
                 user-select: none;
                 vertical-align: top;
@@ -899,7 +899,7 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                 line-height: 42px;
                 min-width: 100%;
                 padding-bottom: 1px;
-                padding-top: 1px;
+                padding-top: 16px;
                 position: relative;
                 user-select: none;
                 vertical-align: top;
@@ -2218,7 +2218,7 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
                 line-height: 42px;
                 min-width: 100%;
                 padding-bottom: 1px;
-                padding-top: 1px;
+                padding-top: 16px;
                 position: relative;
                 user-select: none;
                 vertical-align: top;
@@ -3048,7 +3048,7 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
                 line-height: 42px;
                 min-width: 100%;
                 padding-bottom: 1px;
-                padding-top: 1px;
+                padding-top: 16px;
                 position: relative;
                 user-select: none;
                 vertical-align: top;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
@@ -69,7 +69,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                 line-height: 42px;
                 min-width: 100%;
                 padding-bottom: 1px;
-                padding-top: 1px;
+                padding-top: 16px;
                 position: relative;
                 user-select: none;
                 vertical-align: top;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
@@ -30,7 +30,7 @@ const classNames = mergeStyleSets({
     display: 'none',
     background: theme.palette.themePrimary,
     position: 'absolute',
-    top: 0,
+    top: 16,
     bottom: 0,
     width: '1px',
     zIndex: 5

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.BulkOperations.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.BulkOperations.Example.tsx.shot
@@ -132,7 +132,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                     line-height: 42px;
                     min-width: 100%;
                     padding-bottom: 1px;
-                    padding-top: 1px;
+                    padding-top: 16px;
                     position: relative;
                     user-select: none;
                     vertical-align: top;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.QuickActions.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.QuickActions.Example.tsx.shot
@@ -78,7 +78,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                   line-height: 42px;
                   min-width: 100%;
                   padding-bottom: 1px;
-                  padding-top: 1px;
+                  padding-top: 16px;
                   position: relative;
                   user-select: none;
                   vertical-align: top;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -833,7 +833,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                   line-height: 42px;
                   min-width: 100%;
                   padding-bottom: 1px;
-                  padding-top: 1px;
+                  padding-top: 16px;
                   position: relative;
                   user-select: none;
                   vertical-align: top;
@@ -1386,7 +1386,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                     bottom: 0px;
                     display: none;
                     position: absolute;
-                    top: 0px;
+                    top: 16px;
                     width: 1px;
                     z-index: 5;
                   }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Animation.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Animation.Example.tsx.shot
@@ -91,7 +91,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                   line-height: 42px;
                   min-width: 100%;
                   padding-bottom: 1px;
-                  padding-top: 1px;
+                  padding-top: 16px;
                   position: relative;
                   user-select: none;
                   vertical-align: top;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -272,7 +272,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                     line-height: 42px;
                     min-width: 100%;
                     padding-bottom: 1px;
-                    padding-top: 1px;
+                    padding-top: 16px;
                     position: relative;
                     user-select: none;
                     vertical-align: top;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -273,7 +273,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                     line-height: 42px;
                     min-width: 100%;
                     padding-bottom: 1px;
-                    padding-top: 1px;
+                    padding-top: 16px;
                     position: relative;
                     user-select: none;
                     vertical-align: top;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
@@ -69,7 +69,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                 line-height: 42px;
                 min-width: 100%;
                 padding-bottom: 1px;
-                padding-top: 1px;
+                padding-top: 16px;
                 position: relative;
                 user-select: none;
                 vertical-align: top;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
@@ -69,7 +69,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                 line-height: 42px;
                 min-width: 100%;
                 padding-bottom: 1px;
-                padding-top: 1px;
+                padding-top: 16px;
                 position: relative;
                 user-select: none;
                 vertical-align: top;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -69,7 +69,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                 line-height: 42px;
                 min-width: 100%;
                 padding-bottom: 1px;
-                padding-top: 1px;
+                padding-top: 16px;
                 position: relative;
                 user-select: none;
                 vertical-align: top;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
@@ -69,7 +69,7 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                 line-height: 42px;
                 min-width: 100%;
                 padding-bottom: 1px;
-                padding-top: 1px;
+                padding-top: 16px;
                 position: relative;
                 user-select: none;
                 vertical-align: top;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -625,7 +625,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                     line-height: 42px;
                     min-width: 100%;
                     padding-bottom: 1px;
-                    padding-top: 1px;
+                    padding-top: 16px;
                     position: relative;
                     user-select: none;
                     vertical-align: top;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -591,7 +591,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                     line-height: 42px;
                     min-width: 100%;
                     padding-bottom: 1px;
-                    padding-top: 1px;
+                    padding-top: 16px;
                     position: relative;
                     user-select: none;
                     vertical-align: top;
@@ -1073,7 +1073,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
-                        font-family: "FabricMDL2Icons-6";
+                        font-family: "FabricMDL2Icons-14";
                         font-style: normal;
                         font-weight: normal;
                         speak: none;
@@ -1081,19 +1081,19 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                       {
                         color: #0078d4;
                         display: none;
-                        font-size: 16px;
-                        left: -7.5px;
+                        font-size: 14px;
+                        left: -6.5px;
                         overflow: visible;
                         position: absolute;
-                        top: -18px;
+                        top: -28px;
                         z-index: 10;
                       }
-                  data-icon-name="CaretDownSolid8"
+                  data-icon-name="CircleShapeSolid"
                   data-is-focusable={false}
                   data-sizer-index={1}
                   role="presentation"
                 >
-                  
+                  
                 </i>
                 <div
                   aria-hidden={true}
@@ -1103,10 +1103,10 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                         background: #0078d4;
                         bottom: 0px;
                         display: none;
-                        height: 37px;
+                        height: 42px;
                         overflow: hidden;
                         position: absolute;
-                        top: 6px;
+                        top: 0px;
                         width: 1px;
                         z-index: 10;
                       }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -463,7 +463,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                   line-height: 42px;
                   min-width: 100%;
                   padding-bottom: 1px;
-                  padding-top: 1px;
+                  padding-top: 16px;
                   position: relative;
                   user-select: none;
                   vertical-align: top;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -69,7 +69,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                 line-height: 42px;
                 min-width: 100%;
                 padding-bottom: 1px;
-                padding-top: 1px;
+                padding-top: 16px;
                 position: relative;
                 user-select: none;
                 vertical-align: top;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -69,7 +69,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                 line-height: 42px;
                 min-width: 100%;
                 padding-bottom: 1px;
-                padding-top: 1px;
+                padding-top: 16px;
                 position: relative;
                 user-select: none;
                 vertical-align: top;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Basic.Example.tsx.shot
@@ -100,7 +100,7 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                   line-height: 42px;
                   min-width: 100%;
                   padding-bottom: 1px;
-                  padding-top: 1px;
+                  padding-top: 16px;
                   position: relative;
                   user-select: none;
                   vertical-align: top;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.PlainCard.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.PlainCard.Example.tsx.shot
@@ -97,7 +97,7 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                   line-height: 42px;
                   min-width: 100%;
                   padding-bottom: 1px;
-                  padding-top: 1px;
+                  padding-top: 16px;
                   position: relative;
                   user-select: none;
                   vertical-align: top;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Target.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Target.Example.tsx.shot
@@ -101,7 +101,7 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                   line-height: 42px;
                   min-width: 100%;
                   padding-bottom: 1px;
-                  padding-top: 1px;
+                  padding-top: 16px;
                   position: relative;
                   user-select: none;
                   vertical-align: top;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
@@ -247,7 +247,7 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                     line-height: 42px;
                     min-width: 100%;
                     padding-bottom: 1px;
-                    padding-top: 1px;
+                    padding-top: 16px;
                     position: relative;
                     user-select: none;
                     vertical-align: top;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Ramp.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Ramp.Example.tsx.shot
@@ -70,7 +70,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                 line-height: 42px;
                 min-width: 100%;
                 padding-bottom: 1px;
-                padding-top: 1px;
+                padding-top: 16px;
                 position: relative;
                 user-select: none;
                 vertical-align: top;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Drop hint icon for drag-drop changed to 'CircleShapeSolid'
This also enable us to add a paddingTop to DetailsList header to make the icon visible
The current drop hint icon will look as the following (DetailsList.Advanced.Example.tsx) :
![image](https://user-images.githubusercontent.com/6286818/63426867-79f43580-c431-11e9-97e4-f6625b33fae5.png)

Updated corresponding snapshots
Updated the advanced example to show as how to override this property at DetailsList level

#### Focus areas to test

DetailsList with drag-drop feature


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10221)