### PR TITLE
Disable card codepen

### DIFF
--- a/change/@uifabric-react-cards-2019-08-21-10-57-50-disableCardCodepen.json
+++ b/change/@uifabric-react-cards-2019-08-21-10-57-50-disableCardCodepen.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Disabling 'export to codepen' functionality in Card examples.",
+  "packageName": "@uifabric/react-cards",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "1944001393a9e6836d8c36a3ca282c0f91b7096a",
+  "date": "2019-08-21T17:57:50.236Z"
+}

--- a/packages/react-cards/src/components/Card/Card.doc.tsx
+++ b/packages/react-cards/src/components/Card/Card.doc.tsx
@@ -10,10 +10,6 @@ const CardVerticalExampleCode = require('!raw-loader!@uifabric/react-cards/src/c
 const CardCompactExampleCode = require('!raw-loader!@uifabric/react-cards/src/components/Card/examples/Card.Compact.Example.tsx') as string;
 const CardConfigureExampleCode = require('!raw-loader!@uifabric/react-cards/src/components/Card/examples/Card.Configure.Example.tsx') as string;
 
-const CardVerticalExampleCodepen = require('!@uifabric/codepen-loader!@uifabric/react-cards/src/components/Card/examples/Card.Vertical.Example.tsx') as string;
-const CardCompactExampleCodepen = require('!@uifabric/codepen-loader!@uifabric/react-cards/src/components/Card/examples/Card.Compact.Example.tsx') as string;
-const CardConfigureExampleCodepen = require('!@uifabric/codepen-loader!@uifabric/react-cards/src/components/Card/examples/Card.Configure.Example.tsx') as string;
-
 export const CardPageProps: IDocPageProps = {
   title: 'Card',
   componentName: 'Card',
@@ -22,19 +18,16 @@ export const CardPageProps: IDocPageProps = {
     {
       title: 'Vertical Card',
       code: CardVerticalExampleCode,
-      codepenJS: CardVerticalExampleCodepen,
       view: <CardVerticalExample />
     },
     {
       title: 'Compact Card',
       code: CardCompactExampleCode,
-      codepenJS: CardCompactExampleCodepen,
       view: <CardCompactExample />
     },
     {
       title: 'Configure Properties',
       code: CardConfigureExampleCode,
-      codepenJS: CardConfigureExampleCodepen,
       view: <CardConfigureExample />
     }
   ],


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10203
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR disables the `Export to codepen` functionality from `Card` examples since the script tries to import `Card` from `office-ui-fabric-react` instead of `@uifabric/react-cards`.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10227)