### PR TITLE
Added optional month change callback property to Calendar and DatePicker

### DIFF
--- a/change/office-ui-fabric-react-2019-09-15-18-01-58-feature-datepicker_calendar_onMonthChange.json
+++ b/change/office-ui-fabric-react-2019-09-15-18-01-58-feature-datepicker_calendar_onMonthChange.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "DatePicker: utilize custom onChange handler when provided (#10424)",
+  "packageName": "office-ui-fabric-react",
+  "email": "mateusz.przybyla@outlook.com",
+  "commit": "43b5d9fd49e1822e6b2e659b40d8c55fc9f09b25",
+  "date": "2019-09-15T16:01:58.648Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -2017,6 +2017,7 @@ export interface ICalendarProps extends IBaseProps<ICalendar>, React.HTMLAttribu
     maxDate?: Date;
     minDate?: Date;
     navigationIcons?: ICalendarIconStrings;
+    onChangeMonth?: (date: Date) => void;
     onDismiss?: () => void;
     onSelectDate?: (date: Date, selectedDateRangeArray?: Date[]) => void;
     restrictedDates?: Date[];
@@ -3136,6 +3137,7 @@ export interface IDatePickerProps extends IBaseProps<IDatePicker>, React.HTMLAtt
     maxDate?: Date;
     minDate?: Date;
     onAfterMenuDismiss?: () => void;
+    onChangeMonth?: (date: Date) => void;
     onSelectDate?: (date: Date | null | undefined) => void;
     parseDateFromString?: (dateStr: string) => Date | null;
     pickerAriaLabel?: string;

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.test.tsx
@@ -392,4 +392,43 @@ describe('Calendar', () => {
       expect(monthHeader).toBeTruthy();
     });
   });
+
+  describe('Test month change callback gets called', () => {
+    const defaultDate = new Date(2019, 7, 1);
+    const monthChanged = (monthDate: Date) => {
+      currentMonth = monthDate;
+    };
+
+    let currentMonth: Date;
+
+    beforeAll(() => {
+      currentMonth = new Date(2019, 1, 1);
+    });
+
+    it('navigating next month invokes callback', () => {
+      const renderedComponent = (ReactTestUtils.renderIntoDocument(
+        <Calendar strings={dayPickerStrings} value={defaultDate} onChangeMonth={monthChanged} />
+      ) as unknown) as Calendar;
+
+      expect(renderedComponent.state.selectedDate!.getMonth()).toBe(7);
+
+      const nextMonthButton = ReactTestUtils.findRenderedDOMComponentWithClass(renderedComponent, 'ms-DatePicker-nextMonth');
+      ReactTestUtils.Simulate.click(nextMonthButton);
+
+      expect(currentMonth.getMonth()).toBe(8);
+    });
+
+    it('navigating prev month invokes callback', () => {
+      const renderedComponent = (ReactTestUtils.renderIntoDocument(
+        <Calendar strings={dayPickerStrings} value={defaultDate} onChangeMonth={monthChanged} />
+      ) as unknown) as Calendar;
+
+      expect(renderedComponent.state.selectedDate!.getMonth()).toBe(7);
+
+      const prevMonthButton = ReactTestUtils.findRenderedDOMComponentWithClass(renderedComponent, 'ms-DatePicker-prevMonth');
+      ReactTestUtils.Simulate.click(prevMonthButton);
+
+      expect(currentMonth.getMonth()).toBe(6);
+    });
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.tsx
@@ -46,6 +46,7 @@ export interface ICalendarState {
 export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> implements ICalendar {
   public static defaultProps: ICalendarProps = {
     onSelectDate: undefined,
+    onChangeMonth: undefined,
     onDismiss: undefined,
     isMonthPickerVisible: true,
     isDayPickerVisible: true,
@@ -257,10 +258,17 @@ export class Calendar extends BaseComponent<ICalendarProps, ICalendarState> impl
   }
 
   private _navigateDayPickerDay = (date: Date): void => {
-    this.setState({
-      navigatedDayDate: date,
-      navigatedMonthDate: date
-    });
+    this.setState(
+      {
+        navigatedDayDate: date,
+        navigatedMonthDate: date
+      },
+      () => {
+        if (this.props.onChangeMonth !== undefined) {
+          this.props.onChangeMonth(date);
+        }
+      }
+    );
   };
 
   private _navigateMonthPickerDay = (date: Date): void => {

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.types.ts
@@ -34,6 +34,12 @@ export interface ICalendarProps extends IBaseProps<ICalendar>, React.HTMLAttribu
   onSelectDate?: (date: Date, selectedDateRangeArray?: Date[]) => void;
 
   /**
+   * Callback issued when a month is changed
+   * @param date - The date with current month
+   */
+  onChangeMonth?: (date: Date) => void;
+
+  /**
    * Callback issued when calendar is closed
    */
   onDismiss?: () => void;

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -68,7 +68,8 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
     dateTimeFormatter: undefined,
     showCloseButton: false,
     underlined: false,
-    allFocusable: false
+    allFocusable: false,
+    onChangeMonth: undefined
   };
 
   private _calendar = React.createRef<ICalendar>();
@@ -222,6 +223,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
               <CalendarType
                 {...calendarProps}
                 onSelectDate={this._onSelectDate}
+                onChangeMonth={this.props.onChangeMonth}
                 onDismiss={this._calendarDismissed}
                 isMonthPickerVisible={this.props.isMonthPickerVisible}
                 showMonthPickerAsOverlay={this.props.showMonthPickerAsOverlay}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
@@ -181,6 +181,7 @@ describe('DatePicker', () => {
       formatDay: (date: Date) => 'd',
       formatYear: (date: Date) => 'y'
     };
+    const monthChangeCallback = jest.fn();
 
     const datePicker = shallow(
       <DatePickerBase
@@ -194,6 +195,7 @@ describe('DatePicker', () => {
         firstWeekOfYear={FirstWeekOfYear.FirstFullWeek}
         showGoToToday={false}
         dateTimeFormatter={dateTimeFormatter}
+        onChangeMonth={monthChangeCallback}
       />
     );
     datePicker.setState({ isDatePickerShown: true });
@@ -238,6 +240,10 @@ describe('DatePicker', () => {
 
     it('renders Calendar with same dateTimeFormatter', () => {
       expect(calendarProps.dateTimeFormatter).toBe(dateTimeFormatter);
+    });
+
+    it('renders Calendar with same onChangeMonth callback', () => {
+      expect(calendarProps.onChangeMonth).toBe(monthChangeCallback);
     });
   });
 

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
@@ -65,6 +65,12 @@ export interface IDatePickerProps extends IBaseProps<IDatePicker>, React.HTMLAtt
   onSelectDate?: (date: Date | null | undefined) => void;
 
   /**
+   * Callback issued when a month is changed
+   * @param date - The date with current month
+   */
+  onChangeMonth?: (date: Date) => void;
+
+  /**
    * Label for the DatePicker
    */
   label?: string;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10322
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Added onChangeMonth optional callback property to Calendar and DatePicker components along with some tests.

#### Focus areas to test
Was not able to get change file. Tries `yarn change` and `npm run change` with following result
```
Target branch is "upstream/master"
Checking for changes against "upstream/master"
fetching latest from remotes
No change files are needed
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10329)