### PR TITLE
Dropdown: fix misalignment of option text in IE11

### DIFF
--- a/change/office-ui-fabric-react-2019-09-17-17-22-09-dropdownOptionAlignment.json
+++ b/change/office-ui-fabric-react-2019-09-17-17-22-09-dropdownOptionAlignment.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Dropdown: change dropdown item height styling to 1vh",
+  "comment": "Dropdown: adjust option styling for IE11",
   "packageName": "office-ui-fabric-react",
   "email": "naethell@microsoft.com",
   "commit": "f6ca241142ee54cd2f32ad993382e55f9ecf141c",

--- a/change/office-ui-fabric-react-2019-09-17-17-22-09-dropdownOptionAlignment.json
+++ b/change/office-ui-fabric-react-2019-09-17-17-22-09-dropdownOptionAlignment.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Dropdown: change dropdown item height styling to 1vh",
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com",
+  "commit": "f6ca241142ee54cd2f32ad993382e55f9ecf141c",
+  "date": "2019-09-18T00:22:09.872Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -112,7 +112,7 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
       width: '100%',
       minHeight: DROPDOWN_ITEM_HEIGHT,
       lineHeight: 20,
-      height: 'auto',
+      height: '1vh',
       position: 'relative',
       border: '1px solid transparent',
       borderRadius: 0,

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -1,5 +1,5 @@
 import { IDropdownStyles, IDropdownStyleProps } from './Dropdown.types';
-import { IStyleFunction, IsFocusVisibleClassName, isIE11 } from '../../Utilities';
+import { IStyleFunction, IsFocusVisibleClassName } from '../../Utilities';
 import { RectangleEdge } from '../../utilities/positioning';
 import {
   FontWeights,
@@ -112,7 +112,7 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
       width: '100%',
       minHeight: DROPDOWN_ITEM_HEIGHT,
       lineHeight: 20,
-      height: isIE11 ? 0 : 'auto', // auto does not work properly in IE11
+      height: 0,
       position: 'relative',
       border: '1px solid transparent',
       borderRadius: 0,

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -112,7 +112,7 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
       width: '100%',
       minHeight: DROPDOWN_ITEM_HEIGHT,
       lineHeight: 20,
-      height: isIE11 ? 0 : 'auto', // auto does not work in IE11 properly
+      height: isIE11 ? 0 : 'auto', // auto does not work properly in IE11
       position: 'relative',
       border: '1px solid transparent',
       borderRadius: 0,

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -31,7 +31,7 @@ const GlobalClassNames = {
   titleHasError: 'ms-Dropdown-title--hasError'
 };
 
-const DROPDOWN_HEIGHT = 34;
+const DROPDOWN_HEIGHT = 32;
 const DROPDOWN_ITEM_HEIGHT = 36;
 
 const highContrastAdjustMixin = {

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -1,5 +1,5 @@
 import { IDropdownStyles, IDropdownStyleProps } from './Dropdown.types';
-import { IStyleFunction, IsFocusVisibleClassName } from '../../Utilities';
+import { IStyleFunction, IsFocusVisibleClassName, isIE11 } from '../../Utilities';
 import { RectangleEdge } from '../../utilities/positioning';
 import {
   FontWeights,
@@ -112,7 +112,7 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
       width: '100%',
       minHeight: DROPDOWN_ITEM_HEIGHT,
       lineHeight: 20,
-      height: 0, // IE11 fix, is overridden by minHeight
+      height: isIE11 ? 0 : 'auto', // auto does not work in IE11 properly
       position: 'relative',
       border: '1px solid transparent',
       borderRadius: 0,

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -31,7 +31,7 @@ const GlobalClassNames = {
   titleHasError: 'ms-Dropdown-title--hasError'
 };
 
-const DROPDOWN_HEIGHT = 32;
+const DROPDOWN_HEIGHT = 34;
 const DROPDOWN_ITEM_HEIGHT = 36;
 
 const highContrastAdjustMixin = {
@@ -112,7 +112,7 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
       width: '100%',
       minHeight: DROPDOWN_ITEM_HEIGHT,
       lineHeight: 20,
-      height: '1vh',
+      height: 0, // IE11 fix, is overridden by minHeight
       position: 'relative',
       border: '1px solid transparent',
       borderRadius: 0,


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #10437
- [X] Include a change request file using `$ yarn change`

#### Description of changes

IE11 seems to handle 'auto' differently than other browsers, causing misalignment in the text for dropdown options. 

This PR sets the dropdown option height to '0' when in IE11 - the min height of the dropdown option overrides this value. I tried simply removing the height styling, but the height still needs to be specified for dropdown options in IE11, otherwise we seem to have the same problem.

Setting height to '1vh', as mentioned in the linked issue, works too, but I noticed that we don't really use 'vh' elsewhere in the code, so I stuck to using a simple number.

Before:
![image](https://user-images.githubusercontent.com/14134000/65284946-f2611b80-daef-11e9-8f9b-4a1716a30ecd.png)

After:
![image](https://user-images.githubusercontent.com/14134000/65284966-0278fb00-daf0-11e9-9d51-e517a05b7a37.png)

#### Focus areas to test

Ensure that Dropdown has no visual changes other than the misalignment fix in IE11.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10546)