### PR TITLE
Fabric 6: CherryPick MessageBar: Fix high contrast mode issue where you cannot tell which buttons you have focus on.

### DIFF
--- a/change/office-ui-fabric-react-2019-07-25-22-24-45-cliffkoh-messageBar.json
+++ b/change/office-ui-fabric-react-2019-07-25-22-24-45-cliffkoh-messageBar.json
@@ -1,0 +1,8 @@
+{
+  "comment": "MessageBar: Fix high contrast mode issue where you cannot tell which buttons you have focus on.",
+  "type": "patch",
+  "packageName": "office-ui-fabric-react",
+  "email": "cliff.koh@microsoft.com",
+  "commit": "56d02a9d9cf05868799723721e6c9f35dd10c528",
+  "date": "2019-07-26T05:24:45.198Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/MessageBarButton/MessageBarButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/MessageBarButton/MessageBarButton.styles.ts
@@ -1,5 +1,5 @@
 import { IButtonStyles } from '../Button.types';
-import { ITheme, concatStyleSets } from '../../../Styling';
+import { ITheme, concatStyleSets, getFocusStyle } from '../../../Styling';
 import { memoizeFunction } from '../../../Utilities';
 import { getStyles as getBaseButtonStyles } from '../BaseButton.styles';
 
@@ -7,10 +7,20 @@ export const getStyles = memoizeFunction(
   (theme: ITheme, customStyles?: IButtonStyles, focusInset?: string, focusColor?: string): IButtonStyles => {
     const baseButtonStyles: IButtonStyles = getBaseButtonStyles(theme);
     const messageBarButtonStyles: IButtonStyles = {
-      root: {
-        backgroundColor: theme.palette.neutralQuaternaryAlt,
-        color: theme.palette.neutralPrimary
-      },
+      root: [
+        getFocusStyle(theme, {
+          inset: 1,
+          highContrastStyle: {
+            outlineOffset: '-4px',
+            outlineColor: 'ActiveBorder'
+          },
+          borderColor: 'transparent'
+        }),
+        {
+          backgroundColor: theme.palette.neutralQuaternaryAlt,
+          color: theme.palette.neutralPrimary
+        }
+      ],
 
       rootHovered: {
         backgroundColor: theme.palette.neutralTertiaryAlt,

--- a/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/MessageBar/MessageBar.styles.ts
@@ -92,17 +92,27 @@ export const getStyles = (props: IMessageBarStyleProps): IMessageBarStyles => {
     }
   };
 
-  const dismissalAndExpandStyle: IStyle = {
-    flexShrink: 0,
-    margin: 8,
-    marginLeft: 0,
-    selectors: {
-      '& .ms-Button-icon': dismissalAndExpandIconStyle,
-      [SmallScreenSelector]: {
-        margin: '0px 0px 0px 8px'
+  const dismissalAndExpandStyle: IStyle = [
+    getFocusStyle(theme, {
+      inset: 1,
+      highContrastStyle: {
+        outlineOffset: '-4px',
+        outlineColor: 'Window'
+      },
+      borderColor: 'transparent'
+    }),
+    {
+      flexShrink: 0,
+      margin: 8,
+      marginLeft: 0,
+      selectors: {
+        '& .ms-Button-icon': dismissalAndExpandIconStyle,
+        [SmallScreenSelector]: {
+          margin: '0px 0px 0px 8px'
+        }
       }
     }
-  };
+  ];
 
   const focusStyle = getFocusStyle(theme, { borderColor: palette.black });
 

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Basic.Example.tsx.shot
@@ -471,7 +471,8 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                     border: none;
                     bottom: -2px;
                     left: -2px;
-                    outline-color: ButtonText;
+                    outline-color: Window;
+                    outline-offset: -4px;
                     right: -2px;
                     top: -2px;
                   }
@@ -837,7 +838,8 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                     border: none;
                     bottom: -2px;
                     left: -2px;
-                    outline-color: ButtonText;
+                    outline-color: Window;
+                    outline-offset: -4px;
                     right: -2px;
                     top: -2px;
                   }
@@ -995,7 +997,8 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                     border: none;
                     bottom: -2px;
                     left: -2px;
-                    outline-color: ButtonText;
+                    outline-color: Window;
+                    outline-offset: -4px;
                     right: -2px;
                     top: -2px;
                   }
@@ -1325,21 +1328,22 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                     border: 0;
                   }
                   .ms-Fabric--isFocusVisible &:focus:after {
-                    border: 1px solid #ffffff;
-                    bottom: 0px;
+                    border: 1px solid transparent;
+                    bottom: 2px;
                     content: "";
-                    left: 0px;
+                    left: 2px;
                     outline: 1px solid #666666;
                     position: absolute;
-                    right: 0px;
-                    top: 0px;
+                    right: 2px;
+                    top: 2px;
                     z-index: 1;
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
                     bottom: -2px;
                     left: -2px;
-                    outline-color: ButtonText;
+                    outline-color: ActiveBorder;
+                    outline-offset: -4px;
                     right: -2px;
                     top: -2px;
                   }
@@ -1443,21 +1447,22 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                     border: 0;
                   }
                   .ms-Fabric--isFocusVisible &:focus:after {
-                    border: 1px solid #ffffff;
-                    bottom: 0px;
+                    border: 1px solid transparent;
+                    bottom: 2px;
                     content: "";
-                    left: 0px;
+                    left: 2px;
                     outline: 1px solid #666666;
                     position: absolute;
-                    right: 0px;
-                    top: 0px;
+                    right: 2px;
+                    top: 2px;
                     z-index: 1;
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
                     bottom: -2px;
                     left: -2px;
-                    outline-color: ButtonText;
+                    outline-color: ActiveBorder;
+                    outline-offset: -4px;
                     right: -2px;
                     top: -2px;
                   }
@@ -1778,21 +1783,22 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                       border: 0;
                     }
                     .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 0px;
