### PR TITLE
Fix regression in 'commandBarButtonAs' override fallback

### DIFF
--- a/change/office-ui-fabric-react-2019-08-28-13-40-03-command-bar-button.json
+++ b/change/office-ui-fabric-react-2019-08-28-13-40-03-command-bar-button.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix override handling for CommandBarButton",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "commit": "60dff6f06cf20de307ebf784ee77b5855b0ea453",
+  "date": "2019-08-28T20:40:03.869Z"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -8,6 +8,7 @@ import { FocusZone, FocusZoneDirection } from '../../FocusZone';
 import { classNamesFunction } from '../../Utilities';
 import { CommandBarButton, IButtonProps } from '../../Button';
 import { TooltipHost } from '../../Tooltip';
+import { IComponentAs } from '@uifabric/utilities';
 
 const getClassNames = classNamesFunction<ICommandBarStyleProps, ICommandBarStyles>();
 
@@ -156,15 +157,15 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
   };
 
   private _commandButton = (item: ICommandBarItemProps, props: ICommandBarItemProps): JSX.Element => {
-    if (this.props.buttonAs) {
-      const Type = this.props.buttonAs;
-      return <Type {...props as IButtonProps} defaultRender={CommandBarButton} />;
-    }
-    if (item.commandBarButtonAs) {
-      const Type = item.commandBarButtonAs;
-      return <Type {...props as ICommandBarItemProps} />;
-    }
-    return <CommandBarButton {...props as IButtonProps} defaultRender={CommandBarButton} />;
+    const ButtonAs = this.props.buttonAs as (IComponentAs<ICommandBarItemProps> | undefined);
+    const CommandBarButtonAs = item.commandBarButtonAs as (IComponentAs<ICommandBarItemProps> | undefined);
+    const DefaultButtonAs = (CommandBarButton as {}) as IComponentAs<ICommandBarItemProps>;
+
+    // The prop types between these three possible implementations overlap enough that a force-cast is safe.
+    const Type = ButtonAs || CommandBarButtonAs || DefaultButtonAs;
+
+    // Always pass the default implementation to the override so it may be composed.
+    return <Type {...props as ICommandBarItemProps} defaultRender={DefaultButtonAs} />;
   };
 
   private _onButtonClick(item: ICommandBarItemProps): (ev: React.MouseEvent<HTMLButtonElement>) => void {


### PR DESCRIPTION
Fixed an issue where passing `commandBarButtonAs` in an item passed to `CommandBar` would no longer work correctly, because that pathway no longer passed `defaultRender` to the provided implementation.

The original break appears to have been caused due to type-safety issues; the fix basically force-casts everything and adds a comment for why it is necessary.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10301)