### PR TITLE
Rating: duplicate ID fix

### DIFF
--- a/change/office-ui-fabric-react-2019-09-06-13-05-17-v-mare-Rating-star-id-fix.json
+++ b/change/office-ui-fabric-react-2019-09-06-13-05-17-v-mare-Rating-star-id-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Rating: Fixed duplicates ID on stars with fractional values.",
+  "packageName": "office-ui-fabric-react",
+  "email": "v-mare@microsoft.com",
+  "commit": "3498b5168dcc2deec69da4bba9136fa41a47cc0f",
+  "date": "2019-09-06T20:05:17.399Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
@@ -121,7 +121,7 @@ export class RatingBase extends React.Component<IRatingProps, IRatingState> {
             role="presentation"
             type="button"
           >
-            {this._getLabel((rating as number) % 1 ? rating : i)}
+            {this._getLabel(Math.ceil(rating) === i ? rating : i)}
             <RatingStar key={i + 'rating'} {...ratingStarProps} />
           </button>
         );

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
@@ -121,7 +121,7 @@ export class RatingBase extends React.Component<IRatingProps, IRatingState> {
             role="presentation"
             type="button"
           >
-            {this._getLabel(Math.ceil(rating) === i ? rating : i)}
+            {this._getLabel(i)}
             <RatingStar key={i + 'rating'} {...ratingStarProps} />
           </button>
         );

--- a/packages/office-ui-fabric-react/src/components/Rating/examples/Rating.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/examples/Rating.Basic.Example.tsx
@@ -44,7 +44,7 @@ export class RatingBasicExample extends React.Component<
           onChange={this._onLargeStarChange}
           onFocus={this._onFocus}
           onBlur={this._onBlur}
-          ariaLabelFormat={'{0} of {1} stars selected'}
+          ariaLabelFormat={'Select {0} of {1} stars'}
         />
         Small Stars
         <Rating
@@ -55,7 +55,7 @@ export class RatingBasicExample extends React.Component<
           getAriaLabel={this._getRatingComponentAriaLabel}
           onFocus={this._onFocus}
           onBlur={this._onBlur}
-          ariaLabelFormat={'{0} of {1} stars selected'}
+          ariaLabelFormat={'Select {0} of {1} stars'}
         />
         10 Small Stars
         <Rating
@@ -66,7 +66,7 @@ export class RatingBasicExample extends React.Component<
           getAriaLabel={this._getRatingComponentAriaLabel}
           onFocus={this._onFocus}
           onBlur={this._onBlur}
-          ariaLabelFormat={'{0} of {1} stars selected'}
+          ariaLabelFormat={'Select {0} of {1} stars'}
         />
         Disabled:
         <Rating
@@ -76,7 +76,7 @@ export class RatingBasicExample extends React.Component<
           disabled={true}
           onFocus={this._onFocus}
           onBlur={this._onBlur}
-          ariaLabelFormat={'{0} of {1} stars selected'}
+          ariaLabelFormat={'Select {0} of {1} stars'}
         />
         Half star in readOnly mode:
         <Rating
@@ -85,7 +85,7 @@ export class RatingBasicExample extends React.Component<
           rating={2.5}
           getAriaLabel={this._getRatingComponentAriaLabel}
           readOnly={true}
-          ariaLabelFormat={'{0} of {1} stars selected'}
+          ariaLabelFormat={'Select {0} of {1} stars'}
         />
         Custom icons:
         <Rating
@@ -96,7 +96,7 @@ export class RatingBasicExample extends React.Component<
           onFocus={this._onFocus}
           onBlur={this._onBlur}
           getAriaLabel={this._getRatingComponentAriaLabel}
-          ariaLabelFormat={'{0} of {1} stars selected'}
+          ariaLabelFormat={'Select {0} of {1} stars'}
           icon="StarburstSolid"
           unselectedIcon="Starburst"
         />
@@ -109,7 +109,7 @@ export class RatingBasicExample extends React.Component<
           getAriaLabel={this._getRatingComponentAriaLabel}
           onFocus={this._onFocus}
           onBlur={this._onBlur}
-          ariaLabelFormat={'{0} of {1} stars selected'}
+          ariaLabelFormat={'Select {0} of {1} stars'}
           theme={this._customTheme}
         />
       </div>

--- a/packages/office-ui-fabric-react/src/components/Rating/examples/Rating.ButtonControlled.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/examples/Rating.ButtonControlled.Example.tsx
@@ -28,7 +28,7 @@ export class RatingButtonControlledExample extends React.Component<
           readOnly={true}
           allowZeroStars={true}
           getAriaLabel={this._getRatingComponentAriaLabel}
-          ariaLabelFormat={'{0} of {1} stars selected'}
+          ariaLabelFormat={'Select {0} of {1} stars'}
         />
         <PrimaryButton
           text={'Click to change rating to ' + (maxrating - this.state.rating)}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.Basic.Example.tsx.shot
@@ -4080,9 +4080,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 position: absolute;
                 width: 1px;
               }
