### PR TITLE
SwatchColorPicker: Prevent unnecessary re-renders

### DIFF
--- a/change/office-ui-fabric-react-2019-09-16-16-40-44-ColorPickerPerf3.json
+++ b/change/office-ui-fabric-react-2019-09-16-16-40-44-ColorPickerPerf3.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Changing ColorPicker to use a selectedId instead of selectedIndex in its state.",
+  "packageName": "office-ui-fabric-react",
+  "email": "kushaly@microsoft.com",
+  "commit": "f388d37561eecf3c458a19367c4cdc41768f1f88",
+  "date": "2019-09-16T23:40:44.615Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -620,7 +620,7 @@ export class ColorPickerBase extends React.Component<IColorPickerProps, IColorPi
 export const ColorPickerGridCell: React.StatelessComponent<IColorPickerGridCellProps>;
 
 // @public (undocumented)
-export class ColorPickerGridCellBase extends React.Component<IColorPickerGridCellProps, {}> {
+export class ColorPickerGridCellBase extends React.PureComponent<IColorPickerGridCellProps, {}> {
     // (undocumented)
     static defaultProps: IColorPickerGridCellProps;
     // (undocumented)

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.base.tsx
@@ -60,7 +60,7 @@ const getClassNames = classNamesFunction<IColorPickerGridCellStyleProps, IColorP
 
 class ColorCell extends GridCell<IColorCellProps, IGridCellProps<IColorCellProps>> {}
 
-export class ColorPickerGridCellBase extends React.Component<IColorPickerGridCellProps, {}> {
+export class ColorPickerGridCellBase extends React.PureComponent<IColorPickerGridCellProps, {}> {
   public static defaultProps = {
     circle: true,
     disabled: false,

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.tsx
@@ -8,4 +8,4 @@ export const ColorPickerGridCell: React.StatelessComponent<IColorPickerGridCellP
   IColorPickerGridCellProps,
   IColorPickerGridCellStyleProps,
   IColorPickerGridCellStyles
->(ColorPickerGridCellBase, getStyles, undefined, { scope: 'ColorPickerGridCell' });
+>(ColorPickerGridCellBase, getStyles, undefined, { scope: 'ColorPickerGridCell' }, true);

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
@@ -1,20 +1,12 @@
 import * as React from 'react';
-import {
-  Async,
-  classNamesFunction,
-  findIndex,
-  KeyCodes,
-  getId,
-  warnMutuallyExclusive,
-  warnConditionallyRequiredProps
-} from '../../Utilities';
+import { Async, classNamesFunction, KeyCodes, getId, warnMutuallyExclusive, warnConditionallyRequiredProps } from '../../Utilities';
 import { ISwatchColorPickerProps, ISwatchColorPickerStyleProps, ISwatchColorPickerStyles } from './SwatchColorPicker.types';
 import { Grid } from '../../utilities/grid/Grid';
 import { IColorCellProps } from './ColorPickerGridCell.types';
 import { ColorPickerGridCell } from './ColorPickerGridCell';
 
 export interface ISwatchColorPickerState {
-  selectedIndex?: number;
+  selectedId?: string;
 }
 
 const getClassNames = classNamesFunction<ISwatchColorPickerStyleProps, ISwatchColorPickerStyles>();
@@ -57,13 +49,8 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
     this.isNavigationIdle = true;
     this.async = new Async(this);
 
-    let selectedIndex: number | undefined;
-    if (props.selectedId) {
-      selectedIndex = this._getSelectedIndex(props.colorCells, props.selectedId);
-    }
-
     this.state = {
-      selectedIndex
+      selectedId: props.selectedId
     };
   }
 
@@ -71,7 +58,7 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
   public UNSAFE_componentWillReceiveProps(newProps: ISwatchColorPickerProps): void {
     if (newProps.selectedId !== undefined) {
       this.setState({
-        selectedIndex: this._getSelectedIndex(newProps.colorCells, newProps.selectedId)
+        selectedId: newProps.selectedId
       });
     }
   }
@@ -108,9 +95,7 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
     return (
       <Grid
         {...this.props}
-        items={colorCells.map((item, index) => {
-          return { ...item, index: index };
-        })}
+        items={colorCells}
         columnCount={columnCount}
         onRenderItem={this._renderOption}
         positionInSet={positionInSet && positionInSet}
@@ -141,17 +126,6 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
   };
 
   /**
-   * Get the selected item's index
-   * @param items - The items to search
-   * @param selectedId - The selected item's id to find
-   * @returns - The index of the selected item's id, -1 if there was no match
-   */
-  private _getSelectedIndex(items: IColorCellProps[], selectedId: string): number | undefined {
-    const selectedIndex = findIndex(items, item => item.id === selectedId);
-    return selectedIndex >= 0 ? selectedIndex : undefined;
-  }
-
-  /**
    * Render a color cell
    * @param item - The item to render
    * @returns - Element representing the item
@@ -169,7 +143,7 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
         onClick={this._onCellClick}
         onHover={this._onGridCellHovered}
         onFocus={this._onGridCellFocused}
-        selected={this.state.selectedIndex !== undefined && this.state.selectedIndex === item.index}
+        selected={this.state.selectedId === item.id}
         circle={this.props.cellShape === 'circle'}
         label={item.label}
         onMouseEnter={this._onMouseEnter}
@@ -332,11 +306,9 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
       return;
     }
 
-    const index = item.index as number;
-
     // If we have a valid index and it is not already
     // selected, select it
-    if (index >= 0 && index !== this.state.selectedIndex) {
+    if (item.id !== this.state.selectedId) {
       if (this.props.onCellFocused && this._cellFocused) {
         this._cellFocused = false;
         this.props.onCellFocused();
@@ -349,7 +321,7 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
       // Update internal state only if the component is uncontrolled
       if (this.props.isControlled !== true) {
         this.setState({
-          selectedIndex: index
+          selectedId: item.id
         });
       }
     }

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.types.ts
@@ -32,7 +32,12 @@ export interface ISwatchColorPickerProps {
   selectedId?: string;
 
   /**
-   * The color cells that will be made available to the user
+   * The color cells that will be made available to the user.
+   *
+   * Note: When the reference to this prop changes,
+   * regardless of how many color cells change, all of the color cells
+   * will be re-rendered (potentially bad perf.) because we memoize
+   * based on this prop's reference.
    */
   colorCells: IColorCellProps[];
 

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/examples/SwatchColorPicker.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/examples/SwatchColorPicker.Basic.Example.tsx
@@ -8,6 +8,28 @@ export interface IBasicSwatchColorPickerExampleState {
   previewColor2: string | undefined;
 }
 
+const colorCellsExample1 = [
+  { id: 'a', label: 'orange', color: '#ca5010' },
+  { id: 'b', label: 'cyan', color: '#038387' },
+  { id: 'c', label: 'blueMagenta', color: '#8764b8' },
+  { id: 'd', label: 'magenta', color: '#881798' },
+  { id: 'e', label: 'white', color: '#ffffff' }
+];
+const colorCellsExample2 = [
+  { id: 'a', label: 'red', color: '#a4262c' },
+  { id: 'b', label: 'orange', color: '#ca5010' },
+  { id: 'c', label: 'orangeYellow', color: '#986f0b' },
+  { id: 'd', label: 'yellowGreen', color: '#8cbd18' },
+  { id: 'e', label: 'green', color: '#0b6a0b' },
+  { id: 'f', label: 'cyan', color: '#038387' },
+  { id: 'g', label: 'cyanBlue', color: '#004e8c' },
+  { id: 'h', label: 'magenta', color: '#881798' },
+  { id: 'i', label: 'magentaPink', color: '#9b0062' },
+  { id: 'j', label: 'black', color: '#000000' },
+  { id: 'k', label: 'gray', color: '#7a7574' },
+  { id: 'l', label: 'gray20', color: '#69797e' }
+];
+
 export class SwatchColorPickerBasicExample extends React.Component<any, IBasicSwatchColorPickerExampleState> {
   constructor(props: any) {
     super(props);
@@ -23,31 +45,9 @@ export class SwatchColorPickerBasicExample extends React.Component<any, IBasicSw
     return (
       <div>
         <div>Simple circle swatch color picker:</div>
-        <SwatchColorPicker
-          columnCount={5}
-          selectedId={this.state.color}
-          cellShape={'circle'}
-          colorCells={[
-            { id: 'a', label: 'orange', color: '#ca5010' },
-            { id: 'b', label: 'cyan', color: '#038387' },
-            { id: 'c', label: 'blueMagenta', color: '#8764b8' },
-            { id: 'd', label: 'magenta', color: '#881798' },
-            { id: 'e', label: 'white', color: '#ffffff' }
-          ]}
-        />
+        <SwatchColorPicker columnCount={5} selectedId={this.state.color} cellShape={'circle'} colorCells={colorCellsExample1} />
         <div>Simple square swatch color picker with default size of 20px:</div>
-        <SwatchColorPicker
-          columnCount={5}
-          selectedId={this.state.color}
-          cellShape={'square'}
-          colorCells={[
-            { id: 'a', label: 'orange', color: '#ca5010' },
-            { id: 'b', label: 'cyan', color: '#038387' },
-            { id: 'c', label: 'blueMagenta', color: '#8764b8' },
-            { id: 'd', label: 'magenta', color: '#881798' },
-            { id: 'e', label: 'white', color: '#ffffff' }
-          ]}
-        />
+        <SwatchColorPicker columnCount={5} selectedId={this.state.color} cellShape={'square'} colorCells={colorCellsExample1} />
         <div>Simple square swatch color picker with custom size of 35px:</div>
         <SwatchColorPicker
           columnCount={5}
@@ -55,13 +55,7 @@ export class SwatchColorPickerBasicExample extends React.Component<any, IBasicSw
           cellWidth={35}
           selectedId={this.state.color}
           cellShape={'square'}
-          colorCells={[
-            { id: 'a', label: 'orange', color: '#ca5010' },
-            { id: 'b', label: 'cyan', color: '#038387' },
-            { id: 'c', label: 'blueMagenta', color: '#8764b8' },
-            { id: 'd', label: 'magenta', color: '#881798' },
-            { id: 'e', label: 'white', color: '#ffffff' }
-          ]}
+          colorCells={colorCellsExample1}
         />
         <div>Simple swatch color picker with multiple rows and larger cells that updates its icon color and shows a preview color:</div>
         <div
@@ -83,20 +77,7 @@ export class SwatchColorPickerBasicExample extends React.Component<any, IBasicSw
           cellHeight={35}
           cellWidth={35}
           cellBorderWidth={3}
-          colorCells={[
-            { id: 'a', label: 'red', color: '#a4262c' },
-            { id: 'b', label: 'orange', color: '#ca5010' },
-            { id: 'c', label: 'orangeYellow', color: '#986f0b' },
-            { id: 'd', label: 'yellowGreen', color: '#8cbd18' },
-            { id: 'e', label: 'green', color: '#0b6a0b' },
-            { id: 'f', label: 'cyan', color: '#038387' },
-            { id: 'g', label: 'cyanBlue', color: '#004e8c' },
-            { id: 'h', label: 'magenta', color: '#881798' },
-            { id: 'i', label: 'magentaPink', color: '#9b0062' },
-            { id: 'j', label: 'black', color: '#000000' },
-            { id: 'k', label: 'gray', color: '#7a7574' },
-            { id: 'l', label: 'gray20', color: '#69797e' }
-          ]}
+          colorCells={colorCellsExample2}
         />
         <div>Simple disabled circle swatch color picker:</div>
         <SwatchColorPicker
@@ -104,13 +85,7 @@ export class SwatchColorPickerBasicExample extends React.Component<any, IBasicSw
           columnCount={5}
           selectedId={this.state.color}
           cellShape={'circle'}
-          colorCells={[
-            { id: 'a', label: 'orange', color: '#ca5010' },
-            { id: 'b', label: 'cyan', color: '#038387' },
-            { id: 'c', label: 'blueMagenta', color: '#8764b8' },
-            { id: 'd', label: 'magenta', color: '#881798' },
-            { id: 'e', label: 'white', color: '#ffffff' }
-          ]}
+          colorCells={colorCellsExample1}
         />
       </div>
     );


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
When a SwatchColorPicker is asked to re-render, it does a few things wrong which results in it having to update all its color cells even when it need not.
1. ColorPickerGridCell which is a component used to render each cell is not pure. As a result, it causes all color cells to re-render whenever the ColorPicker has to re-render.
2. The Color Picker uses index of the color cell as the state. In order to do so, it maps the items prop to include an index in each item. This results in each Color cell thinking that its props have changed.

This PR fixes both the above problems. I also need to change the example because it was always generating a new reference for color cells.

**Before the change:**
![image](https://user-images.githubusercontent.com/2162858/65002245-b76ca700-d8a7-11e9-9b48-08bf6437363d.png)

**After the change:**
![image](https://user-images.githubusercontent.com/2162858/65002165-5f35a500-d8a7-11e9-8265-611c3eb0006b.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10469)