+                      border: 1px solid transparent;
+                      bottom: 2px;
                       content: "";
-                      left: 0px;
+                      left: 2px;
                       outline: 1px solid #666666;
                       position: absolute;
-                      right: 0px;
-                      top: 0px;
+                      right: 2px;
+                      top: 2px;
                       z-index: 1;
                     }
                     @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                       border: none;
                       bottom: -2px;
                       left: -2px;
-                      outline-color: ButtonText;
+                      outline-color: ActiveBorder;
+                      outline-offset: -4px;
                       right: -2px;
                       top: -2px;
                     }
@@ -1896,21 +1902,22 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                       border: 0;
                     }
                     .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 0px;
+                      border: 1px solid transparent;
+                      bottom: 2px;
                       content: "";
-                      left: 0px;
+                      left: 2px;
                       outline: 1px solid #666666;
                       position: absolute;
-                      right: 0px;
-                      top: 0px;
+                      right: 2px;
+                      top: 2px;
                       z-index: 1;
                     }
                     @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                       border: none;
                       bottom: -2px;
                       left: -2px;
-                      outline-color: ButtonText;
+                      outline-color: ActiveBorder;
+                      outline-offset: -4px;
                       right: -2px;
                       top: -2px;
                     }
@@ -2233,21 +2240,22 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                       border: 0;
                     }
                     .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 0px;
+                      border: 1px solid transparent;
+                      bottom: 2px;
                       content: "";
-                      left: 0px;
+                      left: 2px;
                       outline: 1px solid #666666;
                       position: absolute;
-                      right: 0px;
-                      top: 0px;
+                      right: 2px;
+                      top: 2px;
                       z-index: 1;
                     }
                     @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                       border: none;
                       bottom: -2px;
                       left: -2px;
-                      outline-color: ButtonText;
+                      outline-color: ActiveBorder;
+                      outline-offset: -4px;
                       right: -2px;
                       top: -2px;
                     }
@@ -2387,7 +2395,8 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                     border: none;
                     bottom: -2px;
                     left: -2px;
-                    outline-color: ButtonText;
+                    outline-color: Window;
+                    outline-offset: -4px;
                     right: -2px;
                     top: -2px;
                   }
@@ -2713,7 +2722,8 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                   border: none;
                   bottom: -2px;
                   left: -2px;
-                  outline-color: ButtonText;
+                  outline-color: Window;
+                  outline-offset: -4px;
                   right: -2px;
                   top: -2px;
                 }
