### PR TITLE
CalendarMonth: Prefer createRef over legacy string ref

### DIFF
--- a/change/office-ui-fabric-react-2019-09-09-10-46-19-keco-calendarmonth-string-ref.json
+++ b/change/office-ui-fabric-react-2019-09-09-10-46-19-keco-calendarmonth-string-ref.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "CalendarMonth: Prefer createRef over string ref",
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com",
+  "commit": "8be3407f9e11859e60b074b05b321df68c71776a",
+  "date": "2019-09-09T17:46:19.266Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarMonth.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarMonth.tsx
@@ -44,6 +44,9 @@ export interface ICalendarMonthState {
 }
 
 export class CalendarMonth extends BaseComponent<ICalendarMonthProps, ICalendarMonthState> {
+  /**
+   * @deprecated unused, prefer 'ref' and 'componentRef' of ICalendarMonthProps.
+   */
   public refs: {
     [key: string]: React.ReactInstance;
     navigatedMonth: HTMLElement;
@@ -51,6 +54,7 @@ export class CalendarMonth extends BaseComponent<ICalendarMonthProps, ICalendarM
 
   private _selectMonthCallbacks: (() => void)[];
   private _calendarYearRef: CalendarYear;
+  private _navigatedMonthRef: React.RefObject<HTMLButtonElement>;
   private _focusOnUpdate: boolean;
 
   public constructor(props: ICalendarMonthProps) {
@@ -219,7 +223,7 @@ export class CalendarMonth extends BaseComponent<ICalendarMonthProps, ICalendarM
                         aria-label={dateTimeFormatter.formatMonthYear(indexedMonth, strings)}
                         aria-selected={isCurrentMonth || isNavigatedMonth}
                         data-is-focusable={isInBounds ? true : undefined}
-                        ref={isNavigatedMonth ? 'navigatedMonth' : undefined}
+                        ref={isNavigatedMonth ? this._navigatedMonthRef : undefined}
                         type="button"
                       >
                         {month}
@@ -238,9 +242,9 @@ export class CalendarMonth extends BaseComponent<ICalendarMonthProps, ICalendarM
   public focus() {
     if (this._calendarYearRef) {
       this._calendarYearRef.focus();
-    } else if (this.refs.navigatedMonth) {
-      this.refs.navigatedMonth.tabIndex = 0;
-      this.refs.navigatedMonth.focus();
+    } else if (this._navigatedMonthRef.current) {
+      this._navigatedMonthRef.current.tabIndex = 0;
+      this._navigatedMonthRef.current.focus();
     }
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10376
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Uses `React.createRef` in legacy `CalendarMonth` control over legacy string ref approach to avoid run-time error in above linked issue.

Judging from above linked issue we'll want to cherry-pick fix into `6.x` release if approach approved.

#### Focus areas to test

- CI should pass
- Focus should continue to work with Calendar month selection.
