### PR TITLE
Button: Fixing SplitButton outline when focused

### DIFF
--- a/change/office-ui-fabric-react-2019-08-30-17-46-18-splitButtonFocus.json
+++ b/change/office-ui-fabric-react-2019-08-30-17-46-18-splitButtonFocus.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Button: Fixing SplitButton outline when focused.",
+  "packageName": "office-ui-fabric-react",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "commit": "517b38898616f600760338c49205bfd0652d58c9",
+  "date": "2019-08-30T22:46:18.924Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -24,7 +24,7 @@ export const getStyles = memoizeFunction(
 
     const splitButtonStyles: IButtonStyles = {
       splitButtonContainer: [
-        getFocusStyle(theme, { highContrastStyle: buttonHighContrastFocus }),
+        getFocusStyle(theme, { highContrastStyle: buttonHighContrastFocus, inset: 2 }),
         {
           display: 'inline-flex',
           selectors: {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CustomSplit.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CustomSplit.Example.tsx.shot
@@ -45,13 +45,13 @@ exports[`Component Examples renders Button.CustomSplit.Example.tsx correctly 1`]
         }
         .ms-Fabric--isFocusVisible &:focus:after {
           border: 1px solid #ffffff;
-          bottom: 1px;
+          bottom: 3px;
           content: "";
-          left: 1px;
+          left: 3px;
           outline: 1px solid #605e5c;
           position: absolute;
-          right: 1px;
-          top: 1px;
+          right: 3px;
+          top: 3px;
           z-index: 1;
         }
         @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Split.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Split.Example.tsx.shot
@@ -60,13 +60,13 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           }
           .ms-Fabric--isFocusVisible &:focus:after {
             border: 1px solid #ffffff;
-            bottom: 1px;
+            bottom: 3px;
             content: "";
-            left: 1px;
+            left: 3px;
             outline: 1px solid #605e5c;
             position: absolute;
-            right: 1px;
-            top: 1px;
+            right: 3px;
+            top: 3px;
             z-index: 1;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -384,13 +384,13 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           }
           .ms-Fabric--isFocusVisible &:focus:after {
             border: 1px solid #ffffff;
-            bottom: 1px;
+            bottom: 3px;
             content: "";
-            left: 1px;
+            left: 3px;
             outline: 1px solid #605e5c;
             position: absolute;
-            right: 1px;
-            top: 1px;
+            right: 3px;
+            top: 3px;
             z-index: 1;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -722,13 +722,13 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           }
           .ms-Fabric--isFocusVisible &:focus:after {
             border: 1px solid #ffffff;
-            bottom: 1px;
+            bottom: 3px;
             content: "";
-            left: 1px;
+            left: 3px;
             outline: 1px solid #605e5c;
             position: absolute;
-            right: 1px;
-            top: 1px;
+            right: 3px;
+            top: 3px;
             z-index: 1;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -1054,13 +1054,13 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           }
           .ms-Fabric--isFocusVisible &:focus:after {
             border: 1px solid #ffffff;
-            bottom: 1px;
+            bottom: 3px;
             content: "";
-            left: 1px;
+            left: 3px;
             outline: 1px solid #605e5c;
             position: absolute;
-            right: 1px;
-            top: 1px;
+            right: 3px;
+            top: 3px;
             z-index: 1;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
@@ -84,13 +84,13 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                     }
                     .ms-Fabric--isFocusVisible &:focus:after {
                       border: 1px solid #ffffff;
-                      bottom: 1px;
+                      bottom: 3px;
                       content: "";
-                      left: 1px;
+                      left: 3px;
                       outline: 1px solid #605e5c;
                       position: absolute;
-                      right: 1px;
-                      top: 1px;
+                      right: 3px;
+                      top: 3px;
                       z-index: 1;
                     }
                     @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
@@ -482,13 +482,13 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                     }
                     .ms-Fabric--isFocusVisible &:focus:after {
                       border: 1px solid #ffffff;
-                      bottom: 1px;
+                      bottom: 3px;
                       content: "";
-                      left: 1px;
+                      left: 3px;
                       outline: 1px solid #605e5c;
                       position: absolute;
-                      right: 1px;
-                      top: 1px;
+                      right: 3px;
+                      top: 3px;
                       z-index: 1;
                     }
                     @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
@@ -569,13 +569,13 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
             }
             .ms-Fabric--isFocusVisible &:focus:after {
               border: 1px solid #ffffff;
-              bottom: 1px;
+              bottom: 3px;
               content: "";
-              left: 1px;
+              left: 3px;
               outline: 1px solid #605e5c;
               position: absolute;
-              right: 1px;
-              top: 1px;
+              right: 3px;
+              top: 3px;
               z-index: 1;
             }
             @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
@@ -475,13 +475,13 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
           }
           .ms-Fabric--isFocusVisible &:focus:after {
             border: 1px solid #ffffff;
-            bottom: 1px;
+            bottom: 3px;
             content: "";
-            left: 1px;
+            left: 3px;
             outline: 1px solid #605e5c;
             position: absolute;
-            right: 1px;
-            top: 1px;
+            right: 3px;
+            top: 3px;
             z-index: 1;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10269
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The focus outline in `SplitButtons` was not showing correctly. This PR introduces changes to fix that.

| State | Before | After |
|-------|--------|-------|
| Default Rest | ![image](https://user-images.githubusercontent.com/7798177/64055245-ee755580-cb50-11e9-8653-32963ae93b5c.png) | ![image](https://user-images.githubusercontent.com/7798177/64055245-ee755580-cb50-11e9-8653-32963ae93b5c.png) |
| Default Focused | ![image](https://user-images.githubusercontent.com/7798177/64055268-0cdb5100-cb51-11e9-81f6-61899cc0f10f.png) | ![image](https://user-images.githubusercontent.com/7798177/64055306-46ac5780-cb51-11e9-8d5d-ea8859a4394b.png) |
| Primary Rest | ![image](https://user-images.githubusercontent.com/7798177/64055274-182e7c80-cb51-11e9-8b9e-f1c6ac25f724.png) | ![image](https://user-images.githubusercontent.com/7798177/64055274-182e7c80-cb51-11e9-8b9e-f1c6ac25f724.png) |
| Primary Focused | ![image](https://user-images.githubusercontent.com/7798177/64055284-25e40200-cb51-11e9-94c0-4b484a76010f.png) | ![image](https://user-images.githubusercontent.com/7798177/64055313-5461dd00-cb51-11e9-8345-cbb59d630977.png) |


#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10328)