### PR TITLE
Add '.is-selected' to ChoiceGroupOption when input is disabled

### DIFF
--- a/change/office-ui-fabric-react-2019-09-09-12-13-12-keco-choicegroupoption-is-disabled.json
+++ b/change/office-ui-fabric-react-2019-09-09-12-13-12-keco-choicegroupoption-is-disabled.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add .is-disabled to ChoiceGroupOption when disabled",
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com",
+  "commit": "0606a256096122b70180b760a815c3dbcbe65b9c",
+  "date": "2019-09-09T19:13:12.243Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
@@ -283,7 +283,8 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
         width: '100%',
         height: '100%',
         margin: 0
-      }
+      },
+      disabled && 'is-disabled'
     ],
     field: [
       classNames.field,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10379
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add `.is-selected` classname to `ChoiceGroupOption`'s `input` element when it is marked as `disabled`. Following pattern used across a sub-set of other Fabric components, namely input and anchor elements.

#### Focus areas to test

- CI should pass

cc: @dli68