### PR TITLE
Remove monaco webpack plugin

### DIFF
--- a/apps/fabric-website/package.json
+++ b/apps/fabric-website/package.json
@@ -56,7 +56,6 @@
     "@uifabric/set-version": "^7.0.1",
     "@uifabric/theme-samples": "^7.0.3",
     "json-loader": "^0.5.7",
-    "monaco-editor-webpack-plugin": "^1.7.0",
     "office-ui-fabric-react": "^7.27.0",
     "tslib": "^1.7.1",
     "whatwg-fetch": "2.0.4"

--- a/change/@uifabric-example-app-base-2019-08-22-18-15-37-remove-monaco-plugin.json
+++ b/change/@uifabric-example-app-base-2019-08-22-18-15-37-remove-monaco-plugin.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Get rid of monaco-editor-webpack-plugin",
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com",
+  "commit": "8404e0edc3591a74cda292aedd1e4bff58768e7c",
+  "date": "2019-08-23T01:15:28.617Z"
+}

--- a/change/@uifabric-fabric-website-2019-08-22-18-15-37-remove-monaco-plugin.json
+++ b/change/@uifabric-fabric-website-2019-08-22-18-15-37-remove-monaco-plugin.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Get rid of monaco-editor-webpack-plugin",
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com",
+  "commit": "8404e0edc3591a74cda292aedd1e4bff58768e7c",
+  "date": "2019-08-23T01:15:26.191Z"
+}

--- a/change/@uifabric-tsx-editor-2019-08-22-18-15-37-remove-monaco-plugin.json
+++ b/change/@uifabric-tsx-editor-2019-08-22-18-15-37-remove-monaco-plugin.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Get rid of monaco-editor-webpack-plugin and fix demo app",
+  "packageName": "@uifabric/tsx-editor",
+  "email": "elcraig@microsoft.com",
+  "commit": "8404e0edc3591a74cda292aedd1e4bff58768e7c",
+  "date": "2019-08-23T01:15:37.266Z"
+}

--- a/packages/example-app-base/package.json
+++ b/packages/example-app-base/package.json
@@ -49,7 +49,6 @@
     "@uifabric/tsx-editor": "^0.3.0",
     "color-check": "0.0.2",
     "markdown-to-jsx": "6.6.1",
-    "monaco-editor-webpack-plugin": "^1.7.0",
     "office-ui-fabric-core": "^10.0.0",
     "office-ui-fabric-react": "^7.27.0",
     "react-custom-scrollbars": "^4.2.1",

--- a/packages/tsx-editor/config/pre-copy.json
+++ b/packages/tsx-editor/config/pre-copy.json
@@ -1,5 +1,5 @@
 {
   "copyTo": {
-    "dist": ["@uifabric/example-app-base/index.html", "react/umd/react.development.js", "react-dom/umd/react-dom.development.js"]
+    "dist": ["./index.html", "react/umd/react.development.js", "react-dom/umd/react-dom.development.js"]
   }
 }

--- a/packages/tsx-editor/index.html
+++ b/packages/tsx-editor/index.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html dir="ltr" lang="en-us">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" user-scalable="no" />
+    <title>UI Fabric React Examples</title>
+  </head>
+
+  <body>
+    <div id="content"></div>
+    <script type="text/javascript">
+      window.FabricConfig = {
+        // Uncommenting this prevents the fontfaces from being registered.
+        // Alternatively you can specify a base url which contains the font/icon assets.
+        // fontBaseUrl: '',
+        // mergeStyles: {
+        //   injectionMode: 2
+        // }
+      };
+
+      var url = document.location.href;
+      var isLocalHost = url.indexOf('localhost') !== -1 || url.indexOf('127.0.0.1') !== -1;
+
+      var minMatch = url.match(/\bmin=([01])\b/);
+      var minParam = minMatch && minMatch[1];
+      var useMinified = minParam !== '0' && (minParam === '1' || location.pathname === '/fabric-react/master/');
+      var jsSuffix = useMinified ? '.min.js' : '.js';
+
+      function loadScript(n) {
+        for (var i = 0; i < n.length; i++) {
+          var s = document.createElement('script');
+          s.src = n[i];
+          s.async = false;
+          document.body.appendChild(s);
+        }
+      }
+
+      const scripts = [];
+
+      if (isLocalHost) {
+        scripts.push('./react.development.js');
+        scripts.push('./react-dom.development.js');
+      } else {
+        scripts.push('//cdnjs.cloudflare.com/ajax/libs/react/16.8.6/umd/react.production.min.js');
+        scripts.push('//cdnjs.cloudflare.com/ajax/libs/react-dom/16.8.6/umd/react-dom.production.min.js');
+      }
+
+      scripts.push('demo-app' + jsSuffix);
+
+      loadScript(scripts);
+
+      // Required configuration to make Monaco work (this is simpler than the fabric-website version
+      // since demo app JS is never served cross-domain from a CDN)
+      window.MonacoEnvironment = {
+        getWorkerUrl: function(workerId, label) {
+          var workerName = label === 'typescript' || label === 'javascript' ? 'ts.worker' : 'editor.worker';
+          return workerName + jsSuffix;
+        }
+      };
+    </script>
+  </body>
+</html>

