### PR TITLE
Checkbox visibility for details header

### DIFF
--- a/change/office-ui-fabric-react-2019-09-18-13-51-32-checkbox-visibility-details-header.json
+++ b/change/office-ui-fabric-react-2019-09-18-13-51-32-checkbox-visibility-details-header.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Apply CheckboxVisiblity to header as well in DetailsList",
+  "packageName": "office-ui-fabric-react",
+  "email": "thomas.gassmann@hotmail.com",
+  "commit": "184b1853c0fd593241dd362fb40f7fbdaf8d1ac7",
+  "date": "2019-09-18T11:51:32.292Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -145,11 +145,13 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
       theme,
       onRenderDetailsCheckbox,
       groupNestingDepth,
-      useFastIcons
+      useFastIcons,
+      checkboxVisibility
     } = this.props;
     const { isAllSelected, columnResizeDetails, isSizing, isAllCollapsed } = this.state;
     const showCheckbox = selectAllVisibility !== SelectAllVisibility.none;
     const isCheckboxHidden = selectAllVisibility === SelectAllVisibility.hidden;
+    const isCheckboxAlwaysVisible = checkboxVisibility === CheckboxVisibility.always;
 
     const columnReorderProps = this._getColumnReorderProps();
     const frozenColumnCountFromStart =
@@ -220,6 +222,7 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
                         className={classNames.check}
                         onRenderDetailsCheckbox={onRenderDetailsCheckbox}
                         useFastIcons={useFastIcons}
+                        isVisible={isCheckboxAlwaysVisible}
                       />
                     )
                   },


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10489
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Previously the CheckboxVisiblity property would not apply to the header
of the DetailsList. This change passes the property down and forces the
checkbox to be displayed, if the CheckboxVisibility is set to 'always'.

This would change the default behavior of `CheckboxVisibility.always` on the `DetailsList`. I'm therefore happy for suggestions on how else this could/should be implemented.

#### Focus areas to test

DetailsList, DetailsHeader, DetailsRowCheck


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10490)