### PR TITLE
Provide a utility to compose 'IComponentAs' components

### DIFF
--- a/change/@uifabric-experiments-2020-01-02-16-09-53-compose-component-as.json
+++ b/change/@uifabric-experiments-2020-01-02-16-09-53-compose-component-as.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Consume compose functions where appropriate",
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com",
+  "commit": "d9eaef588f46c10fe8c1791957571a8eb467d02e",
+  "date": "2020-01-03T00:09:49.172Z"
+}

--- a/change/@uifabric-utilities-2019-09-15-11-50-42-compose-component-as.json
+++ b/change/@uifabric-utilities-2019-09-15-11-50-42-compose-component-as.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add composeComponentAs to compose React decorator components",
+  "packageName": "@uifabric/utilities",
+  "email": "tmichon@microsoft.com",
+  "commit": "0ad2440153218b174cb0d6a12d91c0ca1764c2f6",
+  "date": "2019-09-15T18:50:42.353Z"
+}

--- a/change/office-ui-fabric-react-2020-01-02-16-09-53-compose-component-as.json
+++ b/change/office-ui-fabric-react-2020-01-02-16-09-53-compose-component-as.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Consume compose functions where appropriate",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "commit": "d9eaef588f46c10fe8c1791957571a8eb467d02e",
+  "date": "2020-01-03T00:09:53.098Z"
+}

--- a/packages/experiments/src/components/BAFAccordion/Accordion.tsx
+++ b/packages/experiments/src/components/BAFAccordion/Accordion.tsx
@@ -3,7 +3,7 @@
  */
 
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
-import { BaseComponent, css } from 'office-ui-fabric-react/lib/Utilities';
+import { BaseComponent, css, composeRenderFunction } from 'office-ui-fabric-react/lib/Utilities';
 import * as React from 'react';
 import './Accordion.scss';
 import { IAccordion, IAccordionProps } from './Accordion.types';
@@ -32,7 +32,7 @@ export class Accordion extends BaseComponent<IAccordionProps, IAccordionState> i
 
   public render(): JSX.Element {
     const { onRenderMenu, className, buttonAs, onClick, ...other } = this.props;
-    let { menuIconProps, onRenderContent } = this.props;
+    let { menuIconProps } = this.props;
 
     const AccordionButton = buttonAs || DefaultButton;
 
@@ -40,7 +40,7 @@ export class Accordion extends BaseComponent<IAccordionProps, IAccordionState> i
       menuIconProps = this.state.isContentVisible ? { iconName: 'ChevronUp' } : { iconName: 'ChevronDown' };
     }
 
