### PR TITLE
Pickers: Fix background color so it doesn't override border subtly

### DIFF
--- a/change/office-ui-fabric-react-2019-09-10-16-07-13-pickers-fixbackgroundcolor.json
+++ b/change/office-ui-fabric-react-2019-09-10-16-07-13-pickers-fixbackgroundcolor.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "make background color of input transparent so it doesn't clip border",
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com",
+  "commit": "32f0b9cc893c0d33c423143da95ce6c5710172fc",
+  "date": "2019-09-10T23:07:13.267Z"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.styles.ts
@@ -92,7 +92,8 @@ export function getStyles(props: IBasePickerStyleProps): IBasePickerStyles {
         outline: 'none',
         padding: '0 6px 0',
         alignSelf: 'flex-end',
-        borderRadius: effects.roundedCorner2
+        borderRadius: effects.roundedCorner2,
+        backgroundColor: 'transparent'
       },
       inputClassName
     ],


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #10153
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Pickers: Fix background color so it doesn't override border subtly

#### Focus areas to test

(optional)
