### PR TITLE
Adding filetype mapping for .b file extension

### DIFF
--- a/packages/file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/file-type-icons/src/FileTypeIconMap.ts
@@ -249,7 +249,7 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   },
   docset: {},
   docx: {
-    extensions: ['doc', 'docm', 'docx', 'docb']
+    extensions: ['b', 'doc', 'docm', 'docx', 'docb']
   },
   dotx: {
     extensions: ['dot', 'dotm', 'dotx']


### PR DESCRIPTION
#### Pull request checklist

- [ ] Rq by ramkumar and rogergu

#### Description of changes

Adding .b extension to the filetype icons that get mapped to Office doc file extension for proper rendering in list and grid view

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10407)