### PR TITLE
Website: Fix PopupMenu title

### DIFF
--- a/apps/fabric-website/src/pages/Controls/PopupMenuPage/PopupMenuPage.doc.ts
+++ b/apps/fabric-website/src/pages/Controls/PopupMenuPage/PopupMenuPage.doc.ts
@@ -5,7 +5,6 @@ const componentUrl = 'https://github.com/OfficeDev/office-ui-fabric-react/tree/m
 
 export const PopupMenuPageProps: TFabricPlatformPageProps = {
   ios: {
-    title: 'Popup Menu',
     overview: require('!raw-loader!@uifabric/fabric-website/src/pages/Controls/PopupMenuPage/docs/ios/PopupMenuOverview.md') as string,
     related,
     componentUrl

--- a/apps/fabric-website/src/pages/Controls/PopupMenuPage/PopupMenuPage.tsx
+++ b/apps/fabric-website/src/pages/Controls/PopupMenuPage/PopupMenuPage.tsx
@@ -8,7 +8,14 @@ const baseUrl = 'https://github.com/OfficeDev/office-ui-fabric-react/tree/master
 
 export const PopupMenuPage: React.StatelessComponent<IControlsPageProps> = props => {
   const { platform } = props;
-  return <ControlsAreaPage {...props} {...PopupMenuPageProps[platform]} otherSections={_otherSections(platform) as IPageSectionProps[]} />;
+  return (
+    <ControlsAreaPage
+      {...props}
+      title="Popup Menu"
+      {...PopupMenuPageProps[platform]}
+      otherSections={_otherSections(platform) as IPageSectionProps[]}
+    />
+  );
 };
 
 function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {

--- a/change/@uifabric-fabric-website-2019-08-30-16-06-24-popupmenu-heading.json
+++ b/change/@uifabric-fabric-website-2019-08-30-16-06-24-popupmenu-heading.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add PopupMenu title",
+  "packageName": "@uifabric/fabric-website",
+  "email": "emlynam@microsoft.com",
+  "commit": "8d4cfae2dabddb2fd3b620c12c36d1bb7c11e421",
+  "date": "2019-08-30T23:06:24.090Z"
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ yarn change`

#### Description of changes

When I added the Android PopupMenu page, I missed updating the title. Now the title is shared between iOS and Android.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10330)