### PR TITLE
Golden Folder grid view CSS cleanup and update to filetype salt to bust thru CDN cache

### DIFF
--- a/change/@uifabric-experiments-2019-09-12-16-43-54-caperez-golden_v5_fabric6.json
+++ b/change/@uifabric-experiments-2019-09-12-16-43-54-caperez-golden_v5_fabric6.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Golden Folder grid view CSS cleanup and update to filetype salt to bust thru CDN cache",
+  "packageName": "@uifabric/experiments",
+  "email": "caperez@microsoft.com",
+  "commit": "599531b28e137575c7b5e742c4c86d89f17901fe",
+  "date": "2019-09-12T23:43:33.059Z"
+}

--- a/change/@uifabric-file-type-icons-2019-09-12-16-43-54-caperez-golden_v5_fabric6.json
+++ b/change/@uifabric-file-type-icons-2019-09-12-16-43-54-caperez-golden_v5_fabric6.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Golden Folder grid view CSS cleanup and update to filetype salt to bust thru CDN cache",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "caperez@microsoft.com",
+  "commit": "599531b28e137575c7b5e742c4c86d89f17901fe",
+  "date": "2019-09-12T23:43:54.131Z"
+}

--- a/packages/experiments/src/components/FolderCover/FolderCover.tsx
+++ b/packages/experiments/src/components/FolderCover/FolderCover.tsx
@@ -16,9 +16,9 @@ export interface IFolderCoverState {
 
 const FolderCoverLayoutValues = {
   smallWidth: 72 as 72,
-  smallHeight: 52 as 52,
+  smallHeight: 44 as 44,
   largeWidth: 112 as 112,
-  largeHeight: 80 as 80,
+  largeHeight: 72 as 72,
   contentPadding: 4 as 4
 };
 
@@ -128,8 +128,6 @@ function getFolderCoverLayoutFromProps(folderCoverProps: IFolderCoverProps): IFo
   const { folderCoverSize = 'large' } = folderCoverProps;
 
   const contentSize = { ...SIZES[folderCoverSize] };
-
-  contentSize.height -= 8;
 
   return {
     contentSize

--- a/packages/experiments/src/components/FolderCover/FolderCover.tsx
+++ b/packages/experiments/src/components/FolderCover/FolderCover.tsx
@@ -72,7 +72,7 @@ export class FolderCover extends React.Component<IFolderCoverProps, IFolderCover
       metadata,
       signal,
       children,
-      isFluent, //
+      isFluent,
       ...divProps
     } = this.props;
 

--- a/packages/experiments/src/components/FolderCover/FolderCover.tsx
+++ b/packages/experiments/src/components/FolderCover/FolderCover.tsx
@@ -72,7 +72,7 @@ export class FolderCover extends React.Component<IFolderCoverProps, IFolderCover
       metadata,
       signal,
       children,
-      //      isFluent,
+      isFluent, //
       ...divProps
     } = this.props;
 

--- a/packages/experiments/src/components/FolderCover/FolderCover.tsx
+++ b/packages/experiments/src/components/FolderCover/FolderCover.tsx
@@ -72,18 +72,14 @@ export class FolderCover extends React.Component<IFolderCoverProps, IFolderCover
       metadata,
       signal,
       children,
-      isFluent,
+      //      isFluent,
       ...divProps
     } = this.props;
 
     const assets = ASSETS[size][type];
     const metadataIcon = <span className={css('ms-FolderCover-metadata', FolderCoverStyles.metadata)}>{metadata}</span>;
 
-    const signalIcon = (
-      <span className={css('ms-FolderCover-signal', FolderCoverStyles.signal, isFluent ? SignalStyles.isFluent : SignalStyles.dark)}>
-        {signal}
-      </span>
-    );
+    const signalIcon = <span className={css('ms-FolderCover-signal', FolderCoverStyles.signal, SignalStyles.isFluent)}>{signal}</span>;
     return (
       <div
         {...divProps}
@@ -93,23 +89,16 @@ export class FolderCover extends React.Component<IFolderCoverProps, IFolderCover
           [`ms-FolderCover--isDefault ${FolderCoverStyles.isDefault}`]: type === 'default',
           [`ms-FolderCover--isMedia ${FolderCoverStyles.isMedia}`]: type === 'media',
           [`ms-FolderCover--hideContent ${FolderCoverStyles.hideContent}`]: hideContent,
-          [`ms-FolderCover--isFluent ${FolderCoverStyles.isFluent}`]: isFluent
+          [`ms-FolderCover--isFluent ${FolderCoverStyles.isFluent}`]: true
         })}
       >
         <Icon aria-hidden={true} className={css('ms-FolderCover-back', FolderCoverStyles.back)} iconName={assets.back} />
         {this._renderChildren({ children })}
         <Icon aria-hidden={true} className={css('ms-FolderCover-front', FolderCoverStyles.front)} iconName={assets.front} />
