### PR TITLE
DetailsList: add Announced to DetailsList examples that have column sorting

### DIFF
--- a/change/office-ui-fabric-react-2019-09-11-15-52-19-addAnnouncedToSortedDetailsList.json
+++ b/change/office-ui-fabric-react-2019-09-11-15-52-19-addAnnouncedToSortedDetailsList.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "DetailsList: add Announced to examples with sortable columns",
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com",
+  "commit": "e4f9941fb5b14f087a6b13ae7e0b484110dbd159",
+  "date": "2019-09-11T22:52:19.031Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { CommandBar } from 'office-ui-fabric-react/lib/CommandBar';
+import { Announced } from 'office-ui-fabric-react/lib/Announced';
 import { IContextualMenuProps, IContextualMenuItem, DirectionalHint, ContextualMenu } from 'office-ui-fabric-react/lib/ContextualMenu';
 import {
   CheckboxVisibility,
@@ -71,6 +72,7 @@ export interface IDetailsListAdvancedExampleState {
   selectionMode?: SelectionMode;
   sortedColumnKey?: string;
   selectionCount: number;
+  announced?: JSX.Element;
 }
 
 export class DetailsListAdvancedExample extends React.Component<{}, IDetailsListAdvancedExampleState> {
@@ -121,7 +123,8 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
       isLazyLoaded,
       items,
       layoutMode,
-      selectionMode
+      selectionMode,
+      announced
     } = this.state;
 
     const isGrouped = groups && groups.length > 0;
@@ -155,6 +158,8 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
         />
 
         {isGrouped ? <TextField label="Group item limit" onChange={this._onItemLimitChanged} /> : null}
+
+        {announced}
 
         <DetailsList
           setKey="items"
@@ -542,6 +547,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
 
     this.setState({
       items: sortedItems,
+      announced: <Announced message={`${columnKey} is sorted ${isSortedDescending ? 'descending' : 'ascending'}`} />,
       groups: undefined,
       columns: this._buildColumns(
         sortedItems,

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { Toggle } from 'office-ui-fabric-react/lib/Toggle';
 import { Fabric } from 'office-ui-fabric-react/lib/Fabric';
+import { Announced } from 'office-ui-fabric-react/lib/Announced';
 import { DetailsList, DetailsListLayoutMode, Selection, SelectionMode, IColumn } from 'office-ui-fabric-react/lib/DetailsList';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
 import { mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
@@ -55,6 +56,7 @@ export interface IDetailsListDocumentsExampleState {
   selectionDetails: string;
   isModalSelection: boolean;
   isCompactMode: boolean;
+  announced?: JSX.Element;
 }
 
 export interface IDocument {
@@ -170,12 +172,13 @@ export class DetailsListDocumentsExample extends React.Component<{}, IDetailsLis
       columns: columns,
       selectionDetails: this._getSelectionDetails(),
       isModalSelection: false,
-      isCompactMode: false
+      isCompactMode: false,
+      announced: undefined
     };
   }
 
   public render() {
-    const { columns, isCompactMode, items, selectionDetails, isModalSelection } = this.state;
+    const { columns, isCompactMode, items, selectionDetails, isModalSelection, announced } = this.state;
 
     return (
       <Fabric>
@@ -199,6 +202,7 @@ export class DetailsListDocumentsExample extends React.Component<{}, IDetailsLis
           <TextField label="Filter by name:" onChange={this._onChangeText} styles={controlStyles} />
         </div>
         <div className={classNames.selectionDetails}>{selectionDetails}</div>
+        {announced}
         <MarqueeSelection selection={this._selection}>
           <DetailsList
             items={items}
@@ -271,6 +275,9 @@ export class DetailsListDocumentsExample extends React.Component<{}, IDetailsLis
       if (newCol === currColumn) {
         currColumn.isSortedDescending = !currColumn.isSortedDescending;
         currColumn.isSorted = true;
+        this.setState({
+          announced: <Announced message={`${currColumn.name} is sorted ${currColumn.isSortedDescending ? 'descending' : 'ascending'}`} />
+        });
       } else {
         newCol.isSorted = false;
         newCol.isSortedDescending = true;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: #7786, #6646 
- [X] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds the Announced component to the DetailsList examples that implement column sorting.

Before, nothing was being read out on column sort. We looked into other ways of accomplishing this readout, but Announced seems like the most effective solution at the moment.

Now, when sorting columns in both the Documents and Advanced example, the screen reader should read out the following update: **"{column name} is sorted ascending/descending"**

This logic seems to make the most sense in the handlers for the column's `onClick` methods, as that's when the sorting—or whatever else someone wants the column header to do—happens. Let me know if you think otherwise, though!

There are two open issues that reference this missing functionality: https://github.com/OfficeDev/office-ui-fabric-react/issues/7786, https://github.com/OfficeDev/office-ui-fabric-react/issues/6646. This integration of Announced in these DetailsList examples should serve as guidance for those hoping to provide sorting updates to a screen reader.

#### Focus areas to test

Open the DetailsList Documents or Advanced example in Edge and turn on Narrator. Navigate to the header of a column that can be sorted. Select the 
