### PR TITLE
Hacked an examplecard msicon override for a specific DetailsList Drag and Drop page in fabric website

### DIFF
--- a/apps/fabric-website/src/pages/Controls/DetailsListPage/DetailsListDragDropPage.tsx
+++ b/apps/fabric-website/src/pages/Controls/DetailsListPage/DetailsListDragDropPage.tsx
@@ -1,7 +1,19 @@
 import * as React from 'react';
 import { ControlsAreaPage, IControlsPageProps } from '../ControlsAreaPage';
 import { DetailsListDragDropPageProps } from './DetailsListDragDropPage.doc';
+import { mergeStyles } from 'office-ui-fabric-react';
 
 export const DetailsListDragDropPage: React.StatelessComponent<IControlsPageProps> = props => {
-  return <ControlsAreaPage {...props} {...DetailsListDragDropPageProps[props.platform]} />;
+  const className = mergeStyles({
+    selectors: {
+      '.ExampleCard .ms-Icon': {
+        display: 'none'
+      }
+    }
+  });
+  return (
+    <div className={className}>
+      <ControlsAreaPage {...props} {...DetailsListDragDropPageProps[props.platform]} />;
+    </div>
+  );
 };

--- a/apps/fabric-website/src/pages/Controls/DetailsListPage/DetailsListDragDropPage.tsx
+++ b/apps/fabric-website/src/pages/Controls/DetailsListPage/DetailsListDragDropPage.tsx
@@ -6,7 +6,11 @@ import { mergeStyles } from 'office-ui-fabric-react';
 export const DetailsListDragDropPage: React.StatelessComponent<IControlsPageProps> = props => {
   const className = mergeStyles({
     selectors: {
-      '.ExampleCard .ms-Icon': {
+      '.ExampleCard .ms-Icon.ms-DetailsHeader-dropHintCaretStyle': {
+        display: 'none'
+      },
+
+      '.ExampleCard .ms-DetailsHeader-cell .ms-Icon': {
         display: 'none'
       }
     }

--- a/apps/fabric-website/webpack.config.js
+++ b/apps/fabric-website/webpack.config.js
@@ -1,7 +1,6 @@
 // @ts-check
 
 module.exports = function(env) {
-  const getResolveAlias = require('../../scripts/webpack/getResolveAlias');
   const path = require('path');
   const resources = require('@uifabric/build/webpack/webpack-resources');
   const { addMonacoConfig } = require('@uifabric/tsx-editor/scripts/monaco-webpack');
@@ -36,7 +35,14 @@ module.exports = function(env) {
       },
 
       resolve: {
-        alias: getResolveAlias()
+        alias: {
+          '@uifabric/fabric-website/src': path.join(__dirname, 'src'),
+          '@uifabric/fabric-website/lib': path.join(__dirname, 'lib'),
+          'office-ui-fabric-react$': path.resolve(__dirname, '../../packages/office-ui-fabric-react/lib'),
+          'office-ui-fabric-react/src': path.resolve(__dirname, '../../packages/office-ui-fabric-react/src'),
+          'office-ui-fabric-react/lib': path.resolve(__dirname, '../../packages/office-ui-fabric-react/lib'),
+          '@uifabric/api-docs/lib': path.resolve(__dirname, '../../packages/api-docs/lib')
+        }
       }
     }),
     /* only production */ isProductionArg

--- a/apps/fabric-website/webpack.config.js
+++ b/apps/fabric-website/webpack.config.js
@@ -1,6 +1,7 @@
 // @ts-check
 
 module.exports = function(env) {
+  const getResolveAlias = require('../../scripts/webpack/getResolveAlias');
   const path = require('path');
   const resources = require('@uifabric/build/webpack/webpack-resources');
   const { addMonacoConfig } = require('@uifabric/tsx-editor/scripts/monaco-webpack');
@@ -35,14 +36,7 @@ module.exports = function(env) {
       },
 
       resolve: {
-        alias: {
-          '@uifabric/fabric-website/src': path.join(__dirname, 'src'),
-          '@uifabric/fabric-website/lib': path.join(__dirname, 'lib'),
-          'office-ui-fabric-react$': path.resolve(__dirname, '../../packages/office-ui-fabric-react/lib'),
-          'office-ui-fabric-react/src': path.resolve(__dirname, '../../packages/office-ui-fabric-react/src'),
-          'office-ui-fabric-react/lib': path.resolve(__dirname, '../../packages/office-ui-fabric-react/lib'),
-          '@uifabric/api-docs/lib': path.resolve(__dirname, '../../packages/api-docs/lib')
-        }
+        alias: getResolveAlias()
       }
     }),
     /* only production */ isProductionArg

--- a/apps/fabric-website/webpack.serve.config.js
+++ b/apps/fabric-website/webpack.serve.config.js
@@ -21,6 +21,10 @@ module.exports = resources.createServeConfig(
       'react-dom': 'ReactDOM'
     },
 
+    optimization: {
+      removeAvailableModules: false
+    },
+
     resolve: {
       alias: {
         '@uifabric/fabric-website/src': path.join(__dirname, 'src'),

--- a/change/@uifabric-fabric-website-2019-09-05-14-14-55-hack-dl-dnd.json
+++ b/change/@uifabric-fabric-website-2019-09-05-14-14-55-hack-dl-dnd.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Hacked an examplecard msicon override for a specific DetailsList Drag and Drop page in fabric website",
+  "packageName": "@uifabric/fabric-website",
+  "email": "kchau@microsoft.com",
+  "commit": "b988c64fa3b73070e9e58607d4100ba26ffa44ab",
+  "date": "2019-09-05T21:14:55.319Z"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10237
- [x] Include a change request file using `$ yarn change`

#### Description of changes

From the discussion from #10237, we're going to hack together an override for a specific example page (so the example itself isn't polluted with the hack).

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10371)