@@ -2857,21 +2867,22 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                     border: 0;
                   }
                   .ms-Fabric--isFocusVisible &:focus:after {
-                    border: 1px solid #ffffff;
-                    bottom: 0px;
+                    border: 1px solid transparent;
+                    bottom: 2px;
                     content: "";
-                    left: 0px;
+                    left: 2px;
                     outline: 1px solid #666666;
                     position: absolute;
-                    right: 0px;
-                    top: 0px;
+                    right: 2px;
+                    top: 2px;
                     z-index: 1;
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
                     bottom: -2px;
                     left: -2px;
-                    outline-color: ButtonText;
+                    outline-color: ActiveBorder;
+                    outline-offset: -4px;
                     right: -2px;
                     top: -2px;
                   }
@@ -2975,21 +2986,22 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                     border: 0;
                   }
                   .ms-Fabric--isFocusVisible &:focus:after {
-                    border: 1px solid #ffffff;
-                    bottom: 0px;
+                    border: 1px solid transparent;
+                    bottom: 2px;
                     content: "";
-                    left: 0px;
+                    left: 2px;
                     outline: 1px solid #666666;
                     position: absolute;
-                    right: 0px;
-                    top: 0px;
+                    right: 2px;
+                    top: 2px;
                     z-index: 1;
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
                     bottom: -2px;
                     left: -2px;
-                    outline-color: ButtonText;
+                    outline-color: ActiveBorder;
+                    outline-offset: -4px;
                     right: -2px;
                     top: -2px;
                   }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Styled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Styled.Example.tsx.shot
@@ -473,7 +473,8 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                     border: none;
                     bottom: -2px;
                     left: -2px;
-                    outline-color: ButtonText;
+                    outline-color: Window;
+                    outline-offset: -4px;
                     right: -2px;
                     top: -2px;
                   }
@@ -841,7 +842,8 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                     border: none;
                     bottom: -2px;
                     left: -2px;
-                    outline-color: ButtonText;
+                    outline-color: Window;
+                    outline-offset: -4px;
                     right: -2px;
                     top: -2px;
                   }
@@ -1000,7 +1002,8 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                     border: none;
                     bottom: -2px;
                     left: -2px;
-                    outline-color: ButtonText;
+                    outline-color: Window;
+                    outline-offset: -4px;
                     right: -2px;
                     top: -2px;
                   }
@@ -1331,21 +1334,22 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                     border: 0;
                   }
                   .ms-Fabric--isFocusVisible &:focus:after {
-                    border: 1px solid #ffffff;
-                    bottom: 0px;
+                    border: 1px solid transparent;
+                    bottom: 2px;
                     content: "";
-                    left: 0px;
+                    left: 2px;
                     outline: 1px solid #666666;
                     position: absolute;
-                    right: 0px;
-                    top: 0px;
+                    right: 2px;
+                    top: 2px;
                     z-index: 1;
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
                     bottom: -2px;
                     left: -2px;
-                    outline-color: ButtonText;
+                    outline-color: ActiveBorder;
+                    outline-offset: -4px;
                     right: -2px;
                     top: -2px;
                   }
@@ -1449,21 +1453,22 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                     border: 0;
                   }
                   .ms-Fabric--isFocusVisible &:focus:after {
-                    border: 1px solid #ffffff;
-                    bottom: 0px;
+                    border: 1px solid transparent;
+                    bottom: 2px;
                     content: "";
-                    left: 0px;
+                    left: 2px;
                     outline: 1px solid #666666;
                     position: absolute;
-                    right: 0px;
-                    top: 0px;
+                    right: 2px;
+                    top: 2px;
                     z-index: 1;
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
                     bottom: -2px;
                     left: -2px;
-                    outline-color: ButtonText;
+                    outline-color: ActiveBorder;
+                    outline-offset: -4px;
                     right: -2px;
                     top: -2px;
                   }
@@ -1786,21 +1791,22 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                       border: 0;
                     }
                     .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 0px;
+                      border: 1px solid transparent;
+                      bottom: 2px;
                       content: "";
