### PR TITLE
Adding .b extension to Office file type (Fabric 6)

### DIFF
--- a/change/@uifabric-file-type-icons-2019-09-11-15-40-34-caperez-fluid_filetype_fab6.json
+++ b/change/@uifabric-file-type-icons-2019-09-11-15-40-34-caperez-fluid_filetype_fab6.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Adding .b extension to Office file type",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "caperez@microsoft.com",
+  "commit": "8be57fd7168bd9182abcf2a288d291112e38a7fd",
+  "date": "2019-09-11T22:40:34.213Z"
+}

--- a/packages/file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/file-type-icons/src/FileTypeIconMap.ts
@@ -249,7 +249,7 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   },
   docset: {},
   docx: {
-    extensions: ['doc', 'docm', 'docx', 'docb']
+    extensions: ['b', 'doc', 'docm', 'docx', 'docb']
   },
   dotx: {
     extensions: ['dot', 'dotm', 'dotx']


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Adding .b extension to Office file type
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

just added one extension to the filetypeiconmap in the filetype icons package.

#### Focus areas to test

files with .b extension, in Fabric 6-based apps


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10430)