-    onRenderContent = onRenderContent || onRenderMenu;
+    const onRenderContent = onRenderMenu ? composeRenderFunction(this.props.onRenderContent, onRenderMenu) : this.props.onRenderContent;
 
     return (
       <div className={css('ba-Accordion', this.state.isContentVisible && 'ba-Accordion--contentVisible', className)}>
@@ -52,9 +52,7 @@ export class Accordion extends BaseComponent<IAccordionProps, IAccordionState> i
           aria-expanded={this.state.isContentVisible}
           {...other}
         />
-        {this.state.isContentVisible && (
-          <div className={'ba-Accordion-content'}>{onRenderContent && onRenderContent(this.props.menuProps)}</div>
-        )}
+        {this.state.isContentVisible && <div className={'ba-Accordion-content'}>{onRenderContent(this.props.menuProps)}</div>}
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.base.tsx
@@ -4,6 +4,7 @@ import { Icon } from '../../../Icon';
 import { IChoiceGroupOptionProps, IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles } from './ChoiceGroupOption.types';
 import { classNamesFunction, getNativeProps, inputProperties, css, initializeComponentRef } from '../../../Utilities';
 import { IProcessedStyleSet } from '../../../Styling';
+import { composeRenderFunction } from '@uifabric/utilities';
 
 const getClassNames = classNamesFunction<IChoiceGroupOptionStyleProps, IChoiceGroupOptionStyles>();
 
@@ -94,10 +95,13 @@ export class ChoiceGroupOptionBase extends React.Component<IChoiceGroupOptionPro
   };
 
   private _onRenderField = (props: IChoiceGroupOptionProps): JSX.Element => {
-    const { onRenderLabel = this._onRenderLabel, id, imageSrc, imageAlt = '', selectedImageSrc, iconProps } = props;
+    const { id, imageSrc, imageAlt = '', selectedImageSrc, iconProps } = props;
 
     const imageSize = props.imageSize ? props.imageSize : { width: 32, height: 32 };
-    const label = onRenderLabel!(props, this._onRenderLabel);
+
+    const onRenderLabel = props.onRenderLabel ? composeRenderFunction(props.onRenderLabel, this._onRenderLabel) : this._onRenderLabel;
+
+    const label = onRenderLabel(props);
 
     return (
       <label htmlFor={id} className={this._classNames.field}>

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -8,7 +8,7 @@ import { FocusZone, FocusZoneDirection } from '../../FocusZone';
 import { classNamesFunction } from '../../Utilities';
 import { CommandBarButton, IButtonProps } from '../../Button';
 import { TooltipHost } from '../../Tooltip';
-import { IComponentAs, getNativeProps, divProperties } from '@uifabric/utilities';
+import { IComponentAs, getNativeProps, divProperties, composeComponentAs } from '@uifabric/utilities';
 import { mergeStyles, IStyle } from '@uifabric/styling';
 
 const getClassNames = classNamesFunction<ICommandBarStyleProps, ICommandBarStyles>();
@@ -174,10 +174,18 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
     const DefaultButtonAs = (CommandBarButton as {}) as IComponentAs<ICommandBarItemProps>;
 
     // The prop types between these three possible implementations overlap enough that a force-cast is safe.
-    const Type = ButtonAs || CommandBarButtonAs || DefaultButtonAs;
+    let Type = DefaultButtonAs;
+
+    if (CommandBarButtonAs) {
+      Type = composeComponentAs(CommandBarButtonAs, Type);
+    }
+
+    if (ButtonAs) {
+      Type = composeComponentAs(ButtonAs, Type);
+    }
 
     // Always pass the default implementation to the override so it may be composed.
-    return <Type {...props as ICommandBarItemProps} defaultRender={DefaultButtonAs} />;
+    return <Type {...props as ICommandBarItemProps} />;
   };
 
   private _onButtonClick(item: ICommandBarItemProps): (ev: React.MouseEvent<HTMLButtonElement>) => void {
@@ -194,7 +202,6 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
 
   private _onRenderOverflowButton = (overflowItems: ICommandBarItemProps[]): JSX.Element => {
     const {
-      overflowButtonAs: OverflowButtonType = CommandBarButton,
       overflowButtonProps = {} // assure that props is not empty
     } = this.props;
 
@@ -210,6 +217,10 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
       menuProps: { ...overflowButtonProps.menuProps, items: combinedOverflowItems },
       menuIconProps: { iconName: 'More', ...overflowButtonProps.menuIconProps }
     };
+
+    const OverflowButtonType = this.props.overflowButtonAs
+      ? composeComponentAs(this.props.overflowButtonAs, CommandBarButton)
+      : CommandBarButton;
 
     return <OverflowButtonType {...overflowProps as IButtonProps} />;
   };

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -42,6 +42,7 @@ import { DEFAULT_CELL_STYLE_PROPS } from './DetailsRow.styles';
 import { CHECK_CELL_WIDTH as CHECKBOX_WIDTH } from './DetailsRowCheck.styles';
 // For every group level there is a GroupSpacer added. Importing this const to have the source value in one place.
 import { SPACER_WIDTH as GROUP_EXPAND_WIDTH } from '../GroupedList/GroupSpacer';
+import { composeRenderFunction } from '@uifabric/utilities';
 
 const getClassNames = classNamesFunction<IDetailsListStyleProps, IDetailsListStyles>();
 
@@ -538,7 +539,6 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
       onRenderMissingItem,
       onRenderItemColumn,
       getCellValueKey,
-      onRenderRow = this._onRenderRow,
       selectionMode = this._selection.mode,
       viewport,
       checkboxVisibility,
@@ -554,6 +554,9 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
       enableUpdateAnimations,
       useFastIcons
     } = this.props;
