### PR TITLE
[6.0] Mark IMarkdownTableCellProps#as as optional to address type-mismatch

### DIFF
--- a/change/@uifabric-example-app-base-2019-09-04-15-19-55-keco-markdown-to-jsx-type.json
+++ b/change/@uifabric-example-app-base-2019-09-04-15-19-55-keco-markdown-to-jsx-type.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Cherry-pick: Mark IMarkdownTableCellProps 'as' optional",
+  "packageName": "@uifabric/example-app-base",
+  "email": "KevinTCoughlin@users.noreply.github.com",
+  "commit": "bb83a2c5bc50d4e3ff8fc86613cbf1288e84536e",
+  "date": "2019-09-04T22:19:55.025Z"
+}

--- a/packages/example-app-base/src/components/MarkdownTable/MarkdownTable.types.ts
+++ b/packages/example-app-base/src/components/MarkdownTable/MarkdownTable.types.ts
@@ -15,7 +15,7 @@ export interface IMarkdownTableCellProps extends IMarkdownTableProps {
    * Render the table cell as a th or td.
    * @default 'td'
    */
-  as: 'th' | 'td';
+  as?: 'th' | 'td';
 }
 
 export type IMarkdownTableStyleProps = Required<Pick<IMarkdownTableProps, 'theme'>> & Pick<IMarkdownTableProps, 'className'>;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Cherry-picking a change from Fabric 7 into `6.0` to unblock `@uifabric/example-app-base` changes in OneDrive & SharePoint.

There is a types mismatch with `markdown-to-jsx` types with the `as` field.

See https://github.com/OfficeDev/office-ui-fabric-react/pull/9209/files#r289208548 by @JasonGore.

#### Focus areas to test

- CI should pass (compile)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10361)