### PR TITLE
Primarybutton aria

### DIFF
--- a/change/office-ui-fabric-react-2019-08-22-09-49-52-primarybutton-aria.json
+++ b/change/office-ui-fabric-react-2019-08-22-09-49-52-primarybutton-aria.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "make sure to skip aria-describedby for onRenderDescription is nullRender",
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com",
+  "commit": "848e0bb2a102fa6d0cc6be601fff635657889ece",
+  "date": "2019-08-22T16:49:52.716Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -19,7 +19,7 @@ import { IButtonProps, IButton } from './Button.types';
 import { IButtonClassNames, getBaseButtonClassNames } from './BaseButton.classNames';
 import { getClassNames as getBaseSplitButtonClassNames, ISplitButtonClassNames } from './SplitButton/SplitButton.classNames';
 import { KeytipData } from '../../KeytipData';
-import { memoizeFunction } from '@uifabric/utilities';
+import { memoizeFunction, nullRender } from '@uifabric/utilities';
 import { IKeytipProps } from '../Keytip/Keytip.types';
 
 /**
@@ -166,7 +166,9 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     let ariaDescribedBy = undefined;
     if (ariaDescription) {
       ariaDescribedBy = _ariaDescriptionId;
-    } else if (secondaryText) {
+    } else if (secondaryText && this.props.onRenderDescription !== nullRender) {
+      // for buttons like CompoundButton with a valid onRenderDescription, we need to set an ariaDescribedBy
+      // for buttons that do not render anything (via nullRender), we should not set an ariaDescribedBy
       ariaDescribedBy = _descriptionId;
     } else if ((nativeProps as any)['aria-describedby']) {
       ariaDescribedBy = (nativeProps as any)['aria-describedby'];

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Basic.Example.tsx.shot
@@ -146,8 +146,6 @@ exports[`Component Examples renders Dialog.Basic.Example.tsx correctly 1`] = `
     </label>
   </div>
   <button
-    aria-describedby="id__4"
-    aria-labelledby="id__3"
     className=
         ms-Button
         ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Blocking.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Blocking.Example.tsx.shot
@@ -3,8 +3,6 @@
 exports[`Component Examples renders Dialog.Blocking.Example.tsx correctly 1`] = `
 <div>
   <button
-    aria-describedby="id__1"
-    aria-labelledby="id__0"
     className=
         ms-Button
         ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.LargeHeader.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.LargeHeader.Example.tsx.shot
@@ -3,8 +3,6 @@
 exports[`Component Examples renders Dialog.LargeHeader.Example.tsx correctly 1`] = `
 <div>
   <button
-    aria-describedby="id__1"
-    aria-labelledby="id__0"
     className=
         ms-Button
         ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Modeless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Modeless.Example.tsx.shot
@@ -153,8 +153,6 @@ exports[`Component Examples renders Dialog.Modeless.Example.tsx correctly 1`] = 
       </label>
     </div>
     <button
-      aria-describedby="id__2"
-      aria-labelledby="id__1"
       className=
           ms-Button
           ms-Button--default
@@ -269,8 +267,6 @@ exports[`Component Examples renders Dialog.Modeless.Example.tsx correctly 1`] = 
       </div>
     </button>
     <button
-      aria-describedby="id__5"
-      aria-labelledby="id__4"
       className=
           ms-Button
           ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.TopOffsetFixed.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.TopOffsetFixed.Example.tsx.shot
@@ -3,8 +3,6 @@
 exports[`Component Examples renders Dialog.TopOffsetFixed.Example.tsx correctly 1`] = `
 <div>
   <button
-    aria-describedby="id__1"
-    aria-labelledby="id__0"
     className=
         ms-Button
         ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.DialogInPanel.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.DialogInPanel.Example.tsx.shot
@@ -3,8 +3,6 @@
 exports[`Component Examples renders FocusTrapZone.DialogInPanel.Example.tsx correctly 1`] = `
 <div>
   <button
-    aria-describedby="id__1"
-    aria-labelledby="id__0"
     className=
         ms-Button
         ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.NestedLayers.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.NestedLayers.Example.tsx.shot
@@ -3,8 +3,6 @@
 exports[`Component Examples renders Layer.NestedLayers.Example.tsx correctly 1`] = `
 <div>
   <button
-    aria-describedby="id__1"
-    aria-labelledby="id__0"
     className=
         ms-Button
         ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Basic.Example.tsx.shot
@@ -146,8 +146,6 @@ exports[`Component Examples renders Modal.Basic.Example.tsx correctly 1`] = `
     </label>
   </div>
   <button
-    aria-describedby="id__4"
-    aria-labelledby="id__3"
     className=
         ms-Button
         ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Modeless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Modeless.Example.tsx.shot
@@ -148,8 +148,6 @@ exports[`Component Examples renders Modal.Modeless.Example.tsx correctly 1`] = `
     </label>
   </div>
   <button
-    aria-describedby="id__4"
-    aria-labelledby="id__3"
     className=
         ms-Button
         ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Controlled.Example.tsx.shot
@@ -3,8 +3,6 @@
 exports[`Component Examples renders Panel.Controlled.Example.tsx correctly 1`] = `
 <div>
   <button
-    aria-describedby="id__1"
-    aria-labelledby="id__0"
     className=
         ms-Button
         ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Custom.Example.tsx.shot
@@ -3,8 +3,6 @@
 exports[`Component Examples renders Panel.Custom.Example.tsx correctly 1`] = `
 <div>
   <button
-    aria-describedby="id__1"
-    aria-labelledby="id__0"
     className=
         ms-Button
         ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.CustomLeft.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.CustomLeft.Example.tsx.shot
@@ -3,8 +3,6 @@
 exports[`Component Examples renders Panel.CustomLeft.Example.tsx correctly 1`] = `
 <div>
   <button
-    aria-describedby="id__1"
-    aria-labelledby="id__0"
     className=
         ms-Button
         ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.ExtraLarge.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.ExtraLarge.Example.tsx.shot
@@ -3,8 +3,6 @@
 exports[`Component Examples renders Panel.ExtraLarge.Example.tsx correctly 1`] = `
 <div>
   <button
-    aria-describedby="id__1"
-    aria-labelledby="id__0"
     className=
         ms-Button
         ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Footer.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Footer.Example.tsx.shot
@@ -3,8 +3,6 @@
 exports[`Component Examples renders Panel.Footer.Example.tsx correctly 1`] = `
 <div>
   <button
-    aria-describedby="id__1"
-    aria-labelledby="id__0"
     className=
         ms-Button
         ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HandleDismissTarget.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HandleDismissTarget.Example.tsx.shot
@@ -3,8 +3,6 @@
 exports[`Component Examples renders Panel.HandleDismissTarget.Example.tsx correctly 1`] = `
 <div>
   <button
-    aria-describedby="id__1"
-    aria-labelledby="id__0"
     className=
         ms-Button
         ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Large.Example.tsx.shot
@@ -3,8 +3,6 @@
 exports[`Component Examples renders Panel.Large.Example.tsx correctly 1`] = `
 <div>
   <button
-    aria-describedby="id__1"
-    aria-labelledby="id__0"
     className=
         ms-Button
         ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.LargeFixed.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.LargeFixed.Example.tsx.shot
@@ -3,8 +3,6 @@
 exports[`Component Examples renders Panel.LargeFixed.Example.tsx correctly 1`] = `
 <div>
   <button
-    aria-describedby="id__1"
-    aria-labelledby="id__0"
     className=
         ms-Button
         ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Medium.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Medium.Example.tsx.shot
@@ -3,8 +3,6 @@
 exports[`Component Examples renders Panel.Medium.Example.tsx correctly 1`] = `
 <div>
   <button
-    aria-describedby="id__1"
-    aria-labelledby="id__0"
     className=
         ms-Button
         ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Navigation.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Navigation.Example.tsx.shot
@@ -3,8 +3,6 @@
 exports[`Component Examples renders Panel.Navigation.Example.tsx correctly 1`] = `
 <div>
   <button
-    aria-describedby="id__1"
-    aria-labelledby="id__0"
     className=
         ms-Button
         ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.PreventDefault.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.PreventDefault.Example.tsx.shot
@@ -3,8 +3,6 @@
 exports[`Component Examples renders Panel.PreventDefault.Example.tsx correctly 1`] = `
 <div>
   <button
-    aria-describedby="id__1"
-    aria-labelledby="id__0"
     className=
         ms-Button
         ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Scroll.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.Scroll.Example.tsx.shot
@@ -3,8 +3,6 @@
 exports[`Component Examples renders Panel.Scroll.Example.tsx correctly 1`] = `
 <div>
   <button
-    aria-describedby="id__1"
-    aria-labelledby="id__0"
     className=
         ms-Button
         ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.SmallFluid.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.SmallFluid.Example.tsx.shot
@@ -3,8 +3,6 @@
 exports[`Component Examples renders Panel.SmallFluid.Example.tsx correctly 1`] = `
 <div>
   <button
-    aria-describedby="id__1"
-    aria-labelledby="id__0"
     className=
         ms-Button
         ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.SmallLeft.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.SmallLeft.Example.tsx.shot
@@ -3,8 +3,6 @@
 exports[`Component Examples renders Panel.SmallLeft.Example.tsx correctly 1`] = `
 <div>
   <button
-    aria-describedby="id__1"
-    aria-labelledby="id__0"
     className=
         ms-Button
         ms-Button--default

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.SmallRight.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.SmallRight.Example.tsx.shot
@@ -3,8 +3,6 @@
 exports[`Component Examples renders Panel.SmallRight.Example.tsx correctly 1`] = `
 <div>
   <button
-    aria-describedby="id__1"
-    aria-labelledby="id__0"
     className=
         ms-Button
         ms-Button--default


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10235
- [x] Include a change request file using `$ yarn change`

#### Description of changes

In PrimaryButton and other single line buttons, they do not render a description anywhere. This change makes sure that we do not generate broken aria-describedBy references in those cases. Updates to snapshots reveal that we have a lot of usage of this pattern in our examples.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10238)