### PR TITLE
[6.0] DatePicker: cherry-pick "utilize custom onChange handler when provided #10424"

### DIFF
--- a/change/@uifabric-date-time-2019-09-17-10-25-23-datePickerTextFieldOnChange6.0.json
+++ b/change/@uifabric-date-time-2019-09-17-10-25-23-datePickerTextFieldOnChange6.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "DatePicker: call custom text field onChange handler if it exists in default onChange handler",
+  "packageName": "@uifabric/date-time",
+  "email": "naethell@microsoft.com",
+  "commit": "c43321b1c06a6e5844ca4edf70c84fb061c8579e",
+  "date": "2019-09-17T17:25:09.524Z"
+}

--- a/change/office-ui-fabric-react-2019-09-17-10-25-23-datePickerTextFieldOnChange6.0.json
+++ b/change/office-ui-fabric-react-2019-09-17-10-25-23-datePickerTextFieldOnChange6.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "DatePicker: call custom text field onChange handler if it exists in default onChande handler",
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com",
+  "commit": "c43321b1c06a6e5844ca4edf70c84fb061c8579e",
+  "date": "2019-09-17T17:25:23.568Z"
+}

--- a/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
@@ -326,7 +326,9 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
   };
 
   private _onTextFieldChanged = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue: string): void => {
-    if (this.props.allowTextInput) {
+    const { allowTextInput, textField } = this.props;
+
+    if (allowTextInput) {
       if (this.state.isDatePickerShown) {
         this._dismissDatePickerPopup();
       }
@@ -337,6 +339,10 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
         errorMessage: isRequired && !value ? strings!.isRequiredErrorMessage || ' ' : undefined,
         formattedDate: newValue
       });
+    }
+
+    if (textField && textField.onChange) {
+      textField.onChange(ev, newValue);
     }
   };
 

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -329,7 +329,9 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
   };
 
   private _onTextFieldChanged = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue: string): void => {
-    if (this.props.allowTextInput) {
+    const { allowTextInput, textField } = this.props;
+
+    if (allowTextInput) {
       if (this.state.isDatePickerShown) {
         this._dismissDatePickerPopup();
       }
@@ -340,6 +342,10 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
         errorMessage: isRequired && !value ? strings!.isRequiredErrorMessage || ' ' : undefined,
         formattedDate: newValue
       });
+    }
+
+    if (textField && textField.onChange) {
+      textField.onChange(ev, newValue);
     }
   };
 

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
@@ -94,6 +94,21 @@ describe('DatePicker', () => {
     datePicker.unmount();
   });
 
+  it('should call custom onChange when allowTextInput is true', () => {
+    const onChange = jest.fn();
+    const datePicker = mount(<DatePickerBase allowTextInput={true} textField={{ onChange: onChange }} />);
+    const textField = datePicker.find('input');
+
+    expect(textField).toBeDefined();
+
+    textField.simulate('change', { target: { value: 'Jan 1 2020' } }).simulate('blur');
+    textField.simulate('change', { target: { value: '' } }).simulate('blur');
+
+    expect(onChange).toHaveBeenCalledTimes(2);
+
+    datePicker.unmount();
+  });
+
   // @todo: usage of document.querySelector is incorrectly testing DOM mounted by previous tests and needs to be fixed.
   it.skip('should call onSelectDate only once when allowTextInput is true and popup is used to select the value', () => {
     const onSelectDate = jest.fn();


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Cherry-pick changes from master (https://github.com/OfficeDev/office-ui-fabric-react/pull/10424) that utilize the custom `onChange` handler when provided.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10478)