-        {isFluent ? (
-          <React.Fragment>
-            {metadataIcon}
-            {signalIcon}
-          </React.Fragment>
-        ) : (
-          <React.Fragment>
-            {signalIcon}
-            {metadataIcon}
-          </React.Fragment>
-        )}
+        <React.Fragment>
+          {metadataIcon}
+          {signalIcon}
+        </React.Fragment>
       </div>
     );
   }
@@ -136,13 +125,11 @@ export function getFolderCoverLayout(element: JSX.Element): IFolderCoverLayout {
 }
 
 function getFolderCoverLayoutFromProps(folderCoverProps: IFolderCoverProps): IFolderCoverLayout {
-  const { folderCoverSize = 'large', isFluent } = folderCoverProps;
+  const { folderCoverSize = 'large' } = folderCoverProps;
 
   const contentSize = { ...SIZES[folderCoverSize] };
 
-  if (isFluent) {
-    contentSize.height -= 8;
-  }
+  contentSize.height -= 8;
 
   return {
     contentSize

--- a/packages/experiments/src/components/FolderCover/FolderCover.types.ts
+++ b/packages/experiments/src/components/FolderCover/FolderCover.types.ts
@@ -32,10 +32,6 @@ export interface IFolderCoverProps extends IBaseProps, React.HTMLAttributes<HTML
    */
   metadata?: React.ReactNode;
   /**
-   * Support fluent color, yellow folder cover.
-   */
-  isFluent?: boolean;
-  /**
    * The children to pass into the content area of the folder cover.
    */
   children?: React.Props<{}>['children'] | ((childrenProps: IFolderCoverChildrenProps) => JSX.Element | null);

--- a/packages/experiments/src/components/FolderCover/FolderCover.types.ts
+++ b/packages/experiments/src/components/FolderCover/FolderCover.types.ts
@@ -32,6 +32,10 @@ export interface IFolderCoverProps extends IBaseProps, React.HTMLAttributes<HTML
    */
   metadata?: React.ReactNode;
   /**
+   * Support fluent color, yellow folder cover.
+   */
+  isFluent?: boolean;
+  /**
    * The children to pass into the content area of the folder cover.
    */
   children?: React.Props<{}>['children'] | ((childrenProps: IFolderCoverChildrenProps) => JSX.Element | null);

--- a/packages/experiments/src/components/FolderCover/initializeFolderCovers.tsx
+++ b/packages/experiments/src/components/FolderCover/initializeFolderCovers.tsx
@@ -15,7 +15,7 @@ export function initializeFolderCovers(baseUrl: string = ASSET_CDN_BASE_URL, opt
       icons: {
         folderCoverLargeDefaultFront: <img src={`${baseUrl}/lg-fg.svg`} />,
         folderCoverLargeDefaultBack: <img src={`${baseUrl}/lg-bg.svg`} />,
-        folderCoverLargeMediaFront: <img src={`${baseUrl}/lg-fg-media`} />,
+        folderCoverLargeMediaFront: <img src={`${baseUrl}/lg-fg-media.svg`} />,
         folderCoverLargeMediaBack: <img src={`${baseUrl}/lg-bg.svg`} />
       }
     },
@@ -33,7 +33,7 @@ export function initializeFolderCovers(baseUrl: string = ASSET_CDN_BASE_URL, opt
       icons: {
         folderCoverSmallDefaultFront: <img src={`${baseUrl}/sm-fg.svg`} />,
         folderCoverSmallDefaultBack: <img src={`${baseUrl}/sm-bg.svg`} />,
-        folderCoverSmallMediaFront: <img src={`${baseUrl}/sm-fg-media`} />,
+        folderCoverSmallMediaFront: <img src={`${baseUrl}/sm-fg-media.svg`} />,
         folderCoverSmallMediaBack: <img src={`${baseUrl}/sm-bg.svg`} />
       }
     },

--- a/packages/experiments/src/components/FolderCover/initializeFolderCovers.tsx
+++ b/packages/experiments/src/components/FolderCover/initializeFolderCovers.tsx
@@ -13,10 +13,10 @@ export function initializeFolderCovers(baseUrl: string = ASSET_CDN_BASE_URL, opt
         overflow: 'hidden'
       },
       icons: {
-        folderCoverLargeDefaultFront: <img src={`${baseUrl}/folder-large_frontplate_nopreview.svg`} />,
-        folderCoverLargeDefaultBack: <img src={`${baseUrl}/folder-large_backplate.svg`} />,
-        folderCoverLargeMediaFront: <img src={`${baseUrl}/folder-large_frontplate_thumbnail.svg`} />,
-        folderCoverLargeMediaBack: <img src={`${baseUrl}/folder-large_backplate.svg`} />
+        folderCoverLargeDefaultFront: <img src={`${baseUrl}/lg-fg.svg`} />,
+        folderCoverLargeDefaultBack: <img src={`${baseUrl}/lg-bg.svg`} />,
+        folderCoverLargeMediaFront: <img src={`${baseUrl}/lg-fg-media`} />,
+        folderCoverLargeMediaBack: <img src={`${baseUrl}/lg-bg.svg`} />
       }
     },
     options
@@ -31,12 +31,10 @@ export function initializeFolderCovers(baseUrl: string = ASSET_CDN_BASE_URL, opt
         overflow: 'hidden'
       },
       icons: {
-        // Yes, it's mis-named.
-        folderCoverSmallDefaultFront: <img src={`${baseUrl}/folder-small_frontplate_thumbnail.svg`} />,
-        folderCoverSmallDefaultBack: <img src={`${baseUrl}/folder-small_backplate.svg`} />,
-        // Yes, it's mis-named.
-        folderCoverSmallMediaFront: <img src={`${baseUrl}/folder-small_frontplate_nopreview.svg`} />,
-        folderCoverSmallMediaBack: <img src={`${baseUrl}/folder-small_backplate.svg`} />
+        folderCoverSmallDefaultFront: <img src={`${baseUrl}/sm-fg.svg`} />,
+        folderCoverSmallDefaultBack: <img src={`${baseUrl}/sm-bg.svg`} />,
+        folderCoverSmallMediaFront: <img src={`${baseUrl}/sm-fg-media`} />,
+        folderCoverSmallMediaBack: <img src={`${baseUrl}/sm-bg.svg`} />
       }
     },
     options

