### PR TITLE
Update SearchBox roles

### DIFF
--- a/change/office-ui-fabric-react-2019-09-17-10-16-33-update-search-roles.json
+++ b/change/office-ui-fabric-react-2019-09-17-10-16-33-update-search-roles.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add landmark and widget role to searchbox",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "f559f2b95df4136e1f1831b4a3c969fcb4739fec",
+  "date": "2019-09-17T17:16:33.464Z"
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -109,7 +109,7 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
     ]);
 
     return (
-      <div ref={this._rootElement} className={classNames.root} onFocusCapture={this._onFocusCapture}>
+      <div aria-role="search" ref={this._rootElement} className={classNames.root} onFocusCapture={this._onFocusCapture}>
         <div className={classNames.iconContainer} onClick={this._onClickFocus} aria-hidden={true}>
           <Icon iconName="Search" {...iconProps} className={classNames.icon} />
         </div>
@@ -123,6 +123,7 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
           onKeyDown={this._onKeyDown}
           value={value}
           disabled={disabled}
+          aria-role="searchbox"
           aria-label={ariaLabel ? ariaLabel : placeholder}
           ref={this._inputElement}
         />

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -109,7 +109,7 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
     ]);
 
     return (
-      <div aria-role="search" ref={this._rootElement} className={classNames.root} onFocusCapture={this._onFocusCapture}>
+      <div role="search" ref={this._rootElement} className={classNames.root} onFocusCapture={this._onFocusCapture}>
         <div className={classNames.iconContainer} onClick={this._onClickFocus} aria-hidden={true}>
           <Icon iconName="Search" {...iconProps} className={classNames.icon} />
         </div>
@@ -123,7 +123,7 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
           onKeyDown={this._onKeyDown}
           value={value}
           disabled={disabled}
-          aria-role="searchbox"
+          role="searchbox"
           aria-label={ariaLabel ? ariaLabel : placeholder}
           ref={this._inputElement}
         />

--- a/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`SearchBox renders SearchBox correctly 1`] = `
 <div
+  aria-role="search"
   className=
       ms-SearchBox
       {
@@ -84,6 +85,7 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
     </i>
   </div>
   <input
+    aria-role="searchbox"
     className=
         ms-SearchBox-field
         {
@@ -135,6 +137,7 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
 
 exports[`SearchBox renders SearchBox without animation correctly 1`] = `
 <div
+  aria-role="search"
   className=
       ms-SearchBox
       {
@@ -215,6 +218,7 @@ exports[`SearchBox renders SearchBox without animation correctly 1`] = `
     </i>
   </div>
   <input
+    aria-role="searchbox"
     className=
         ms-SearchBox-field
         {
@@ -255,7 +259,7 @@ exports[`SearchBox renders SearchBox without animation correctly 1`] = `
         &::-ms-clear {
           display: none;
         }
-    id="SearchBox5"
+    id="SearchBox2"
     onChange={[Function]}
     onInput={[Function]}
     onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`SearchBox renders SearchBox correctly 1`] = `
 <div
-  aria-role="search"
   className=
       ms-SearchBox
       {
@@ -44,6 +43,7 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
         color: #005a9e;
       }
   onFocusCapture={[Function]}
+  role="search"
 >
   <div
     aria-hidden={true}
@@ -85,7 +85,6 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
     </i>
   </div>
   <input
-    aria-role="searchbox"
     className=
         ms-SearchBox-field
         {
@@ -130,6 +129,7 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
     onChange={[Function]}
     onInput={[Function]}
     onKeyDown={[Function]}
+    role="searchbox"
     value=""
   />
 </div>
@@ -137,7 +137,6 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
 
 exports[`SearchBox renders SearchBox without animation correctly 1`] = `
 <div
