### PR TITLE
Contextual Menu calls onMenuOpened when it does not need to

### DIFF
--- a/change/office-ui-fabric-react-2019-09-16-16-14-32-PersistedContextualMenu.json
+++ b/change/office-ui-fabric-react-2019-09-16-16-14-32-PersistedContextualMenu.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Contextual Menu calls onMenuOpened when hidden is changed from undefined to false.",
+  "packageName": "office-ui-fabric-react",
+  "email": "kushaly@microsoft.com",
+  "commit": "9d70e17c26c39eaf5d5e838e9723132c416a30f4",
+  "date": "2019-09-16T23:14:32.297Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -364,8 +364,11 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
     }
   }
 
-  // Return whether the contextual menu is hidden.
-  // Undefined value for hidden is equivalent to hidden being false.
+  /**
+   * Return whether the contextual menu is hidden.
+   * Undefined value for hidden is equivalent to hidden being false.
+   * @param props - Props for the component
+   */
   private _isHidden(props: IContextualMenuProps) {
     return !!props.hidden;
   }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -156,8 +156,9 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
       const newTarget = newProps.target;
       this._setTargetWindowAndElement(newTarget!);
     }
-    if (newProps.hidden !== this.props.hidden) {
-      if (newProps.hidden) {
+
+    if (this._isHidden(newProps) !== this._isHidden(this.props)) {
+      if (this._isHidden(newProps)) {
         this._onMenuClosed();
       } else {
         this._onMenuOpened();
@@ -361,6 +362,12 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
     } else {
       return null;
     }
+  }
+
+  // Return whether the contextual menu is hidden.
+  // Undefined value for hidden is equivalent to hidden being false.
+  private _isHidden(props: IContextualMenuProps) {
+    return !!props.hidden;
   }
 
   private _onMenuOpened() {

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -250,6 +250,7 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
    * to improve rendering performance when it becomes visible.
    * Note: When ContextualMenu is hidden its content will not be rendered. It will only render
    * once the ContextualMenu is visible.
+   * @defaultValue undefined
    */
   hidden?: boolean;
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
While doing something related, I saw that ContextualMenu calls `onMenuOpened` when hidden prop changes from `undefined` to `false`. Before and after the prop change, the contextual menu is still shown. So, that looks like it is wrong behavior.

This PR fixes that.


#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10466)