--- a/packages/tsx-editor/package.json
+++ b/packages/tsx-editor/package.json
@@ -50,7 +50,6 @@
     "@uifabric/set-version": "^7.0.1",
     "@uifabric/fluent-theme": "^7.1.2",
     "monaco-editor": "^0.17.0",
-    "monaco-editor-webpack-plugin": "^1.7.0",
     "office-ui-fabric-react": "^7.27.0",
     "tslib": "^1.7.1",
     "typescript": "3.5.1"

--- a/packages/tsx-editor/src/demo/App.tsx
+++ b/packages/tsx-editor/src/demo/App.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
-import { PrimaryButton, Stack, Label, mergeStyleSets } from 'office-ui-fabric-react';
+import { PrimaryButton, Stack, mergeStyleSets, Spinner, SpinnerSize } from 'office-ui-fabric-react';
 import { ITextModel } from '../components/Editor.types';
+import { EditorPreview } from '../components/index';
+import * as editorModule from '../components/Editor';
+
+import * as fabricModule from 'office-ui-fabric-react';
+
+(window as any).Fabric = fabricModule; // tslint:disable-line:no-any
+
+const example = require('!raw-loader!../transpiler/examples/class.txt');
+const outputId = 'output';
 
 interface ITranspiledOutput {
   outputString?: string;
@@ -8,49 +17,54 @@ interface ITranspiledOutput {
 }
 
 const classNames = mergeStyleSets({
-  error: {
-    backgroundColor: '#FEF0F0',
-    color: '#FF5E79'
-  },
   component: {
-    backgroundColor: 'lightgray'
+    border: '1px solid lightgray'
   }
 });
 
 interface IAppState {
   error?: string;
   editorHidden?: boolean;
-  editor?: HTMLElement;
+  editorModule?: typeof editorModule;
 }
 
-export class App extends React.Component {
+const width = 800;
+const height = 500;
+
+export class App extends React.Component<{}, IAppState> {
   public state: IAppState = {
     editorHidden: true
   };
 
   public render() {
-    const editor = (
-      <Stack className={classNames.component} gap={4}>
-        {this.state.editor}
-        {this.state.error !== undefined && <Label className={classNames.error}>{this.state.error}</Label>}
-      </Stack>
-    );
-
     return (
-      <div>
-        <PrimaryButton onClick={this.buttonClicked} />
-        {!this.state.editorHidden && editor}
-        <div id="output" />
-      </div>
+      <Stack styles={{ root: { width, margin: '0 auto' } }} tokens={{ childrenGap: 20 }}>
+        <h1>Typescript + React editor</h1>
+        <Stack.Item grow={false}>
+          <PrimaryButton text="Show/hide editor" onClick={this._buttonClicked} />
+        </Stack.Item>
+        {!this.state.editorHidden && (
+          <div className={classNames.component}>
+            {this.state.editorModule ? (
+              <editorModule.Editor width={width} height={height} code={example} language="typescript" onChange={this._onChange} />
+            ) : (
+              <Stack horizontalAlign="center" verticalAlign="center" styles={{ root: { height } }}>
+                <Spinner size={SpinnerSize.large} label="Loading editor..." />
+              </Stack>
+            )}
+          </div>
+        )}
+        <EditorPreview id={outputId} error={this.state.error} />
+      </Stack>
     );
   }
 
-  private onChange = (editor: ITextModel) => {
+  private _onChange = (model: ITextModel) => {
     require.ensure(['../transpiler/transpile'], require => {
       const { evalCode, transpile } = require('../transpiler/transpile');
-      transpile(editor).then((output: ITranspiledOutput) => {
+      transpile(model).then((output: ITranspiledOutput) => {
         if (output.outputString) {
-          const evalCodeError = evalCode(output.outputString);
+          const evalCodeError = evalCode(output.outputString, outputId);
           if (evalCodeError) {
             this.setState({
               error: evalCodeError.error
@@ -69,26 +83,17 @@ export class App extends React.Component {
     });
   };
 
-  private buttonClicked = (): void => {
+  private _buttonClicked = (): void => {
     if (this.state.editorHidden) {
-      require.ensure([], require => {
-        const Editor = require('../components/Editor').Editor;
-        this.setState({
-          editor: (
-            <div>
-              <div>
-                <Label>Typescript + React editor</Label>
-              </div>
-              <React.Suspense fallback={<div>Loading...</div>}>
-                <Editor width={800} height={500} code="console.log('hello world');" language="typescript" onChange={this.onChange} />
-              </React.Suspense>
-            </div>
-          ),
-          editorHidden: false
-        });
+      this.setState({ editorHidden: false }, () => {
+        if (!this.state.editorModule) {
+          require.ensure([], require => {
+            this.setState({ editorModule: require('../components/Editor') });
+          });
+        }
       });
     } else {
-      this.setState({ editor: null, editorHidden: true });
+      this.setState({ error: undefined, editorHidden: true });
     }
   };
 }

--- a/packages/tsx-editor/src/demo/index.tsx
+++ b/packages/tsx-editor/src/demo/index.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { App } from './App';
-import { FluentCustomizations } from '@uifabric/fluent-theme';
-import { Customizer, mergeStyles } from 'office-ui-fabric-react';
+import { mergeStyles, initializeIcons, Fabric } from 'office-ui-fabric-react';
+
+initializeIcons();
 
 // Inject some global styles
 mergeStyles({
@@ -16,8 +17,8 @@ mergeStyles({
 });
 
 ReactDOM.render(
-  <Customizer {...FluentCustomizations}>
+  <Fabric>
     <App />
-  </Customizer>,
+  </Fabric>,
   document.getElementById('content')
 );

--- a/packages/tsx-editor/webpack.config.js
+++ b/packages/tsx-editor/webpack.config.js
@@ -1,34 +1,31 @@
 const path = require('path');
 const resources = require('@uifabric/build/webpack/webpack-resources');
-const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
+const { addMonacoConfig } = require('./scripts/monaco-webpack');
 
 const BUNDLE_NAME = 'tsx-editor';
 const IS_PRODUCTION = process.argv.indexOf('--production') > -1;
 
-module.exports = resources.createConfig(BUNDLE_NAME, IS_PRODUCTION, {
-  entry: {
-    [BUNDLE_NAME]: './lib/index.js'
-  },
+module.exports = resources.createConfig(
+  BUNDLE_NAME,
+  IS_PRODUCTION,
+  addMonacoConfig({
+    entry: {
+      [BUNDLE_NAME]: './lib/index.js'
+    },
 
-  output: {
-    libraryTarget: 'var',
-    library: 'FabricTsxEditor'
-  },
+    output: {
+      libraryTarget: 'var',
+      library: 'FabricTsxEditor'
+    },
 
-  externals: [{ react: 'React' }, { 'react-dom': 'ReactDOM' }],
+    externals: [{ react: 'React' }, { 'react-dom': 'ReactDOM' }],
 
-  plugins: [
-    new MonacoWebpackPlugin({
-      // available options are documented at https://github.com/Microsoft/monaco-editor-webpack-plugin#options
-      languages: ['typescript']
-    })
-  ],
-
-  resolve: {
-    alias: {
-      '@uifabric/tsx-editor/src': path.join(__dirname, 'src'),
-      '@uifabric/tsx-editor/lib': path.join(__dirname, 'lib'),
-      '@uifabric/tsx-editor': path.join(__dirname, 'lib')
+    resolve: {
+      alias: {
+        '@uifabric/tsx-editor/src': path.join(__dirname, 'src'),
+        '@uifabric/tsx-editor/lib': path.join(__dirname, 'lib'),
+        '@uifabric/tsx-editor': path.join(__dirname, 'lib')
+      }
     }
-  }
-});
+  })
+);

--- a/packages/tsx-editor/webpack.serve.config.js
+++ b/packages/tsx-editor/webpack.serve.config.js
@@ -2,37 +2,40 @@ const path = require('path');
 const resources = require('../../scripts/webpack/webpack-resources');
 const webpack = resources.webpack;
 const { BundleAnalyzerPlugin } = require('webpack-bundle-analyzer');
-const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
+const { addMonacoConfig } = require('./scripts/monaco-webpack');
 
+const BUNDLE_NAME = 'demo-app';
 const PACKAGE_NAME = require('./package.json').name;
 
-module.exports = resources.createServeConfig({
-  entry: './src/demo/index.tsx',
+module.exports = resources.createServeConfig(
+  addMonacoConfig({
+    entry: {
+      [BUNDLE_NAME]: './src/demo/index.tsx'
+    },
 
-  output: {
-    filename: 'demo-app.js'
-  },
+    output: {
+      chunkFilename: `${BUNDLE_NAME}-[name].js`
+    },
 
-  externals: {
-    react: 'React',
-    'react-dom': 'ReactDOM'
-  },
+    devServer: {
+      writeToDisk: true // for debugging
+    },
 
-  plugins: [
-    new MonacoWebpackPlugin({
-      // available options are documented at https://github.com/Microsoft/monaco-editor-webpack-plugin#options
-      languages: ['typescript']
-    }),
-    new BundleAnalyzerPlugin()
-  ],
+    externals: {
+      react: 'React',
+      'react-dom': 'ReactDOM'
+    },
 
-  resolve: {
-    alias: {
-      '@uifabric/tsx-editor/src': path.join(__dirname, 'src'),
-      '@uifabric/tsx-editor/lib': path.join(__dirname, 'lib'),
-      '@uifabric/tsx-editor': path.join(__dirname, 'lib'),
-      'Props.ts.js': 'Props',
-      'Example.tsx.js': 'Example'
+    plugins: [new BundleAnalyzerPlugin()],
+
+    resolve: {
+      alias: {
+        '@uifabric/tsx-editor/src': path.join(__dirname, 'src'),
+        '@uifabric/tsx-editor/lib': path.join(__dirname, 'lib'),
+        '@uifabric/tsx-editor': path.join(__dirname, 'lib'),
+        'Props.ts.js': 'Props',
+        'Example.tsx.js': 'Example'
+      }
     }
-  }
-});
+  })
+);

--- a/yarn.lock
+++ b/yarn.lock
@@ -1855,7 +1855,7 @@
   dependencies:
     "@types/webpack" "*"
 
-"@types/webpack@*", "@types/webpack@^4.4.19":
+"@types/webpack@*":
   version "4.4.34"
   resolved "https://registry.yarnpkg.com/@types/webpack/-/webpack-4.4.34.tgz#e5f88b9a795da11683b4ec4a07d1c2b023b19810"
   integrity sha512-GnEBgjHsfO1M7DIQ0dAupSofcmDItE3Zsu3reK8SQpl/6N0rtUQxUmQzVFAS5ou/FGjsYKjXAWfItLZ0kNFTfQ==
@@ -10618,13 +10618,6 @@ moment@2.x.x, moment@^2.22.1:
   version "2.24.0"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.24.0.tgz#0d055d53f5052aa653c9f6eb68bb5d12bf5c2b5b"
   integrity sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg==
-
-monaco-editor-webpack-plugin@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/monaco-editor-webpack-plugin/-/monaco-editor-webpack-plugin-1.7.0.tgz#920cbeecca25f15d70d568a7e11b0ba4daf1ae83"
-  integrity sha512-oItymcnlL14Sjd7EF7q+CMhucfwR/2BxsqrXIBrWL6LQplFfAfV+grLEQRmVHeGSBZ/Gk9ptzfueXnWcoEcFuA==
-  dependencies:
-    "@types/webpack" "^4.4.19"
 
 monaco-editor@^0.17.0:
   version "0.17.1"


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Remove dependency on `monaco-editor-webpack-plugin` since we're not using it in production and it has an invalid peer dependency (which was causing problems for @KevinTCoughlin and possibly others). 

I also noticed the demo app for the tsx-editor project wasn't really working (even before getting rid of the plugin), so I fixed that.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10231)