-          id="RatingLabel13-2.5"
+          id="RatingLabel13-1"
         >
-          2.5 of 5 stars selected
+          1 of 5 stars selected
         </span>
         <div
           className=
@@ -4219,9 +4219,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 position: absolute;
                 width: 1px;
               }
-          id="RatingLabel13-2.5"
+          id="RatingLabel13-2"
         >
-          2.5 of 5 stars selected
+          2 of 5 stars selected
         </span>
         <div
           className=
@@ -4498,9 +4498,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 position: absolute;
                 width: 1px;
               }
-          id="RatingLabel13-2.5"
+          id="RatingLabel13-4"
         >
-          2.5 of 5 stars selected
+          4 of 5 stars selected
         </span>
         <div
           className=
@@ -4637,9 +4637,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 position: absolute;
                 width: 1px;
               }
-          id="RatingLabel13-2.5"
+          id="RatingLabel13-5"
         >
-          2.5 of 5 stars selected
+          5 of 5 stars selected
         </span>
         <div
           className=
@@ -4862,9 +4862,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 position: absolute;
                 width: 1px;
               }
-          id="RatingLabel16-2.5"
+          id="RatingLabel16-1"
         >
-          2.5 of 5 stars selected
+          1 of 5 stars selected
         </span>
         <div
           className=
@@ -5019,9 +5019,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 position: absolute;
                 width: 1px;
               }
-          id="RatingLabel16-2.5"
+          id="RatingLabel16-2"
         >
-          2.5 of 5 stars selected
+          2 of 5 stars selected
         </span>
         <div
           className=
@@ -5334,9 +5334,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 position: absolute;
                 width: 1px;
               }
-          id="RatingLabel16-2.5"
+          id="RatingLabel16-4"
         >
-          2.5 of 5 stars selected
+          4 of 5 stars selected
         </span>
         <div
           className=
@@ -5491,9 +5491,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 position: absolute;
                 width: 1px;
               }
-          id="RatingLabel16-2.5"
+          id="RatingLabel16-5"
         >
-          2.5 of 5 stars selected
+          5 of 5 stars selected
         </span>
         <div
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.Basic.Example.tsx.shot
@@ -161,7 +161,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel1-1"
         >
-          1 of 5 stars selected
+          Select 1 of 5 stars
         </span>
         <div
           className=
@@ -318,7 +318,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel1-2"
         >
-          2 of 5 stars selected
+          Select 2 of 5 stars
         </span>
         <div
           className=
@@ -475,7 +475,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel1-3"
         >
-          3 of 5 stars selected
+          Select 3 of 5 stars
         </span>
         <div
           className=
@@ -632,7 +632,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel1-4"
         >
-          4 of 5 stars selected
+          Select 4 of 5 stars
         </span>
         <div
           className=
@@ -789,7 +789,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel1-5"
         >
-          5 of 5 stars selected
+          Select 5 of 5 stars
         </span>
         <div
           className=
@@ -1014,7 +1014,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel4-1"
         >
-          1 of 5 stars selected
+          Select 1 of 5 stars
         </span>
         <div
           className=
@@ -1171,7 +1171,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel4-2"
         >
-          2 of 5 stars selected
+          Select 2 of 5 stars
         </span>
         <div
           className=
@@ -1329,7 +1329,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel4-3"
         >
-          3 of 5 stars selected
+          Select 3 of 5 stars
         </span>
         <div
           className=
@@ -1486,7 +1486,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel4-4"
         >
-          4 of 5 stars selected
+          Select 4 of 5 stars
         </span>
         <div
           className=
@@ -1643,7 +1643,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel4-5"
         >
-          5 of 5 stars selected
+          Select 5 of 5 stars
         </span>
         <div
           className=
@@ -1869,7 +1869,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel7-1"
         >
-          1 of 10 stars selected
+          Select 1 of 10 stars
         </span>
         <div
           className=
@@ -2026,7 +2026,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel7-2"
         >
-          2 of 10 stars selected
+          Select 2 of 10 stars
         </span>
         <div
           className=
@@ -2183,7 +2183,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel7-3"
         >
-          3 of 10 stars selected
+          Select 3 of 10 stars
         </span>
         <div
           className=
@@ -2340,7 +2340,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel7-4"
         >
-          4 of 10 stars selected
+          Select 4 of 10 stars
         </span>
         <div
           className=
@@ -2497,7 +2497,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel7-5"
         >
-          5 of 10 stars selected
+          Select 5 of 10 stars
         </span>
         <div
           className=
@@ -2654,7 +2654,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel7-6"
         >
-          6 of 10 stars selected
+          Select 6 of 10 stars
         </span>
         <div
           className=
@@ -2811,7 +2811,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel7-7"
         >
-          7 of 10 stars selected
+          Select 7 of 10 stars
         </span>
         <div
           className=
@@ -2968,7 +2968,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel7-8"
         >
-          8 of 10 stars selected
+          Select 8 of 10 stars
         </span>
         <div
           className=