--- a/packages/experiments/src/components/Tile/Tile.scss
+++ b/packages/experiments/src/components/Tile/Tile.scss
@@ -126,7 +126,7 @@
 .foreground {
   display: inline-flex;
   position: relative;
-  overflow: hidden;
+  overflow: visible;
   max-width: 100%;
   max-height: 100%;
   flex-direction: row;

--- a/packages/file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/file-type-icons/src/initializeFileTypeIcons.tsx
@@ -12,7 +12,7 @@ const ICON_SIZES: number[] = [16, 20, 32, 40, 48, 64, 96];
 // (though most users will see them within a week). To force immediate refresh, append a
 // unique string to the end of the URL. The CDN uses the URL as the cache key, so passing a
 // new URL will cause the CDN to create a new cache key.
-const REFRESH_STRING = '?refresh1';
+const REFRESH_STRING = '?v5';
 
 export function initializeFileTypeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: Partial<IIconOptions>): void {
   ICON_SIZES.forEach((size: number) => {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Locks all Grid Folders to "Fluent" design
- [ ] Clean up filename system for the grid view SVG plates
- [ ] Changes the "salt" at the end of the filetype icon URL to ensure all systems update
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Removing isFluent as an option when it comes to folders in grid view. All are golden. Removing some problems and overly long filenames in the grid view SVG plates.

Changing the salt added at the end of the URL of filetype icons so no gray folders show up any more.

#### Focus areas to test

DetailsList rendering files in List and Grid


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10441)