### PR TITLE
Adding .b extension to Office file type

### DIFF
--- a/change/@uifabric-file-type-icons-2019-09-11-15-21-11-caperez-fluid_filetype.json
+++ b/change/@uifabric-file-type-icons-2019-09-11-15-21-11-caperez-fluid_filetype.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "updating office file type to include .b",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "caperez@microsoft.com",
+  "commit": "59b7ad45e279e234a94b9eaa493140cc9ac85eda",
+  "date": "2019-09-11T22:21:11.248Z"
+}

--- a/packages/file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/file-type-icons/src/FileTypeIconMap.ts
@@ -249,7 +249,7 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   },
   docset: {},
   docx: {
-    extensions: ['doc', 'docm', 'docx', 'docb']
+    extensions: ['b', 'doc', 'docm', 'docx', 'docb']
   },
   dotx: {
     extensions: ['dot', 'dotm', 'dotx']


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Adding .b extension to Office file type
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

just added one extension to the filetypeiconmap in the filetype icons package.

#### Focus areas to test

files with .b extension


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10427)