### PR TITLE
Scrub: check if file exists before deleting

### DIFF
--- a/scripts/scrub.js
+++ b/scripts/scrub.js
@@ -30,7 +30,7 @@ function prompt(question) {
 function deleteIfSymlink(itemPath, failedPaths) {
   try {
     // Compare realpath since fs.statSync(itemPath).isSymbolicLink() doesn't work on Windows
-    if (fs.realpathSync(itemPath) !== itemPath) {
+    if (fs.existsSync(itemPath) && fs.realpathSync(itemPath) !== itemPath) {
       if (verbose) {
         console.log('  Deleting symlink: ' + itemPath);
       }


### PR DESCRIPTION
If the repo where the script was run didn't have remnants of a Rush install (which was how I'd always tested it), it errored out when trying to delete pnpm-local because it didn't exist.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10246)