### PR TITLE
added isSelectable prop for Tile.types; hide checkbox for non-selectable-item

### DIFF
--- a/change/@uifabric-experiments-2019-08-28-15-55-16-huaxi-tile-selectable.json
+++ b/change/@uifabric-experiments-2019-08-28-15-55-16-huaxi-tile-selectable.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "added isSelectable prop for Tile.types; unshow checkbox if item is not selectable",
+  "packageName": "@uifabric/experiments",
+  "email": "huaxi@microsoft.com",
+  "commit": "b5240a289ee31211cd039980f97064645630ff2c",
+  "date": "2019-08-28T22:55:16.075Z"
+}

--- a/packages/experiments/src/components/Tile/Tile.tsx
+++ b/packages/experiments/src/components/Tile/Tile.tsx
@@ -142,6 +142,7 @@ export class Tile extends React.Component<ITileProps, ITileState> {
     const {
       children,
       selectionIndex = -1,
+      isSelectable: isItemSelectable,
       invokeSelection = false,
       selection,
       background,
@@ -168,7 +169,7 @@ export class Tile extends React.Component<ITileProps, ITileState> {
 
     const { isSelected = false, isModal = false } = this.state;
 
-    const isSelectable = !!selection && selectionIndex > -1;
+    const isSelectable = isItemSelectable || (!!selection && selectionIndex > -1);
     const isInvokable = (!!href || !!onClick || !!invokeSelection) && !isModal;
     const ariaLabelWithSelectState = isSelected && ariaLabelSelected ? `${ariaLabel}, ${ariaLabelSelected}` : ariaLabel;
     const content = (
@@ -207,7 +208,7 @@ export class Tile extends React.Component<ITileProps, ITileState> {
         href={href}
         onClick={onClick}
         ref={this.props.linkRef}
-        data-selection-invoke={isInvokable && selectionIndex > -1 ? true : undefined}
+        data-selection-invoke={isSelectable || (isInvokable && selectionIndex > -1) ? true : undefined}
         className={css('ms-Tile-link', TileStyles.link)}
       >
         {content}

--- a/packages/experiments/src/components/Tile/Tile.tsx
+++ b/packages/experiments/src/components/Tile/Tile.tsx
@@ -207,7 +207,7 @@ export class Tile extends React.Component<ITileProps, ITileState> {
         href={href}
         onClick={onClick}
         ref={this.props.linkRef}
-        data-selection-invoke={isSelectable || (isInvokable && selectionIndex > -1) ? true : undefined}
+        data-selection-invoke={isInvokable && selectionIndex > -1 ? true : undefined}
         className={css('ms-Tile-link', TileStyles.link)}
       >
         {content}

--- a/packages/experiments/src/components/Tile/Tile.tsx
+++ b/packages/experiments/src/components/Tile/Tile.tsx
@@ -142,7 +142,6 @@ export class Tile extends React.Component<ITileProps, ITileState> {
     const {
       children,
       selectionIndex = -1,
-      isSelectable: isItemSelectable,
       invokeSelection = false,
       selection,
       background,
@@ -169,7 +168,7 @@ export class Tile extends React.Component<ITileProps, ITileState> {
 
     const { isSelected = false, isModal = false } = this.state;
 
-    const isSelectable = isItemSelectable || (!!selection && selectionIndex > -1);
+    const { isSelectable = !!selection && selectionIndex > -1 } = this.props;
     const isInvokable = (!!href || !!onClick || !!invokeSelection) && !isModal;
     const ariaLabelWithSelectState = isSelected && ariaLabelSelected ? `${ariaLabel}, ${ariaLabelSelected}` : ariaLabel;
     const content = (

--- a/packages/experiments/src/components/Tile/Tile.types.ts
+++ b/packages/experiments/src/components/Tile/Tile.types.ts
@@ -31,6 +31,10 @@ export interface ITileProps extends IBaseProps, React.AllHTMLAttributes<HTMLSpan
    */
   selectionIndex?: number;
   /**
+   * Whether or not item is selectable;
+   */
+  isSelectable?: boolean;
+  /**
    * Selection controller for the item rendered in the tile.
    */
   selection?: ISelection;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Currently, in Tile View, if item is not selectable, Fabric shows a disabled "checkbox". Ideally, we should not show a checkbox for non-selectable item.

Before Changes:
![checkbox shown up for non-selectable-item](https://user-images.githubusercontent.com/3360621/63898246-f5636300-c9ac-11e9-9ace-073eccf8ecae.png)

#### Focus areas to test
Tile View


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10306)