-                      left: 0px;
+                      left: 2px;
                       outline: 1px solid #666666;
                       position: absolute;
-                      right: 0px;
-                      top: 0px;
+                      right: 2px;
+                      top: 2px;
                       z-index: 1;
                     }
                     @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                       border: none;
                       bottom: -2px;
                       left: -2px;
-                      outline-color: ButtonText;
+                      outline-color: ActiveBorder;
+                      outline-offset: -4px;
                       right: -2px;
                       top: -2px;
                     }
@@ -1904,21 +1910,22 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                       border: 0;
                     }
                     .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 0px;
+                      border: 1px solid transparent;
+                      bottom: 2px;
                       content: "";
-                      left: 0px;
+                      left: 2px;
                       outline: 1px solid #666666;
                       position: absolute;
-                      right: 0px;
-                      top: 0px;
+                      right: 2px;
+                      top: 2px;
                       z-index: 1;
                     }
                     @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                       border: none;
                       bottom: -2px;
                       left: -2px;
-                      outline-color: ButtonText;
+                      outline-color: ActiveBorder;
+                      outline-offset: -4px;
                       right: -2px;
                       top: -2px;
                     }
@@ -2243,21 +2250,22 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                       border: 0;
                     }
                     .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 0px;
+                      border: 1px solid transparent;
+                      bottom: 2px;
                       content: "";
-                      left: 0px;
+                      left: 2px;
                       outline: 1px solid #666666;
                       position: absolute;
-                      right: 0px;
-                      top: 0px;
+                      right: 2px;
+                      top: 2px;
                       z-index: 1;
                     }
                     @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                       border: none;
                       bottom: -2px;
                       left: -2px;
-                      outline-color: ButtonText;
+                      outline-color: ActiveBorder;
+                      outline-offset: -4px;
                       right: -2px;
                       top: -2px;
                     }
@@ -2398,7 +2406,8 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                     border: none;
                     bottom: -2px;
                     left: -2px;
-                    outline-color: ButtonText;
+                    outline-color: Window;
+                    outline-offset: -4px;
                     right: -2px;
                     top: -2px;
                   }
@@ -2724,7 +2733,8 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                   border: none;
                   bottom: -2px;
                   left: -2px;
-                  outline-color: ButtonText;
+                  outline-color: Window;
+                  outline-offset: -4px;
                   right: -2px;
                   top: -2px;
                 }
@@ -2869,21 +2879,22 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                     border: 0;
                   }
                   .ms-Fabric--isFocusVisible &:focus:after {
-                    border: 1px solid #ffffff;
-                    bottom: 0px;
+                    border: 1px solid transparent;
+                    bottom: 2px;
                     content: "";
-                    left: 0px;
+                    left: 2px;
                     outline: 1px solid #666666;
                     position: absolute;
-                    right: 0px;
-                    top: 0px;
+                    right: 2px;
+                    top: 2px;
                     z-index: 1;
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
                     bottom: -2px;
                     left: -2px;
-                    outline-color: ButtonText;
+                    outline-color: ActiveBorder;
+                    outline-offset: -4px;
                     right: -2px;
                     top: -2px;
                   }
@@ -2987,21 +2998,22 @@ exports[`Component Examples renders MessageBar.Styled.Example.tsx correctly 1`] 
                     border: 0;
                   }
                   .ms-Fabric--isFocusVisible &:focus:after {
-                    border: 1px solid #ffffff;
-                    bottom: 0px;
+                    border: 1px solid transparent;
+                    bottom: 2px;
                     content: "";
-                    left: 0px;
+                    left: 2px;
                     outline: 1px solid #666666;
                     position: absolute;
-                    right: 0px;
-                    top: 0px;
+                    right: 2px;
+                    top: 2px;
                     z-index: 1;
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
                     border: none;
                     bottom: -2px;
                     left: -2px;
-                    outline-color: ButtonText;
+                    outline-color: ActiveBorder;
+                    outline-offset: -4px;
                     right: -2px;
                     top: -2px;
                   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes ##9934
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Cherrypicking #9953 into 6.0 so it can be consumed in AI Builder.
There were merge conflicts, so I only added the `getFocusStyle` code, and updated the snapshots. 


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10263)