### PR TITLE
bumping beachball to allow uncommitted changes

### DIFF
--- a/azure-pipelines.release.yml
+++ b/azure-pipelines.release.yml
@@ -36,11 +36,9 @@ steps:
       yarn
     displayName: yarn
 
-  # TODO: disable this step until a proper fix to this is found
-  #       root cause: this step is generating a set of changes that are not checked in and not accounted for in the change files
-  # - script: |
-  #     npm run generate-version-files
-  #   displayName: npm run generate-version-files
+  - script: |
+      yarn generate-version-files
+    displayName: yarn generate-version-files
 
   - script: |
       yarn build --production

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "update-a11y": "cd apps/a11y-tests && npm run update-snapshots",
     "check-for-changed-files": "cd scripts && just-scripts check-for-modified-files",
     "prettier": "node scripts/prettier.js",
-    "generate-version-files": "cd scripts && just-scripts generate-version-files",
+    "generate-version-files": "yarn workspace @uifabric/build just generate-version-files",
     "codepen": "cd packages/office-ui-fabric-react && node ../../scripts/local-codepen.js",
     "dom-test": "cd apps/dom-tests && just-scripts jest-dom-with-webpack"
   },

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "dom-test": "cd apps/dom-tests && just-scripts jest-dom-with-webpack"
   },
   "devDependencies": {
-    "beachball": "^1.12.2",
+    "beachball": "^1.13.0",
     "lerna": "^3.15.0",
     "lint-staged": "^7.0.5"
   },

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -23,7 +23,7 @@
     "async": "^2.6.1",
     "autoprefixer": "^7.1.5",
     "babylon": "^7.0.0-beta.47",
-    "beachball": "^1.12.2",
+    "beachball": "^1.13.0",
     "bundlesize": "^0.15.2",
     "chalk": "^2.1.0",
     "codecov": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3883,10 +3883,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-beachball@^1.12.2:
-  version "1.12.2"
-  resolved "https://registry.yarnpkg.com/beachball/-/beachball-1.12.2.tgz#8c7cd2bccdc0e21add4a9cc410eef03c957ce474"
-  integrity sha512-BPR/32hsl0CIcLXZWuQYpbdJG/sHbRjkoBJRJ3PJR/mesTWfJKrMzihaf72i/YxR3nU/yTOfuPhOhIvDZu7Q/g==
+beachball@^1.13.0:
+  version "1.13.0"
+  resolved "https://registry.yarnpkg.com/beachball/-/beachball-1.13.0.tgz#c87e71c565f7b29d36bf2f8a06c73d70fd79b6d8"
+  integrity sha512-RaTATKvLpX8jnz6nkkhM3jMv0RrZd4x13UMXnj3GDhl9fgx0ru6UMuXxFwUyRMzEMHKCcJhWr7LkQV56WXn+Og==
   dependencies:
     fs-extra "^8.0.1"
     git-url-parse "^11.1.2"


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10297
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Following a beachball fix of https://github.com/microsoft/beachball/issues/107, I now can re-enable the set-version script again. There is also an improvement in beachball that allows staged changes to be counted towards change file description.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10342)