@@ -3125,7 +3125,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel7-9"
         >
-          9 of 10 stars selected
+          Select 9 of 10 stars
         </span>
         <div
           className=
@@ -3282,7 +3282,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel7-10"
         >
-          10 of 10 stars selected
+          Select 10 of 10 stars
         </span>
         <div
           className=
@@ -3483,7 +3483,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel10-1"
         >
-          1 of 5 stars selected
+          Select 1 of 5 stars
         </span>
         <div
           className=
@@ -3591,7 +3591,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel10-2"
         >
-          2 of 5 stars selected
+          Select 2 of 5 stars
         </span>
         <div
           className=
@@ -3699,7 +3699,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel10-3"
         >
-          3 of 5 stars selected
+          Select 3 of 5 stars
         </span>
         <div
           className=
@@ -3807,7 +3807,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel10-4"
         >
-          4 of 5 stars selected
+          Select 4 of 5 stars
         </span>
         <div
           className=
@@ -3915,7 +3915,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel10-5"
         >
-          5 of 5 stars selected
+          Select 5 of 5 stars
         </span>
         <div
           className=
@@ -4082,7 +4082,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel13-1"
         >
-          1 of 5 stars selected
+          Select 1 of 5 stars
         </span>
         <div
           className=
@@ -4221,7 +4221,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel13-2"
         >
-          2 of 5 stars selected
+          Select 2 of 5 stars
         </span>
         <div
           className=
@@ -4359,9 +4359,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 position: absolute;
                 width: 1px;
               }
-          id="RatingLabel13-2.5"
+          id="RatingLabel13-3"
         >
-          2.5 of 5 stars selected
+          Select 3 of 5 stars
         </span>
         <div
           className=
@@ -4500,7 +4500,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel13-4"
         >
-          4 of 5 stars selected
+          Select 4 of 5 stars
         </span>
         <div
           className=
@@ -4639,7 +4639,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel13-5"
         >
-          5 of 5 stars selected
+          Select 5 of 5 stars
         </span>
         <div
           className=
@@ -4864,7 +4864,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel16-1"
         >
-          1 of 5 stars selected
+          Select 1 of 5 stars
         </span>
         <div
           className=
@@ -5021,7 +5021,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel16-2"
         >
-          2 of 5 stars selected
+          Select 2 of 5 stars
         </span>
         <div
           className=
@@ -5177,9 +5177,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
                 position: absolute;
                 width: 1px;
               }
-          id="RatingLabel16-2.5"
+          id="RatingLabel16-3"
         >
-          2.5 of 5 stars selected
+          Select 3 of 5 stars
         </span>
         <div
           className=
@@ -5336,7 +5336,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel16-4"
         >
-          4 of 5 stars selected
+          Select 4 of 5 stars
         </span>
         <div
           className=
@@ -5493,7 +5493,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel16-5"
         >
-          5 of 5 stars selected
+          Select 5 of 5 stars
         </span>
         <div
           className=
@@ -5719,7 +5719,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel19-1"
         >
-          1 of 5 stars selected
+          Select 1 of 5 stars
         </span>
         <div
           className=
@@ -5876,7 +5876,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel19-2"
         >
-          2 of 5 stars selected
+          Select 2 of 5 stars
         </span>
         <div
           className=
@@ -6033,7 +6033,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel19-3"
         >
-          3 of 5 stars selected
+          Select 3 of 5 stars
         </span>
         <div
           className=
@@ -6190,7 +6190,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel19-4"
         >
-          4 of 5 stars selected
+          Select 4 of 5 stars
         </span>
         <div
           className=
@@ -6347,7 +6347,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
               }
           id="RatingLabel19-5"
         >
-          5 of 5 stars selected
+          Select 5 of 5 stars
         </span>
         <div
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.ButtonControlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.ButtonControlled.Example.tsx.shot
@@ -132,7 +132,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
               }
           id="RatingLabel1-1"
         >
-          1 of 5 stars selected
+          Select 1 of 5 stars
         </span>
         <div
           className=
@@ -271,7 +271,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
               }
           id="RatingLabel1-2"
         >
-          2 of 5 stars selected
+          Select 2 of 5 stars
         </span>
         <div
           className=
@@ -410,7 +410,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
               }
           id="RatingLabel1-3"
         >
-          3 of 5 stars selected
+          Select 3 of 5 stars
         </span>
         <div
           className=
@@ -549,7 +549,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
               }
           id="RatingLabel1-4"
         >
-          4 of 5 stars selected
+          Select 4 of 5 stars
         </span>
         <div
           className=
@@ -688,7 +688,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
               }
           id="RatingLabel1-5"
         >
-          5 of 5 stars selected
+          Select 5 of 5 stars
         </span>
         <div
           className=


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #10261 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

When the rating given was a fractional value like 2.5 it would make all the IDs of the hidden spans on the stars (read like an aria-labels) the same. This update makes it so the star with the fractional value is the only star to have that value incorporated as part of its ID.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10380)