### PR TITLE
Expose hideLegend prop for stacked bar chart

### DIFF
--- a/change/@uifabric-charting-2019-09-09-15-06-50-user-v-ragor-Bug_1070386.json
+++ b/change/@uifabric-charting-2019-09-09-15-06-50-user-v-ragor-Bug_1070386.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "Expose hideLegend prop for stacked bar chart",
   "packageName": "@uifabric/charting",
   "email": "v-ragor@microsoft.com",

--- a/change/@uifabric-charting-2019-09-09-15-06-50-user-v-ragor-Bug_1070386.json
+++ b/change/@uifabric-charting-2019-09-09-15-06-50-user-v-ragor-Bug_1070386.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Expose hideLegend prop for stacked bar chart",
+  "packageName": "@uifabric/charting",
+  "email": "v-ragor@microsoft.com",
+  "commit": "21d5f3be8e206956a48b9c15ea15e55c7ffe36c8",
+  "date": "2019-09-09T09:36:50.928Z"
+}

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -56,7 +56,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
   }
 
   public render(): JSX.Element {
-    const { barHeight, data, theme, hideRatio, styles, href, hideDenominator } = this.props;
+    const { barHeight, data, theme, hideRatio, hideLegend, styles, href, hideDenominator } = this.props;
     this._adjustProps();
     const { palette } = theme!;
     const legends = this._getLegendData(data!, hideRatio!, palette);
@@ -80,7 +80,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
     return (
       <div className={this._classNames.root}>
         {bars}
-        <div className={this._classNames.legendContainer}>{legends}</div>
+        {!hideLegend && <div className={this._classNames.legendContainer}>{legends}</div>}
         {isCalloutVisible ? (
           <Callout
             gapSpace={5}

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.types.ts
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.types.ts
@@ -35,6 +35,13 @@ export interface IMultiStackedBarChartProps {
   hideRatio?: boolean[];
 
   /**
+   * Do not show the legend at the bottom of chart
+   *
+   * @default false
+   */
+  hideLegend?: boolean;
+
+  /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */
   styles?: IStyleFunctionOrObject<IMultiStackedBarChartStyleProps, IMultiStackedBarChartStyles>;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Expose hideLegend prop for stacked bar chart
default value for hideLegend is false

(give an overview)

#### Focus areas to test

(optional)

#### Screenshots
![NoHidelegendProp](https://user-images.githubusercontent.com/13463251/64522194-19ad3100-d317-11e9-9808-49fb6803ff83.png)
![stackedBarChartHideLegend](https://user-images.githubusercontent.com/13463251/64522206-1fa31200-d317-11e9-8020-a572e6a46c48.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10388)