### PR TITLE
Fix DetailsColumn function mutations due to Function.prototype.bind

### DIFF
--- a/change/office-ui-fabric-react-2019-09-03-17-31-28-keco-details-column-fn-mutate.json
+++ b/change/office-ui-fabric-react-2019-09-03-17-31-28-keco-details-column-fn-mutate.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "DetailsList: Fix function mutations with onClick and onContextMenuClick in DetailsColumn",
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com",
+  "commit": "30f9ef58adfe5c792ebab236788119208029ed11",
+  "date": "2019-09-04T00:31:27.996Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { Icon, FontIcon } from '../../Icon';
 import { initializeComponentRef, EventGroup, Async, IDisposable, classNamesFunction, IClassNames } from '../../Utilities';
-import { IColumn, ColumnActionsMode } from './DetailsList.types';
+import { ColumnActionsMode } from './DetailsList.types';
 
 import { ITooltipHostProps } from '../../Tooltip';
 import { IDragDropOptions } from './../../utilities/dragdrop/interfaces';
@@ -109,8 +109,8 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
                   aria-describedby={
                     !this.props.onRenderColumnHeaderTooltip && this._hasAccessibleLabel() ? `${parentId}-${column.key}-tooltip` : undefined
                   }
-                  onContextMenu={this._onColumnContextMenu.bind(this, column)}
-                  onClick={this._onColumnClick.bind(this, column)}
+                  onContextMenu={this._onColumnContextMenu}
+                  onClick={this._onColumnClick}
                   aria-haspopup={column.columnActionsMode === ColumnActionsMode.hasDropdown}
                   aria-expanded={column.columnActionsMode === ColumnActionsMode.hasDropdown ? !!column.isMenuOpen : undefined}
                 >
@@ -196,12 +196,12 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
     return <span className={tooltipHostProps.hostClassName}>{tooltipHostProps.children}</span>;
   };
 
-  private _onColumnClick(column: IColumn, ev: React.MouseEvent<HTMLElement>): void {
+  private _onColumnClick(ev: React.MouseEvent<HTMLElement>): void {
+    const { onColumnClick, column } = this.props;
+
     if (column.columnActionsMode === ColumnActionsMode.disabled) {
       return;
     }
-
-    const { onColumnClick } = this.props;
 
     if (column.onColumnClick) {
       column.onColumnClick(ev, column);
@@ -284,8 +284,8 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
     }
   };
 
-  private _onColumnContextMenu(column: IColumn, ev: React.MouseEvent<HTMLElement>): void {
-    const { onColumnContextMenu } = this.props;
+  private _onColumnContextMenu(ev: React.MouseEvent<HTMLElement>): void {
+    const { onColumnContextMenu, column } = this.props;
     if (column.onColumnContextMenu) {
       column.onColumnContextMenu(column, ev);
       ev.preventDefault();

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -196,7 +196,7 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
     return <span className={tooltipHostProps.hostClassName}>{tooltipHostProps.children}</span>;
   };
 
-  private _onColumnClick(ev: React.MouseEvent<HTMLElement>): void {
+  private _onColumnClick = (ev: React.MouseEvent<HTMLElement>): void => {
     const { onColumnClick, column } = this.props;
 
     if (column.columnActionsMode === ColumnActionsMode.disabled) {
@@ -210,7 +210,7 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
     if (onColumnClick) {
       onColumnClick(ev, column);
     }
-  }
+  };
 
   private _getColumnDragDropOptions(): IDragDropOptions {
     const { columnIndex } = this.props;
@@ -284,7 +284,7 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
     }
   };
 
-  private _onColumnContextMenu(ev: React.MouseEvent<HTMLElement>): void {
+  private _onColumnContextMenu = (ev: React.MouseEvent<HTMLElement>): void => {
     const { onColumnContextMenu, column } = this.props;
     if (column.onColumnContextMenu) {
       column.onColumnContextMenu(column, ev);
@@ -294,7 +294,7 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
       onColumnContextMenu(column, ev);
       ev.preventDefault();
     }
-  }
+  };
 
   private _onRootMouseDown = (ev: MouseEvent): void => {
     const { isDraggable } = this.props;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10341
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Refactors `private` methods used in JSX for render method of `DetailsColumn` from `Function.prototype.bind` usage to avoid function mutations.

#### Focus areas to test

- CI should pass
- DetailsColumn context menu and click handling should work as expected in examples.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10346)