### PR TITLE
Card: aligns horizontal/vertical to start rather than space-between

### DIFF
--- a/change/@uifabric-react-cards-2019-08-25-22-12-44-card-fix.json
+++ b/change/@uifabric-react-cards-2019-08-25-22-12-44-card-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Card: fixing vertical and horizontal alignment to start rather than space-between.",
+  "packageName": "@uifabric/react-cards",
+  "email": "dzearing@hotmail.com",
+  "commit": "4ef6e8836a4a18dc3859aa01a2e1641f00787113",
+  "date": "2019-08-26T05:12:44.678Z"
+}

--- a/packages/react-cards/src/components/Card/Card.view.tsx
+++ b/packages/react-cards/src/components/Card/Card.view.tsx
@@ -88,8 +88,8 @@ export const CardView: ICardComponent['view'] = props => {
       horizontal={compact}
       tokens={tokens as IStackComponent['tokens']}
       verticalFill
-      verticalAlign="space-between"
-      horizontalAlign="space-between"
+      verticalAlign="start"
+      horizontalAlign="stretch"
     >
       {cardChildren}
     </Slots.root>

--- a/packages/react-cards/src/components/Card/Card.view.tsx
+++ b/packages/react-cards/src/components/Card/Card.view.tsx
@@ -89,7 +89,7 @@ export const CardView: ICardComponent['view'] = props => {
       tokens={tokens as IStackComponent['tokens']}
       verticalFill
       verticalAlign="start"
-      horizontalAlign="stretch"
+      horizontalAlign={compact ? 'start' : 'stretch'}
     >
       {cardChildren}
     </Slots.root>

--- a/packages/react-cards/src/components/Card/CardItem/__snapshots__/CardItem.test.tsx.snap
+++ b/packages/react-cards/src/components/Card/CardItem/__snapshots__/CardItem.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Card Item renders correctly 1`] = `
       ms-Stack
       ms-Card
       {
-        align-items: space-between;
+        align-items: stretch;
         border-radius: 2px;
         box-shadow: 0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108);
         box-sizing: border-box;
@@ -15,7 +15,7 @@ exports[`Card Item renders correctly 1`] = `
         flex-direction: column;
         flex-wrap: nowrap;
         height: inherit;
-        justify-content: space-between;
+        justify-content: flex-start;
         max-width: 286px;
         min-width: 212px;
         transition: box-shadow 0.5s ease;
@@ -68,7 +68,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
       ms-Stack
       ms-Card
       {
-        align-items: space-between;
+        align-items: flex-start;
         border-radius: 2px;
         box-shadow: 0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108);
         box-sizing: border-box;
@@ -77,7 +77,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
         flex-direction: row;
         flex-wrap: nowrap;
         height: auto;
-        justify-content: space-between;
+        justify-content: flex-start;
         max-width: 500px;
         min-width: 300px;
         transition: box-shadow 0.5s ease;
@@ -155,7 +155,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
       ms-Stack
       ms-Card
       {
-        align-items: space-between;
+        align-items: stretch;
         border-radius: 2px;
         box-shadow: 0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108);
         box-sizing: border-box;
@@ -164,7 +164,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
         flex-direction: column;
         flex-wrap: nowrap;
         height: inherit;
-        justify-content: space-between;
+        justify-content: flex-start;
         max-width: 286px;
         min-width: 212px;
         transition: box-shadow 0.5s ease;
@@ -242,7 +242,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
       ms-Stack
       ms-Card
       {
-        align-items: space-between;
+        align-items: flex-start;
         border-radius: 2px;
         box-shadow: 0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108);
         box-sizing: border-box;
@@ -251,7 +251,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
         flex-direction: row;
         flex-wrap: nowrap;
         height: auto;
-        justify-content: space-between;
+        justify-content: flex-start;
         max-width: 500px;
         min-width: 300px;
         transition: box-shadow 0.5s ease;
@@ -329,7 +329,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
       ms-Stack
       ms-Card
       {
-        align-items: space-between;
+        align-items: stretch;
         border-radius: 2px;
         box-shadow: 0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108);
         box-sizing: border-box;
@@ -338,7 +338,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
         flex-direction: column;
         flex-wrap: nowrap;
         height: inherit;
-        justify-content: space-between;
+        justify-content: flex-start;
         max-width: 286px;
         min-width: 212px;
         transition: box-shadow 0.5s ease;
@@ -416,7 +416,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
       ms-Stack
       ms-Card
       {
-        align-items: space-between;
+        align-items: flex-start;
         border-radius: 2px;
         box-shadow: 0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108);
         box-sizing: border-box;
@@ -425,7 +425,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
         flex-direction: row;
         flex-wrap: nowrap;
         height: auto;
-        justify-content: space-between;
+        justify-content: flex-start;
         max-width: 500px;
         min-width: 300px;
         transition: box-shadow 0.5s ease;
@@ -528,7 +528,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
       ms-Stack
       ms-Card
       {
-        align-items: space-between;
+        align-items: stretch;
         border-radius: 2px;
         box-shadow: 0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108);
         box-sizing: border-box;
@@ -537,7 +537,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
         flex-direction: column;
         flex-wrap: nowrap;
         height: inherit;
-        justify-content: space-between;
+        justify-content: flex-start;
         max-width: 286px;
         min-width: 212px;
         transition: box-shadow 0.5s ease;
@@ -640,7 +640,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
       ms-Stack
       ms-Card
       {
-        align-items: space-between;
+        align-items: flex-start;
         border-radius: 2px;
         box-shadow: 0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108);
         box-sizing: border-box;
@@ -649,7 +649,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
         flex-direction: row;
         flex-wrap: nowrap;
         height: auto;
-        justify-content: space-between;
+        justify-content: flex-start;
         max-width: 500px;
         min-width: 300px;
         transition: box-shadow 0.5s ease;
@@ -702,7 +702,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
       ms-Stack
       ms-Card
       {
-        align-items: space-between;
+        align-items: stretch;
         border-radius: 2px;
         box-shadow: 0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108);
         box-sizing: border-box;
@@ -711,7 +711,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
         flex-direction: column;
         flex-wrap: nowrap;
         height: inherit;
-        justify-content: space-between;
+        justify-content: flex-start;
         max-width: 286px;
         min-width: 212px;
         transition: box-shadow 0.5s ease;
@@ -764,7 +764,7 @@ exports[`Card Item renders correctly when having tokens passed to it 1`] = `
       ms-Stack
       ms-Card
       {
-        align-items: space-between;
+        align-items: stretch;
         border-radius: 2px;
         box-shadow: 0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108);
         box-sizing: border-box;
@@ -773,7 +773,7 @@ exports[`Card Item renders correctly when having tokens passed to it 1`] = `
         flex-direction: column;
         flex-wrap: nowrap;
         height: inherit;
-        justify-content: space-between;
+        justify-content: flex-start;
         max-width: 286px;
         min-width: 212px;
         transition: box-shadow 0.5s ease;

--- a/packages/react-cards/src/components/Card/CardSection/__snapshots__/CardSection.test.tsx.snap
+++ b/packages/react-cards/src/components/Card/CardSection/__snapshots__/CardSection.test.tsx.snap
@@ -6,7 +6,7 @@ exports[`Card Section renders correctly 1`] = `
       ms-Stack
       ms-Card
       {
-        align-items: space-between;
+        align-items: stretch;
         border-radius: 2px;
         box-shadow: 0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108);
         box-sizing: border-box;
@@ -15,7 +15,7 @@ exports[`Card Section renders correctly 1`] = `
         flex-direction: column;
         flex-wrap: nowrap;
         height: inherit;
-        justify-content: space-between;
+        justify-content: flex-start;
         max-width: 286px;
         min-width: 212px;
         transition: box-shadow 0.5s ease;
@@ -80,7 +80,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
       ms-Stack
       ms-Card
       {
-        align-items: space-between;
+        align-items: flex-start;
         border-radius: 2px;
         box-shadow: 0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108);
         box-sizing: border-box;
@@ -89,7 +89,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
         flex-direction: row;
         flex-wrap: nowrap;
         height: auto;
-        justify-content: space-between;
+        justify-content: flex-start;
         max-width: 500px;
         min-width: 300px;
         transition: box-shadow 0.5s ease;
@@ -191,7 +191,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
       ms-Stack
       ms-Card
       {
-        align-items: space-between;
+        align-items: stretch;
         border-radius: 2px;
         box-shadow: 0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108);
         box-sizing: border-box;
@@ -200,7 +200,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
         flex-direction: column;
         flex-wrap: nowrap;
         height: inherit;
-        justify-content: space-between;
+        justify-content: flex-start;
         max-width: 286px;
         min-width: 212px;
         transition: box-shadow 0.5s ease;
@@ -302,7 +302,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
       ms-Stack
       ms-Card
       {
-        align-items: space-between;
+        align-items: flex-start;
         border-radius: 2px;
         box-shadow: 0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108);
         box-sizing: border-box;
@@ -311,7 +311,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
         flex-direction: row;
         flex-wrap: nowrap;
         height: auto;
-        justify-content: space-between;
+        justify-content: flex-start;
         max-width: 500px;
         min-width: 300px;
         transition: box-shadow 0.5s ease;
@@ -413,7 +413,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
       ms-Stack
       ms-Card
       {
-        align-items: space-between;
+        align-items: stretch;
         border-radius: 2px;
         box-shadow: 0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108);
         box-sizing: border-box;
@@ -422,7 +422,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
         flex-direction: column;
         flex-wrap: nowrap;
         height: inherit;
-        justify-content: space-between;
+        justify-content: flex-start;
         max-width: 286px;
         min-width: 212px;
         transition: box-shadow 0.5s ease;
@@ -524,7 +524,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
       ms-Stack
       ms-Card
       {
-        align-items: space-between;
+        align-items: flex-start;
         border-radius: 2px;
         box-shadow: 0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108);
         box-sizing: border-box;
@@ -533,7 +533,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
         flex-direction: row;
         flex-wrap: nowrap;
         height: auto;
-        justify-content: space-between;
+        justify-content: flex-start;
         max-width: 500px;
         min-width: 300px;
         transition: box-shadow 0.5s ease;
@@ -672,7 +672,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
       ms-Stack
       ms-Card
       {
-        align-items: space-between;
+        align-items: stretch;
         border-radius: 2px;
         box-shadow: 0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108);
         box-sizing: border-box;
@@ -681,7 +681,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
         flex-direction: column;
         flex-wrap: nowrap;
         height: inherit;
-        justify-content: space-between;
+        justify-content: flex-start;
         max-width: 286px;
         min-width: 212px;
         transition: box-shadow 0.5s ease;
@@ -820,7 +820,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
       ms-Stack
       ms-Card
       {
-        align-items: space-between;
+        align-items: flex-start;
         border-radius: 2px;
         box-shadow: 0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108);
         box-sizing: border-box;
@@ -829,7 +829,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
         flex-direction: row;
         flex-wrap: nowrap;
         height: auto;
-        justify-content: space-between;
+        justify-content: flex-start;
         max-width: 500px;
         min-width: 300px;
         transition: box-shadow 0.5s ease;
@@ -894,7 +894,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
       ms-Stack
       ms-Card
       {
-        align-items: space-between;
+        align-items: stretch;
         border-radius: 2px;
         box-shadow: 0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108);
         box-sizing: border-box;
@@ -903,7 +903,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
         flex-direction: column;
         flex-wrap: nowrap;
         height: inherit;
-        justify-content: space-between;
+        justify-content: flex-start;
         max-width: 286px;
         min-width: 212px;
         transition: box-shadow 0.5s ease;
@@ -968,7 +968,7 @@ exports[`Card Section renders correctly when having tokens passed to it 1`] = `
       ms-Stack
       ms-Card
       {
-        align-items: space-between;
+        align-items: stretch;
         border-radius: 2px;
         box-shadow: 0 1.6px 3.6px 0 rgba(0, 0, 0, 0.132), 0 0.3px 0.9px 0 rgba(0, 0, 0, 0.108);
         box-sizing: border-box;
@@ -977,7 +977,7 @@ exports[`Card Section renders correctly when having tokens passed to it 1`] = `
         flex-direction: column;
         flex-wrap: nowrap;
         height: inherit;
-        justify-content: space-between;
+        justify-content: flex-start;
         max-width: 286px;
         min-width: 212px;
         transition: box-shadow 0.5s ease;

--- a/packages/react-cards/src/components/Card/__snapshots__/Card.view.test.tsx.snap
+++ b/packages/react-cards/src/components/Card/__snapshots__/Card.view.test.tsx.snap
@@ -5,13 +5,13 @@ exports[`CardView renders a Compact Card with an onClick function specified corr
   className=
       ms-Stack
       {
-        align-items: space-between;
+        align-items: flex-start;
         box-sizing: border-box;
         display: flex;
         flex-direction: row;
         flex-wrap: nowrap;
         height: 100%;
-        justify-content: space-between;
+        justify-content: flex-start;
         width: auto;
       }
       & > * {
@@ -54,13 +54,13 @@ exports[`CardView renders a Compact Card with contents correctly 1`] = `
   className=
       ms-Stack
       {
-        align-items: space-between;
+        align-items: flex-start;
         box-sizing: border-box;
         display: flex;
         flex-direction: row;
         flex-wrap: nowrap;
         height: 100%;
-        justify-content: space-between;
+        justify-content: flex-start;
         width: auto;
       }
       & > * {
@@ -144,13 +144,13 @@ exports[`CardView renders a Compact Card without contents correctly 1`] = `
   className=
       ms-Stack
       {
-        align-items: space-between;
+        align-items: flex-start;
         box-sizing: border-box;
         display: flex;
         flex-direction: row;
         flex-wrap: nowrap;
         height: 100%;
-        justify-content: space-between;
+        justify-content: flex-start;
         width: auto;
       }
       & > * {
@@ -170,13 +170,13 @@ exports[`CardView renders a Vertical Card with an onClick function specified cor
   className=
       ms-Stack
       {
-        align-items: space-between;
+        align-items: stretch;
         box-sizing: border-box;
         display: flex;
         flex-direction: column;
         flex-wrap: nowrap;
         height: 100%;
-        justify-content: space-between;
+        justify-content: flex-start;
         width: auto;
       }
       & > * {
@@ -219,13 +219,13 @@ exports[`CardView renders a Vertical Card with contents correctly 1`] = `
   className=
       ms-Stack
       {
-        align-items: space-between;
+        align-items: stretch;
         box-sizing: border-box;
         display: flex;
         flex-direction: column;
         flex-wrap: nowrap;
         height: 100%;
-        justify-content: space-between;
+        justify-content: flex-start;
         width: auto;
       }
       & > * {
@@ -309,13 +309,13 @@ exports[`CardView renders a Vertical Card without contents correctly 1`] = `
   className=
       ms-Stack
       {
-        align-items: space-between;
+        align-items: stretch;
         box-sizing: border-box;
         display: flex;
         flex-direction: column;
         flex-wrap: nowrap;
         height: 100%;
-        justify-content: space-between;
+        justify-content: flex-start;
         width: auto;
       }
       & > * {


### PR DESCRIPTION
There seems to be no clear reason why we'd want to align content within a card to space between, as it means unpredictable alignments.

Fixing to default to start, at least. I might be doing the wrong thing here.