### PR TITLE
DatePicker: utilize custom onChange handler when provided

### DIFF
--- a/change/@uifabric-date-time-2019-09-11-14-19-48-datePickerTextFieldOnChange.json
+++ b/change/@uifabric-date-time-2019-09-11-14-19-48-datePickerTextFieldOnChange.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "DatePicker: call custom text field onChange handler if it exists in default onChange handler",
+  "packageName": "@uifabric/date-time",
+  "email": "naethell@microsoft.com",
+  "commit": "66c08397d029b26f7044440f86232aa72ae4d352",
+  "date": "2019-09-11T21:19:33.301Z"
+}

--- a/change/office-ui-fabric-react-2019-09-11-14-19-48-datePickerTextFieldOnChange.json
+++ b/change/office-ui-fabric-react-2019-09-11-14-19-48-datePickerTextFieldOnChange.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "DatePicker: call custom text field onChange handler if it exists in default onChange handler",
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com",
+  "commit": "66c08397d029b26f7044440f86232aa72ae4d352",
+  "date": "2019-09-11T21:19:48.603Z"
+}

--- a/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
@@ -323,7 +323,9 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
   };
 
   private _onTextFieldChanged = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue: string): void => {
-    if (this.props.allowTextInput) {
+    const { allowTextInput, textField } = this.props;
+
+    if (allowTextInput) {
       if (this.state.isDatePickerShown) {
         this._dismissDatePickerPopup();
       }
@@ -334,6 +336,10 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
         errorMessage: isRequired && !value ? strings!.isRequiredErrorMessage || ' ' : undefined,
         formattedDate: newValue
       });
+    }
+
+    if (textField && textField.onChange) {
+      textField.onChange(ev, newValue);
     }
   };
 

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -326,7 +326,9 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
   };
 
   private _onTextFieldChanged = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue: string): void => {
-    if (this.props.allowTextInput) {
+    const { allowTextInput, textField } = this.props;
+
+    if (allowTextInput) {
       if (this.state.isDatePickerShown) {
         this._dismissDatePickerPopup();
       }
@@ -337,6 +339,10 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
         errorMessage: isRequired && !value ? strings!.isRequiredErrorMessage || ' ' : undefined,
         formattedDate: newValue
       });
+    }
+
+    if (textField && textField.onChange) {
+      textField.onChange(ev, newValue);
     }
   };
 

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
@@ -94,6 +94,21 @@ describe('DatePicker', () => {
     datePicker.unmount();
   });
 
+  it('should call custom onChange when allowTextInput is true', () => {
+    const onChange = jest.fn();
+    const datePicker = mount(<DatePickerBase allowTextInput={true} textField={{ onChange: onChange }} />);
+    const textField = datePicker.find('input');
+
+    expect(textField).toBeDefined();
+
+    textField.simulate('change', { target: { value: 'Jan 1 2020' } }).simulate('blur');
+    textField.simulate('change', { target: { value: '' } }).simulate('blur');
+
+    expect(onChange).toHaveBeenCalledTimes(2);
+
+    datePicker.unmount();
+  });
+
   // @todo: usage of document.querySelector is incorrectly testing DOM mounted by previous tests and needs to be fixed.
   it.skip('should call onSelectDate only once when allowTextInput is true and popup is used to select the value', () => {
     const onSelectDate = jest.fn();


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #10406
- [X] Include a change request file using `$ yarn change`

#### Description of changes

These changes integrate the optional custom `onChange` handler within the existing default `onChange` handler.

Now, a user can pass in their own `onChange` handler to the `textField` prop of DatePicker and see their `onChange` called.

I made these changes both to the `date-time` package and the `office-ui-fabric-react` package. Let me know if these changes should just go in one.

#### Focus areas to test

Ensure that a custom `onChange` handler is called in addition to the existing default `onChange` handler.

I added a test for this scenario, too.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10424)