### PR TITLE
Button: Add prop to set aria-expanded value [7.0]

### DIFF
--- a/change/office-ui-fabric-react-2019-09-16-17-45-26-button-ariaexpanded-7.json
+++ b/change/office-ui-fabric-react-2019-09-16-17-45-26-button-ariaexpanded-7.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Button: Add prop to set aria-expanded value",
+  "packageName": "office-ui-fabric-react",
+  "email": "erabelle@microsoft.com",
+  "commit": "53221b522ace43a5cd01b57dc633eda5762d446f",
+  "date": "2019-09-17T00:45:26.502Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1872,6 +1872,7 @@ export interface IButton {
 export interface IButtonProps extends React.AllHTMLAttributes<HTMLAnchorElement | HTMLButtonElement | HTMLDivElement | BaseButton | Button | HTMLSpanElement> {
     allowDisabledFocus?: boolean;
     ariaDescription?: string;
+    ariaExpanded?: boolean;
     ariaHidden?: boolean;
     ariaLabel?: string;
     // @deprecated

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -113,7 +113,8 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       variantClassName,
       theme,
       toggle,
-      getClassNames
+      getClassNames,
+      ariaExpanded
     } = this.props;
 
     // Button is disabled if the whole button (in case of splitbutton is disabled) or if the primary action is disabled
@@ -207,7 +208,8 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       'aria-describedby': ariaDescribedBy,
       'aria-disabled': isPrimaryButtonDisabled,
       'data-is-focusable': dataIsFocusable,
-      'aria-pressed': toggle ? !!checked : undefined // aria-pressed attribute should only be present for toggle buttons
+      'aria-pressed': toggle ? !!checked : undefined, // aria-pressed attribute should only be present for toggle buttons
+      'aria-expanded': ariaExpanded
     });
 
     if (ariaHidden) {
@@ -218,7 +220,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       return this._onRenderSplitButtonContent(tag, buttonProps);
     } else if (this.props.menuProps) {
       assign(buttonProps, {
-        'aria-expanded': this._isExpanded,
+        'aria-expanded': ariaExpanded || this._isExpanded,
         'aria-owns': this.state.menuProps ? this._labelId + '-menu' : null,
         'aria-haspopup': true
       });

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -208,8 +208,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       'aria-describedby': ariaDescribedBy,
       'aria-disabled': isPrimaryButtonDisabled,
       'data-is-focusable': dataIsFocusable,
-      'aria-pressed': toggle ? !!checked : undefined, // aria-pressed attribute should only be present for toggle buttons
-      'aria-expanded': ariaExpanded
+      'aria-pressed': toggle ? !!checked : undefined // aria-pressed attribute should only be present for toggle buttons
     });
 
     if (ariaHidden) {
@@ -220,10 +219,14 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       return this._onRenderSplitButtonContent(tag, buttonProps);
     } else if (this.props.menuProps) {
       assign(buttonProps, {
-        'aria-expanded': ariaExpanded || this._isExpanded,
+        'aria-expanded': this._isExpanded,
         'aria-owns': this.state.menuProps ? this._labelId + '-menu' : null,
         'aria-haspopup': true
       });
+    }
+
+    if (ariaExpanded !== undefined) {
+      buttonProps['aria-expanded'] = ariaExpanded;
     }
 
     return this._onRenderContent(tag, buttonProps);

--- a/packages/office-ui-fabric-react/src/components/Button/Button.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.test.tsx
@@ -98,6 +98,16 @@ describe('Button', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('applies aria-expanded', () => {
+    const button = render(
+      <DefaultButton href="http://www.microsoft.com" target="_blank" aria-expanded={true}>
+        Hello
+      </DefaultButton>
+    );
+
+    expect(button.getAttribute('aria-expanded')).toEqual('true');
+  });
+
   describe('DefaultButton', () => {
     it('can render without an onClick.', () => {
       const button = render(<DefaultButton>Hello</DefaultButton>);

--- a/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
@@ -109,6 +109,12 @@ export interface IButtonProps
   ariaLabel?: string;
 
   /**
+   * The expanded status of the button for the benefit of screen readers. This value is already determined internally for buttons with
+   * expandable menus. This prop may be passed as an override when the button does not contain `menuProps`.
+   */
+  ariaExpanded?: boolean;
+
+  /**
    * Detailed description of the button for the benefit of screen readers.
    *
    * Besides the compound button, other button types will need more information provided to screen reader.


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add prop ariaExpanded to Button to allow passing in value. The aria-expanded value is currently determined internally by the presence of menuProps. This prop will allow the value to be set when menuProps is not provided, but the button still needs to track expanded state of a container (for example, the Details Pane command in SPO).

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10468)