### PR TITLE
TextField: remove invalid aria-labelledby

### DIFF
--- a/change/office-ui-fabric-react-2019-09-11-14-09-01-textFieldCustomLabel.json
+++ b/change/office-ui-fabric-react-2019-09-11-14-09-01-textFieldCustomLabel.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "TextField: remove invalid aria-labelledby",
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com",
+  "commit": "3711fcd3145e19b939a2b0c58c5e9b655562d13f",
+  "date": "2019-09-11T21:09:01.169Z"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -448,7 +448,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
 
   private _renderInput(): React.ReactElement<React.HTMLAttributes<HTMLInputElement>> {
     const inputProps = getNativeProps<React.HTMLAttributes<HTMLInputElement>>(this.props, inputProperties, ['defaultValue']);
-    const ariaLabelledBy = this.props['aria-labelledby'] || (this.props.label ? this._labelId : undefined);
+    const ariaLabelledBy = this.props['aria-labelledby'] || (this.props.label && !this.props.onRenderLabel ? this._labelId : undefined);
     return (
       <input
         type={'text'}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
@@ -239,7 +239,6 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
         <input
           aria-describedby="TextFieldDescription3"
           aria-invalid={false}
-          aria-labelledby="TextFieldLabel4"
           className=
               ms-TextField-field
               {


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #10411
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Removes `aria-labelledby` from the text field when a custom rendered label is provided, since a label with `id === this._labelId` does not exist.

#### Focus areas to test

Ensure that a custom text field is rendered without `aria-labelledby` set to an invalid id.
