### PR TITLE
Fix Tooltip clickable areas

### DIFF
--- a/change/office-ui-fabric-react-2019-09-04-10-01-47-master.json
+++ b/change/office-ui-fabric-react-2019-09-04-10-01-47-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "give tooltip hoverable area an index lower than the content",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "555cf61228750ecabaad6b250b563fcff757e9c8",
+  "date": "2019-09-04T17:01:47.513Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.doc.tsx
@@ -35,7 +35,7 @@ export const TooltipPageProps: IDocPageProps = {
       view: <TooltipDisplayExample />
     },
     {
-      title: 'Tooltip with list',
+      title: 'Tooltip with list of link',
       code: TooltipCustomExampleCode,
       view: <TooltipCustomExample />
     },

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.doc.tsx
@@ -35,7 +35,7 @@ export const TooltipPageProps: IDocPageProps = {
       view: <TooltipDisplayExample />
     },
     {
-      title: 'Tooltip with list of link',
+      title: 'Tooltip with list of links',
       code: TooltipCustomExampleCode,
       view: <TooltipCustomExample />
     },

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
@@ -19,13 +19,14 @@ export const getStyles = (props: ITooltipStyleProps): ITooltipStyles => {
         padding: '8px',
         maxWidth: maxWidth,
         selectors: {
-          ':after': {
+          ':before': {
             content: `''`,
             position: 'absolute',
             bottom: tooltipGapSpace,
             left: tooltipGapSpace,
             right: tooltipGapSpace,
-            top: tooltipGapSpace
+            top: tooltipGapSpace,
+            zIndex: 0
           }
         }
       },
@@ -35,6 +36,8 @@ export const getStyles = (props: ITooltipStyleProps): ITooltipStyles => {
       'ms-Tooltip-content',
       fonts.small,
       {
+        position: 'relative',
+        zIndex: 1,
         color: palette.neutralPrimary,
         wordWrap: 'break-word',
         overflowWrap: 'break-word',

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
@@ -19,7 +19,7 @@ export const getStyles = (props: ITooltipStyleProps): ITooltipStyles => {
         padding: '8px',
         maxWidth: maxWidth,
         selectors: {
-          ':before': {
+          ':after': {
             content: `''`,
             position: 'absolute',
             bottom: tooltipGapSpace,

--- a/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Basic.Example.tsx
@@ -12,7 +12,7 @@ export class TooltipBasicExample extends React.Component<any, any> {
     return (
       <div>
         <TooltipHost
-          content={<a href="#">Click Me</a>}
+          content="This is the tooltip"
           id={this._hostId}
           calloutProps={{ gapSpace: 0 }}
           styles={{ root: { display: 'inline-block' } }}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Basic.Example.tsx
@@ -12,7 +12,7 @@ export class TooltipBasicExample extends React.Component<any, any> {
     return (
       <div>
         <TooltipHost
-          content="This is the tooltip"
+          content={<a href="#">Click Me</a>}
           id={this._hostId}
           calloutProps={{ gapSpace: 0 }}
           styles={{ root: { display: 'inline-block' } }}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Custom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/examples/Tooltip.Custom.Example.tsx
@@ -16,8 +16,16 @@ export class TooltipCustomExample extends React.Component<any, any> {
             return (
               <div>
                 <ul style={{ margin: 0, padding: 0 }}>
-                  <li>1. One</li>
-                  <li>2. Two</li>
+                  <li>
+                    <a target="_blank" href="#">
+                      1. One
+                    </a>
+                  </li>
+                  <li>
+                    <a target="_blank" href="#">
+                      2. Two
+                    </a>
+                  </li>
                 </ul>
               </div>
             );


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #10356
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Give the tooltip pseudo element a z-index lower than the content inside the tooltip. 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10357)