### PR TITLE
Checkbox: Tab focus rectangle fix

### DIFF
--- a/change/office-ui-fabric-react-2019-09-03-16-51-13-v-mare-Checkbox-focus-rect-fix.json
+++ b/change/office-ui-fabric-react-2019-09-03-16-51-13-v-mare-Checkbox-focus-rect-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Checkbox: Added initializeFocusRects to fix focus issue.",
+  "packageName": "office-ui-fabric-react",
+  "email": "v-mare@microsoft.com",
+  "commit": "77da1f7cd4c2990f741bb8a81c6b8b5ad8fa894e",
+  "date": "2019-09-03T23:51:13.026Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.base.tsx
@@ -1,5 +1,12 @@
 import * as React from 'react';
-import { getId, classNamesFunction, mergeAriaAttributeValues, initializeComponentRef, warnMutuallyExclusive } from '../../Utilities';
+import {
+  getId,
+  classNamesFunction,
+  mergeAriaAttributeValues,
+  initializeComponentRef,
+  warnMutuallyExclusive,
+  initializeFocusRects
+} from '../../Utilities';
 import { Icon } from '../../Icon';
 import { ICheckbox, ICheckboxProps, ICheckboxStyleProps, ICheckboxStyles } from './Checkbox.types';
 import { KeytipData } from '../../KeytipData';
@@ -57,6 +64,8 @@ export class CheckboxBase extends React.Component<ICheckboxProps, ICheckboxState
       isChecked: !!(props.checked !== undefined ? props.checked : props.defaultChecked),
       isIndeterminate: !!(props.indeterminate !== undefined ? props.indeterminate : props.defaultIndeterminate)
     };
+
+    initializeFocusRects();
   }
 
   /**


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #10320 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The focus rectangle would not show when tabbing through checkboxes in Codepen or Codesandbox so `intializeFocusRects()` was added to Checkbox's constructor.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10344)