### PR TITLE
SpinButton: fix vertical alignment

### DIFF
--- a/apps/vr-tests/src/stories/SpinButton.stories.tsx
+++ b/apps/vr-tests/src/stories/SpinButton.stories.tsx
@@ -13,10 +13,7 @@ const props: ISpinButtonProps = {
   max: 0,
   step: 1
 };
-const propsWithStyles: ISpinButtonProps = {
-  ...props,
-  styles: { root: { width: 300 } }
-};
+const styles = { root: { width: 300 } };
 const iconProps = { iconName: 'IncreaseIndentLegacy' };
 
 storiesOf('SpinButton', module)
@@ -59,6 +56,7 @@ storiesOf('SpinButton', module)
     { rtl: true }
   );
 
+// The stories for label placement are separate since they don't need to include hover/click states
 storiesOf('SpinButton - Label Placement', module)
   .addDecorator(FabricDecorator)
   .addDecorator(story => (
@@ -70,7 +68,7 @@ storiesOf('SpinButton - Label Placement', module)
     'Label at end',
     () => (
       <Fabric>
-        <SpinButton {...propsWithStyles} labelPosition={Position.end} />
+        <SpinButton {...props} styles={styles} labelPosition={Position.end} />
       </Fabric>
     ),
     { rtl: true }
@@ -79,36 +77,40 @@ storiesOf('SpinButton - Label Placement', module)
     'Label at end with icon',
     () => (
       <Fabric>
-        <SpinButton {...propsWithStyles} labelPosition={Position.end} iconProps={iconProps} />
+        <SpinButton {...props} styles={styles} labelPosition={Position.end} iconProps={iconProps} />
       </Fabric>
     ),
     { rtl: true }
   )
   .addStory('Label on top', () => (
-    <Fabric styles={{ root: { width: 610 } }}>
-      <SpinButton {...propsWithStyles} labelPosition={Position.top} />
-      <TextField
-        label="Should vertically align with SpinButton"
-        styles={{ root: { width: 300 } }}
-      />
+    <Fabric styles={{ root: { width: 460 } }}>
+      <SpinButton {...props} styles={{ root: { width: 150 } }} labelPosition={Position.top} />
+      <TextField label="Should vertically align with SpinButton" styles={styles} />
     </Fabric>
   ))
   .addStory('Label on top with icon', () => (
-    <Fabric styles={{ root: { width: 610 } }}>
-      <SpinButton {...propsWithStyles} labelPosition={Position.top} iconProps={iconProps} />
-      <TextField
-        label="Should vertically align with SpinButton"
-        styles={{ root: { width: 300 } }}
+    <Fabric styles={{ root: { width: 460 } }}>
+      <SpinButton
+        {...props}
+        styles={{ root: { width: 150 } }}
+        labelPosition={Position.top}
+        iconProps={iconProps}
       />
+      <TextField label="Should vertically align with SpinButton" styles={styles} />
     </Fabric>
   ))
   .addStory('Label on bottom', () => (
     <Fabric>
-      <SpinButton {...propsWithStyles} labelPosition={Position.bottom} />
+      <SpinButton {...props} styles={styles} labelPosition={Position.bottom} />
     </Fabric>
   ))
   .addStory('Label on bottom with icon', () => (
     <Fabric>
-      <SpinButton {...propsWithStyles} labelPosition={Position.bottom} iconProps={iconProps} />
+      <SpinButton
+        {...props}
+        styles={styles}
+        labelPosition={Position.bottom}
+        iconProps={iconProps}
+      />
     </Fabric>
   ));

--- a/apps/vr-tests/src/stories/SpinButton.stories.tsx
+++ b/apps/vr-tests/src/stories/SpinButton.stories.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecoratorFixedWidth, FabricDecoratorFullWidth } from '../utilities';
+import { FabricDecoratorFixedWidth, FabricDecorator } from '../utilities';
 import {
   Fabric,
   SpinButton,
@@ -21,9 +21,6 @@ const props: ISpinButtonProps = {
   step: 1
 };
 const styles: Partial<ISpinButtonStyles> = { root: { width: 300 } };
-const inlineStyles: Partial<ISpinButtonStyles> = {
-  root: { width: 115, display: 'inline-block' }
-};
 const textFieldStyles: Partial<ITextFieldStyles> = {
   root: { width: 250, display: 'inline-block' }
 };
@@ -70,8 +67,8 @@ storiesOf('SpinButton', module)
   );
 
 // The stories for label placement are separate since they don't need to include hover/click states
