### PR TITLE
SpinButton: Conditionally render label and icon container with margin-right

### DIFF
--- a/change/office-ui-fabric-react-2019-09-09-10-22-57-keco-spinbutton-label-container.json
+++ b/change/office-ui-fabric-react-2019-09-09-10-22-57-keco-spinbutton-label-container.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Only render SpinButton label container if label or icon is present",
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com",
+  "commit": "912210e2a0f36b0951af95248fa12674a2f16289",
+  "date": "2019-09-09T17:22:57.013Z"
+}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -167,7 +167,7 @@ export class SpinButton extends React.Component<ISpinButtonProps, ISpinButtonSta
 
     return (
       <div className={classNames.root}>
-        {labelPosition !== Position.bottom && (
+        {labelPosition !== Position.bottom && (iconProps || label) && (
           <div className={classNames.labelWrapper}>
             {iconProps && <Icon {...iconProps} className={classNames.icon} aria-hidden="true" />}
             {label && (
@@ -246,7 +246,7 @@ export class SpinButton extends React.Component<ISpinButtonProps, ISpinButtonSta
             </div>
           )}
         </KeytipData>
-        {labelPosition === Position.bottom && (
+        {labelPosition === Position.bottom && (iconProps || label) && (
           <div className={classNames.labelWrapper}>
             {iconProps && <Icon iconName={iconProps.iconName} className={classNames.icon} aria-hidden="true" />}
             {label && (


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10373
- [x] Include a change request file using `$ yarn change`

#### Description of changes

As described in the above linked issue, `SpinButton` has a DIV container for both _optional_ `Icon` and `Label` elements. That container has a `margin-right` set is currently rendered even if both icon and label are omitted. This fixes the above by only rendering the container if either of those props are set.

#### Focus areas to test

- CI should pass
- `SpinButton` should not render label and icon container if both are not set.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10392)