+
+    const onRenderRow = this.props.onRenderRow ? composeRenderFunction(this.props.onRenderRow, this._onRenderRow) : this._onRenderRow;
+
     const collapseAllVisibility = groupProps && groupProps.collapseAllVisibility;
     const selection = this._selection;
     const dragDropHelper = this._dragDropHelper;
@@ -598,7 +601,7 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
       return null;
     }
 
-    return onRenderRow(rowProps, this._onRenderRow);
+    return onRenderRow(rowProps);
   };
 
   private _onGroupExpandStateChanged = (isSomeGroupExpanded: boolean): void => {
@@ -1038,6 +1041,7 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
       indentWidth
     } = this.props;
     const groupNestingDepth = this._getGroupNestingDepth();
+
     const onRenderFooter = onRenderDetailsGroupFooter
       ? (props: IGroupDividerProps, defaultRender?: IRenderFunction<IGroupDividerProps>) => {
           return onRenderDetailsGroupFooter(

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
@@ -3,6 +3,7 @@ import { IDetailsRowCheckProps, IDetailsCheckboxProps, IDetailsRowCheckStyleProp
 import { css, styled, classNamesFunction } from '../../Utilities';
 import { Check, getCheck } from '../../Check';
 import { getStyles } from './DetailsRowCheck.styles';
+import { composeRenderFunction } from '@uifabric/utilities';
 
 const getClassNames = classNamesFunction<IDetailsRowCheckStyleProps, IDetailsRowCheckStyles>();
 
@@ -23,7 +24,10 @@ const DetailsRowCheckBase: React.FunctionComponent<IDetailsRowCheckProps> = prop
     ...buttonProps
   } = props;
   const defaultCheckboxRender = useFastIcons ? _fastDefaultCheckboxRender : _defaultCheckboxRender;
-  const onRenderCheckbox = onRenderDetailsCheckbox || defaultCheckboxRender;
+
+  const onRenderCheckbox = onRenderDetailsCheckbox
+    ? composeRenderFunction(onRenderDetailsCheckbox, defaultCheckboxRender)
+    : defaultCheckboxRender;
 
   const classNames = getClassNames(styles, {
     theme: theme!,
@@ -50,7 +54,7 @@ const DetailsRowCheckBase: React.FunctionComponent<IDetailsRowCheckProps> = prop
       data-selection-toggle={true}
       data-automationid="DetailsRowCheck"
     >
-      {onRenderCheckbox(detailsCheckboxProps, defaultCheckboxRender)}
+      {onRenderCheckbox(detailsCheckboxProps)}
     </div>
   ) : (
     <div {...buttonProps} className={css(classNames.root, classNames.check)} />

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -5,6 +5,7 @@ import { classNamesFunction, divProperties, getNativeProps, getWindow, initializ
 import { FocusZone, FocusZoneDirection, IFocusZone } from '../../FocusZone';
 import { Icon } from '../../Icon';
 import { INav, INavLink, INavLinkGroup, INavProps, INavStyleProps, INavStyles } from './Nav.types';
+import { composeComponentAs, composeRenderFunction } from '@uifabric/utilities';
 
 // The number pixels per indentation level for Nav links.
 const _indentationSize = 14;
@@ -88,7 +89,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
   };
 
   private _renderNavLink(link: INavLink, linkIndex: number, nestingLevel: number): JSX.Element {
-    const { styles, groups, theme, onRenderLink = this._onRenderLink, linkAs: LinkAs = ActionButton, selectedAriaLabel } = this.props;
+    const { styles, groups, theme, selectedAriaLabel } = this.props;
     const isLinkWithIcon = link.icon || link.iconProps;
     const isSelectedLink = this._isLinkSelected(link);
     const classNames = getClassNames(styles!, {
@@ -103,6 +104,9 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
     // Prevent hijacking of the parent window if link.target is defined
     const rel = link.url && link.target && !isRelativeUrl(link.url) ? 'noopener noreferrer' : undefined;
     const selectedStateAriaLabel = isSelectedLink && selectedAriaLabel ? selectedAriaLabel : undefined;
+
+    const LinkAs = this.props.linkAs ? composeComponentAs(this.props.linkAs, ActionButton) : ActionButton;
+    const onRenderLink = this.props.onRenderLink ? composeRenderFunction(this.props.onRenderLink, this._onRenderLink) : this._onRenderLink;
 
     return (
       <LinkAs
@@ -125,9 +129,8 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
             : undefined
         }
         link={link}
-        defaultRender={ActionButton}
       >
-        {onRenderLink(link, this._onRenderLink)}
+        {onRenderLink(link)}
       </LinkAs>
     );
   }

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -123,7 +123,16 @@ export const colGroupProperties: string[];
 export const colProperties: string[];
 
 // @public
+export function composeComponentAs<TProps>(outer: IComponentAs<TProps>, inner: IComponentAs<TProps>): IComponentAs<TProps>;
+
+// @public
+export function composeRenderFunction<TProps>(outer: IRenderFunction<TProps>, inner: IRenderFunction<TProps>): IRenderFunction<TProps>;
+
+// @public
 export function createArray<T>(size: number, getItem: (index: number) => T): T[];
+
+// @public
+export function createMemoizer<F extends (input: any) => any>(getValue: F): F;
 
 // Warning: (ae-incompatible-release-tags) The symbol "css" is marked as @public, but its signature references "ICssInput" which is marked as @internal
 // 

--- a/packages/utilities/src/componentAs/__snapshots__/composeComponentAs.test.tsx.snap
+++ b/packages/utilities/src/componentAs/__snapshots__/composeComponentAs.test.tsx.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`composeComponentAs passes Base as defaultRender to DecoratorB through DecoratorA 1`] = `
+<div
+  data-a="a"
+>
+  <div
+    data-b="b"
+  >
+    <div
+      data-value="test"
+    />
+  </div>
+</div>
+`;
+
+exports[`composeComponentAs passes Base to DecoratorA 1`] = `
+<div
+  data-a="a"
+>
+  <div
+    data-value="test"
+  />
+</div>
+`;
+
+exports[`composeComponentAs passes Base to DecoratorB through DecoratorA 1`] = `
+<div
+  data-a="a"
+>
+  <div
+    data-b="b"
+  >
+    <div
+      data-value="test"
+    />
+  </div>
+</div>
+`;
+
+exports[`composeComponentAs renders without defaultRender 1`] = `
+<div
+  data-a="a"
+>
+  <div
+    data-b="b"
+  />
+</div>
+`;

--- a/packages/utilities/src/componentAs/composeComponentAs.test.tsx
+++ b/packages/utilities/src/componentAs/composeComponentAs.test.tsx
@@ -1,0 +1,64 @@
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+import { IComponentAsProps } from '../IComponentAs';
+import { composeComponentAs } from './composeComponentAs';
+
+interface IExampleProps {
+  value: string;
+}
+
+const Base: React.ComponentType<IExampleProps> = (props: IExampleProps): JSX.Element | null => {
+  return <div data-value={props.value} />;
+};
+
+const DecoratorA: React.ComponentType<IComponentAsProps<IExampleProps>> = (props: IComponentAsProps<IExampleProps>): JSX.Element | null => {
+  const { defaultRender: DefaultRender, ...exampleProps } = props;
+
+  return <div data-a="a">{DefaultRender ? <DefaultRender {...exampleProps} /> : null}</div>;
+};
+
+const DecoratorB: React.ComponentType<IComponentAsProps<IExampleProps>> = (props: IComponentAsProps<IExampleProps>): JSX.Element | null => {
+  const { defaultRender: DefaultRender, ...exampleProps } = props;
+
+  return <div data-b="b">{DefaultRender ? <DefaultRender {...exampleProps} /> : null}</div>;
+};
+
+describe('composeComponentAs', () => {
+  it('passes Base to DecoratorA', () => {
+    const DecoratorAWithBase = composeComponentAs(DecoratorA, Base);
+
+    const component = renderer.create(<DecoratorAWithBase value="test" />);
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('passes Base to DecoratorB through DecoratorA', () => {
+    const DecoratorAAndBWithBase = composeComponentAs(DecoratorA, composeComponentAs(DecoratorB, Base));
+
+    const component = renderer.create(<DecoratorAAndBWithBase value="test" />);
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('passes Base as defaultRender to DecoratorB through DecoratorA', () => {
+    const DecoratorAAroundB = composeComponentAs(DecoratorA, DecoratorB);
+
+    const component = renderer.create(<DecoratorAAroundB value="test" defaultRender={Base} />);
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('renders without defaultRender', () => {
+    const DecoratorAAroundB = composeComponentAs(DecoratorA, DecoratorB);
+
+    const component = renderer.create(<DecoratorAAroundB value="test" />);
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('avoids recomposing already-composed components', () => {
+    const DecoratorAAroundB = composeComponentAs(DecoratorA, DecoratorB);
+
+    expect(composeComponentAs(DecoratorA, DecoratorB)).toBe(DecoratorAAroundB);
+  });
+});

--- a/packages/utilities/src/componentAs/composeComponentAs.tsx
+++ b/packages/utilities/src/componentAs/composeComponentAs.tsx
@@ -1,0 +1,52 @@
+import * as React from 'react';
+import { IComponentAs, IComponentAsProps } from '../IComponentAs';
+import { createMemoizer } from '../memoize';
+
+interface IComposeComponentAs {
+  <TProps>(outer: IComponentAs<TProps>): (inner: IComponentAs<TProps>) => IComponentAs<TProps>;
+}
+
+function createComposedComponent<TProps>(outer: IComponentAs<TProps>): (inner: IComponentAs<TProps>) => IComponentAs<TProps> {
+  const Outer = outer;
+
+  const outerMemoizer = createMemoizer((inner: IComponentAs<TProps>) => {
+    if (outer === inner) {
+      throw new Error('Attempted to compose a component with itself.');
+    }
+
+    const Inner = inner;
+
+    const innerMemoizer = createMemoizer((defaultRender: IComponentAs<TProps>) => {
+      const InnerWithDefaultRender: React.ComponentType<IComponentAsProps<TProps>> = (
+        innerProps: IComponentAsProps<TProps>
+      ): JSX.Element => {
+        return <Inner {...innerProps} defaultRender={defaultRender} />;
+      };
+
+      return InnerWithDefaultRender;
+    });
+
+    const OuterWithDefaultRender: React.ComponentType<IComponentAsProps<TProps>> = (outerProps: IComponentAsProps<TProps>): JSX.Element => {
+      const { defaultRender } = outerProps;
+
+      return <Outer {...outerProps} defaultRender={defaultRender ? innerMemoizer(defaultRender) : Inner} />;
+    };
+
+    return OuterWithDefaultRender;
+  });
+
+  return outerMemoizer;
+}
+
+const componentAsMemoizer = createMemoizer<IComposeComponentAs>(createComposedComponent);
+
+/**
+ * Composes two components which conform to the `IComponentAs` specification; that is, two
+ * components which accept a `defaultRender` prop, which is a 'default' implementation of
+ * a component which accepts the same overall props.
+ *
+ * @public
+ */
+export function composeComponentAs<TProps>(outer: IComponentAs<TProps>, inner: IComponentAs<TProps>): IComponentAs<TProps> {
+  return componentAsMemoizer(outer)(inner);
+}

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -53,6 +53,7 @@ export { assign, filteredAssign, mapEnumByName, shallowCompare, values } from '.
 export * from './osDetector';
 export * from './overflow';
 export * from './properties';
+export * from './renderFunction/composeRenderFunction';
 export * from './resources';
 export * from './rtl';
 export * from './safeRequestAnimationFrame';

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -23,6 +23,7 @@ export * from './array';
 export * from './asAsync';
 export * from './assertNever';
 export * from './classNamesFunction';
+export * from './componentAs/composeComponentAs';
 export * from './controlled';
 export * from './createRef';
 export * from './css';

--- a/packages/utilities/src/memoize.ts
+++ b/packages/utilities/src/memoize.ts
@@ -124,6 +124,47 @@ export function memoizeFunction<T extends (...args: any[]) => RET_TYPE, RET_TYPE
   } as any;
 }
 
+/**
+ * Creates a memoizer for a single-value function, backed by a WeakMap.
+ * With a WeakMap, the memoized values are only kept as long as the source objects,
+ * ensuring that there is no memory leak.
+ *
+ * This function assumes that the input values passed to the wrapped function will be
+ * `function` or `object` types. To memoize functions which accept other inputs, use
+ * `memoizeFunction`, which memoizes against arbitrary inputs using a lookup cache.
+ *
+ * @public
+ */
+export function createMemoizer<F extends (input: any) => any>(getValue: F): F {
+  if (!_weakMap) {
+    // Without a `WeakMap` implementation, memoization is not possible.
+    return getValue;
+  }
+
+  const cache = new _weakMap();
+
+  function memoizedGetValue(input: any): any {
+    if (!input || (typeof input !== 'function' && typeof input !== 'object')) {
+      // A WeakMap can only be used to test against reference values, i.e. 'function' and 'object'.
+      // All other inputs cannot be memoized against in this manner.
+      return getValue(input);
+    }
+
+    if (cache.has(input)) {
+      // tslint:disable-next-line:no-non-null-assertion
+      return cache.get(input)!;
+    }
+
+    const value = getValue(input);
+
+    cache.set(input, value);
+
+    return value;
+  }
+
+  return memoizedGetValue as F;
+}
+
 function _normalizeArg(val: null | undefined): { empty: boolean } | any;
 function _normalizeArg(val: object): any;
 function _normalizeArg(val: any): any {

--- a/packages/utilities/src/renderFunction/__snapshots__/composeRenderFunction.test.tsx.snap
+++ b/packages/utilities/src/renderFunction/__snapshots__/composeRenderFunction.test.tsx.snap
@@ -1,0 +1,49 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`composeComponentAs passes Base as defaultRender to DecoratorB through DecoratorA 1`] = `
+<div
+  data-a="a"
+>
+  <div
+    data-b="b"
+  >
+    <div
+      data-value="test"
+    />
+  </div>
+</div>
+`;
+
+exports[`composeComponentAs passes Base to DecoratorA 1`] = `
+<div
+  data-a="a"
+>
+  <div
+    data-value="test"
+  />
+</div>
+`;
+
+exports[`composeComponentAs passes Base to DecoratorB through DecoratorA 1`] = `
+<div
+  data-a="a"
+>
+  <div
+    data-b="b"
+  >
+    <div
+      data-value="test"
+    />
+  </div>
+</div>
+`;
+
+exports[`composeComponentAs renders without defaultRender 1`] = `
+<div
+  data-a="a"
+>
+  <div
+    data-b="b"
+  />
+</div>
+`;

--- a/packages/utilities/src/renderFunction/composeRenderFunction.test.tsx
+++ b/packages/utilities/src/renderFunction/composeRenderFunction.test.tsx
@@ -1,0 +1,68 @@
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+import { IRenderFunction } from '../IRenderFunction';
+import { composeRenderFunction } from './composeRenderFunction';
+
+interface IExampleProps {
+  value: string;
+}
+
+const renderBase = (props: IExampleProps): JSX.Element | null => {
+  return <div data-value={props.value} />;
+};
+
+const renderDecoratorA = (props?: IExampleProps, defaultRender?: IRenderFunction<IExampleProps>): JSX.Element | null => {
+  if (!props) {
+    return null;
+  }
+
+  return <div data-a="a">{defaultRender ? defaultRender(props) : null}</div>;
+};
+
+const renderDecoratorB = (props?: IExampleProps, defaultRender?: IRenderFunction<IExampleProps>): JSX.Element | null => {
+  if (!props) {
+    return null;
+  }
+
+  return <div data-b="b">{defaultRender ? defaultRender(props) : null}</div>;
+};
+
+describe('composeComponentAs', () => {
+  it('passes Base to DecoratorA', () => {
+    const renderDecoratorAWithBase = composeRenderFunction(renderDecoratorA, renderBase);
+
+    const component = renderer.create(<>{renderDecoratorAWithBase({ value: 'test' })}</>);
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('passes Base to DecoratorB through DecoratorA', () => {
+    const renderDecoratorAAndBWithBase = composeRenderFunction(renderDecoratorA, composeRenderFunction(renderDecoratorB, renderBase));
+
+    const component = renderer.create(<>{renderDecoratorAAndBWithBase({ value: 'test' })}</>);
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('passes Base as defaultRender to DecoratorB through DecoratorA', () => {
+    const renderDecoratorAAroundB = composeRenderFunction(renderDecoratorA, renderDecoratorB);
+
+    const component = renderer.create(<>{renderDecoratorAAroundB({ value: 'test' }, renderBase)}</>);
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('renders without defaultRender', () => {
+    const renderDecoratorAAroundB = composeRenderFunction(renderDecoratorA, renderDecoratorB);
+
+    const component = renderer.create(<>{renderDecoratorAAroundB({ value: 'test' })}</>);
+
+    expect(component.toJSON()).toMatchSnapshot();
+  });
+
+  it('avoids recomposing already-composed components', () => {
+    const renderDecoratorAAroundB = composeRenderFunction(renderDecoratorA, renderDecoratorB);
+
+    expect(composeRenderFunction(renderDecoratorA, renderDecoratorB)).toBe(renderDecoratorAAroundB);
+  });
+});

--- a/packages/utilities/src/renderFunction/composeRenderFunction.tsx
+++ b/packages/utilities/src/renderFunction/composeRenderFunction.tsx
@@ -1,0 +1,34 @@
+import { IRenderFunction } from '../IRenderFunction';
+import { createMemoizer } from '../memoize';
+
+interface IRenderFunctionComposer {
+  <TProps>(outer: IRenderFunction<TProps>): (inner: IRenderFunction<TProps>) => IRenderFunction<TProps>;
+}
+
+function createComposedRenderFunction<TProps>(outer: IRenderFunction<TProps>): (inner: IRenderFunction<TProps>) => IRenderFunction<TProps> {
+  const outerMemoizer = createMemoizer((inner: IRenderFunction<TProps>) => {
+    const innerMemoizer = createMemoizer((defaultRender: IRenderFunction<TProps>) => {
+      return (innerProps?: TProps) => {
+        return inner(innerProps, defaultRender);
+      };
+    });
+
+    return (outerProps?: TProps, defaultRender?: IRenderFunction<TProps>) => {
+      return outer(outerProps, defaultRender ? innerMemoizer(defaultRender) : inner);
+    };
+  });
+
+  return outerMemoizer;
+}
+
+const memoizer = createMemoizer<IRenderFunctionComposer>(createComposedRenderFunction);
+
+/**
+ * Composes two 'render functions' to produce a final render function that renders
+ * the outer function, passing the inner function as 'default render'. The inner function
+ * is then passed the original 'default render' prop.
+ * @public
+ */
+export function composeRenderFunction<TProps>(outer: IRenderFunction<TProps>, inner: IRenderFunction<TProps>): IRenderFunction<TProps> {
+  return memoizer(outer)(inner);
+}


### PR DESCRIPTION
Several Fabric components accept props along the following lines:
```ts
___As: IComponentAs<I___Props>;
```
The component type passed to the prop is expected to accept the props of the original component and generally invoke the `defaultRender` component, which is the original logic.
Depending on circumstances, sometimes the provider of an `IComponentAs` may need to 'compose' the implementation with some other implementation, such as the `CommandBar` composing `props.commandBarButtonAs` with a given `item.commandBarButtonAs`. In that case, such components need a memoized function which produces the union of two such component overrides.

This change introduces `composeComponentAs`, a `function` which accepts two components that conform to the `IComponentAs` specification and produces a final `IComponentAs` that first renders the 'outer' component and then the 'inner' component, passing `defaultRender` from the original props through to the 'inner' component.

This utility can help make composition of 'decorator' components smoother, since callers won't need to re-implement this logic themselves. Such re-implementations are usually buggy since they don't account for edge cases or aren't memoized. This utility will also make it easier to adopt the `IComponentAs` pattern more generally instead of the existing `onRender___` pattern, since the weak points of `IComponentAs` have now been eliminated.

This change adds unit tests and exposes `composeComponentAs` from the root of `@uifabric/utilities`.

This change also adds a `composeRenderFunction` function, which does a similar behavior for two implementations of `IRenderFunction<TProps>`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10448)