### PR TITLE
Fix newline issue in tsx-editor test

### DIFF
--- a/change/@uifabric-tsx-editor-2019-09-17-16-01-25-tsx-test.json
+++ b/change/@uifabric-tsx-editor-2019-09-17-16-01-25-tsx-test.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Fix newline issue in test",
+  "packageName": "@uifabric/tsx-editor",
+  "email": "elcraig@microsoft.com",
+  "commit": "36f3c57bf0d4403f4a2573cba56fe5759e7edc77",
+  "date": "2019-09-17T23:01:25.825Z"
+}

--- a/packages/tsx-editor/src/transpiler/transpileHelpers.test.ts
+++ b/packages/tsx-editor/src/transpiler/transpileHelpers.test.ts
@@ -3,7 +3,10 @@ import path from 'path';
 import { IDiagnostic, _getLineStarts, _getErrorLineInfo, _getErrorMessages } from './transpileHelpers';
 
 // Real diagnostics copied from loading ./examples/class.txt in the editor while type checking wasn't set up
-const example = fs.readFileSync(path.join(__dirname, 'examples/class.txt')).toString();
+const example = fs
+  .readFileSync(path.join(__dirname, 'examples/class.txt'))
+  .toString()
+  .replace(/\\r/g, '');
 const diagnostics: IDiagnostic[] = [
   { start: 23, length: 7, messageText: "Cannot find module 'react'.", code: 2307, category: 1 },
   { start: 192, length: 3, messageText: "Cannot find namespace 'JSX'.", code: 2503, category: 1 },

--- a/packages/tsx-editor/src/transpiler/transpileHelpers.test.ts
+++ b/packages/tsx-editor/src/transpiler/transpileHelpers.test.ts
@@ -3,20 +3,27 @@ import path from 'path';
 import { IDiagnostic, _getLineStarts, _getErrorLineInfo, _getErrorMessages } from './transpileHelpers';
 
 // Real diagnostics copied from loading ./examples/class.txt in the editor while type checking wasn't set up
-const example = fs
+const exampleLines = fs
   .readFileSync(path.join(__dirname, 'examples/class.txt'))
   .toString()
-  .replace(/\r/g, '');
+  .split(/\r?\n/g);
+const example = exampleLines.join('\n');
+const exampleCRLF = exampleLines.join('\r\n');
 const diagnostics: IDiagnostic[] = [
   { start: 23, length: 7, messageText: "Cannot find module 'react'.", code: 2307, category: 1 },
   { start: 192, length: 3, messageText: "Cannot find namespace 'JSX'.", code: 2503, category: 1 },
   { start: 225, length: 32, messageText: "JSX element implicitly has type 'any'.", code: 7026, category: 1 }
 ];
 const lineStarts = [0, 32, 100, 101, 173, 206, 219, 258, 278, 305, 343, 361, 381, 400, 459, 518, 577, 588, 601, 608, 612, 614];
+const lineStartsCRLF = [0, 33, 102, 104, 177, 211, 225, 265, 286, 314, 353, 372, 393, 413, 473, 533, 593, 605, 619, 627, 632, 635];
 
 describe('_getLineStarts', () => {
-  it('works', () => {
+  it('works with LF', () => {
     expect(_getLineStarts(example)).toEqual(lineStarts);
+  });
+
+  it('works with CRLF', () => {
+    expect(_getLineStarts(exampleCRLF)).toEqual(lineStartsCRLF);
   });
 });
 

--- a/packages/tsx-editor/src/transpiler/transpileHelpers.test.ts
+++ b/packages/tsx-editor/src/transpiler/transpileHelpers.test.ts
@@ -6,7 +6,7 @@ import { IDiagnostic, _getLineStarts, _getErrorLineInfo, _getErrorMessages } fro
 const example = fs
   .readFileSync(path.join(__dirname, 'examples/class.txt'))
   .toString()
-  .replace(/\\r/g, '');
+  .replace(/\r/g, '');
 const diagnostics: IDiagnostic[] = [
   { start: 23, length: 7, messageText: "Cannot find module 'react'.", code: 2307, category: 1 },
   { start: 192, length: 3, messageText: "Cannot find namespace 'JSX'.", code: 2503, category: 1 },


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Fix a test failure caused by Windows having 2 characters in a newline and Mac/Linux only having 1 character. (The test involves character counts from a file read from disk.)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10481)