-storiesOf('SpinButton - Label Placement', module)
-  .addDecorator(FabricDecoratorFullWidth)
+storiesOf('SpinButton', module)
+  .addDecorator(FabricDecorator)
   .addDecorator(story => (
     <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>
       {story()}
@@ -97,19 +94,37 @@ storiesOf('SpinButton - Label Placement', module)
   )
   .addStory('Label on top', () => (
     <Fabric>
-      <SpinButton {...props} styles={inlineStyles} labelPosition={Position.top} />
-      <TextField label="Should vertically align with SpinButton" styles={textFieldStyles} />
+      <SpinButton
+        {...props}
+        styles={{ root: { width: 120, display: 'inline-block' } }}
+        labelPosition={Position.top}
+      />
+      {/* DO NOT delete this TextField! It's here to verify that the SpinButton's field and label
+        vertically align with other form components (this positioning can get messed up since
+        SpinButton's optional icon is 1px larger than the label line height). */}
+      <TextField
+        label="Should vertically align with SpinButton"
+        placeholder="(verify field and label alignment)"
+        styles={textFieldStyles}
+      />
     </Fabric>
   ))
   .addStory('Label on top with icon', () => (
     <Fabric>
       <SpinButton
         {...props}
-        styles={inlineStyles}
+        styles={{ root: { width: 150, display: 'inline-block' } }}
         labelPosition={Position.top}
         iconProps={iconProps}
       />
-      <TextField label="Should vertically align with SpinButton" styles={textFieldStyles} />
+      {/* DO NOT delete this TextField! It's here to verify that the SpinButton's field and label
+        vertically align with other form components (this positioning can get messed up since
+        SpinButton's optional icon is 1px larger than the label line height). */}
+      <TextField
+        label="Should vertically align with SpinButton"
+        placeholder="(verify field and label alignment)"
+        styles={textFieldStyles}
+      />
     </Fabric>
   ))
   .addStory('Label on bottom', () => (

--- a/apps/vr-tests/src/stories/SpinButton.stories.tsx
+++ b/apps/vr-tests/src/stories/SpinButton.stories.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities';
+import { FabricDecorator, FabricDecoratorFixedWidth } from '../utilities';
 import { Fabric, SpinButton, TextField, ISpinButtonProps } from 'office-ui-fabric-react';
 import { Position } from 'office-ui-fabric-react/lib/utilities/positioning';
 
@@ -11,12 +11,16 @@ const props: ISpinButtonProps = {
   label: 'Basic SpinButton:',
   min: 0,
   max: 0,
-  step: 1,
+  step: 1
+};
+const propsWithStyles: ISpinButtonProps = {
+  ...props,
   styles: { root: { width: 300 } }
 };
+const iconProps = { iconName: 'IncreaseIndentLegacy' };
 
 storiesOf('SpinButton', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(FabricDecoratorFixedWidth)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()
@@ -49,56 +53,62 @@ storiesOf('SpinButton', module)
     'With icon',
     () => (
       <Fabric>
-        <SpinButton {...props} iconProps={{ iconName: 'IncreaseIndentLegacy' }} />
-      </Fabric>
-    ),
-    { rtl: true }
-  )
-  .addStory(
-    'Label at end',
-    () => (
-      <Fabric>
-        <SpinButton {...props} labelPosition={Position.end} />
-      </Fabric>
-    ),
-    { rtl: true }
-  )
-  .addStory(
-    'Label on top',
-    () => (
-      <Fabric>
-        <SpinButton {...props} labelPosition={Position.top} />
-        <TextField
-          label="Should vertically align with SpinButton"
-          styles={{ root: { width: 300 } }}
-        />
-      </Fabric>
-    ),
-    { rtl: true }
-  )
-  .addStory(
-    'Label on top with icon',
-    () => (
-      <Fabric>
-        <SpinButton
-          {...props}
-          labelPosition={Position.top}
-          iconProps={{ iconName: 'IncreaseIndentLegacy' }}
-        />
-        <TextField
-          label="Should vertically align with SpinButton"
-          styles={{ root: { width: 300 } }}
-        />
-      </Fabric>
-    ),
-    { rtl: true }
-  )
-  .addStory(
-    'Label on bottom',
-    () => (
-      <Fabric>
-        <SpinButton {...props} labelPosition={Position.bottom} />
+        <SpinButton {...props} iconProps={iconProps} />
       </Fabric>
     ),
     { rtl: true }
   );
+
+storiesOf('SpinButton - Label Placement', module)
+  .addDecorator(FabricDecorator)
+  .addDecorator(story => (
+    <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>
+      {story()}
+    </Screener>
+  ))
+  .addStory(
+    'Label at end',
+    () => (
+      <Fabric>
+        <SpinButton {...propsWithStyles} labelPosition={Position.end} />
+      </Fabric>
+    ),
+    { rtl: true }
+  )
+  .addStory(
+    'Label at end with icon',
+    () => (
+      <Fabric>
+        <SpinButton {...propsWithStyles} labelPosition={Position.end} iconProps={iconProps} />
+      </Fabric>
+    ),
+    { rtl: true }
+  )
+  .addStory('Label on top', () => (
+    <Fabric styles={{ root: { width: 610 } }}>
+      <SpinButton {...propsWithStyles} labelPosition={Position.top} />
+      <TextField
+        label="Should vertically align with SpinButton"
+        styles={{ root: { width: 300 } }}
+      />
+    </Fabric>
+  ))
+  .addStory('Label on top with icon', () => (
+    <Fabric styles={{ root: { width: 610 } }}>
+      <SpinButton {...propsWithStyles} labelPosition={Position.top} iconProps={iconProps} />
+      <TextField
+        label="Should vertically align with SpinButton"
+        styles={{ root: { width: 300 } }}
+      />
+    </Fabric>
+  ))
+  .addStory('Label on bottom', () => (
+    <Fabric>
+      <SpinButton {...propsWithStyles} labelPosition={Position.bottom} />
+    </Fabric>
+  ))
+  .addStory('Label on bottom with icon', () => (
+    <Fabric>
+      <SpinButton {...propsWithStyles} labelPosition={Position.bottom} iconProps={iconProps} />
+    </Fabric>
+  ));

--- a/apps/vr-tests/src/stories/SpinButton.stories.tsx
+++ b/apps/vr-tests/src/stories/SpinButton.stories.tsx
@@ -2,8 +2,15 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator, FabricDecoratorFixedWidth } from '../utilities';
-import { Fabric, SpinButton, TextField, ISpinButtonProps } from 'office-ui-fabric-react';
+import { FabricDecoratorFixedWidth, FabricDecoratorFullWidth } from '../utilities';
+import {
+  Fabric,
+  SpinButton,
+  TextField,
+  ISpinButtonProps,
+  ISpinButtonStyles,
+  ITextFieldStyles
+} from 'office-ui-fabric-react';
 import { Position } from 'office-ui-fabric-react/lib/utilities/positioning';
 
 const props: ISpinButtonProps = {
@@ -13,7 +20,13 @@ const props: ISpinButtonProps = {
   max: 0,
   step: 1
 };
-const styles = { root: { width: 300 } };
+const styles: Partial<ISpinButtonStyles> = { root: { width: 300 } };
+const inlineStyles: Partial<ISpinButtonStyles> = {
+  root: { width: 115, display: 'inline-block' }
+};
+const textFieldStyles: Partial<ITextFieldStyles> = {
+  root: { width: 250, display: 'inline-block' }
+};
 const iconProps = { iconName: 'IncreaseIndentLegacy' };
 
 storiesOf('SpinButton', module)
@@ -58,7 +71,7 @@ storiesOf('SpinButton', module)
 
 // The stories for label placement are separate since they don't need to include hover/click states
 storiesOf('SpinButton - Label Placement', module)
-  .addDecorator(FabricDecorator)
+  .addDecorator(FabricDecoratorFullWidth)
   .addDecorator(story => (
     <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>
       {story()}
@@ -83,20 +96,20 @@ storiesOf('SpinButton - Label Placement', module)
     { rtl: true }
   )
   .addStory('Label on top', () => (
-    <Fabric styles={{ root: { width: 500 } }}>
-      <SpinButton {...props} styles={{ root: { width: 150 } }} labelPosition={Position.top} />
-      <TextField label="Should vertically align with SpinButton" styles={styles} />
+    <Fabric>
+      <SpinButton {...props} styles={inlineStyles} labelPosition={Position.top} />
+      <TextField label="Should vertically align with SpinButton" styles={textFieldStyles} />
     </Fabric>
   ))
   .addStory('Label on top with icon', () => (
-    <Fabric styles={{ root: { width: 500 } }}>
+    <Fabric>
       <SpinButton
         {...props}
-        styles={{ root: { width: 150 } }}
+        styles={inlineStyles}
         labelPosition={Position.top}
         iconProps={iconProps}
       />
-      <TextField label="Should vertically align with SpinButton" styles={styles} />
+      <TextField label="Should vertically align with SpinButton" styles={textFieldStyles} />
     </Fabric>
   ))
   .addStory('Label on bottom', () => (

--- a/apps/vr-tests/src/stories/SpinButton.stories.tsx
+++ b/apps/vr-tests/src/stories/SpinButton.stories.tsx
@@ -83,13 +83,13 @@ storiesOf('SpinButton - Label Placement', module)
     { rtl: true }
   )
   .addStory('Label on top', () => (
-    <Fabric styles={{ root: { width: 460 } }}>
+    <Fabric styles={{ root: { width: 500 } }}>
       <SpinButton {...props} styles={{ root: { width: 150 } }} labelPosition={Position.top} />
       <TextField label="Should vertically align with SpinButton" styles={styles} />
     </Fabric>
   ))
   .addStory('Label on top with icon', () => (
-    <Fabric styles={{ root: { width: 460 } }}>
+    <Fabric styles={{ root: { width: 500 } }}>
       <SpinButton
         {...props}
         styles={{ root: { width: 150 } }}

--- a/apps/vr-tests/src/stories/SpinButton.stories.tsx
+++ b/apps/vr-tests/src/stories/SpinButton.stories.tsx
@@ -2,20 +2,21 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecoratorFixedWidth } from '../utilities';
-import { Fabric, SpinButton } from 'office-ui-fabric-react';
+import { FabricDecorator } from '../utilities';
+import { Fabric, SpinButton, TextField, ISpinButtonProps } from 'office-ui-fabric-react';
 import { Position } from 'office-ui-fabric-react/lib/utilities/positioning';
 
-const props = {
+const props: ISpinButtonProps = {
   defaultValue: '0',
   label: 'Basic SpinButton:',
   min: 0,
   max: 0,
-  step: 1
+  step: 1,
+  styles: { root: { width: 300 } }
 };
 
 storiesOf('SpinButton', module)
-  .addDecorator(FabricDecoratorFixedWidth)
+  .addDecorator(FabricDecorator)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()
@@ -58,6 +59,45 @@ storiesOf('SpinButton', module)
     () => (
       <Fabric>
         <SpinButton {...props} labelPosition={Position.end} />
+      </Fabric>
+    ),
+    { rtl: true }
+  )
+  .addStory(
+    'Label on top',
+    () => (
+      <Fabric>
+        <SpinButton {...props} labelPosition={Position.top} />
+        <TextField
+          label="Should vertically align with SpinButton"
+          styles={{ root: { width: 300 } }}
+        />
+      </Fabric>
+    ),
+    { rtl: true }
+  )
+  .addStory(
+    'Label on top with icon',
+    () => (
+      <Fabric>
+        <SpinButton
+          {...props}
+          labelPosition={Position.top}
+          iconProps={{ iconName: 'IncreaseIndentLegacy' }}
+        />
+        <TextField
+          label="Should vertically align with SpinButton"
+          styles={{ root: { width: 300 } }}
+        />
+      </Fabric>
+    ),
+    { rtl: true }
+  )
+  .addStory(
+    'Label on bottom',
+    () => (
+      <Fabric>
+        <SpinButton {...props} labelPosition={Position.bottom} />
       </Fabric>
     ),
     { rtl: true }

--- a/change/office-ui-fabric-react-2019-10-23-15-05-01-spinbutton-styling.json
+++ b/change/office-ui-fabric-react-2019-10-23-15-05-01-spinbutton-styling.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "SpinButton: fix vertical alignment relative to other fields",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "commit": "f3921dc1771bc6b0c9dec6460798030bc2ef2231",
+  "date": "2019-10-23T22:05:01.798Z",
+  "file": "/Users/elizabeth/git/fabric-react8/change/office-ui-fabric-react-2019-10-23-15-05-01-spinbutton-styling.json"
+}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.styles.ts
@@ -140,21 +140,26 @@ export const getStyles = memoizeFunction(
         minWidth: DEFAULT_MIN_WIDTH
       },
       labelWrapper: {
-        display: 'inline-flex'
+        display: 'inline-flex',
+        alignItems: 'center'
       },
       labelWrapperStart: {
         height: DEFAULT_HEIGHT,
-        alignItems: 'center',
         float: 'left',
         marginRight: LABEL_MARGIN
       },
       labelWrapperEnd: {
         height: DEFAULT_HEIGHT,
-        alignItems: 'center',
         float: 'right',
         marginLeft: LABEL_MARGIN
       },
-      labelWrapperTop: {},
+      labelWrapperTop: {
+        // Due to the lineHeight set on the label (below), the height of the wrapper (contains icon+label)
+        // ends up 1px taller than a standard label height, causing the vertical alignment to be off when
+        // the SpinButton is displayed with the label on top next to other form fields.
+        // Decrease the label's effective height slightly to compensate.
+        marginBottom: -1
+      },
       labelWrapperBottom: {},
       icon: {
         padding: '0 5px',

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.styles.ts
@@ -157,7 +157,7 @@ export const getStyles = memoizeFunction(
         // Due to the lineHeight set on the label (below), the height of the wrapper (contains icon+label)
         // ends up 1px taller than a standard label height, causing the vertical alignment to be off when
         // the SpinButton is displayed with the label on top next to other form fields.
-        // Decrease the label's effective height slightly to compensate.
+        // Decrease the wrapper's effective height slightly to compensate.
         marginBottom: -1
       },
       labelWrapperBottom: {},

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
@@ -257,7 +257,7 @@ export interface ISpinButtonStyles {
   root: IStyle;
 
   /**
-   * Style for the label wrapper element of the component
+   * Style for the label wrapper element of the component.
    * The label wrapper contains the icon and the label.
    */
   labelWrapper: IStyle;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10132
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The SpinButton was slightly out of vertical alignment with other form components due to having a `line-height` applied to the label (intended to center the label and icon against each other when an icon is provided). I experimented with some different approaches, and the best way I could find to address both the icon/label alignment and the alignment against other controls was to add `margin-bottom: -1px` to the label/icon wrapper. Open to suggestions for other approaches.

While working on this, I also noticed that the icon's vertical alignment was totally wrong when the label was on top or bottom. Setting `align-items: center` for all variants of label wrapper positioning seemed to fix this.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10276)