### PR TITLE
Editor: fix check for web worker availability

### DIFF
--- a/change/@uifabric-tsx-editor-2019-09-19-15-48-22-editor-supported.json
+++ b/change/@uifabric-tsx-editor-2019-09-19-15-48-22-editor-supported.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix web worker check",
+  "packageName": "@uifabric/tsx-editor",
+  "email": "elcraig@microsoft.com",
+  "commit": "17f52a8e9ac4538477fb7d6b8e76129b4f7f4a29",
+  "date": "2019-09-19T22:48:22.374Z"
+}

--- a/packages/tsx-editor/src/utilities/isEditorSupported.ts
+++ b/packages/tsx-editor/src/utilities/isEditorSupported.ts
@@ -2,9 +2,9 @@ import { getWindow, isIE11 } from 'office-ui-fabric-react/lib/Utilities';
 import { getMonacoConfig } from '@uifabric/monaco-editor/lib/configureEnvironment';
 import { tryParseExample } from '../transpiler/exampleParser';
 import { getSetting } from '../utilities/settings';
-import { IPackageGroup } from '../interfaces/packageGroup';
+import { IBasicPackageGroup } from '../interfaces/packageGroup';
 
-export function isEditorSupported(code: string, supportedPackages: IPackageGroup[]): boolean {
+export function isEditorSupported(code: string, supportedPackages: IBasicPackageGroup[]): boolean {
   const win = getWindow();
   return (
     // Not server-side rendering
@@ -15,9 +15,8 @@ export function isEditorSupported(code: string, supportedPackages: IPackageGroup
     getSetting('useEditor') === '1' &&
     // Not IE 11
     !isIE11() &&
-    // Service worker available (for some reason win.navigator.serviceWorker is always undefined,
-    // at least in Chrome...?)
-    !!navigator.serviceWorker &&
+    // Web worker available
+    typeof Worker !== 'undefined' &&
     // No immediate issues detected in example (or exceptions thrown from parsing)
     typeof tryParseExample(code!, supportedPackages) !== 'string'
   );


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

When checking if example editing is supported, we should check for the existence of `Worker` (web worker) not `navigator.serviceWorker`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10547)