-  aria-role="search"
   className=
       ms-SearchBox
       {
@@ -179,6 +178,7 @@ exports[`SearchBox renders SearchBox without animation correctly 1`] = `
         color: #005a9e;
       }
   onFocusCapture={[Function]}
+  role="search"
 >
   <div
     aria-hidden={true}
@@ -218,7 +218,6 @@ exports[`SearchBox renders SearchBox without animation correctly 1`] = `
     </i>
   </div>
   <input
-    aria-role="searchbox"
     className=
         ms-SearchBox-field
         {
@@ -259,10 +258,11 @@ exports[`SearchBox renders SearchBox without animation correctly 1`] = `
         &::-ms-clear {
           display: none;
         }
-    id="SearchBox2"
+    id="SearchBox5"
     onChange={[Function]}
     onInput={[Function]}
     onKeyDown={[Function]}
+    role="searchbox"
     value=""
   />
 </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
@@ -10,7 +10,6 @@ exports[`Component Examples renders FloatingPeoplePicker.Basic.Example.tsx corre
     }
   >
     <div
-      aria-role="search"
       className=
           ms-SearchBox
           {
@@ -52,6 +51,7 @@ exports[`Component Examples renders FloatingPeoplePicker.Basic.Example.tsx corre
             color: #005a9e;
           }
       onFocusCapture={[Function]}
+      role="search"
     >
       <div
         aria-hidden={true}
@@ -94,7 +94,6 @@ exports[`Component Examples renders FloatingPeoplePicker.Basic.Example.tsx corre
       </div>
       <input
         aria-label="Search for person"
-        aria-role="searchbox"
         className=
             ms-SearchBox-field
             {
@@ -140,6 +139,7 @@ exports[`Component Examples renders FloatingPeoplePicker.Basic.Example.tsx corre
         onInput={[Function]}
         onKeyDown={[Function]}
         placeholder="Search for person"
+        role="searchbox"
         value=""
       />
     </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
@@ -10,6 +10,7 @@ exports[`Component Examples renders FloatingPeoplePicker.Basic.Example.tsx corre
     }
   >
     <div
+      aria-role="search"
       className=
           ms-SearchBox
           {
@@ -93,6 +94,7 @@ exports[`Component Examples renders FloatingPeoplePicker.Basic.Example.tsx corre
       </div>
       <input
         aria-label="Search for person"
+        aria-role="searchbox"
         className=
             ms-SearchBox-field
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
@@ -28,6 +28,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
         }
   >
     <div
+      aria-role="search"
       className=
           ms-SearchBox
           {
@@ -112,6 +113,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
       </div>
       <input
         aria-label="Search"
+        aria-role="searchbox"
         className=
             ms-SearchBox-field
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
@@ -28,7 +28,6 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
         }
   >
     <div
-      aria-role="search"
       className=
           ms-SearchBox
           {
@@ -71,6 +70,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
             color: #005a9e;
           }
       onFocusCapture={[Function]}
+      role="search"
     >
       <div
         aria-hidden={true}
@@ -113,7 +113,6 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
       </div>
       <input
         aria-label="Search"
-        aria-role="searchbox"
         className=
             ms-SearchBox-field
             {
@@ -159,6 +158,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
         onInput={[Function]}
         onKeyDown={[Function]}
         placeholder="Search"
+        role="searchbox"
         value=""
       />
     </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.CustomIcon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.CustomIcon.Example.tsx.shot
@@ -5,7 +5,6 @@ exports[`Component Examples renders SearchBox.CustomIcon.Example.tsx correctly 1
   className="ms-SearchBoxExample"
 >
   <div
-    aria-role="search"
     className=
         ms-SearchBox
         {
@@ -47,6 +46,7 @@ exports[`Component Examples renders SearchBox.CustomIcon.Example.tsx correctly 1
           color: #005a9e;
         }
     onFocusCapture={[Function]}
+    role="search"
   >
     <div
       aria-hidden={true}
@@ -89,7 +89,6 @@ exports[`Component Examples renders SearchBox.CustomIcon.Example.tsx correctly 1
     </div>
     <input
       aria-label="Filter"
-      aria-role="searchbox"
       className=
           ms-SearchBox-field
           {
@@ -135,6 +134,7 @@ exports[`Component Examples renders SearchBox.CustomIcon.Example.tsx correctly 1
       onInput={[Function]}
       onKeyDown={[Function]}
       placeholder="Filter"
+      role="searchbox"
       value=""
     />
   </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.CustomIcon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.CustomIcon.Example.tsx.shot
@@ -5,6 +5,7 @@ exports[`Component Examples renders SearchBox.CustomIcon.Example.tsx correctly 1
   className="ms-SearchBoxExample"
 >
   <div
+    aria-role="search"
     className=
         ms-SearchBox
         {
@@ -88,6 +89,7 @@ exports[`Component Examples renders SearchBox.CustomIcon.Example.tsx correctly 1
     </div>
     <input
       aria-label="Filter"
+      aria-role="searchbox"
       className=
           ms-SearchBox-field
           {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
@@ -5,6 +5,7 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
   className="ms-SearchBoxExample"
 >
   <div
+    aria-role="search"
     className=
         ms-SearchBox
         is-disabled
@@ -92,6 +93,7 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
     </div>
     <input
       aria-label="Search"
+      aria-role="searchbox"
       className=
           ms-SearchBox-field
           {
@@ -142,6 +144,7 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
     />
   </div>
   <div
+    aria-role="search"
     className=
         ms-SearchBox
         is-disabled
@@ -231,6 +234,7 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
     </div>
     <input
       aria-label="Search"
+      aria-role="searchbox"
       className=
           ms-SearchBox-field
           {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
@@ -5,7 +5,6 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
   className="ms-SearchBoxExample"
 >
   <div
-    aria-role="search"
     className=
         ms-SearchBox
         is-disabled
@@ -51,6 +50,7 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
           color: #005a9e;
         }
     onFocusCapture={[Function]}
+    role="search"
   >
     <div
       aria-hidden={true}
@@ -93,7 +93,6 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
     </div>
     <input
       aria-label="Search"
-      aria-role="searchbox"
       className=
           ms-SearchBox-field
           {
@@ -140,11 +139,11 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
       onInput={[Function]}
       onKeyDown={[Function]}
       placeholder="Search"
+      role="searchbox"
       value=""
     />
   </div>
   <div
-    aria-role="search"
     className=
         ms-SearchBox
         is-disabled
@@ -192,6 +191,7 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
           color: #005a9e;
         }
     onFocusCapture={[Function]}
+    role="search"
   >
     <div
       aria-hidden={true}
@@ -234,7 +234,6 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
     </div>
     <input
       aria-label="Search"
-      aria-role="searchbox"
       className=
           ms-SearchBox-field
           {
@@ -281,6 +280,7 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
       onInput={[Function]}
       onKeyDown={[Function]}
       placeholder="Search"
+      role="searchbox"
       value=""
     />
   </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
@@ -5,6 +5,7 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
   className="ms-SearchBoxExample"
 >
   <div
+    aria-role="search"
     className=
         ms-SearchBox
         {
@@ -88,6 +89,7 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
     </div>
     <input
       aria-label="Search"
+      aria-role="searchbox"
       className=
           ms-SearchBox-field
           {
@@ -137,6 +139,7 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
     />
   </div>
   <div
+    aria-role="search"
     className=
         ms-SearchBox
         {
@@ -218,6 +221,7 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
     </div>
     <input
       aria-label="Search with no animation"
+      aria-role="searchbox"
       className=
           ms-SearchBox-field
           {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
@@ -5,7 +5,6 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
   className="ms-SearchBoxExample"
 >
   <div
-    aria-role="search"
     className=
         ms-SearchBox
         {
@@ -47,6 +46,7 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
           color: #005a9e;
         }
     onFocusCapture={[Function]}
+    role="search"
   >
     <div
       aria-hidden={true}
@@ -89,7 +89,6 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
     </div>
     <input
       aria-label="Search"
-      aria-role="searchbox"
       className=
           ms-SearchBox-field
           {
@@ -135,11 +134,11 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
       onInput={[Function]}
       onKeyDown={[Function]}
       placeholder="Search"
+      role="searchbox"
       value=""
     />
   </div>
   <div
-    aria-role="search"
     className=
         ms-SearchBox
         {
@@ -181,6 +180,7 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
           color: #005a9e;
         }
     onFocusCapture={[Function]}
+    role="search"
   >
     <div
       aria-hidden={true}
@@ -221,7 +221,6 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
     </div>
     <input
       aria-label="Search with no animation"
-      aria-role="searchbox"
       className=
           ms-SearchBox-field
           {
@@ -267,6 +266,7 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
       onInput={[Function]}
       onKeyDown={[Function]}
       placeholder="Search with no animation"
+      role="searchbox"
       value=""
     />
   </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
@@ -2,7 +2,6 @@
 
 exports[`Component Examples renders SearchBox.Small.Example.tsx correctly 1`] = `
 <div
-  aria-role="search"
   className=
       ms-SearchBox
       {
@@ -45,6 +44,7 @@ exports[`Component Examples renders SearchBox.Small.Example.tsx correctly 1`] = 
         color: #005a9e;
       }
   onFocusCapture={[Function]}
+  role="search"
 >
   <div
     aria-hidden={true}
@@ -87,7 +87,6 @@ exports[`Component Examples renders SearchBox.Small.Example.tsx correctly 1`] = 
   </div>
   <input
     aria-label="Search"
-    aria-role="searchbox"
     className=
         ms-SearchBox-field
         {
@@ -133,6 +132,7 @@ exports[`Component Examples renders SearchBox.Small.Example.tsx correctly 1`] = 
     onInput={[Function]}
     onKeyDown={[Function]}
     placeholder="Search"
+    role="searchbox"
     value=""
   />
 </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
@@ -2,6 +2,7 @@
 
 exports[`Component Examples renders SearchBox.Small.Example.tsx correctly 1`] = `
 <div
+  aria-role="search"
   className=
       ms-SearchBox
       {
@@ -86,6 +87,7 @@ exports[`Component Examples renders SearchBox.Small.Example.tsx correctly 1`] = 
   </div>
   <input
     aria-label="Search"
+    aria-role="searchbox"
     className=
         ms-SearchBox-field
         {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
@@ -2,6 +2,7 @@
 
 exports[`Component Examples renders SearchBox.Underlined.Example.tsx correctly 1`] = `
 <div
+  aria-role="search"
   className=
       ms-SearchBox
       is-underlined
@@ -87,6 +88,7 @@ exports[`Component Examples renders SearchBox.Underlined.Example.tsx correctly 1
   </div>
   <input
     aria-label="Search"
+    aria-role="searchbox"
     className=
         ms-SearchBox-field
         {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
@@ -2,7 +2,6 @@
 
 exports[`Component Examples renders SearchBox.Underlined.Example.tsx correctly 1`] = `
 <div
-  aria-role="search"
   className=
       ms-SearchBox
       is-underlined
@@ -46,6 +45,7 @@ exports[`Component Examples renders SearchBox.Underlined.Example.tsx correctly 1
         color: #005a9e;
       }
   onFocusCapture={[Function]}
+  role="search"
 >
   <div
     aria-hidden={true}
@@ -88,7 +88,6 @@ exports[`Component Examples renders SearchBox.Underlined.Example.tsx correctly 1
   </div>
   <input
     aria-label="Search"
-    aria-role="searchbox"
     className=
         ms-SearchBox-field
         {
@@ -134,6 +133,7 @@ exports[`Component Examples renders SearchBox.Underlined.Example.tsx correctly 1
     onInput={[Function]}
     onKeyDown={[Function]}
     placeholder="Search"
+    role="searchbox"
     value=""
   />
 </div>


### PR DESCRIPTION
As per: https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques

and 

https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Search_role

Updating Search to include both landmark role and widget roles. 


Another example matching our use case: https://www.digitala11y.com/search-role/
```
<div role="search">
  <input role="searchbox" type="text">
  <button role="button">Search</button>
</div>
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10477)