### PR TITLE
Adding a prop shouldUpdateWhenHidden to decide whether to update hidden callouts

### DIFF
--- a/change/office-ui-fabric-react-2019-09-16-15-56-59-PersistedCallout.json
+++ b/change/office-ui-fabric-react-2019-09-16-15-56-59-PersistedCallout.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Adding a prop shouldUpdateWhenHidden to decide whether to udpate hidden callouts and contextual menus",
+  "packageName": "office-ui-fabric-react",
+  "email": "kushaly@microsoft.com",
+  "commit": "355ebb3c68fc1ef9bd20adacbc464c0e519bb394",
+  "date": "2019-09-16T22:56:59.045Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -2119,6 +2119,7 @@ export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement> {
     role?: string;
     setInitialFocus?: boolean;
     shouldRestoreFocus?: boolean;
+    shouldUpdateWhenHidden?: boolean;
     style?: React.CSSProperties;
     styles?: IStyleFunctionOrObject<ICalloutContentStyleProps, ICalloutContentStyles>;
     target?: Target;
@@ -3030,6 +3031,7 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
     onRenderSubMenu?: IRenderFunction<IContextualMenuProps>;
     shouldFocusOnContainer?: boolean;
     shouldFocusOnMount?: boolean;
+    shouldUpdateWhenHidden?: boolean;
     styles?: IStyleFunctionOrObject<IContextualMenuStyleProps, IContextualMenuStyles>;
     subMenuHoverDelay?: number;
     target?: Target;

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.types.ts
@@ -229,6 +229,15 @@ export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement> {
   hidden?: boolean;
 
   /**
+   * If true, the component even when hidden=true.
+   * Note that this would consume resources to update even though
+   * nothing is being shown to the user.
+   * This might be helpful though if your updates are small and you want the
+   * callout to be revealed fast to the user when hidden is set to false.
+   */
+  shouldUpdateWhenHidden?: boolean;
+
+  /**
    * If specified, determines whether the underlying "Popup" component should try to restore
    * focus when it is dismissed.  When set to false, the Popup won't try to restore focus to
    * the last focused element.

--- a/packages/office-ui-fabric-react/src/components/Callout/Callout.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/Callout.types.ts
@@ -229,7 +229,7 @@ export interface ICalloutProps extends React.HTMLAttributes<HTMLDivElement> {
   hidden?: boolean;
 
   /**
-   * If true, the component even when hidden=true.
+   * If true, the component will be updated even when hidden=true.
    * Note that this would consume resources to update even though
    * nothing is being shown to the user.
    * This might be helpful though if your updates are small and you want the

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -114,7 +114,7 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
   }
 
   public shouldComponentUpdate(newProps: ICalloutProps, newState: ICalloutState): boolean {
-    if (this.props.hidden && newProps.hidden) {
+    if (!newProps.shouldUpdateWhenHidden && this.props.hidden && newProps.hidden) {
       // Do not update when hidden.
       return false;
     }

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.test.tsx
@@ -36,6 +36,22 @@ describe('CalloutContentBase', () => {
     // Showing content should trigger a render update.
     callout.setProps({ target: targetElement2, hidden: false });
     expect(renderMock).toHaveBeenCalled();
+    renderMock.mockClear();
+
+    callout.setProps({
+      target: targetElement2,
+      hidden: true
+    });
+
+    // Updating content should trigger a render update.
+    // even when hidden when shouldUpdateWhenHidden is true.
+    callout.setProps({
+      target: targetElement1,
+      hidden: true,
+      shouldUpdateWhenHidden: true
+    });
+    expect(renderMock).toHaveBeenCalled();
+    renderMock.mockClear();
   });
 
   it('Ensure callout content does not update when props are shallow equal', () => {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -142,7 +142,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
   };
 
   public shouldComponentUpdate(newProps: IContextualMenuProps, newState: IContextualMenuState): boolean {
-    if (this.props.hidden && newProps.hidden) {
+    if (!newProps.shouldUpdateWhenHidden && this.props.hidden && newProps.hidden) {
       // Do not update when hidden.
       return false;
     }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -254,6 +254,15 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
   hidden?: boolean;
 
   /**
+   * If true, the component even when hidden=true.
+   * Note that this would consume resources to update even though
+   * nothing is being shown to the user.
+   * This might be helpful though if your updates are small and you want the
+   * callout to be revealed fast to the user when hidden is set to false.
+   */
+  shouldUpdateWhenHidden?: boolean;
+
+  /**
    * If true, the contextual menu will not be updated until
    * focus enters the menu via other means. This will only result
    * in different behavior when shouldFocusOnMount = false

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -254,11 +254,11 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
   hidden?: boolean;
 
   /**
-   * If true, the component even when hidden=true.
+   * If true, the component will be updated even when hidden=true.
    * Note that this would consume resources to update even though
    * nothing is being shown to the user.
    * This might be helpful though if your updates are small and you want the
-   * callout to be revealed fast to the user when hidden is set to false.
+   * contextual menu to be revealed fast to the user when hidden is set to false.
    */
   shouldUpdateWhenHidden?: boolean;
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Previously, to improve perf. we added code to stop updating a hidden callout or a contextual menu. This helped in not spending time to update Callouts which were not shown to the user.

Currently, we are working on a performance improvement that iteratively updates a hidden Callout during browser idle time. This would help us show a hidden Callout very fast to the user. For this however, we need the updates to propagated to a hidden callout as well. Hence, this change. 

To maintain backwards compatibility and because in the default case, I still think it is valuable to not update a hidden Callout, I am introducing a prop rather than change behavior.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10465)