### PR TITLE
DetailsList: initialize selection object mode with selectionMode prop if it is defined

### DIFF
--- a/change/office-ui-fabric-react-2019-09-19-16-53-36-detailsListDocumentsExample.json
+++ b/change/office-ui-fabric-react-2019-09-19-16-53-36-detailsListDocumentsExample.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "DetailsList: initialize selection object mode with selectionMode prop if it is defined",
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com",
+  "commit": "1b60a86309fa911834c5b320233ba7ec1a7f45c6",
+  "date": "2019-09-19T23:53:36.441Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -125,7 +125,7 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
       new Selection({
         onSelectionChanged: undefined,
         getKey: props.getKey,
-        selectionMode: this.props.selectionMode
+        selectionMode: props.selectionMode
       });
 
     if (!this.props.disableSelectionZone) {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -120,7 +120,13 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
       isSomeGroupExpanded: props.groupProps && !props.groupProps.isAllGroupsCollapsed
     };
 
-    this._selection = props.selection || new Selection({ onSelectionChanged: undefined, getKey: props.getKey });
+    this._selection =
+      props.selection ||
+      new Selection({
+        onSelectionChanged: undefined,
+        getKey: props.getKey,
+        selectionMode: this.props.selectionMode
+      });
 
     if (!this.props.disableSelectionZone) {
       this._selection.setItems(props.items as IObjectWithKey[], false);

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import * as renderer from 'react-test-renderer';
+import * as ReactTestUtils from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 
 import { DetailsList } from './DetailsList';
@@ -9,9 +10,9 @@ import { DetailsListBase } from './DetailsList.base';
 import { IDetailsList, IColumn, DetailsListLayoutMode, CheckboxVisibility } from './DetailsList.types';
 import { IDetailsColumnProps } from 'office-ui-fabric-react/lib/components/DetailsList/DetailsColumn';
 import { IDetailsHeaderProps, DetailsHeader } from './DetailsHeader';
-import { EventGroup, IRenderFunction } from '../../Utilities';
+import { EventGroup, IRenderFunction, KeyCodes } from '../../Utilities';
 import { IDragDropEvents } from './../../utilities/dragdrop/index';
-import { SelectionMode, Selection } from '../../utilities/selection/index';
+import { SelectionMode, Selection, SelectionZone } from '../../utilities/selection/index';
 import { getTheme } from '../../Styling';
 
 // Populate mock data for testing
@@ -475,5 +476,12 @@ describe('DetailsList', () => {
 
     expect(onRenderCheckboxMock).toHaveBeenCalledTimes(6);
     expect(onRenderCheckboxMock.mock.calls[5][0]).toEqual({ checked: true, theme });
+  });
+
+  it('initializes the selection mode object with the selectionMode prop', () => {
+    const component = mount(<DetailsList items={mockData(5)} columns={mockData(5, true)} selectionMode={SelectionMode.none} />);
+
+    const selectionZone = component.find(SelectionZone);
+    expect(selectionZone.props().selectionMode).toEqual(SelectionMode.none);
   });
 });

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
@@ -481,6 +481,6 @@ describe('DetailsList', () => {
     const component = mount(<DetailsList items={mockData(5)} columns={mockData(5, true)} selectionMode={SelectionMode.none} />);
 
     const selectionZone = component.find(SelectionZone);
-    expect(selectionZone.props().selectionMode).toEqual(SelectionMode.none);
+    expect(selectionZone.props().selection.mode).toEqual(SelectionMode.none);
   });
 });

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.test.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import * as ReactDOM from 'react-dom';
 import * as renderer from 'react-test-renderer';
-import * as ReactTestUtils from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 
 import { DetailsList } from './DetailsList';
@@ -10,7 +9,7 @@ import { DetailsListBase } from './DetailsList.base';
 import { IDetailsList, IColumn, DetailsListLayoutMode, CheckboxVisibility } from './DetailsList.types';
 import { IDetailsColumnProps } from 'office-ui-fabric-react/lib/components/DetailsList/DetailsColumn';
 import { IDetailsHeaderProps, DetailsHeader } from './DetailsHeader';
-import { EventGroup, IRenderFunction, KeyCodes } from '../../Utilities';
+import { EventGroup, IRenderFunction } from '../../Utilities';
 import { IDragDropEvents } from './../../utilities/dragdrop/index';
 import { SelectionMode, Selection, SelectionZone } from '../../utilities/selection/index';
 import { getTheme } from '../../Styling';

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
@@ -73,8 +73,7 @@ export interface IDocument {
 }
 
 export class DetailsListDocumentsExample extends React.Component<{}, IDetailsListDocumentsExampleState> {
-  private _selectionNone: Selection;
-  private _selectionMultiple: Selection;
+  private _selection: Selection;
   private _allItems: IDocument[];
 
   constructor(props: {}) {
@@ -160,17 +159,12 @@ export class DetailsListDocumentsExample extends React.Component<{}, IDetailsLis
       }
     ];
 
-    this._selectionNone = new Selection({
-      selectionMode: SelectionMode.none
-    });
-
-    this._selectionMultiple = new Selection({
+    this._selection = new Selection({
       onSelectionChanged: () => {
         this.setState({
           selectionDetails: this._getSelectionDetails()
         });
-      },
-      selectionMode: SelectionMode.multiple
+      }
     });
 
     this.state = {
@@ -209,33 +203,48 @@ export class DetailsListDocumentsExample extends React.Component<{}, IDetailsLis
         </div>
         <div className={classNames.selectionDetails}>{selectionDetails}</div>
         {announcedMessage ? <Announced message={announcedMessage} /> : undefined}
-        <MarqueeSelection selection={isModalSelection ? this._selectionMultiple : this._selectionNone}>
+        {isModalSelection ? (
+          <MarqueeSelection selection={this._selection}>
+            <DetailsList
+              key={1}
+              items={items}
+              compact={isCompactMode}
+              columns={columns}
+              selectionMode={SelectionMode.multiple}
+              getKey={this._getKey}
+              setKey="multiple"
+              layoutMode={DetailsListLayoutMode.justified}
+              isHeaderVisible={true}
+              selection={this._selection}
+              selectionPreservedOnEmptyClick={true}
+              onItemInvoked={this._onItemInvoked}
+              enterModalSelectionOnTouch={true}
+              ariaLabelForSelectionColumn="Toggle selection"
+              ariaLabelForSelectAllCheckbox="Toggle selection for all items"
+              checkButtonAriaLabel="Row checkbox"
+            />
+          </MarqueeSelection>
+        ) : (
           <DetailsList
-            key={isModalSelection ? 1 : 2}
+            key={2}
             items={items}
             compact={isCompactMode}
             columns={columns}
-            selectionMode={isModalSelection ? SelectionMode.multiple : SelectionMode.none}
+            selectionMode={SelectionMode.none}
             getKey={this._getKey}
-            setKey="set"
+            setKey="none"
             layoutMode={DetailsListLayoutMode.justified}
             isHeaderVisible={true}
-            selection={isModalSelection ? this._selectionMultiple : this._selectionNone}
-            selectionPreservedOnEmptyClick={true}
             onItemInvoked={this._onItemInvoked}
-            enterModalSelectionOnTouch={true}
-            ariaLabelForSelectionColumn={isModalSelection ? 'Toggle selection' : undefined}
-            ariaLabelForSelectAllCheckbox={isModalSelection ? 'Toggle selection for all items' : undefined}
-            checkButtonAriaLabel={isModalSelection ? 'Row checkbox' : undefined}
           />
-        </MarqueeSelection>
+        )}
       </Fabric>
     );
   }
 
   public componentDidUpdate(previousProps: any, previousState: IDetailsListDocumentsExampleState) {
     if (previousState.isModalSelection !== this.state.isModalSelection && !this.state.isModalSelection) {
-      this._selectionMultiple.setAllSelected(false);
+      this._selection.setAllSelected(false);
     }
   }
 
@@ -262,13 +271,13 @@ export class DetailsListDocumentsExample extends React.Component<{}, IDetailsLis
   }
 
   private _getSelectionDetails(): string {
-    const selectionCount = this._selectionMultiple.getSelectedCount();
+    const selectionCount = this._selection.getSelectedCount();
 
     switch (selectionCount) {
       case 0:
         return 'No items selected';
       case 1:
-        return '1 item selected: ' + (this._selectionMultiple.getSelection()[0] as IDocument).name;
+        return '1 item selected: ' + (this._selection.getSelection()[0] as IDocument).name;
       default:
         return `${selectionCount} items selected`;
     }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
@@ -73,7 +73,8 @@ export interface IDocument {
 }
 
 export class DetailsListDocumentsExample extends React.Component<{}, IDetailsListDocumentsExampleState> {
-  private _selection: Selection;
+  private _selectionNone: Selection;
+  private _selectionMultiple: Selection;
   private _allItems: IDocument[];
 
   constructor(props: {}) {
@@ -159,12 +160,17 @@ export class DetailsListDocumentsExample extends React.Component<{}, IDetailsLis
       }
     ];
 
-    this._selection = new Selection({
+    this._selectionNone = new Selection({
+      selectionMode: SelectionMode.none
+    });
+
+    this._selectionMultiple = new Selection({
       onSelectionChanged: () => {
         this.setState({
           selectionDetails: this._getSelectionDetails()
         });
-      }
+      },
+      selectionMode: SelectionMode.multiple
     });
 
     this.state = {
@@ -203,8 +209,9 @@ export class DetailsListDocumentsExample extends React.Component<{}, IDetailsLis
         </div>
         <div className={classNames.selectionDetails}>{selectionDetails}</div>
         {announcedMessage ? <Announced message={announcedMessage} /> : undefined}
-        <MarqueeSelection selection={this._selection}>
+        <MarqueeSelection selection={isModalSelection ? this._selectionMultiple : this._selectionNone}>
           <DetailsList
+            key={isModalSelection ? 1 : 2}
             items={items}
             compact={isCompactMode}
             columns={columns}
@@ -213,13 +220,13 @@ export class DetailsListDocumentsExample extends React.Component<{}, IDetailsLis
             setKey="set"
             layoutMode={DetailsListLayoutMode.justified}
             isHeaderVisible={true}
-            selection={this._selection}
+            selection={isModalSelection ? this._selectionMultiple : this._selectionNone}
             selectionPreservedOnEmptyClick={true}
             onItemInvoked={this._onItemInvoked}
             enterModalSelectionOnTouch={true}
-            ariaLabelForSelectionColumn="Toggle selection"
-            ariaLabelForSelectAllCheckbox="Toggle selection for all items"
-            checkButtonAriaLabel="Row checkbox"
+            ariaLabelForSelectionColumn={isModalSelection ? 'Toggle selection' : undefined}
+            ariaLabelForSelectAllCheckbox={isModalSelection ? 'Toggle selection for all items' : undefined}
+            checkButtonAriaLabel={isModalSelection ? 'Row checkbox' : undefined}
           />
         </MarqueeSelection>
       </Fabric>
@@ -228,7 +235,7 @@ export class DetailsListDocumentsExample extends React.Component<{}, IDetailsLis
 
   public componentDidUpdate(previousProps: any, previousState: IDetailsListDocumentsExampleState) {
     if (previousState.isModalSelection !== this.state.isModalSelection && !this.state.isModalSelection) {
-      this._selection.setAllSelected(false);
+      this._selectionMultiple.setAllSelected(false);
     }
   }
 
@@ -255,13 +262,13 @@ export class DetailsListDocumentsExample extends React.Component<{}, IDetailsLis
   }
 
   private _getSelectionDetails(): string {
-    const selectionCount = this._selection.getSelectedCount();
+    const selectionCount = this._selectionMultiple.getSelectedCount();
 
     switch (selectionCount) {
       case 0:
         return 'No items selected';
       case 1:
-        return '1 item selected: ' + (this._selection.getSelection()[0] as IDocument).name;
+        return '1 item selected: ' + (this._selectionMultiple.getSelection()[0] as IDocument).name;
       default:
         return `${selectionCount} items selected`;
     }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
@@ -206,7 +206,6 @@ export class DetailsListDocumentsExample extends React.Component<{}, IDetailsLis
         {isModalSelection ? (
           <MarqueeSelection selection={this._selection}>
             <DetailsList
-              key={1}
               items={items}
               compact={isCompactMode}
               columns={columns}
@@ -226,7 +225,6 @@ export class DetailsListDocumentsExample extends React.Component<{}, IDetailsLis
           </MarqueeSelection>
         ) : (
           <DetailsList
-            key={2}
             items={items}
             compact={isCompactMode}
             columns={columns}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -556,453 +556,235 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
     No items selected
   </div>
   <div
-    className=
-
-        {
-          cursor: default;
-          position: relative;
-        }
+    className="ms-Viewport"
+    style={
+      Object {
+        "minHeight": 1,
+        "minWidth": 1,
+      }
+    }
   >
     <div
-      className="ms-Viewport"
-      style={
-        Object {
-          "minHeight": 1,
-          "minWidth": 1,
-        }
-      }
+      className=
+          ms-DetailsList
+          is-horizontalConstrained
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            -webkit-overflow-scrolling: touch;
+            background: #ffffff;
+            color: #323130;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
+            overflow-x: auto;
+            overflow-y: visible;
+            position: relative;
+          }
+          & .ms-List-cell {
+            min-height: 38px;
+            word-break: break-word;
+          }
+      data-automationid="DetailsList"
+      data-is-scrollable="false"
     >
       <div
-        className=
-            ms-DetailsList
-            is-horizontalConstrained
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              -webkit-overflow-scrolling: touch;
-              background: #ffffff;
-              color: #323130;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 12px;
-              font-weight: 400;
-              overflow-x: auto;
-              overflow-y: visible;
-              position: relative;
-            }
-            & .ms-List-cell {
-              min-height: 38px;
-              word-break: break-word;
-            }
-        data-automationid="DetailsList"
-        data-is-scrollable="false"
+        aria-colcount={3}
+        aria-readonly="true"
+        aria-rowcount={501}
+        role="grid"
       >
         <div
-          aria-colcount={3}
-          aria-readonly="true"
-          aria-rowcount={501}
-          role="grid"
+          className=
+              ms-DetailsList-headerWrapper
+
+          onKeyDown={[Function]}
+          role="presentation"
         >
           <div
             className=
-                ms-DetailsList-headerWrapper
-
+                ms-FocusZone
+                ms-DetailsHeader
+                &:focus {
+                  outline: none;
+                }
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background: #ffffff;
+                  border-bottom: 1px solid #edebe9;
+                  box-sizing: content-box;
+                  cursor: default;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 12px;
+                  font-weight: 400;
+                  height: 42px;
+                  line-height: 42px;
+                  min-width: 100%;
+                  padding-bottom: 1px;
+                  padding-top: 16px;
+                  position: relative;
+                  user-select: none;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &:hover .ms-DetailsHeader-check {
+                  opacity: 1;
+                }
+                & .ms-TooltipHost .ms-DetailsHeader-checkTooltip {
+                  display: block;
+                }
+            data-automationid="DetailsHeader"
+            data-focuszone-id="FocusZone6"
+            onFocus={[Function]}
             onKeyDown={[Function]}
-            role="presentation"
+            onMouseDownCapture={[Function]}
+            onMouseMove={[Function]}
+            role="row"
+            style={
+              Object {
+                "minWidth": 296,
+              }
+            }
           >
             <div
+              aria-colindex={1}
+              aria-sort="none"
               className=
-                  ms-FocusZone
-                  ms-DetailsHeader
-                  &:focus {
-                    outline: none;
-                  }
+                  ms-DetailsHeader-cell
+                  is-actionable
                   {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
-                    background: #ffffff;
-                    border-bottom: 1px solid #edebe9;
-                    box-sizing: content-box;
-                    cursor: default;
+                    box-sizing: border-box;
+                    color: #323130;
                     display: inline-block;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 12px;
                     font-weight: 400;
                     height: 42px;
-                    line-height: 42px;
-                    min-width: 100%;
-                    padding-bottom: 1px;
-                    padding-top: 16px;
+                    line-height: inherit;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 12px;
+                    padding-right: 8px;
+                    padding-top: 0;
                     position: relative;
-                    user-select: none;
+                    text-align: left;
+                    text-overflow: ellipsis;
                     vertical-align: top;
                     white-space: nowrap;
                   }
-                  &:hover .ms-DetailsHeader-check {
-                    opacity: 1;
+                  &::-moz-focus-inner {
+                    border: 0;
                   }
-                  & .ms-TooltipHost .ms-DetailsHeader-checkTooltip {
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 1px;
+                    content: "";
+                    left: 1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: 1px;
+                    top: 1px;
+                    z-index: 1;
+                  }
+                  &:hover {
+                    background: #f3f2f1;
+                    color: #323130;
+                  }
+                  &:active {
+                    background: #edebe9;
+                  }
+                  &:hover i[data-icon-name="GripperBarVertical"] {
                     display: block;
                   }
-              data-automationid="DetailsHeader"
-              data-focuszone-id="FocusZone6"
-              onFocus={[Function]}
-              onKeyDown={[Function]}
-              onMouseDownCapture={[Function]}
-              onMouseMove={[Function]}
-              role="row"
+              data-automationid="ColumnsHeaderColumn"
+              data-is-draggable={false}
+              data-item-key="column1"
+              draggable={false}
+              role="columnheader"
               style={
                 Object {
-                  "minWidth": 296,
+                  "width": 36,
                 }
               }
             >
-              <div
-                aria-colindex={1}
-                aria-sort="none"
+              <span
                 className=
-                    ms-DetailsHeader-cell
-                    is-actionable
+
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      box-sizing: border-box;
-                      color: #323130;
-                      display: inline-block;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 12px;
-                      font-weight: 400;
-                      height: 42px;
-                      line-height: inherit;
-                      margin-bottom: 0;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 0;
-                      outline: transparent;
-                      padding-bottom: 0;
-                      padding-left: 12px;
-                      padding-right: 8px;
-                      padding-top: 0;
-                      position: relative;
-                      text-align: left;
-                      text-overflow: ellipsis;
-                      vertical-align: top;
-                      white-space: nowrap;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 1px;
-                      content: "";
-                      left: 1px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 1px;
-                      top: 1px;
-                      z-index: 1;
-                    }
-                    &:hover {
-                      background: #f3f2f1;
-                      color: #323130;
-                    }
-                    &:active {
-                      background: #edebe9;
-                    }
-                    &:hover i[data-icon-name="GripperBarVertical"] {
+                      bottom: 0px;
                       display: block;
+                      left: 0px;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
                     }
-                data-automationid="ColumnsHeaderColumn"
-                data-is-draggable={false}
-                data-item-key="column1"
-                draggable={false}
-                role="columnheader"
-                style={
-                  Object {
-                    "width": 36,
-                  }
-                }
               >
                 <span
+                  aria-describedby="header5-column1-tooltip"
+                  aria-haspopup={false}
+                  aria-label="File Type"
                   className=
-
+                      ms-DetailsHeader-cellTitle
                       {
-                        bottom: 0px;
-                        display: block;
-                        left: 0px;
-                        position: absolute;
-                        right: 0px;
-                        top: 0px;
+                        align-content: flex-end;
+                        align-items: stretch;
+                        box-sizing: border-box;
+                        display: flex;
+                        flex-direction: row;
+                        flex-wrap: wrap-reverse;
+                        justify-content: flex-start;
+                        max-height: 100%;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 12px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
                       }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #605e5c;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                  data-is-focusable={true}
+                  id="header5-column1"
+                  onClick={[Function]}
+                  onContextMenu={[Function]}
+                  role="button"
                 >
                   <span
-                    aria-describedby="header5-column1-tooltip"
-                    aria-haspopup={false}
-                    aria-label="File Type"
                     className=
-                        ms-DetailsHeader-cellTitle
+                        ms-DetailsHeader-cellName
                         {
-                          align-content: flex-end;
-                          align-items: stretch;
-                          box-sizing: border-box;
-                          display: flex;
-                          flex-direction: row;
-                          flex-wrap: wrap-reverse;
-                          justify-content: flex-start;
-                          max-height: 100%;
-                          outline: transparent;
+                          flex: 0 1 auto;
+                          font-size: 14px;
+                          font-weight: 600;
                           overflow: hidden;
-                          padding-bottom: 0;
-                          padding-left: 12px;
-                          padding-right: 8px;
-                          padding-top: 0;
-                          position: relative;
+                          text-overflow: ellipsis;
                         }
-                        &::-moz-focus-inner {
-                          border: 0;
+                        & .ms-DetailsColumn-nearIcon {
+                          padding-left: 0px;
                         }
-                        .ms-Fabric--isFocusVisible &:focus:after {
-                          border: 1px solid #ffffff;
-                          bottom: 1px;
-                          content: "";
-                          left: 1px;
-                          outline: 1px solid #605e5c;
-                          position: absolute;
-                          right: 1px;
-                          top: 1px;
-                          z-index: 1;
-                        }
-                    data-is-focusable={true}
-                    id="header5-column1"
-                    onClick={[Function]}
-                    onContextMenu={[Function]}
-                    role="button"
+                    id="header5-column1-name"
                   >
-                    <span
-                      className=
-                          ms-DetailsHeader-cellName
-                          {
-                            flex: 0 1 auto;
-                            font-size: 14px;
-                            font-weight: 600;
-                            overflow: hidden;
-                            text-overflow: ellipsis;
-                          }
-                          & .ms-DetailsColumn-nearIcon {
-                            padding-left: 0px;
-                          }
-                      id="header5-column1-name"
-                    >
-                      <i
-                        aria-hidden={true}
-                        className=
-                            ms-Icon
-                            {
-                              display: inline-block;
-                            }
-                            {
-                              -moz-osx-font-smoothing: grayscale;
-                              -webkit-font-smoothing: antialiased;
-                              font-family: "FabricMDL2Icons";
-                              font-style: normal;
-                              font-weight: normal;
-                              speak: none;
-                            }
-                            {
-                              color: #605e5c;
-                              font-size: 16px;
-                              opacity: 1;
-                              padding-bottom: 0px;
-                              padding-left: 0px;
-                              padding-right: 0px;
-                              padding-top: 0px;
-                            }
-                        data-icon-name="Page"
-                        role="presentation"
-                      >
-                        
-                      </i>
-                      <span
-                        className=
-
-                            {
-                              border: 0px;
-                              height: 1px;
-                              margin-bottom: -1px;
-                              margin-left: -1px;
-                              margin-right: -1px;
-                              margin-top: -1px;
-                              overflow: hidden;
-                              padding-bottom: 0px;
-                              padding-left: 0px;
-                              padding-right: 0px;
-                              padding-top: 0px;
-                              position: absolute;
-                              width: 1px;
-                            }
-                      >
-                        File Type
-                      </span>
-                    </span>
-                  </span>
-                </span>
-              </div>
-              <label
-                className=
-
-                    {
-                      border: 0px;
-                      height: 1px;
-                      margin-bottom: -1px;
-                      margin-left: -1px;
-                      margin-right: -1px;
-                      margin-top: -1px;
-                      overflow: hidden;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: absolute;
-                      width: 1px;
-                    }
-                id="header5-column1-tooltip"
-              >
-                Column operations for File type, Press to sort on File type
-              </label>
-              <div
-                aria-colindex={2}
-                aria-sort="ascending"
-                className=
-                    ms-DetailsHeader-cell
-                    is-actionable
-                    is-icon-visible
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      box-sizing: border-box;
-                      color: #323130;
-                      display: inline-block;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 12px;
-                      font-weight: 400;
-                      height: 42px;
-                      line-height: inherit;
-                      margin-bottom: 0;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 0;
-                      outline: transparent;
-                      padding-bottom: 0;
-                      padding-left: 12px;
-                      padding-right: 32px;
-                      padding-top: 0;
-                      position: relative;
-                      text-align: left;
-                      text-overflow: ellipsis;
-                      vertical-align: top;
-                      white-space: nowrap;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 1px;
-                      content: "";
-                      left: 1px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 1px;
-                      top: 1px;
-                      z-index: 1;
-                    }
-                    &:hover {
-                      background: #f3f2f1;
-                      color: #323130;
-                    }
-                    &:active {
-                      background: #edebe9;
-                    }
-                    &:hover i[data-icon-name="GripperBarVertical"] {
-                      display: block;
-                    }
-                data-automationid="ColumnsHeaderColumn"
-                data-is-draggable={false}
-                data-item-key="column2"
-                draggable={false}
-                role="columnheader"
-                style={
-                  Object {
-                    "width": 254,
-                  }
-                }
-              >
-                <span
-                  className=
-
-                      {
-                        bottom: 0px;
-                        display: block;
-                        left: 0px;
-                        position: absolute;
-                        right: 0px;
-                        top: 0px;
-                      }
-                >
-                  <span
-                    aria-describedby="header5-column2-tooltip"
-                    aria-haspopup={false}
-                    aria-labelledby="header5-column2-name"
-                    className=
-                        ms-DetailsHeader-cellTitle
-                        {
-                          align-items: stretch;
-                          box-sizing: border-box;
-                          display: flex;
-                          flex-direction: row;
-                          justify-content: flex-start;
-                          outline: transparent;
-                          overflow: hidden;
-                          padding-bottom: 0;
-                          padding-left: 12px;
-                          padding-right: 8px;
-                          padding-top: 0;
-                          position: relative;
-                        }
-                        &::-moz-focus-inner {
-                          border: 0;
-                        }
-                        .ms-Fabric--isFocusVisible &:focus:after {
-                          border: 1px solid #ffffff;
-                          bottom: 1px;
-                          content: "";
-                          left: 1px;
-                          outline: 1px solid #605e5c;
-                          position: absolute;
-                          right: 1px;
-                          top: 1px;
-                          z-index: 1;
-                        }
-                    data-is-focusable={true}
-                    id="header5-column2"
-                    onClick={[Function]}
-                    onContextMenu={[Function]}
-                    role="button"
-                  >
-                    <span
-                      className=
-                          ms-DetailsHeader-cellName
-                          {
-                            flex: 0 1 auto;
-                            font-size: 14px;
-                            font-weight: 600;
-                            overflow: hidden;
-                            text-overflow: ellipsis;
-                          }
-                      id="header5-column2-name"
-                    >
-                      Name
-                    </span>
                     <i
                       aria-hidden={true}
                       className=
@@ -1020,3498 +802,3707 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                           }
                           {
                             color: #605e5c;
+                            font-size: 16px;
                             opacity: 1;
-                            padding-left: 4px;
-                            position: relative;
-                            top: 1px;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
                           }
-                      data-icon-name="SortUp"
+                      data-icon-name="Page"
                       role="presentation"
                     >
-                      
+                      
                     </i>
-                  </span>
-                </span>
-              </div>
-              <label
-                className=
-
-                    {
-                      border: 0px;
-                      height: 1px;
-                      margin-bottom: -1px;
-                      margin-left: -1px;
-                      margin-right: -1px;
-                      margin-top: -1px;
-                      overflow: hidden;
-                      padding-bottom: 0px;
-                      padding-left: 0px;
-                      padding-right: 0px;
-                      padding-top: 0px;
-                      position: absolute;
-                      width: 1px;
-                    }
-                id="header5-column2-tooltip"
-              >
-                Sorted A to Z
-              </label>
-              <div
-                aria-hidden={true}
-                className=
-                    ms-DetailsHeader-cellSizer
-                    {
-                      background: transparent;
-                      bottom: 0px;
-                      cursor: ew-resize;
-                      display: inline-block;
-                      height: inherit;
-                      outline: transparent;
-                      overflow: hidden;
-                      position: relative;
-                      top: 0px;
-                      width: 16px;
-                      z-index: 1;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0px;
-                    }
-                    &:after {
-                      background: #c8c6c4;
-                      bottom: 0px;
-                      content: "";
-                      left: 50%;
-                      opacity: 0;
-                      position: absolute;
-                      top: 0px;
-                      width: 1px;
-                    }
-                    &:focus:after {
-                      opacity: 1;
-                      transition: opacity 0.3s linear;
-                    }
-                    &:hover:after {
-                      opacity: 1;
-                      transition: opacity 0.3s linear;
-                    }
-                    &.is-resizing:after {
-                      box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.4);
-                      opacity: 1;
-                      transition: opacity 0.3s linear;
-                    }
-                    {
-                      margin-bottom: 0;
-                      margin-left: -8px;
-                      margin-right: -8px;
-                      margin-top: 0;
-                    }
-                data-is-focusable={false}
-                data-sizer-index={1}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onDoubleClick={[Function]}
-                role="button"
-              />
-              <div
-                aria-colindex={3}
-                aria-sort="none"
-                className=
-                    ms-DetailsHeader-cell
-                    is-actionable
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      box-sizing: border-box;
-                      color: #323130;
-                      display: inline-block;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 12px;
-                      font-weight: 400;
-                      height: 42px;
-                      line-height: inherit;
-                      margin-bottom: 0;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 0;
-                      outline: transparent;
-                      padding-bottom: 0;
-                      padding-left: 12px;
-                      padding-right: 32px;
-                      padding-top: 0;
-                      position: relative;
-                      text-align: left;
-                      text-overflow: ellipsis;
-                      vertical-align: top;
-                      white-space: nowrap;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 1px;
-                      content: "";
-                      left: 1px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 1px;
-                      top: 1px;
-                      z-index: 1;
-                    }
-                    &:hover {
-                      background: #f3f2f1;
-                      color: #323130;
-                    }
-                    &:active {
-                      background: #edebe9;
-                    }
-                    &:hover i[data-icon-name="GripperBarVertical"] {
-                      display: block;
-                    }
-                data-automationid="ColumnsHeaderColumn"
-                data-is-draggable={false}
-                data-item-key="column3"
-                draggable={false}
-                role="columnheader"
-                style={
-                  Object {
-                    "width": 114,
-                  }
-                }
-              >
-                <span
-                  className=
-
-                      {
-                        bottom: 0px;
-                        display: block;
-                        left: 0px;
-                        position: absolute;
-                        right: 0px;
-                        top: 0px;
-                      }
-                >
-                  <span
-                    aria-haspopup={false}
-                    aria-labelledby="header5-column3-name"
-                    className=
-                        ms-DetailsHeader-cellTitle
-                        {
-                          align-items: stretch;
-                          box-sizing: border-box;
-                          display: flex;
-                          flex-direction: row;
-                          justify-content: flex-start;
-                          outline: transparent;
-                          overflow: hidden;
-                          padding-bottom: 0;
-                          padding-left: 12px;
-                          padding-right: 8px;
-                          padding-top: 0;
-                          position: relative;
-                        }
-                        &::-moz-focus-inner {
-                          border: 0;
-                        }
-                        .ms-Fabric--isFocusVisible &:focus:after {
-                          border: 1px solid #ffffff;
-                          bottom: 1px;
-                          content: "";
-                          left: 1px;
-                          outline: 1px solid #605e5c;
-                          position: absolute;
-                          right: 1px;
-                          top: 1px;
-                          z-index: 1;
-                        }
-                    data-is-focusable={true}
-                    id="header5-column3"
-                    onClick={[Function]}
-                    onContextMenu={[Function]}
-                    role="button"
-                  >
                     <span
                       className=
-                          ms-DetailsHeader-cellName
+
                           {
-                            flex: 0 1 auto;
-                            font-size: 14px;
-                            font-weight: 600;
+                            border: 0px;
+                            height: 1px;
+                            margin-bottom: -1px;
+                            margin-left: -1px;
+                            margin-right: -1px;
+                            margin-top: -1px;
                             overflow: hidden;
-                            text-overflow: ellipsis;
+                            padding-bottom: 0px;
+                            padding-left: 0px;
+                            padding-right: 0px;
+                            padding-top: 0px;
+                            position: absolute;
+                            width: 1px;
                           }
-                      id="header5-column3-name"
                     >
-                      Date Modified
+                      File Type
                     </span>
                   </span>
                 </span>
-              </div>
-              <div
-                aria-hidden={true}
-                className=
-                    ms-DetailsHeader-cellSizer
-                    {
-                      background: transparent;
-                      bottom: 0px;
-                      cursor: ew-resize;
-                      display: inline-block;
-                      height: inherit;
-                      outline: transparent;
-                      overflow: hidden;
-                      position: relative;
-                      top: 0px;
-                      width: 16px;
-                      z-index: 1;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0px;
-                    }
-                    &:after {
-                      background: #c8c6c4;
-                      bottom: 0px;
-                      content: "";
-                      left: 50%;
-                      opacity: 0;
-                      position: absolute;
-                      top: 0px;
-                      width: 1px;
-                    }
-                    &:focus:after {
-                      opacity: 1;
-                      transition: opacity 0.3s linear;
-                    }
-                    &:hover:after {
-                      opacity: 1;
-                      transition: opacity 0.3s linear;
-                    }
-                    &.is-resizing:after {
-                      box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.4);
-                      opacity: 1;
-                      transition: opacity 0.3s linear;
-                    }
-                    {
-                      margin-bottom: 0px;
-                      margin-left: -16px;
-                      margin-right: 0px;
-                      margin-top: 0px;
-                    }
-                data-is-focusable={false}
-                data-sizer-index={2}
-                onBlur={[Function]}
-                onClick={[Function]}
-                onDoubleClick={[Function]}
-                role="button"
-              />
+              </span>
             </div>
-          </div>
-          <div
-            className=
-                ms-DetailsList-contentWrapper
-
-            onKeyDown={[Function]}
-            role="presentation"
-          >
-            <div
+            <label
               className=
-                  ms-FocusZone
-                  &:focus {
-                    outline: none;
+
+                  {
+                    border: 0px;
+                    height: 1px;
+                    margin-bottom: -1px;
+                    margin-left: -1px;
+                    margin-right: -1px;
+                    margin-top: -1px;
+                    overflow: hidden;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: absolute;
+                    width: 1px;
+                  }
+              id="header5-column1-tooltip"
+            >
+              Column operations for File type, Press to sort on File type
+            </label>
+            <div
+              aria-colindex={2}
+              aria-sort="ascending"
+              className=
+                  ms-DetailsHeader-cell
+                  is-actionable
+                  is-icon-visible
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    box-sizing: border-box;
+                    color: #323130;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 12px;
+                    font-weight: 400;
+                    height: 42px;
+                    line-height: inherit;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 12px;
+                    padding-right: 32px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: left;
+                    text-overflow: ellipsis;
+                    vertical-align: top;
+                    white-space: nowrap;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 1px;
+                    content: "";
+                    left: 1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: 1px;
+                    top: 1px;
+                    z-index: 1;
+                  }
+                  &:hover {
+                    background: #f3f2f1;
+                    color: #323130;
+                  }
+                  &:active {
+                    background: #edebe9;
+                  }
+                  &:hover i[data-icon-name="GripperBarVertical"] {
+                    display: block;
+                  }
+              data-automationid="ColumnsHeaderColumn"
+              data-is-draggable={false}
+              data-item-key="column2"
+              draggable={false}
+              role="columnheader"
+              style={
+                Object {
+                  "width": 254,
+                }
+              }
+            >
+              <span
+                className=
+
+                    {
+                      bottom: 0px;
+                      display: block;
+                      left: 0px;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                    }
+              >
+                <span
+                  aria-describedby="header5-column2-tooltip"
+                  aria-haspopup={false}
+                  aria-labelledby="header5-column2-name"
+                  className=
+                      ms-DetailsHeader-cellTitle
+                      {
+                        align-items: stretch;
+                        box-sizing: border-box;
+                        display: flex;
+                        flex-direction: row;
+                        justify-content: flex-start;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 12px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #605e5c;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                  data-is-focusable={true}
+                  id="header5-column2"
+                  onClick={[Function]}
+                  onContextMenu={[Function]}
+                  role="button"
+                >
+                  <span
+                    className=
+                        ms-DetailsHeader-cellName
+                        {
+                          flex: 0 1 auto;
+                          font-size: 14px;
+                          font-weight: 600;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                        }
+                    id="header5-column2-name"
+                  >
+                    Name
+                  </span>
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon
+                        {
+                          display: inline-block;
+                        }
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          font-family: "FabricMDL2Icons";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                        {
+                          color: #605e5c;
+                          opacity: 1;
+                          padding-left: 4px;
+                          position: relative;
+                          top: 1px;
+                        }
+                    data-icon-name="SortUp"
+                    role="presentation"
+                  >
+                    
+                  </i>
+                </span>
+              </span>
+            </div>
+            <label
+              className=
+
+                  {
+                    border: 0px;
+                    height: 1px;
+                    margin-bottom: -1px;
+                    margin-left: -1px;
+                    margin-right: -1px;
+                    margin-top: -1px;
+                    overflow: hidden;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: absolute;
+                    width: 1px;
+                  }
+              id="header5-column2-tooltip"
+            >
+              Sorted A to Z
+            </label>
+            <div
+              aria-hidden={true}
+              className=
+                  ms-DetailsHeader-cellSizer
+                  {
+                    background: transparent;
+                    bottom: 0px;
+                    cursor: ew-resize;
+                    display: inline-block;
+                    height: inherit;
+                    outline: transparent;
+                    overflow: hidden;
+                    position: relative;
+                    top: 0px;
+                    width: 16px;
+                    z-index: 1;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0px;
+                  }
+                  &:after {
+                    background: #c8c6c4;
+                    bottom: 0px;
+                    content: "";
+                    left: 50%;
+                    opacity: 0;
+                    position: absolute;
+                    top: 0px;
+                    width: 1px;
+                  }
+                  &:focus:after {
+                    opacity: 1;
+                    transition: opacity 0.3s linear;
+                  }
+                  &:hover:after {
+                    opacity: 1;
+                    transition: opacity 0.3s linear;
+                  }
+                  &.is-resizing:after {
+                    box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.4);
+                    opacity: 1;
+                    transition: opacity 0.3s linear;
                   }
                   {
-                    display: inline-block;
-                    min-height: 1px;
-                    min-width: 100%;
+                    margin-bottom: 0;
+                    margin-left: -8px;
+                    margin-right: -8px;
+                    margin-top: 0;
                   }
-              data-focuszone-id="FocusZone7"
+              data-is-focusable={false}
+              data-sizer-index={1}
               onBlur={[Function]}
-              onFocus={[Function]}
+              onClick={[Function]}
+              onDoubleClick={[Function]}
+              role="button"
+            />
+            <div
+              aria-colindex={3}
+              aria-sort="none"
+              className=
+                  ms-DetailsHeader-cell
+                  is-actionable
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    box-sizing: border-box;
+                    color: #323130;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 12px;
+                    font-weight: 400;
+                    height: 42px;
+                    line-height: inherit;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 12px;
+                    padding-right: 32px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: left;
+                    text-overflow: ellipsis;
+                    vertical-align: top;
+                    white-space: nowrap;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid #ffffff;
+                    bottom: 1px;
+                    content: "";
+                    left: 1px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: 1px;
+                    top: 1px;
+                    z-index: 1;
+                  }
+                  &:hover {
+                    background: #f3f2f1;
+                    color: #323130;
+                  }
+                  &:active {
+                    background: #edebe9;
+                  }
+                  &:hover i[data-icon-name="GripperBarVertical"] {
+                    display: block;
+                  }
+              data-automationid="ColumnsHeaderColumn"
+              data-is-draggable={false}
+              data-item-key="column3"
+              draggable={false}
+              role="columnheader"
+              style={
+                Object {
+                  "width": 114,
+                }
+              }
+            >
+              <span
+                className=
+
+                    {
+                      bottom: 0px;
+                      display: block;
+                      left: 0px;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                    }
+              >
+                <span
+                  aria-haspopup={false}
+                  aria-labelledby="header5-column3-name"
+                  className=
+                      ms-DetailsHeader-cellTitle
+                      {
+                        align-items: stretch;
+                        box-sizing: border-box;
+                        display: flex;
+                        flex-direction: row;
+                        justify-content: flex-start;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 12px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #605e5c;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                  data-is-focusable={true}
+                  id="header5-column3"
+                  onClick={[Function]}
+                  onContextMenu={[Function]}
+                  role="button"
+                >
+                  <span
+                    className=
+                        ms-DetailsHeader-cellName
+                        {
+                          flex: 0 1 auto;
+                          font-size: 14px;
+                          font-weight: 600;
+                          overflow: hidden;
+                          text-overflow: ellipsis;
+                        }
+                    id="header5-column3-name"
+                  >
+                    Date Modified
+                  </span>
+                </span>
+              </span>
+            </div>
+            <div
+              aria-hidden={true}
+              className=
+                  ms-DetailsHeader-cellSizer
+                  {
+                    background: transparent;
+                    bottom: 0px;
+                    cursor: ew-resize;
+                    display: inline-block;
+                    height: inherit;
+                    outline: transparent;
+                    overflow: hidden;
+                    position: relative;
+                    top: 0px;
+                    width: 16px;
+                    z-index: 1;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0px;
+                  }
+                  &:after {
+                    background: #c8c6c4;
+                    bottom: 0px;
+                    content: "";
+                    left: 50%;
+                    opacity: 0;
+                    position: absolute;
+                    top: 0px;
+                    width: 1px;
+                  }
+                  &:focus:after {
+                    opacity: 1;
+                    transition: opacity 0.3s linear;
+                  }
+                  &:hover:after {
+                    opacity: 1;
+                    transition: opacity 0.3s linear;
+                  }
+                  &.is-resizing:after {
+                    box-shadow: 0 0 5px 0 rgba(0, 0, 0, 0.4);
+                    opacity: 1;
+                    transition: opacity 0.3s linear;
+                  }
+                  {
+                    margin-bottom: 0px;
+                    margin-left: -16px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                  }
+              data-is-focusable={false}
+              data-sizer-index={2}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onDoubleClick={[Function]}
+              role="button"
+            />
+          </div>
+        </div>
+        <div
+          className=
+              ms-DetailsList-contentWrapper
+
+          onKeyDown={[Function]}
+          role="presentation"
+        >
+          <div
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+                {
+                  display: inline-block;
+                  min-height: 1px;
+                  min-width: 100%;
+                }
+            data-focuszone-id="FocusZone7"
+            onBlur={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDownCapture={[Function]}
+          >
+            <div
+              className="ms-SelectionZone"
+              onClick={[Function]}
+              onContextMenu={[Function]}
+              onDoubleClick={[Function]}
+              onFocusCapture={[Function]}
               onKeyDown={[Function]}
+              onKeyDownCapture={[Function]}
+              onMouseDown={[Function]}
               onMouseDownCapture={[Function]}
+              role="presentation"
             >
               <div
-                className="ms-SelectionZone"
-                onClick={[Function]}
-                onContextMenu={[Function]}
-                onDoubleClick={[Function]}
-                onFocusCapture={[Function]}
-                onKeyDown={[Function]}
-                onKeyDownCapture={[Function]}
-                onMouseDown={[Function]}
-                onMouseDownCapture={[Function]}
+                className="ms-List"
                 role="presentation"
               >
                 <div
-                  className="ms-List"
+                  className="ms-List-surface"
                   role="presentation"
                 >
                   <div
-                    className="ms-List-surface"
+                    className="ms-List-page"
                     role="presentation"
+                    style={Object {}}
                   >
                     <div
-                      className="ms-List-page"
+                      className="ms-List-cell"
+                      data-automationid="ListCell"
+                      data-list-index={0}
                       role="presentation"
-                      style={Object {}}
                     >
                       <div
-                        className="ms-List-cell"
-                        data-automationid="ListCell"
-                        data-list-index={0}
-                        role="presentation"
+                        aria-rowindex={1}
+                        className=
+                            ms-FocusZone
+                            ms-DetailsRow
+                            &:focus {
+                              outline: none;
+                            }
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              animation-duration: 0.367s;
+                              animation-fill-mode: both;
+                              animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                              animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                              background: #ffffff;
+                              border-bottom: 1px solid #f3f2f1;
+                              box-sizing: border-box;
+                              color: #605e5c;
+                              display: inline-flex;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 12px;
+                              font-weight: 400;
+                              min-height: 42px;
+                              min-width: 100%;
+                              outline: transparent;
+                              padding-bottom: 0px;
+                              padding-left: 0px;
+                              padding-right: 0px;
+                              padding-top: 0px;
+                              position: relative;
+                              text-align: left;
+                              vertical-align: top;
+                              white-space: nowrap;
+                            }
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #605e5c;
+                              bottom: 1px;
+                              content: "";
+                              left: 1px;
+                              outline: 1px solid #ffffff;
+                              position: absolute;
+                              right: 1px;
+                              top: 1px;
+                              z-index: 1;
+                            }
+                            .ms-List-cell:first-child &:before {
+                              display: none;
+                            }
+                            &:hover {
+                              background: #f3f2f1;
+                              color: #323130;
+                            }
+                            &:hover .is-row-header {
+                              color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-check {
+                              opacity: 1;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                              opacity: 1;
+                            }
+                        data-automationid="DetailsRow"
+                        data-focuszone-id="FocusZone8"
+                        data-is-focusable={true}
+                        data-item-index={0}
+                        data-selection-index={0}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseDownCapture={[Function]}
+                        role="row"
+                        style={
+                          Object {
+                            "minWidth": 296,
+                          }
+                        }
                       >
                         <div
-                          aria-rowindex={1}
                           className=
-                              ms-FocusZone
-                              ms-DetailsRow
-                              &:focus {
-                                outline: none;
-                              }
+                              ms-DetailsRow-fields
                               {
-                                -moz-osx-font-smoothing: grayscale;
-                                -webkit-font-smoothing: antialiased;
-                                animation-duration: 0.367s;
-                                animation-fill-mode: both;
-                                animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                background: #ffffff;
-                                border-bottom: 1px solid #f3f2f1;
-                                box-sizing: border-box;
-                                color: #605e5c;
-                                display: inline-flex;
-                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                font-size: 12px;
-                                font-weight: 400;
-                                min-height: 42px;
-                                min-width: 100%;
-                                outline: transparent;
-                                padding-bottom: 0px;
-                                padding-left: 0px;
-                                padding-right: 0px;
-                                padding-top: 0px;
-                                position: relative;
-                                text-align: left;
-                                vertical-align: top;
-                                white-space: nowrap;
+                                align-items: stretch;
+                                display: flex;
                               }
-                              &::-moz-focus-inner {
-                                border: 0;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus:after {
-                                border: 1px solid #605e5c;
-                                bottom: 1px;
-                                content: "";
-                                left: 1px;
-                                outline: 1px solid #ffffff;
-                                position: absolute;
-                                right: 1px;
-                                top: 1px;
-                                z-index: 1;
-                              }
-                              .ms-List-cell:first-child &:before {
-                                display: none;
-                              }
-                              &:hover {
-                                background: #f3f2f1;
-                                color: #323130;
-                              }
-                              &:hover .is-row-header {
-                                color: #201f1e;
-                              }
-                              &:hover .ms-DetailsRow-check {
-                                opacity: 1;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                opacity: 1;
-                              }
-                          data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone8"
-                          data-is-focusable={true}
-                          data-item-index={0}
-                          data-selection-index={0}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseDownCapture={[Function]}
-                          role="row"
-                          style={
-                            Object {
-                              "minWidth": 296,
-                            }
-                          }
+                          data-automationid="DetailsRowFields"
+                          role="presentation"
                         >
                           <div
+                            aria-colindex={1}
                             className=
-                                ms-DetailsRow-fields
+                                ms-DetailsRow-cell
                                 {
-                                  align-items: stretch;
-                                  display: flex;
+                                  text-align: center;
                                 }
-                            data-automationid="DetailsRowFields"
-                            role="presentation"
-                          >
-                            <div
-                              aria-colindex={1}
-                              className=
-                                  ms-DetailsRow-cell
-                                  {
-                                    text-align: center;
-                                  }
-                                  &:before {
-                                    content: .;
-                                    display: inline-block;
-                                    height: 100%;
-                                    vertical-align: middle;
-                                    visibility: hidden;
-                                    width: 0px;
-                                  }
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 8px;
-                                  }
-                              data-automation-key="column1"
-                              data-automationid="DetailsRowCell"
-                              role="gridcell"
-                              style={
-                                Object {
-                                  "width": 36,
+                                &:before {
+                                  content: .;
+                                  display: inline-block;
+                                  height: 100%;
+                                  vertical-align: middle;
+                                  visibility: hidden;
+                                  width: 0px;
                                 }
-                              }
-                            >
-                              <img
-                                alt="accdb file icon"
-                                className=
-
-                                    {
-                                      max-height: 16px;
-                                      max-width: 16px;
-                                      vertical-align: middle;
-                                    }
-                                src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/svg/accdb_16x1.svg"
-                              />
-                            </div>
-                            <div
-                              aria-colindex={2}
-                              className=
-                                  is-row-header
-                                  ms-DetailsRow-cell
-                                  {
-                                    color: #323130;
-                                    font-size: 14px;
-                                  }
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 32px;
-                                  }
-                                  &.ms-DetailsRow-cellCheck {
-                                    padding-right: 0px;
-                                  }
-                              data-automation-key="column2"
-                              data-automationid="DetailsRowCell"
-                              role="rowheader"
-                              style={
-                                Object {
-                                  "width": 254,
-                                }
-                              }
-                            >
-                              Lorem ipsum.accdb
-                            </div>
-                            <div
-                              aria-colindex={3}
-                              className=
-                                  ms-DetailsRow-cell
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 32px;
-                                  }
-                                  &.ms-DetailsRow-cellCheck {
-                                    padding-right: 0px;
-                                  }
-                              data-automation-key="column3"
-                              data-automationid="DetailsRowCell"
-                              role="gridcell"
-                              style={
-                                Object {
-                                  "width": 114,
-                                }
-                              }
-                            >
-                              <span>
-                                Fri, 06 Jan 2017 04:41:20 GMT
-                              </span>
-                            </div>
-                          </div>
-                          <span
-                            aria-checked={false}
-                            className=
-
                                 {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
                                   bottom: 0px;
-                                  display: none;
+                                  content: "";
                                   left: 0px;
+                                  outline: 1px solid #ffffff;
                                   position: absolute;
                                   right: 0px;
-                                  top: -1px;
+                                  top: 0px;
+                                  z-index: 1;
                                 }
-                            data-selection-toggle={true}
-                            role="checkbox"
-                          />
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 8px;
+                                }
+                            data-automation-key="column1"
+                            data-automationid="DetailsRowCell"
+                            role="gridcell"
+                            style={
+                              Object {
+                                "width": 36,
+                              }
+                            }
+                          >
+                            <img
+                              alt="accdb file icon"
+                              className=
+
+                                  {
+                                    max-height: 16px;
+                                    max-width: 16px;
+                                    vertical-align: middle;
+                                  }
+                              src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/svg/accdb_16x1.svg"
+                            />
+                          </div>
+                          <div
+                            aria-colindex={2}
+                            className=
+                                is-row-header
+                                ms-DetailsRow-cell
+                                {
+                                  color: #323130;
+                                  font-size: 14px;
+                                }
+                                {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
+                                  bottom: 0px;
+                                  content: "";
+                                  left: 0px;
+                                  outline: 1px solid #ffffff;
+                                  position: absolute;
+                                  right: 0px;
+                                  top: 0px;
+                                  z-index: 1;
+                                }
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 32px;
+                                }
+                                &.ms-DetailsRow-cellCheck {
+                                  padding-right: 0px;
+                                }
+                            data-automation-key="column2"
+                            data-automationid="DetailsRowCell"
+                            role="rowheader"
+                            style={
+                              Object {
+                                "width": 254,
+                              }
+                            }
+                          >
+                            Lorem ipsum.accdb
+                          </div>
+                          <div
+                            aria-colindex={3}
+                            className=
+                                ms-DetailsRow-cell
+                                {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
+                                  bottom: 0px;
+                                  content: "";
+                                  left: 0px;
+                                  outline: 1px solid #ffffff;
+                                  position: absolute;
+                                  right: 0px;
+                                  top: 0px;
+                                  z-index: 1;
+                                }
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 32px;
+                                }
+                                &.ms-DetailsRow-cellCheck {
+                                  padding-right: 0px;
+                                }
+                            data-automation-key="column3"
+                            data-automationid="DetailsRowCell"
+                            role="gridcell"
+                            style={
+                              Object {
+                                "width": 114,
+                              }
+                            }
+                          >
+                            <span>
+                              Fri, 06 Jan 2017 04:41:20 GMT
+                            </span>
+                          </div>
                         </div>
+                        <span
+                          aria-checked={false}
+                          className=
+
+                              {
+                                bottom: 0px;
+                                display: none;
+                                left: 0px;
+                                position: absolute;
+                                right: 0px;
+                                top: -1px;
+                              }
+                          data-selection-toggle={true}
+                          role="checkbox"
+                        />
                       </div>
+                    </div>
+                    <div
+                      className="ms-List-cell"
+                      data-automationid="ListCell"
+                      data-list-index={1}
+                      role="presentation"
+                    >
                       <div
-                        className="ms-List-cell"
-                        data-automationid="ListCell"
-                        data-list-index={1}
-                        role="presentation"
+                        aria-rowindex={2}
+                        className=
+                            ms-FocusZone
+                            ms-DetailsRow
+                            &:focus {
+                              outline: none;
+                            }
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              animation-duration: 0.367s;
+                              animation-fill-mode: both;
+                              animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                              animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                              background: #ffffff;
+                              border-bottom: 1px solid #f3f2f1;
+                              box-sizing: border-box;
+                              color: #605e5c;
+                              display: inline-flex;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 12px;
+                              font-weight: 400;
+                              min-height: 42px;
+                              min-width: 100%;
+                              outline: transparent;
+                              padding-bottom: 0px;
+                              padding-left: 0px;
+                              padding-right: 0px;
+                              padding-top: 0px;
+                              position: relative;
+                              text-align: left;
+                              vertical-align: top;
+                              white-space: nowrap;
+                            }
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #605e5c;
+                              bottom: 1px;
+                              content: "";
+                              left: 1px;
+                              outline: 1px solid #ffffff;
+                              position: absolute;
+                              right: 1px;
+                              top: 1px;
+                              z-index: 1;
+                            }
+                            .ms-List-cell:first-child &:before {
+                              display: none;
+                            }
+                            &:hover {
+                              background: #f3f2f1;
+                              color: #323130;
+                            }
+                            &:hover .is-row-header {
+                              color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-check {
+                              opacity: 1;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                              opacity: 1;
+                            }
+                        data-automationid="DetailsRow"
+                        data-focuszone-id="FocusZone9"
+                        data-is-focusable={true}
+                        data-item-index={1}
+                        data-selection-index={1}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseDownCapture={[Function]}
+                        role="row"
+                        style={
+                          Object {
+                            "minWidth": 296,
+                          }
+                        }
                       >
                         <div
-                          aria-rowindex={2}
                           className=
-                              ms-FocusZone
-                              ms-DetailsRow
-                              &:focus {
-                                outline: none;
-                              }
+                              ms-DetailsRow-fields
                               {
-                                -moz-osx-font-smoothing: grayscale;
-                                -webkit-font-smoothing: antialiased;
-                                animation-duration: 0.367s;
-                                animation-fill-mode: both;
-                                animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                background: #ffffff;
-                                border-bottom: 1px solid #f3f2f1;
-                                box-sizing: border-box;
-                                color: #605e5c;
-                                display: inline-flex;
-                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                font-size: 12px;
-                                font-weight: 400;
-                                min-height: 42px;
-                                min-width: 100%;
-                                outline: transparent;
-                                padding-bottom: 0px;
-                                padding-left: 0px;
-                                padding-right: 0px;
-                                padding-top: 0px;
-                                position: relative;
-                                text-align: left;
-                                vertical-align: top;
-                                white-space: nowrap;
+                                align-items: stretch;
+                                display: flex;
                               }
-                              &::-moz-focus-inner {
-                                border: 0;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus:after {
-                                border: 1px solid #605e5c;
-                                bottom: 1px;
-                                content: "";
-                                left: 1px;
-                                outline: 1px solid #ffffff;
-                                position: absolute;
-                                right: 1px;
-                                top: 1px;
-                                z-index: 1;
-                              }
-                              .ms-List-cell:first-child &:before {
-                                display: none;
-                              }
-                              &:hover {
-                                background: #f3f2f1;
-                                color: #323130;
-                              }
-                              &:hover .is-row-header {
-                                color: #201f1e;
-                              }
-                              &:hover .ms-DetailsRow-check {
-                                opacity: 1;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                opacity: 1;
-                              }
-                          data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone9"
-                          data-is-focusable={true}
-                          data-item-index={1}
-                          data-selection-index={1}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseDownCapture={[Function]}
-                          role="row"
-                          style={
-                            Object {
-                              "minWidth": 296,
-                            }
-                          }
+                          data-automationid="DetailsRowFields"
+                          role="presentation"
                         >
                           <div
+                            aria-colindex={1}
                             className=
-                                ms-DetailsRow-fields
+                                ms-DetailsRow-cell
                                 {
-                                  align-items: stretch;
-                                  display: flex;
+                                  text-align: center;
                                 }
-                            data-automationid="DetailsRowFields"
-                            role="presentation"
-                          >
-                            <div
-                              aria-colindex={1}
-                              className=
-                                  ms-DetailsRow-cell
-                                  {
-                                    text-align: center;
-                                  }
-                                  &:before {
-                                    content: .;
-                                    display: inline-block;
-                                    height: 100%;
-                                    vertical-align: middle;
-                                    visibility: hidden;
-                                    width: 0px;
-                                  }
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 8px;
-                                  }
-                              data-automation-key="column1"
-                              data-automationid="DetailsRowCell"
-                              role="gridcell"
-                              style={
-                                Object {
-                                  "width": 36,
+                                &:before {
+                                  content: .;
+                                  display: inline-block;
+                                  height: 100%;
+                                  vertical-align: middle;
+                                  visibility: hidden;
+                                  width: 0px;
                                 }
-                              }
-                            >
-                              <img
-                                alt="accdb file icon"
-                                className=
-
-                                    {
-                                      max-height: 16px;
-                                      max-width: 16px;
-                                      vertical-align: middle;
-                                    }
-                                src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/svg/accdb_16x1.svg"
-                              />
-                            </div>
-                            <div
-                              aria-colindex={2}
-                              className=
-                                  is-row-header
-                                  ms-DetailsRow-cell
-                                  {
-                                    color: #323130;
-                                    font-size: 14px;
-                                  }
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 32px;
-                                  }
-                                  &.ms-DetailsRow-cellCheck {
-                                    padding-right: 0px;
-                                  }
-                              data-automation-key="column2"
-                              data-automationid="DetailsRowCell"
-                              role="rowheader"
-                              style={
-                                Object {
-                                  "width": 254,
-                                }
-                              }
-                            >
-                              Amet consectetur.accdb
-                            </div>
-                            <div
-                              aria-colindex={3}
-                              className=
-                                  ms-DetailsRow-cell
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 32px;
-                                  }
-                                  &.ms-DetailsRow-cellCheck {
-                                    padding-right: 0px;
-                                  }
-                              data-automation-key="column3"
-                              data-automationid="DetailsRowCell"
-                              role="gridcell"
-                              style={
-                                Object {
-                                  "width": 114,
-                                }
-                              }
-                            >
-                              <span>
-                                Fri, 06 Jan 2017 04:41:20 GMT
-                              </span>
-                            </div>
-                          </div>
-                          <span
-                            aria-checked={false}
-                            className=
-
                                 {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
                                   bottom: 0px;
-                                  display: none;
+                                  content: "";
                                   left: 0px;
+                                  outline: 1px solid #ffffff;
                                   position: absolute;
                                   right: 0px;
-                                  top: -1px;
+                                  top: 0px;
+                                  z-index: 1;
                                 }
-                            data-selection-toggle={true}
-                            role="checkbox"
-                          />
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 8px;
+                                }
+                            data-automation-key="column1"
+                            data-automationid="DetailsRowCell"
+                            role="gridcell"
+                            style={
+                              Object {
+                                "width": 36,
+                              }
+                            }
+                          >
+                            <img
+                              alt="accdb file icon"
+                              className=
+
+                                  {
+                                    max-height: 16px;
+                                    max-width: 16px;
+                                    vertical-align: middle;
+                                  }
+                              src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/svg/accdb_16x1.svg"
+                            />
+                          </div>
+                          <div
+                            aria-colindex={2}
+                            className=
+                                is-row-header
+                                ms-DetailsRow-cell
+                                {
+                                  color: #323130;
+                                  font-size: 14px;
+                                }
+                                {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
+                                  bottom: 0px;
+                                  content: "";
+                                  left: 0px;
+                                  outline: 1px solid #ffffff;
+                                  position: absolute;
+                                  right: 0px;
+                                  top: 0px;
+                                  z-index: 1;
+                                }
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 32px;
+                                }
+                                &.ms-DetailsRow-cellCheck {
+                                  padding-right: 0px;
+                                }
+                            data-automation-key="column2"
+                            data-automationid="DetailsRowCell"
+                            role="rowheader"
+                            style={
+                              Object {
+                                "width": 254,
+                              }
+                            }
+                          >
+                            Amet consectetur.accdb
+                          </div>
+                          <div
+                            aria-colindex={3}
+                            className=
+                                ms-DetailsRow-cell
+                                {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
+                                  bottom: 0px;
+                                  content: "";
+                                  left: 0px;
+                                  outline: 1px solid #ffffff;
+                                  position: absolute;
+                                  right: 0px;
+                                  top: 0px;
+                                  z-index: 1;
+                                }
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 32px;
+                                }
+                                &.ms-DetailsRow-cellCheck {
+                                  padding-right: 0px;
+                                }
+                            data-automation-key="column3"
+                            data-automationid="DetailsRowCell"
+                            role="gridcell"
+                            style={
+                              Object {
+                                "width": 114,
+                              }
+                            }
+                          >
+                            <span>
+                              Fri, 06 Jan 2017 04:41:20 GMT
+                            </span>
+                          </div>
                         </div>
+                        <span
+                          aria-checked={false}
+                          className=
+
+                              {
+                                bottom: 0px;
+                                display: none;
+                                left: 0px;
+                                position: absolute;
+                                right: 0px;
+                                top: -1px;
+                              }
+                          data-selection-toggle={true}
+                          role="checkbox"
+                        />
                       </div>
+                    </div>
+                    <div
+                      className="ms-List-cell"
+                      data-automationid="ListCell"
+                      data-list-index={2}
+                      role="presentation"
+                    >
                       <div
-                        className="ms-List-cell"
-                        data-automationid="ListCell"
-                        data-list-index={2}
-                        role="presentation"
+                        aria-rowindex={3}
+                        className=
+                            ms-FocusZone
+                            ms-DetailsRow
+                            &:focus {
+                              outline: none;
+                            }
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              animation-duration: 0.367s;
+                              animation-fill-mode: both;
+                              animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                              animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                              background: #ffffff;
+                              border-bottom: 1px solid #f3f2f1;
+                              box-sizing: border-box;
+                              color: #605e5c;
+                              display: inline-flex;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 12px;
+                              font-weight: 400;
+                              min-height: 42px;
+                              min-width: 100%;
+                              outline: transparent;
+                              padding-bottom: 0px;
+                              padding-left: 0px;
+                              padding-right: 0px;
+                              padding-top: 0px;
+                              position: relative;
+                              text-align: left;
+                              vertical-align: top;
+                              white-space: nowrap;
+                            }
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #605e5c;
+                              bottom: 1px;
+                              content: "";
+                              left: 1px;
+                              outline: 1px solid #ffffff;
+                              position: absolute;
+                              right: 1px;
+                              top: 1px;
+                              z-index: 1;
+                            }
+                            .ms-List-cell:first-child &:before {
+                              display: none;
+                            }
+                            &:hover {
+                              background: #f3f2f1;
+                              color: #323130;
+                            }
+                            &:hover .is-row-header {
+                              color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-check {
+                              opacity: 1;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                              opacity: 1;
+                            }
+                        data-automationid="DetailsRow"
+                        data-focuszone-id="FocusZone10"
+                        data-is-focusable={true}
+                        data-item-index={2}
+                        data-selection-index={2}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseDownCapture={[Function]}
+                        role="row"
+                        style={
+                          Object {
+                            "minWidth": 296,
+                          }
+                        }
                       >
                         <div
-                          aria-rowindex={3}
                           className=
-                              ms-FocusZone
-                              ms-DetailsRow
-                              &:focus {
-                                outline: none;
-                              }
+                              ms-DetailsRow-fields
                               {
-                                -moz-osx-font-smoothing: grayscale;
-                                -webkit-font-smoothing: antialiased;
-                                animation-duration: 0.367s;
-                                animation-fill-mode: both;
-                                animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                background: #ffffff;
-                                border-bottom: 1px solid #f3f2f1;
-                                box-sizing: border-box;
-                                color: #605e5c;
-                                display: inline-flex;
-                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                font-size: 12px;
-                                font-weight: 400;
-                                min-height: 42px;
-                                min-width: 100%;
-                                outline: transparent;
-                                padding-bottom: 0px;
-                                padding-left: 0px;
-                                padding-right: 0px;
-                                padding-top: 0px;
-                                position: relative;
-                                text-align: left;
-                                vertical-align: top;
-                                white-space: nowrap;
+                                align-items: stretch;
+                                display: flex;
                               }
-                              &::-moz-focus-inner {
-                                border: 0;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus:after {
-                                border: 1px solid #605e5c;
-                                bottom: 1px;
-                                content: "";
-                                left: 1px;
-                                outline: 1px solid #ffffff;
-                                position: absolute;
-                                right: 1px;
-                                top: 1px;
-                                z-index: 1;
-                              }
-                              .ms-List-cell:first-child &:before {
-                                display: none;
-                              }
-                              &:hover {
-                                background: #f3f2f1;
-                                color: #323130;
-                              }
-                              &:hover .is-row-header {
-                                color: #201f1e;
-                              }
-                              &:hover .ms-DetailsRow-check {
-                                opacity: 1;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                opacity: 1;
-                              }
-                          data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone10"
-                          data-is-focusable={true}
-                          data-item-index={2}
-                          data-selection-index={2}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseDownCapture={[Function]}
-                          role="row"
-                          style={
-                            Object {
-                              "minWidth": 296,
-                            }
-                          }
+                          data-automationid="DetailsRowFields"
+                          role="presentation"
                         >
                           <div
+                            aria-colindex={1}
                             className=
-                                ms-DetailsRow-fields
+                                ms-DetailsRow-cell
                                 {
-                                  align-items: stretch;
-                                  display: flex;
+                                  text-align: center;
                                 }
-                            data-automationid="DetailsRowFields"
-                            role="presentation"
-                          >
-                            <div
-                              aria-colindex={1}
-                              className=
-                                  ms-DetailsRow-cell
-                                  {
-                                    text-align: center;
-                                  }
-                                  &:before {
-                                    content: .;
-                                    display: inline-block;
-                                    height: 100%;
-                                    vertical-align: middle;
-                                    visibility: hidden;
-                                    width: 0px;
-                                  }
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 8px;
-                                  }
-                              data-automation-key="column1"
-                              data-automationid="DetailsRowCell"
-                              role="gridcell"
-                              style={
-                                Object {
-                                  "width": 36,
+                                &:before {
+                                  content: .;
+                                  display: inline-block;
+                                  height: 100%;
+                                  vertical-align: middle;
+                                  visibility: hidden;
+                                  width: 0px;
                                 }
-                              }
-                            >
-                              <img
-                                alt="accdb file icon"
-                                className=
-
-                                    {
-                                      max-height: 16px;
-                                      max-width: 16px;
-                                      vertical-align: middle;
-                                    }
-                                src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/svg/accdb_16x1.svg"
-                              />
-                            </div>
-                            <div
-                              aria-colindex={2}
-                              className=
-                                  is-row-header
-                                  ms-DetailsRow-cell
-                                  {
-                                    color: #323130;
-                                    font-size: 14px;
-                                  }
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 32px;
-                                  }
-                                  &.ms-DetailsRow-cellCheck {
-                                    padding-right: 0px;
-                                  }
-                              data-automation-key="column2"
-                              data-automationid="DetailsRowCell"
-                              role="rowheader"
-                              style={
-                                Object {
-                                  "width": 254,
-                                }
-                              }
-                            >
-                              Sed do.accdb
-                            </div>
-                            <div
-                              aria-colindex={3}
-                              className=
-                                  ms-DetailsRow-cell
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 32px;
-                                  }
-                                  &.ms-DetailsRow-cellCheck {
-                                    padding-right: 0px;
-                                  }
-                              data-automation-key="column3"
-                              data-automationid="DetailsRowCell"
-                              role="gridcell"
-                              style={
-                                Object {
-                                  "width": 114,
-                                }
-                              }
-                            >
-                              <span>
-                                Fri, 06 Jan 2017 04:41:20 GMT
-                              </span>
-                            </div>
-                          </div>
-                          <span
-                            aria-checked={false}
-                            className=
-
                                 {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
                                   bottom: 0px;
-                                  display: none;
+                                  content: "";
                                   left: 0px;
+                                  outline: 1px solid #ffffff;
                                   position: absolute;
                                   right: 0px;
-                                  top: -1px;
+                                  top: 0px;
+                                  z-index: 1;
                                 }
-                            data-selection-toggle={true}
-                            role="checkbox"
-                          />
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 8px;
+                                }
+                            data-automation-key="column1"
+                            data-automationid="DetailsRowCell"
+                            role="gridcell"
+                            style={
+                              Object {
+                                "width": 36,
+                              }
+                            }
+                          >
+                            <img
+                              alt="accdb file icon"
+                              className=
+
+                                  {
+                                    max-height: 16px;
+                                    max-width: 16px;
+                                    vertical-align: middle;
+                                  }
+                              src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/svg/accdb_16x1.svg"
+                            />
+                          </div>
+                          <div
+                            aria-colindex={2}
+                            className=
+                                is-row-header
+                                ms-DetailsRow-cell
+                                {
+                                  color: #323130;
+                                  font-size: 14px;
+                                }
+                                {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
+                                  bottom: 0px;
+                                  content: "";
+                                  left: 0px;
+                                  outline: 1px solid #ffffff;
+                                  position: absolute;
+                                  right: 0px;
+                                  top: 0px;
+                                  z-index: 1;
+                                }
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 32px;
+                                }
+                                &.ms-DetailsRow-cellCheck {
+                                  padding-right: 0px;
+                                }
+                            data-automation-key="column2"
+                            data-automationid="DetailsRowCell"
+                            role="rowheader"
+                            style={
+                              Object {
+                                "width": 254,
+                              }
+                            }
+                          >
+                            Sed do.accdb
+                          </div>
+                          <div
+                            aria-colindex={3}
+                            className=
+                                ms-DetailsRow-cell
+                                {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
+                                  bottom: 0px;
+                                  content: "";
+                                  left: 0px;
+                                  outline: 1px solid #ffffff;
+                                  position: absolute;
+                                  right: 0px;
+                                  top: 0px;
+                                  z-index: 1;
+                                }
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 32px;
+                                }
+                                &.ms-DetailsRow-cellCheck {
+                                  padding-right: 0px;
+                                }
+                            data-automation-key="column3"
+                            data-automationid="DetailsRowCell"
+                            role="gridcell"
+                            style={
+                              Object {
+                                "width": 114,
+                              }
+                            }
+                          >
+                            <span>
+                              Fri, 06 Jan 2017 04:41:20 GMT
+                            </span>
+                          </div>
                         </div>
+                        <span
+                          aria-checked={false}
+                          className=
+
+                              {
+                                bottom: 0px;
+                                display: none;
+                                left: 0px;
+                                position: absolute;
+                                right: 0px;
+                                top: -1px;
+                              }
+                          data-selection-toggle={true}
+                          role="checkbox"
+                        />
                       </div>
+                    </div>
+                    <div
+                      className="ms-List-cell"
+                      data-automationid="ListCell"
+                      data-list-index={3}
+                      role="presentation"
+                    >
                       <div
-                        className="ms-List-cell"
-                        data-automationid="ListCell"
-                        data-list-index={3}
-                        role="presentation"
+                        aria-rowindex={4}
+                        className=
+                            ms-FocusZone
+                            ms-DetailsRow
+                            &:focus {
+                              outline: none;
+                            }
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              animation-duration: 0.367s;
+                              animation-fill-mode: both;
+                              animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                              animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                              background: #ffffff;
+                              border-bottom: 1px solid #f3f2f1;
+                              box-sizing: border-box;
+                              color: #605e5c;
+                              display: inline-flex;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 12px;
+                              font-weight: 400;
+                              min-height: 42px;
+                              min-width: 100%;
+                              outline: transparent;
+                              padding-bottom: 0px;
+                              padding-left: 0px;
+                              padding-right: 0px;
+                              padding-top: 0px;
+                              position: relative;
+                              text-align: left;
+                              vertical-align: top;
+                              white-space: nowrap;
+                            }
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #605e5c;
+                              bottom: 1px;
+                              content: "";
+                              left: 1px;
+                              outline: 1px solid #ffffff;
+                              position: absolute;
+                              right: 1px;
+                              top: 1px;
+                              z-index: 1;
+                            }
+                            .ms-List-cell:first-child &:before {
+                              display: none;
+                            }
+                            &:hover {
+                              background: #f3f2f1;
+                              color: #323130;
+                            }
+                            &:hover .is-row-header {
+                              color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-check {
+                              opacity: 1;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                              opacity: 1;
+                            }
+                        data-automationid="DetailsRow"
+                        data-focuszone-id="FocusZone11"
+                        data-is-focusable={true}
+                        data-item-index={3}
+                        data-selection-index={3}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseDownCapture={[Function]}
+                        role="row"
+                        style={
+                          Object {
+                            "minWidth": 296,
+                          }
+                        }
                       >
                         <div
-                          aria-rowindex={4}
                           className=
-                              ms-FocusZone
-                              ms-DetailsRow
-                              &:focus {
-                                outline: none;
-                              }
+                              ms-DetailsRow-fields
                               {
-                                -moz-osx-font-smoothing: grayscale;
-                                -webkit-font-smoothing: antialiased;
-                                animation-duration: 0.367s;
-                                animation-fill-mode: both;
-                                animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                background: #ffffff;
-                                border-bottom: 1px solid #f3f2f1;
-                                box-sizing: border-box;
-                                color: #605e5c;
-                                display: inline-flex;
-                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                font-size: 12px;
-                                font-weight: 400;
-                                min-height: 42px;
-                                min-width: 100%;
-                                outline: transparent;
-                                padding-bottom: 0px;
-                                padding-left: 0px;
-                                padding-right: 0px;
-                                padding-top: 0px;
-                                position: relative;
-                                text-align: left;
-                                vertical-align: top;
-                                white-space: nowrap;
+                                align-items: stretch;
+                                display: flex;
                               }
-                              &::-moz-focus-inner {
-                                border: 0;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus:after {
-                                border: 1px solid #605e5c;
-                                bottom: 1px;
-                                content: "";
-                                left: 1px;
-                                outline: 1px solid #ffffff;
-                                position: absolute;
-                                right: 1px;
-                                top: 1px;
-                                z-index: 1;
-                              }
-                              .ms-List-cell:first-child &:before {
-                                display: none;
-                              }
-                              &:hover {
-                                background: #f3f2f1;
-                                color: #323130;
-                              }
-                              &:hover .is-row-header {
-                                color: #201f1e;
-                              }
-                              &:hover .ms-DetailsRow-check {
-                                opacity: 1;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                opacity: 1;
-                              }
-                          data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone11"
-                          data-is-focusable={true}
-                          data-item-index={3}
-                          data-selection-index={3}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseDownCapture={[Function]}
-                          role="row"
-                          style={
-                            Object {
-                              "minWidth": 296,
-                            }
-                          }
+                          data-automationid="DetailsRowFields"
+                          role="presentation"
                         >
                           <div
+                            aria-colindex={1}
                             className=
-                                ms-DetailsRow-fields
+                                ms-DetailsRow-cell
                                 {
-                                  align-items: stretch;
-                                  display: flex;
+                                  text-align: center;
                                 }
-                            data-automationid="DetailsRowFields"
-                            role="presentation"
-                          >
-                            <div
-                              aria-colindex={1}
-                              className=
-                                  ms-DetailsRow-cell
-                                  {
-                                    text-align: center;
-                                  }
-                                  &:before {
-                                    content: .;
-                                    display: inline-block;
-                                    height: 100%;
-                                    vertical-align: middle;
-                                    visibility: hidden;
-                                    width: 0px;
-                                  }
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 8px;
-                                  }
-                              data-automation-key="column1"
-                              data-automationid="DetailsRowCell"
-                              role="gridcell"
-                              style={
-                                Object {
-                                  "width": 36,
+                                &:before {
+                                  content: .;
+                                  display: inline-block;
+                                  height: 100%;
+                                  vertical-align: middle;
+                                  visibility: hidden;
+                                  width: 0px;
                                 }
-                              }
-                            >
-                              <img
-                                alt="accdb file icon"
-                                className=
-
-                                    {
-                                      max-height: 16px;
-                                      max-width: 16px;
-                                      vertical-align: middle;
-                                    }
-                                src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/svg/accdb_16x1.svg"
-                              />
-                            </div>
-                            <div
-                              aria-colindex={2}
-                              className=
-                                  is-row-header
-                                  ms-DetailsRow-cell
-                                  {
-                                    color: #323130;
-                                    font-size: 14px;
-                                  }
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 32px;
-                                  }
-                                  &.ms-DetailsRow-cellCheck {
-                                    padding-right: 0px;
-                                  }
-                              data-automation-key="column2"
-                              data-automationid="DetailsRowCell"
-                              role="rowheader"
-                              style={
-                                Object {
-                                  "width": 254,
-                                }
-                              }
-                            >
-                              Incididunt ut.accdb
-                            </div>
-                            <div
-                              aria-colindex={3}
-                              className=
-                                  ms-DetailsRow-cell
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 32px;
-                                  }
-                                  &.ms-DetailsRow-cellCheck {
-                                    padding-right: 0px;
-                                  }
-                              data-automation-key="column3"
-                              data-automationid="DetailsRowCell"
-                              role="gridcell"
-                              style={
-                                Object {
-                                  "width": 114,
-                                }
-                              }
-                            >
-                              <span>
-                                Fri, 06 Jan 2017 04:41:20 GMT
-                              </span>
-                            </div>
-                          </div>
-                          <span
-                            aria-checked={false}
-                            className=
-
                                 {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
                                   bottom: 0px;
-                                  display: none;
+                                  content: "";
                                   left: 0px;
+                                  outline: 1px solid #ffffff;
                                   position: absolute;
                                   right: 0px;
-                                  top: -1px;
+                                  top: 0px;
+                                  z-index: 1;
                                 }
-                            data-selection-toggle={true}
-                            role="checkbox"
-                          />
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 8px;
+                                }
+                            data-automation-key="column1"
+                            data-automationid="DetailsRowCell"
+                            role="gridcell"
+                            style={
+                              Object {
+                                "width": 36,
+                              }
+                            }
+                          >
+                            <img
+                              alt="accdb file icon"
+                              className=
+
+                                  {
+                                    max-height: 16px;
+                                    max-width: 16px;
+                                    vertical-align: middle;
+                                  }
+                              src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/svg/accdb_16x1.svg"
+                            />
+                          </div>
+                          <div
+                            aria-colindex={2}
+                            className=
+                                is-row-header
+                                ms-DetailsRow-cell
+                                {
+                                  color: #323130;
+                                  font-size: 14px;
+                                }
+                                {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
+                                  bottom: 0px;
+                                  content: "";
+                                  left: 0px;
+                                  outline: 1px solid #ffffff;
+                                  position: absolute;
+                                  right: 0px;
+                                  top: 0px;
+                                  z-index: 1;
+                                }
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 32px;
+                                }
+                                &.ms-DetailsRow-cellCheck {
+                                  padding-right: 0px;
+                                }
+                            data-automation-key="column2"
+                            data-automationid="DetailsRowCell"
+                            role="rowheader"
+                            style={
+                              Object {
+                                "width": 254,
+                              }
+                            }
+                          >
+                            Incididunt ut.accdb
+                          </div>
+                          <div
+                            aria-colindex={3}
+                            className=
+                                ms-DetailsRow-cell
+                                {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
+                                  bottom: 0px;
+                                  content: "";
+                                  left: 0px;
+                                  outline: 1px solid #ffffff;
+                                  position: absolute;
+                                  right: 0px;
+                                  top: 0px;
+                                  z-index: 1;
+                                }
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 32px;
+                                }
+                                &.ms-DetailsRow-cellCheck {
+                                  padding-right: 0px;
+                                }
+                            data-automation-key="column3"
+                            data-automationid="DetailsRowCell"
+                            role="gridcell"
+                            style={
+                              Object {
+                                "width": 114,
+                              }
+                            }
+                          >
+                            <span>
+                              Fri, 06 Jan 2017 04:41:20 GMT
+                            </span>
+                          </div>
                         </div>
+                        <span
+                          aria-checked={false}
+                          className=
+
+                              {
+                                bottom: 0px;
+                                display: none;
+                                left: 0px;
+                                position: absolute;
+                                right: 0px;
+                                top: -1px;
+                              }
+                          data-selection-toggle={true}
+                          role="checkbox"
+                        />
                       </div>
+                    </div>
+                    <div
+                      className="ms-List-cell"
+                      data-automationid="ListCell"
+                      data-list-index={4}
+                      role="presentation"
+                    >
                       <div
-                        className="ms-List-cell"
-                        data-automationid="ListCell"
-                        data-list-index={4}
-                        role="presentation"
+                        aria-rowindex={5}
+                        className=
+                            ms-FocusZone
+                            ms-DetailsRow
+                            &:focus {
+                              outline: none;
+                            }
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              animation-duration: 0.367s;
+                              animation-fill-mode: both;
+                              animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                              animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                              background: #ffffff;
+                              border-bottom: 1px solid #f3f2f1;
+                              box-sizing: border-box;
+                              color: #605e5c;
+                              display: inline-flex;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 12px;
+                              font-weight: 400;
+                              min-height: 42px;
+                              min-width: 100%;
+                              outline: transparent;
+                              padding-bottom: 0px;
+                              padding-left: 0px;
+                              padding-right: 0px;
+                              padding-top: 0px;
+                              position: relative;
+                              text-align: left;
+                              vertical-align: top;
+                              white-space: nowrap;
+                            }
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #605e5c;
+                              bottom: 1px;
+                              content: "";
+                              left: 1px;
+                              outline: 1px solid #ffffff;
+                              position: absolute;
+                              right: 1px;
+                              top: 1px;
+                              z-index: 1;
+                            }
+                            .ms-List-cell:first-child &:before {
+                              display: none;
+                            }
+                            &:hover {
+                              background: #f3f2f1;
+                              color: #323130;
+                            }
+                            &:hover .is-row-header {
+                              color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-check {
+                              opacity: 1;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                              opacity: 1;
+                            }
+                        data-automationid="DetailsRow"
+                        data-focuszone-id="FocusZone12"
+                        data-is-focusable={true}
+                        data-item-index={4}
+                        data-selection-index={4}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseDownCapture={[Function]}
+                        role="row"
+                        style={
+                          Object {
+                            "minWidth": 296,
+                          }
+                        }
                       >
                         <div
-                          aria-rowindex={5}
                           className=
-                              ms-FocusZone
-                              ms-DetailsRow
-                              &:focus {
-                                outline: none;
-                              }
+                              ms-DetailsRow-fields
                               {
-                                -moz-osx-font-smoothing: grayscale;
-                                -webkit-font-smoothing: antialiased;
-                                animation-duration: 0.367s;
-                                animation-fill-mode: both;
-                                animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                background: #ffffff;
-                                border-bottom: 1px solid #f3f2f1;
-                                box-sizing: border-box;
-                                color: #605e5c;
-                                display: inline-flex;
-                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                font-size: 12px;
-                                font-weight: 400;
-                                min-height: 42px;
-                                min-width: 100%;
-                                outline: transparent;
-                                padding-bottom: 0px;
-                                padding-left: 0px;
-                                padding-right: 0px;
-                                padding-top: 0px;
-                                position: relative;
-                                text-align: left;
-                                vertical-align: top;
-                                white-space: nowrap;
+                                align-items: stretch;
+                                display: flex;
                               }
-                              &::-moz-focus-inner {
-                                border: 0;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus:after {
-                                border: 1px solid #605e5c;
-                                bottom: 1px;
-                                content: "";
-                                left: 1px;
-                                outline: 1px solid #ffffff;
-                                position: absolute;
-                                right: 1px;
-                                top: 1px;
-                                z-index: 1;
-                              }
-                              .ms-List-cell:first-child &:before {
-                                display: none;
-                              }
-                              &:hover {
-                                background: #f3f2f1;
-                                color: #323130;
-                              }
-                              &:hover .is-row-header {
-                                color: #201f1e;
-                              }
-                              &:hover .ms-DetailsRow-check {
-                                opacity: 1;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                opacity: 1;
-                              }
-                          data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone12"
-                          data-is-focusable={true}
-                          data-item-index={4}
-                          data-selection-index={4}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseDownCapture={[Function]}
-                          role="row"
-                          style={
-                            Object {
-                              "minWidth": 296,
-                            }
-                          }
+                          data-automationid="DetailsRowFields"
+                          role="presentation"
                         >
                           <div
+                            aria-colindex={1}
                             className=
-                                ms-DetailsRow-fields
+                                ms-DetailsRow-cell
                                 {
-                                  align-items: stretch;
-                                  display: flex;
+                                  text-align: center;
                                 }
-                            data-automationid="DetailsRowFields"
-                            role="presentation"
-                          >
-                            <div
-                              aria-colindex={1}
-                              className=
-                                  ms-DetailsRow-cell
-                                  {
-                                    text-align: center;
-                                  }
-                                  &:before {
-                                    content: .;
-                                    display: inline-block;
-                                    height: 100%;
-                                    vertical-align: middle;
-                                    visibility: hidden;
-                                    width: 0px;
-                                  }
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 8px;
-                                  }
-                              data-automation-key="column1"
-                              data-automationid="DetailsRowCell"
-                              role="gridcell"
-                              style={
-                                Object {
-                                  "width": 36,
+                                &:before {
+                                  content: .;
+                                  display: inline-block;
+                                  height: 100%;
+                                  vertical-align: middle;
+                                  visibility: hidden;
+                                  width: 0px;
                                 }
-                              }
-                            >
-                              <img
-                                alt="accdb file icon"
-                                className=
-
-                                    {
-                                      max-height: 16px;
-                                      max-width: 16px;
-                                      vertical-align: middle;
-                                    }
-                                src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/svg/accdb_16x1.svg"
-                              />
-                            </div>
-                            <div
-                              aria-colindex={2}
-                              className=
-                                  is-row-header
-                                  ms-DetailsRow-cell
-                                  {
-                                    color: #323130;
-                                    font-size: 14px;
-                                  }
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 32px;
-                                  }
-                                  &.ms-DetailsRow-cellCheck {
-                                    padding-right: 0px;
-                                  }
-                              data-automation-key="column2"
-                              data-automationid="DetailsRowCell"
-                              role="rowheader"
-                              style={
-                                Object {
-                                  "width": 254,
-                                }
-                              }
-                            >
-                              Dolore magna.accdb
-                            </div>
-                            <div
-                              aria-colindex={3}
-                              className=
-                                  ms-DetailsRow-cell
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 32px;
-                                  }
-                                  &.ms-DetailsRow-cellCheck {
-                                    padding-right: 0px;
-                                  }
-                              data-automation-key="column3"
-                              data-automationid="DetailsRowCell"
-                              role="gridcell"
-                              style={
-                                Object {
-                                  "width": 114,
-                                }
-                              }
-                            >
-                              <span>
-                                Fri, 06 Jan 2017 04:41:20 GMT
-                              </span>
-                            </div>
-                          </div>
-                          <span
-                            aria-checked={false}
-                            className=
-
                                 {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
                                   bottom: 0px;
-                                  display: none;
+                                  content: "";
                                   left: 0px;
+                                  outline: 1px solid #ffffff;
                                   position: absolute;
                                   right: 0px;
-                                  top: -1px;
+                                  top: 0px;
+                                  z-index: 1;
                                 }
-                            data-selection-toggle={true}
-                            role="checkbox"
-                          />
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 8px;
+                                }
+                            data-automation-key="column1"
+                            data-automationid="DetailsRowCell"
+                            role="gridcell"
+                            style={
+                              Object {
+                                "width": 36,
+                              }
+                            }
+                          >
+                            <img
+                              alt="accdb file icon"
+                              className=
+
+                                  {
+                                    max-height: 16px;
+                                    max-width: 16px;
+                                    vertical-align: middle;
+                                  }
+                              src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/svg/accdb_16x1.svg"
+                            />
+                          </div>
+                          <div
+                            aria-colindex={2}
+                            className=
+                                is-row-header
+                                ms-DetailsRow-cell
+                                {
+                                  color: #323130;
+                                  font-size: 14px;
+                                }
+                                {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
+                                  bottom: 0px;
+                                  content: "";
+                                  left: 0px;
+                                  outline: 1px solid #ffffff;
+                                  position: absolute;
+                                  right: 0px;
+                                  top: 0px;
+                                  z-index: 1;
+                                }
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 32px;
+                                }
+                                &.ms-DetailsRow-cellCheck {
+                                  padding-right: 0px;
+                                }
+                            data-automation-key="column2"
+                            data-automationid="DetailsRowCell"
+                            role="rowheader"
+                            style={
+                              Object {
+                                "width": 254,
+                              }
+                            }
+                          >
+                            Dolore magna.accdb
+                          </div>
+                          <div
+                            aria-colindex={3}
+                            className=
+                                ms-DetailsRow-cell
+                                {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
+                                  bottom: 0px;
+                                  content: "";
+                                  left: 0px;
+                                  outline: 1px solid #ffffff;
+                                  position: absolute;
+                                  right: 0px;
+                                  top: 0px;
+                                  z-index: 1;
+                                }
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 32px;
+                                }
+                                &.ms-DetailsRow-cellCheck {
+                                  padding-right: 0px;
+                                }
+                            data-automation-key="column3"
+                            data-automationid="DetailsRowCell"
+                            role="gridcell"
+                            style={
+                              Object {
+                                "width": 114,
+                              }
+                            }
+                          >
+                            <span>
+                              Fri, 06 Jan 2017 04:41:20 GMT
+                            </span>
+                          </div>
                         </div>
+                        <span
+                          aria-checked={false}
+                          className=
+
+                              {
+                                bottom: 0px;
+                                display: none;
+                                left: 0px;
+                                position: absolute;
+                                right: 0px;
+                                top: -1px;
+                              }
+                          data-selection-toggle={true}
+                          role="checkbox"
+                        />
                       </div>
+                    </div>
+                    <div
+                      className="ms-List-cell"
+                      data-automationid="ListCell"
+                      data-list-index={5}
+                      role="presentation"
+                    >
                       <div
-                        className="ms-List-cell"
-                        data-automationid="ListCell"
-                        data-list-index={5}
-                        role="presentation"
+                        aria-rowindex={6}
+                        className=
+                            ms-FocusZone
+                            ms-DetailsRow
+                            &:focus {
+                              outline: none;
+                            }
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              animation-duration: 0.367s;
+                              animation-fill-mode: both;
+                              animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                              animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                              background: #ffffff;
+                              border-bottom: 1px solid #f3f2f1;
+                              box-sizing: border-box;
+                              color: #605e5c;
+                              display: inline-flex;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 12px;
+                              font-weight: 400;
+                              min-height: 42px;
+                              min-width: 100%;
+                              outline: transparent;
+                              padding-bottom: 0px;
+                              padding-left: 0px;
+                              padding-right: 0px;
+                              padding-top: 0px;
+                              position: relative;
+                              text-align: left;
+                              vertical-align: top;
+                              white-space: nowrap;
+                            }
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #605e5c;
+                              bottom: 1px;
+                              content: "";
+                              left: 1px;
+                              outline: 1px solid #ffffff;
+                              position: absolute;
+                              right: 1px;
+                              top: 1px;
+                              z-index: 1;
+                            }
+                            .ms-List-cell:first-child &:before {
+                              display: none;
+                            }
+                            &:hover {
+                              background: #f3f2f1;
+                              color: #323130;
+                            }
+                            &:hover .is-row-header {
+                              color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-check {
+                              opacity: 1;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                              opacity: 1;
+                            }
+                        data-automationid="DetailsRow"
+                        data-focuszone-id="FocusZone13"
+                        data-is-focusable={true}
+                        data-item-index={5}
+                        data-selection-index={5}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseDownCapture={[Function]}
+                        role="row"
+                        style={
+                          Object {
+                            "minWidth": 296,
+                          }
+                        }
                       >
                         <div
-                          aria-rowindex={6}
                           className=
-                              ms-FocusZone
-                              ms-DetailsRow
-                              &:focus {
-                                outline: none;
-                              }
+                              ms-DetailsRow-fields
                               {
-                                -moz-osx-font-smoothing: grayscale;
-                                -webkit-font-smoothing: antialiased;
-                                animation-duration: 0.367s;
-                                animation-fill-mode: both;
-                                animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                background: #ffffff;
-                                border-bottom: 1px solid #f3f2f1;
-                                box-sizing: border-box;
-                                color: #605e5c;
-                                display: inline-flex;
-                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                font-size: 12px;
-                                font-weight: 400;
-                                min-height: 42px;
-                                min-width: 100%;
-                                outline: transparent;
-                                padding-bottom: 0px;
-                                padding-left: 0px;
-                                padding-right: 0px;
-                                padding-top: 0px;
-                                position: relative;
-                                text-align: left;
-                                vertical-align: top;
-                                white-space: nowrap;
+                                align-items: stretch;
+                                display: flex;
                               }
-                              &::-moz-focus-inner {
-                                border: 0;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus:after {
-                                border: 1px solid #605e5c;
-                                bottom: 1px;
-                                content: "";
-                                left: 1px;
-                                outline: 1px solid #ffffff;
-                                position: absolute;
-                                right: 1px;
-                                top: 1px;
-                                z-index: 1;
-                              }
-                              .ms-List-cell:first-child &:before {
-                                display: none;
-                              }
-                              &:hover {
-                                background: #f3f2f1;
-                                color: #323130;
-                              }
-                              &:hover .is-row-header {
-                                color: #201f1e;
-                              }
-                              &:hover .ms-DetailsRow-check {
-                                opacity: 1;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                opacity: 1;
-                              }
-                          data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone13"
-                          data-is-focusable={true}
-                          data-item-index={5}
-                          data-selection-index={5}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseDownCapture={[Function]}
-                          role="row"
-                          style={
-                            Object {
-                              "minWidth": 296,
-                            }
-                          }
+                          data-automationid="DetailsRowFields"
+                          role="presentation"
                         >
                           <div
+                            aria-colindex={1}
                             className=
-                                ms-DetailsRow-fields
+                                ms-DetailsRow-cell
                                 {
-                                  align-items: stretch;
-                                  display: flex;
+                                  text-align: center;
                                 }
-                            data-automationid="DetailsRowFields"
-                            role="presentation"
-                          >
-                            <div
-                              aria-colindex={1}
-                              className=
-                                  ms-DetailsRow-cell
-                                  {
-                                    text-align: center;
-                                  }
-                                  &:before {
-                                    content: .;
-                                    display: inline-block;
-                                    height: 100%;
-                                    vertical-align: middle;
-                                    visibility: hidden;
-                                    width: 0px;
-                                  }
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 8px;
-                                  }
-                              data-automation-key="column1"
-                              data-automationid="DetailsRowCell"
-                              role="gridcell"
-                              style={
-                                Object {
-                                  "width": 36,
+                                &:before {
+                                  content: .;
+                                  display: inline-block;
+                                  height: 100%;
+                                  vertical-align: middle;
+                                  visibility: hidden;
+                                  width: 0px;
                                 }
-                              }
-                            >
-                              <img
-                                alt="accdb file icon"
-                                className=
-
-                                    {
-                                      max-height: 16px;
-                                      max-width: 16px;
-                                      vertical-align: middle;
-                                    }
-                                src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/svg/accdb_16x1.svg"
-                              />
-                            </div>
-                            <div
-                              aria-colindex={2}
-                              className=
-                                  is-row-header
-                                  ms-DetailsRow-cell
-                                  {
-                                    color: #323130;
-                                    font-size: 14px;
-                                  }
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 32px;
-                                  }
-                                  &.ms-DetailsRow-cellCheck {
-                                    padding-right: 0px;
-                                  }
-                              data-automation-key="column2"
-                              data-automationid="DetailsRowCell"
-                              role="rowheader"
-                              style={
-                                Object {
-                                  "width": 254,
-                                }
-                              }
-                            >
-                              Enim ad.accdb
-                            </div>
-                            <div
-                              aria-colindex={3}
-                              className=
-                                  ms-DetailsRow-cell
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 32px;
-                                  }
-                                  &.ms-DetailsRow-cellCheck {
-                                    padding-right: 0px;
-                                  }
-                              data-automation-key="column3"
-                              data-automationid="DetailsRowCell"
-                              role="gridcell"
-                              style={
-                                Object {
-                                  "width": 114,
-                                }
-                              }
-                            >
-                              <span>
-                                Fri, 06 Jan 2017 04:41:20 GMT
-                              </span>
-                            </div>
-                          </div>
-                          <span
-                            aria-checked={false}
-                            className=
-
                                 {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
                                   bottom: 0px;
-                                  display: none;
+                                  content: "";
                                   left: 0px;
+                                  outline: 1px solid #ffffff;
                                   position: absolute;
                                   right: 0px;
-                                  top: -1px;
+                                  top: 0px;
+                                  z-index: 1;
                                 }
-                            data-selection-toggle={true}
-                            role="checkbox"
-                          />
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 8px;
+                                }
+                            data-automation-key="column1"
+                            data-automationid="DetailsRowCell"
+                            role="gridcell"
+                            style={
+                              Object {
+                                "width": 36,
+                              }
+                            }
+                          >
+                            <img
+                              alt="accdb file icon"
+                              className=
+
+                                  {
+                                    max-height: 16px;
+                                    max-width: 16px;
+                                    vertical-align: middle;
+                                  }
+                              src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/svg/accdb_16x1.svg"
+                            />
+                          </div>
+                          <div
+                            aria-colindex={2}
+                            className=
+                                is-row-header
+                                ms-DetailsRow-cell
+                                {
+                                  color: #323130;
+                                  font-size: 14px;
+                                }
+                                {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
+                                  bottom: 0px;
+                                  content: "";
+                                  left: 0px;
+                                  outline: 1px solid #ffffff;
+                                  position: absolute;
+                                  right: 0px;
+                                  top: 0px;
+                                  z-index: 1;
+                                }
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 32px;
+                                }
+                                &.ms-DetailsRow-cellCheck {
+                                  padding-right: 0px;
+                                }
+                            data-automation-key="column2"
+                            data-automationid="DetailsRowCell"
+                            role="rowheader"
+                            style={
+                              Object {
+                                "width": 254,
+                              }
+                            }
+                          >
+                            Enim ad.accdb
+                          </div>
+                          <div
+                            aria-colindex={3}
+                            className=
+                                ms-DetailsRow-cell
+                                {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
+                                  bottom: 0px;
+                                  content: "";
+                                  left: 0px;
+                                  outline: 1px solid #ffffff;
+                                  position: absolute;
+                                  right: 0px;
+                                  top: 0px;
+                                  z-index: 1;
+                                }
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 32px;
+                                }
+                                &.ms-DetailsRow-cellCheck {
+                                  padding-right: 0px;
+                                }
+                            data-automation-key="column3"
+                            data-automationid="DetailsRowCell"
+                            role="gridcell"
+                            style={
+                              Object {
+                                "width": 114,
+                              }
+                            }
+                          >
+                            <span>
+                              Fri, 06 Jan 2017 04:41:20 GMT
+                            </span>
+                          </div>
                         </div>
+                        <span
+                          aria-checked={false}
+                          className=
+
+                              {
+                                bottom: 0px;
+                                display: none;
+                                left: 0px;
+                                position: absolute;
+                                right: 0px;
+                                top: -1px;
+                              }
+                          data-selection-toggle={true}
+                          role="checkbox"
+                        />
                       </div>
+                    </div>
+                    <div
+                      className="ms-List-cell"
+                      data-automationid="ListCell"
+                      data-list-index={6}
+                      role="presentation"
+                    >
                       <div
-                        className="ms-List-cell"
-                        data-automationid="ListCell"
-                        data-list-index={6}
-                        role="presentation"
+                        aria-rowindex={7}
+                        className=
+                            ms-FocusZone
+                            ms-DetailsRow
+                            &:focus {
+                              outline: none;
+                            }
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              animation-duration: 0.367s;
+                              animation-fill-mode: both;
+                              animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                              animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                              background: #ffffff;
+                              border-bottom: 1px solid #f3f2f1;
+                              box-sizing: border-box;
+                              color: #605e5c;
+                              display: inline-flex;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 12px;
+                              font-weight: 400;
+                              min-height: 42px;
+                              min-width: 100%;
+                              outline: transparent;
+                              padding-bottom: 0px;
+                              padding-left: 0px;
+                              padding-right: 0px;
+                              padding-top: 0px;
+                              position: relative;
+                              text-align: left;
+                              vertical-align: top;
+                              white-space: nowrap;
+                            }
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #605e5c;
+                              bottom: 1px;
+                              content: "";
+                              left: 1px;
+                              outline: 1px solid #ffffff;
+                              position: absolute;
+                              right: 1px;
+                              top: 1px;
+                              z-index: 1;
+                            }
+                            .ms-List-cell:first-child &:before {
+                              display: none;
+                            }
+                            &:hover {
+                              background: #f3f2f1;
+                              color: #323130;
+                            }
+                            &:hover .is-row-header {
+                              color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-check {
+                              opacity: 1;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                              opacity: 1;
+                            }
+                        data-automationid="DetailsRow"
+                        data-focuszone-id="FocusZone14"
+                        data-is-focusable={true}
+                        data-item-index={6}
+                        data-selection-index={6}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseDownCapture={[Function]}
+                        role="row"
+                        style={
+                          Object {
+                            "minWidth": 296,
+                          }
+                        }
                       >
                         <div
-                          aria-rowindex={7}
                           className=
-                              ms-FocusZone
-                              ms-DetailsRow
-                              &:focus {
-                                outline: none;
-                              }
+                              ms-DetailsRow-fields
                               {
-                                -moz-osx-font-smoothing: grayscale;
-                                -webkit-font-smoothing: antialiased;
-                                animation-duration: 0.367s;
-                                animation-fill-mode: both;
-                                animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                background: #ffffff;
-                                border-bottom: 1px solid #f3f2f1;
-                                box-sizing: border-box;
-                                color: #605e5c;
-                                display: inline-flex;
-                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                font-size: 12px;
-                                font-weight: 400;
-                                min-height: 42px;
-                                min-width: 100%;
-                                outline: transparent;
-                                padding-bottom: 0px;
-                                padding-left: 0px;
-                                padding-right: 0px;
-                                padding-top: 0px;
-                                position: relative;
-                                text-align: left;
-                                vertical-align: top;
-                                white-space: nowrap;
+                                align-items: stretch;
+                                display: flex;
                               }
-                              &::-moz-focus-inner {
-                                border: 0;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus:after {
-                                border: 1px solid #605e5c;
-                                bottom: 1px;
-                                content: "";
-                                left: 1px;
-                                outline: 1px solid #ffffff;
-                                position: absolute;
-                                right: 1px;
-                                top: 1px;
-                                z-index: 1;
-                              }
-                              .ms-List-cell:first-child &:before {
-                                display: none;
-                              }
-                              &:hover {
-                                background: #f3f2f1;
-                                color: #323130;
-                              }
-                              &:hover .is-row-header {
-                                color: #201f1e;
-                              }
-                              &:hover .ms-DetailsRow-check {
-                                opacity: 1;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                opacity: 1;
-                              }
-                          data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone14"
-                          data-is-focusable={true}
-                          data-item-index={6}
-                          data-selection-index={6}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseDownCapture={[Function]}
-                          role="row"
-                          style={
-                            Object {
-                              "minWidth": 296,
-                            }
-                          }
+                          data-automationid="DetailsRowFields"
+                          role="presentation"
                         >
                           <div
+                            aria-colindex={1}
                             className=
-                                ms-DetailsRow-fields
+                                ms-DetailsRow-cell
                                 {
-                                  align-items: stretch;
-                                  display: flex;
+                                  text-align: center;
                                 }
-                            data-automationid="DetailsRowFields"
-                            role="presentation"
-                          >
-                            <div
-                              aria-colindex={1}
-                              className=
-                                  ms-DetailsRow-cell
-                                  {
-                                    text-align: center;
-                                  }
-                                  &:before {
-                                    content: .;
-                                    display: inline-block;
-                                    height: 100%;
-                                    vertical-align: middle;
-                                    visibility: hidden;
-                                    width: 0px;
-                                  }
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 8px;
-                                  }
-                              data-automation-key="column1"
-                              data-automationid="DetailsRowCell"
-                              role="gridcell"
-                              style={
-                                Object {
-                                  "width": 36,
+                                &:before {
+                                  content: .;
+                                  display: inline-block;
+                                  height: 100%;
+                                  vertical-align: middle;
+                                  visibility: hidden;
+                                  width: 0px;
                                 }
-                              }
-                            >
-                              <img
-                                alt="accdb file icon"
-                                className=
-
-                                    {
-                                      max-height: 16px;
-                                      max-width: 16px;
-                                      vertical-align: middle;
-                                    }
-                                src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/svg/accdb_16x1.svg"
-                              />
-                            </div>
-                            <div
-                              aria-colindex={2}
-                              className=
-                                  is-row-header
-                                  ms-DetailsRow-cell
-                                  {
-                                    color: #323130;
-                                    font-size: 14px;
-                                  }
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 32px;
-                                  }
-                                  &.ms-DetailsRow-cellCheck {
-                                    padding-right: 0px;
-                                  }
-                              data-automation-key="column2"
-                              data-automationid="DetailsRowCell"
-                              role="rowheader"
-                              style={
-                                Object {
-                                  "width": 254,
-                                }
-                              }
-                            >
-                              Quis nostrud.accdb
-                            </div>
-                            <div
-                              aria-colindex={3}
-                              className=
-                                  ms-DetailsRow-cell
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 32px;
-                                  }
-                                  &.ms-DetailsRow-cellCheck {
-                                    padding-right: 0px;
-                                  }
-                              data-automation-key="column3"
-                              data-automationid="DetailsRowCell"
-                              role="gridcell"
-                              style={
-                                Object {
-                                  "width": 114,
-                                }
-                              }
-                            >
-                              <span>
-                                Fri, 06 Jan 2017 04:41:20 GMT
-                              </span>
-                            </div>
-                          </div>
-                          <span
-                            aria-checked={false}
-                            className=
-
                                 {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
                                   bottom: 0px;
-                                  display: none;
+                                  content: "";
                                   left: 0px;
+                                  outline: 1px solid #ffffff;
                                   position: absolute;
                                   right: 0px;
-                                  top: -1px;
+                                  top: 0px;
+                                  z-index: 1;
                                 }
-                            data-selection-toggle={true}
-                            role="checkbox"
-                          />
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 8px;
+                                }
+                            data-automation-key="column1"
+                            data-automationid="DetailsRowCell"
+                            role="gridcell"
+                            style={
+                              Object {
+                                "width": 36,
+                              }
+                            }
+                          >
+                            <img
+                              alt="accdb file icon"
+                              className=
+
+                                  {
+                                    max-height: 16px;
+                                    max-width: 16px;
+                                    vertical-align: middle;
+                                  }
+                              src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/svg/accdb_16x1.svg"
+                            />
+                          </div>
+                          <div
+                            aria-colindex={2}
+                            className=
+                                is-row-header
+                                ms-DetailsRow-cell
+                                {
+                                  color: #323130;
+                                  font-size: 14px;
+                                }
+                                {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
+                                  bottom: 0px;
+                                  content: "";
+                                  left: 0px;
+                                  outline: 1px solid #ffffff;
+                                  position: absolute;
+                                  right: 0px;
+                                  top: 0px;
+                                  z-index: 1;
+                                }
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 32px;
+                                }
+                                &.ms-DetailsRow-cellCheck {
+                                  padding-right: 0px;
+                                }
+                            data-automation-key="column2"
+                            data-automationid="DetailsRowCell"
+                            role="rowheader"
+                            style={
+                              Object {
+                                "width": 254,
+                              }
+                            }
+                          >
+                            Quis nostrud.accdb
+                          </div>
+                          <div
+                            aria-colindex={3}
+                            className=
+                                ms-DetailsRow-cell
+                                {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
+                                  bottom: 0px;
+                                  content: "";
+                                  left: 0px;
+                                  outline: 1px solid #ffffff;
+                                  position: absolute;
+                                  right: 0px;
+                                  top: 0px;
+                                  z-index: 1;
+                                }
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 32px;
+                                }
+                                &.ms-DetailsRow-cellCheck {
+                                  padding-right: 0px;
+                                }
+                            data-automation-key="column3"
+                            data-automationid="DetailsRowCell"
+                            role="gridcell"
+                            style={
+                              Object {
+                                "width": 114,
+                              }
+                            }
+                          >
+                            <span>
+                              Fri, 06 Jan 2017 04:41:20 GMT
+                            </span>
+                          </div>
                         </div>
+                        <span
+                          aria-checked={false}
+                          className=
+
+                              {
+                                bottom: 0px;
+                                display: none;
+                                left: 0px;
+                                position: absolute;
+                                right: 0px;
+                                top: -1px;
+                              }
+                          data-selection-toggle={true}
+                          role="checkbox"
+                        />
                       </div>
+                    </div>
+                    <div
+                      className="ms-List-cell"
+                      data-automationid="ListCell"
+                      data-list-index={7}
+                      role="presentation"
+                    >
                       <div
-                        className="ms-List-cell"
-                        data-automationid="ListCell"
-                        data-list-index={7}
-                        role="presentation"
+                        aria-rowindex={8}
+                        className=
+                            ms-FocusZone
+                            ms-DetailsRow
+                            &:focus {
+                              outline: none;
+                            }
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              animation-duration: 0.367s;
+                              animation-fill-mode: both;
+                              animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                              animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                              background: #ffffff;
+                              border-bottom: 1px solid #f3f2f1;
+                              box-sizing: border-box;
+                              color: #605e5c;
+                              display: inline-flex;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 12px;
+                              font-weight: 400;
+                              min-height: 42px;
+                              min-width: 100%;
+                              outline: transparent;
+                              padding-bottom: 0px;
+                              padding-left: 0px;
+                              padding-right: 0px;
+                              padding-top: 0px;
+                              position: relative;
+                              text-align: left;
+                              vertical-align: top;
+                              white-space: nowrap;
+                            }
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #605e5c;
+                              bottom: 1px;
+                              content: "";
+                              left: 1px;
+                              outline: 1px solid #ffffff;
+                              position: absolute;
+                              right: 1px;
+                              top: 1px;
+                              z-index: 1;
+                            }
+                            .ms-List-cell:first-child &:before {
+                              display: none;
+                            }
+                            &:hover {
+                              background: #f3f2f1;
+                              color: #323130;
+                            }
+                            &:hover .is-row-header {
+                              color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-check {
+                              opacity: 1;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                              opacity: 1;
+                            }
+                        data-automationid="DetailsRow"
+                        data-focuszone-id="FocusZone15"
+                        data-is-focusable={true}
+                        data-item-index={7}
+                        data-selection-index={7}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseDownCapture={[Function]}
+                        role="row"
+                        style={
+                          Object {
+                            "minWidth": 296,
+                          }
+                        }
                       >
                         <div
-                          aria-rowindex={8}
                           className=
-                              ms-FocusZone
-                              ms-DetailsRow
-                              &:focus {
-                                outline: none;
-                              }
+                              ms-DetailsRow-fields
                               {
-                                -moz-osx-font-smoothing: grayscale;
-                                -webkit-font-smoothing: antialiased;
-                                animation-duration: 0.367s;
-                                animation-fill-mode: both;
-                                animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                background: #ffffff;
-                                border-bottom: 1px solid #f3f2f1;
-                                box-sizing: border-box;
-                                color: #605e5c;
-                                display: inline-flex;
-                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                font-size: 12px;
-                                font-weight: 400;
-                                min-height: 42px;
-                                min-width: 100%;
-                                outline: transparent;
-                                padding-bottom: 0px;
-                                padding-left: 0px;
-                                padding-right: 0px;
-                                padding-top: 0px;
-                                position: relative;
-                                text-align: left;
-                                vertical-align: top;
-                                white-space: nowrap;
+                                align-items: stretch;
+                                display: flex;
                               }
-                              &::-moz-focus-inner {
-                                border: 0;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus:after {
-                                border: 1px solid #605e5c;
-                                bottom: 1px;
-                                content: "";
-                                left: 1px;
-                                outline: 1px solid #ffffff;
-                                position: absolute;
-                                right: 1px;
-                                top: 1px;
-                                z-index: 1;
-                              }
-                              .ms-List-cell:first-child &:before {
-                                display: none;
-                              }
-                              &:hover {
-                                background: #f3f2f1;
-                                color: #323130;
-                              }
-                              &:hover .is-row-header {
-                                color: #201f1e;
-                              }
-                              &:hover .ms-DetailsRow-check {
-                                opacity: 1;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                opacity: 1;
-                              }
-                          data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone15"
-                          data-is-focusable={true}
-                          data-item-index={7}
-                          data-selection-index={7}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseDownCapture={[Function]}
-                          role="row"
-                          style={
-                            Object {
-                              "minWidth": 296,
-                            }
-                          }
+                          data-automationid="DetailsRowFields"
+                          role="presentation"
                         >
                           <div
+                            aria-colindex={1}
                             className=
-                                ms-DetailsRow-fields
+                                ms-DetailsRow-cell
                                 {
-                                  align-items: stretch;
-                                  display: flex;
+                                  text-align: center;
                                 }
-                            data-automationid="DetailsRowFields"
-                            role="presentation"
-                          >
-                            <div
-                              aria-colindex={1}
-                              className=
-                                  ms-DetailsRow-cell
-                                  {
-                                    text-align: center;
-                                  }
-                                  &:before {
-                                    content: .;
-                                    display: inline-block;
-                                    height: 100%;
-                                    vertical-align: middle;
-                                    visibility: hidden;
-                                    width: 0px;
-                                  }
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 8px;
-                                  }
-                              data-automation-key="column1"
-                              data-automationid="DetailsRowCell"
-                              role="gridcell"
-                              style={
-                                Object {
-                                  "width": 36,
+                                &:before {
+                                  content: .;
+                                  display: inline-block;
+                                  height: 100%;
+                                  vertical-align: middle;
+                                  visibility: hidden;
+                                  width: 0px;
                                 }
-                              }
-                            >
-                              <img
-                                alt="accdb file icon"
-                                className=
-
-                                    {
-                                      max-height: 16px;
-                                      max-width: 16px;
-                                      vertical-align: middle;
-                                    }
-                                src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/svg/accdb_16x1.svg"
-                              />
-                            </div>
-                            <div
-                              aria-colindex={2}
-                              className=
-                                  is-row-header
-                                  ms-DetailsRow-cell
-                                  {
-                                    color: #323130;
-                                    font-size: 14px;
-                                  }
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 32px;
-                                  }
-                                  &.ms-DetailsRow-cellCheck {
-                                    padding-right: 0px;
-                                  }
-                              data-automation-key="column2"
-                              data-automationid="DetailsRowCell"
-                              role="rowheader"
-                              style={
-                                Object {
-                                  "width": 254,
-                                }
-                              }
-                            >
-                              Laboris nisi.accdb
-                            </div>
-                            <div
-                              aria-colindex={3}
-                              className=
-                                  ms-DetailsRow-cell
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 32px;
-                                  }
-                                  &.ms-DetailsRow-cellCheck {
-                                    padding-right: 0px;
-                                  }
-                              data-automation-key="column3"
-                              data-automationid="DetailsRowCell"
-                              role="gridcell"
-                              style={
-                                Object {
-                                  "width": 114,
-                                }
-                              }
-                            >
-                              <span>
-                                Fri, 06 Jan 2017 04:41:20 GMT
-                              </span>
-                            </div>
-                          </div>
-                          <span
-                            aria-checked={false}
-                            className=
-
                                 {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
                                   bottom: 0px;
-                                  display: none;
+                                  content: "";
                                   left: 0px;
+                                  outline: 1px solid #ffffff;
                                   position: absolute;
                                   right: 0px;
-                                  top: -1px;
+                                  top: 0px;
+                                  z-index: 1;
                                 }
-                            data-selection-toggle={true}
-                            role="checkbox"
-                          />
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 8px;
+                                }
+                            data-automation-key="column1"
+                            data-automationid="DetailsRowCell"
+                            role="gridcell"
+                            style={
+                              Object {
+                                "width": 36,
+                              }
+                            }
+                          >
+                            <img
+                              alt="accdb file icon"
+                              className=
+
+                                  {
+                                    max-height: 16px;
+                                    max-width: 16px;
+                                    vertical-align: middle;
+                                  }
+                              src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/svg/accdb_16x1.svg"
+                            />
+                          </div>
+                          <div
+                            aria-colindex={2}
+                            className=
+                                is-row-header
+                                ms-DetailsRow-cell
+                                {
+                                  color: #323130;
+                                  font-size: 14px;
+                                }
+                                {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
+                                  bottom: 0px;
+                                  content: "";
+                                  left: 0px;
+                                  outline: 1px solid #ffffff;
+                                  position: absolute;
+                                  right: 0px;
+                                  top: 0px;
+                                  z-index: 1;
+                                }
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 32px;
+                                }
+                                &.ms-DetailsRow-cellCheck {
+                                  padding-right: 0px;
+                                }
+                            data-automation-key="column2"
+                            data-automationid="DetailsRowCell"
+                            role="rowheader"
+                            style={
+                              Object {
+                                "width": 254,
+                              }
+                            }
+                          >
+                            Laboris nisi.accdb
+                          </div>
+                          <div
+                            aria-colindex={3}
+                            className=
+                                ms-DetailsRow-cell
+                                {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
+                                  bottom: 0px;
+                                  content: "";
+                                  left: 0px;
+                                  outline: 1px solid #ffffff;
+                                  position: absolute;
+                                  right: 0px;
+                                  top: 0px;
+                                  z-index: 1;
+                                }
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 32px;
+                                }
+                                &.ms-DetailsRow-cellCheck {
+                                  padding-right: 0px;
+                                }
+                            data-automation-key="column3"
+                            data-automationid="DetailsRowCell"
+                            role="gridcell"
+                            style={
+                              Object {
+                                "width": 114,
+                              }
+                            }
+                          >
+                            <span>
+                              Fri, 06 Jan 2017 04:41:20 GMT
+                            </span>
+                          </div>
                         </div>
+                        <span
+                          aria-checked={false}
+                          className=
+
+                              {
+                                bottom: 0px;
+                                display: none;
+                                left: 0px;
+                                position: absolute;
+                                right: 0px;
+                                top: -1px;
+                              }
+                          data-selection-toggle={true}
+                          role="checkbox"
+                        />
                       </div>
+                    </div>
+                    <div
+                      className="ms-List-cell"
+                      data-automationid="ListCell"
+                      data-list-index={8}
+                      role="presentation"
+                    >
                       <div
-                        className="ms-List-cell"
-                        data-automationid="ListCell"
-                        data-list-index={8}
-                        role="presentation"
+                        aria-rowindex={9}
+                        className=
+                            ms-FocusZone
+                            ms-DetailsRow
+                            &:focus {
+                              outline: none;
+                            }
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              animation-duration: 0.367s;
+                              animation-fill-mode: both;
+                              animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                              animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                              background: #ffffff;
+                              border-bottom: 1px solid #f3f2f1;
+                              box-sizing: border-box;
+                              color: #605e5c;
+                              display: inline-flex;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 12px;
+                              font-weight: 400;
+                              min-height: 42px;
+                              min-width: 100%;
+                              outline: transparent;
+                              padding-bottom: 0px;
+                              padding-left: 0px;
+                              padding-right: 0px;
+                              padding-top: 0px;
+                              position: relative;
+                              text-align: left;
+                              vertical-align: top;
+                              white-space: nowrap;
+                            }
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #605e5c;
+                              bottom: 1px;
+                              content: "";
+                              left: 1px;
+                              outline: 1px solid #ffffff;
+                              position: absolute;
+                              right: 1px;
+                              top: 1px;
+                              z-index: 1;
+                            }
+                            .ms-List-cell:first-child &:before {
+                              display: none;
+                            }
+                            &:hover {
+                              background: #f3f2f1;
+                              color: #323130;
+                            }
+                            &:hover .is-row-header {
+                              color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-check {
+                              opacity: 1;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                              opacity: 1;
+                            }
+                        data-automationid="DetailsRow"
+                        data-focuszone-id="FocusZone16"
+                        data-is-focusable={true}
+                        data-item-index={8}
+                        data-selection-index={8}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseDownCapture={[Function]}
+                        role="row"
+                        style={
+                          Object {
+                            "minWidth": 296,
+                          }
+                        }
                       >
                         <div
-                          aria-rowindex={9}
                           className=
-                              ms-FocusZone
-                              ms-DetailsRow
-                              &:focus {
-                                outline: none;
-                              }
+                              ms-DetailsRow-fields
                               {
-                                -moz-osx-font-smoothing: grayscale;
-                                -webkit-font-smoothing: antialiased;
-                                animation-duration: 0.367s;
-                                animation-fill-mode: both;
-                                animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                background: #ffffff;
-                                border-bottom: 1px solid #f3f2f1;
-                                box-sizing: border-box;
-                                color: #605e5c;
-                                display: inline-flex;
-                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                font-size: 12px;
-                                font-weight: 400;
-                                min-height: 42px;
-                                min-width: 100%;
-                                outline: transparent;
-                                padding-bottom: 0px;
-                                padding-left: 0px;
-                                padding-right: 0px;
-                                padding-top: 0px;
-                                position: relative;
-                                text-align: left;
-                                vertical-align: top;
-                                white-space: nowrap;
+                                align-items: stretch;
+                                display: flex;
                               }
-                              &::-moz-focus-inner {
-                                border: 0;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus:after {
-                                border: 1px solid #605e5c;
-                                bottom: 1px;
-                                content: "";
-                                left: 1px;
-                                outline: 1px solid #ffffff;
-                                position: absolute;
-                                right: 1px;
-                                top: 1px;
-                                z-index: 1;
-                              }
-                              .ms-List-cell:first-child &:before {
-                                display: none;
-                              }
-                              &:hover {
-                                background: #f3f2f1;
-                                color: #323130;
-                              }
-                              &:hover .is-row-header {
-                                color: #201f1e;
-                              }
-                              &:hover .ms-DetailsRow-check {
-                                opacity: 1;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                opacity: 1;
-                              }
-                          data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone16"
-                          data-is-focusable={true}
-                          data-item-index={8}
-                          data-selection-index={8}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseDownCapture={[Function]}
-                          role="row"
-                          style={
-                            Object {
-                              "minWidth": 296,
-                            }
-                          }
+                          data-automationid="DetailsRowFields"
+                          role="presentation"
                         >
                           <div
+                            aria-colindex={1}
                             className=
-                                ms-DetailsRow-fields
+                                ms-DetailsRow-cell
                                 {
-                                  align-items: stretch;
-                                  display: flex;
+                                  text-align: center;
                                 }
-                            data-automationid="DetailsRowFields"
-                            role="presentation"
-                          >
-                            <div
-                              aria-colindex={1}
-                              className=
-                                  ms-DetailsRow-cell
-                                  {
-                                    text-align: center;
-                                  }
-                                  &:before {
-                                    content: .;
-                                    display: inline-block;
-                                    height: 100%;
-                                    vertical-align: middle;
-                                    visibility: hidden;
-                                    width: 0px;
-                                  }
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 8px;
-                                  }
-                              data-automation-key="column1"
-                              data-automationid="DetailsRowCell"
-                              role="gridcell"
-                              style={
-                                Object {
-                                  "width": 36,
+                                &:before {
+                                  content: .;
+                                  display: inline-block;
+                                  height: 100%;
+                                  vertical-align: middle;
+                                  visibility: hidden;
+                                  width: 0px;
                                 }
-                              }
-                            >
-                              <img
-                                alt="accdb file icon"
-                                className=
-
-                                    {
-                                      max-height: 16px;
-                                      max-width: 16px;
-                                      vertical-align: middle;
-                                    }
-                                src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/svg/accdb_16x1.svg"
-                              />
-                            </div>
-                            <div
-                              aria-colindex={2}
-                              className=
-                                  is-row-header
-                                  ms-DetailsRow-cell
-                                  {
-                                    color: #323130;
-                                    font-size: 14px;
-                                  }
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 32px;
-                                  }
-                                  &.ms-DetailsRow-cellCheck {
-                                    padding-right: 0px;
-                                  }
-                              data-automation-key="column2"
-                              data-automationid="DetailsRowCell"
-                              role="rowheader"
-                              style={
-                                Object {
-                                  "width": 254,
-                                }
-                              }
-                            >
-                              Ex ea.accdb
-                            </div>
-                            <div
-                              aria-colindex={3}
-                              className=
-                                  ms-DetailsRow-cell
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 32px;
-                                  }
-                                  &.ms-DetailsRow-cellCheck {
-                                    padding-right: 0px;
-                                  }
-                              data-automation-key="column3"
-                              data-automationid="DetailsRowCell"
-                              role="gridcell"
-                              style={
-                                Object {
-                                  "width": 114,
-                                }
-                              }
-                            >
-                              <span>
-                                Fri, 06 Jan 2017 04:41:20 GMT
-                              </span>
-                            </div>
-                          </div>
-                          <span
-                            aria-checked={false}
-                            className=
-
                                 {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
                                   bottom: 0px;
-                                  display: none;
+                                  content: "";
                                   left: 0px;
+                                  outline: 1px solid #ffffff;
                                   position: absolute;
                                   right: 0px;
-                                  top: -1px;
+                                  top: 0px;
+                                  z-index: 1;
                                 }
-                            data-selection-toggle={true}
-                            role="checkbox"
-                          />
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 8px;
+                                }
+                            data-automation-key="column1"
+                            data-automationid="DetailsRowCell"
+                            role="gridcell"
+                            style={
+                              Object {
+                                "width": 36,
+                              }
+                            }
+                          >
+                            <img
+                              alt="accdb file icon"
+                              className=
+
+                                  {
+                                    max-height: 16px;
+                                    max-width: 16px;
+                                    vertical-align: middle;
+                                  }
+                              src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/svg/accdb_16x1.svg"
+                            />
+                          </div>
+                          <div
+                            aria-colindex={2}
+                            className=
+                                is-row-header
+                                ms-DetailsRow-cell
+                                {
+                                  color: #323130;
+                                  font-size: 14px;
+                                }
+                                {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
+                                  bottom: 0px;
+                                  content: "";
+                                  left: 0px;
+                                  outline: 1px solid #ffffff;
+                                  position: absolute;
+                                  right: 0px;
+                                  top: 0px;
+                                  z-index: 1;
+                                }
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 32px;
+                                }
+                                &.ms-DetailsRow-cellCheck {
+                                  padding-right: 0px;
+                                }
+                            data-automation-key="column2"
+                            data-automationid="DetailsRowCell"
+                            role="rowheader"
+                            style={
+                              Object {
+                                "width": 254,
+                              }
+                            }
+                          >
+                            Ex ea.accdb
+                          </div>
+                          <div
+                            aria-colindex={3}
+                            className=
+                                ms-DetailsRow-cell
+                                {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
+                                  bottom: 0px;
+                                  content: "";
+                                  left: 0px;
+                                  outline: 1px solid #ffffff;
+                                  position: absolute;
+                                  right: 0px;
+                                  top: 0px;
+                                  z-index: 1;
+                                }
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 32px;
+                                }
+                                &.ms-DetailsRow-cellCheck {
+                                  padding-right: 0px;
+                                }
+                            data-automation-key="column3"
+                            data-automationid="DetailsRowCell"
+                            role="gridcell"
+                            style={
+                              Object {
+                                "width": 114,
+                              }
+                            }
+                          >
+                            <span>
+                              Fri, 06 Jan 2017 04:41:20 GMT
+                            </span>
+                          </div>
                         </div>
+                        <span
+                          aria-checked={false}
+                          className=
+
+                              {
+                                bottom: 0px;
+                                display: none;
+                                left: 0px;
+                                position: absolute;
+                                right: 0px;
+                                top: -1px;
+                              }
+                          data-selection-toggle={true}
+                          role="checkbox"
+                        />
                       </div>
+                    </div>
+                    <div
+                      className="ms-List-cell"
+                      data-automationid="ListCell"
+                      data-list-index={9}
+                      role="presentation"
+                    >
                       <div
-                        className="ms-List-cell"
-                        data-automationid="ListCell"
-                        data-list-index={9}
-                        role="presentation"
+                        aria-rowindex={10}
+                        className=
+                            ms-FocusZone
+                            ms-DetailsRow
+                            &:focus {
+                              outline: none;
+                            }
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              animation-duration: 0.367s;
+                              animation-fill-mode: both;
+                              animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                              animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                              background: #ffffff;
+                              border-bottom: 1px solid #f3f2f1;
+                              box-sizing: border-box;
+                              color: #605e5c;
+                              display: inline-flex;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 12px;
+                              font-weight: 400;
+                              min-height: 42px;
+                              min-width: 100%;
+                              outline: transparent;
+                              padding-bottom: 0px;
+                              padding-left: 0px;
+                              padding-right: 0px;
+                              padding-top: 0px;
+                              position: relative;
+                              text-align: left;
+                              vertical-align: top;
+                              white-space: nowrap;
+                            }
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #605e5c;
+                              bottom: 1px;
+                              content: "";
+                              left: 1px;
+                              outline: 1px solid #ffffff;
+                              position: absolute;
+                              right: 1px;
+                              top: 1px;
+                              z-index: 1;
+                            }
+                            .ms-List-cell:first-child &:before {
+                              display: none;
+                            }
+                            &:hover {
+                              background: #f3f2f1;
+                              color: #323130;
+                            }
+                            &:hover .is-row-header {
+                              color: #201f1e;
+                            }
+                            &:hover .ms-DetailsRow-check {
+                              opacity: 1;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                              opacity: 1;
+                            }
+                        data-automationid="DetailsRow"
+                        data-focuszone-id="FocusZone17"
+                        data-is-focusable={true}
+                        data-item-index={9}
+                        data-selection-index={9}
+                        onFocus={[Function]}
+                        onKeyDown={[Function]}
+                        onMouseDownCapture={[Function]}
+                        role="row"
+                        style={
+                          Object {
+                            "minWidth": 296,
+                          }
+                        }
                       >
                         <div
-                          aria-rowindex={10}
                           className=
-                              ms-FocusZone
-                              ms-DetailsRow
-                              &:focus {
-                                outline: none;
-                              }
+                              ms-DetailsRow-fields
                               {
-                                -moz-osx-font-smoothing: grayscale;
-                                -webkit-font-smoothing: antialiased;
-                                animation-duration: 0.367s;
-                                animation-fill-mode: both;
-                                animation-name: keyframes from{opacity:0;}to{opacity:1;};
-                                animation-timing-function: cubic-bezier(.1,.25,.75,.9);
-                                background: #ffffff;
-                                border-bottom: 1px solid #f3f2f1;
-                                box-sizing: border-box;
-                                color: #605e5c;
-                                display: inline-flex;
-                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                                font-size: 12px;
-                                font-weight: 400;
-                                min-height: 42px;
-                                min-width: 100%;
-                                outline: transparent;
-                                padding-bottom: 0px;
-                                padding-left: 0px;
-                                padding-right: 0px;
-                                padding-top: 0px;
-                                position: relative;
-                                text-align: left;
-                                vertical-align: top;
-                                white-space: nowrap;
+                                align-items: stretch;
+                                display: flex;
                               }
-                              &::-moz-focus-inner {
-                                border: 0;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus:after {
-                                border: 1px solid #605e5c;
-                                bottom: 1px;
-                                content: "";
-                                left: 1px;
-                                outline: 1px solid #ffffff;
-                                position: absolute;
-                                right: 1px;
-                                top: 1px;
-                                z-index: 1;
-                              }
-                              .ms-List-cell:first-child &:before {
-                                display: none;
-                              }
-                              &:hover {
-                                background: #f3f2f1;
-                                color: #323130;
-                              }
-                              &:hover .is-row-header {
-                                color: #201f1e;
-                              }
-                              &:hover .ms-DetailsRow-check {
-                                opacity: 1;
-                              }
-                              .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
-                                opacity: 1;
-                              }
-                          data-automationid="DetailsRow"
-                          data-focuszone-id="FocusZone17"
-                          data-is-focusable={true}
-                          data-item-index={9}
-                          data-selection-index={9}
-                          onFocus={[Function]}
-                          onKeyDown={[Function]}
-                          onMouseDownCapture={[Function]}
-                          role="row"
-                          style={
-                            Object {
-                              "minWidth": 296,
-                            }
-                          }
+                          data-automationid="DetailsRowFields"
+                          role="presentation"
                         >
                           <div
+                            aria-colindex={1}
                             className=
-                                ms-DetailsRow-fields
+                                ms-DetailsRow-cell
                                 {
-                                  align-items: stretch;
-                                  display: flex;
+                                  text-align: center;
                                 }
-                            data-automationid="DetailsRowFields"
-                            role="presentation"
-                          >
-                            <div
-                              aria-colindex={1}
-                              className=
-                                  ms-DetailsRow-cell
-                                  {
-                                    text-align: center;
-                                  }
-                                  &:before {
-                                    content: .;
-                                    display: inline-block;
-                                    height: 100%;
-                                    vertical-align: middle;
-                                    visibility: hidden;
-                                    width: 0px;
-                                  }
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 8px;
-                                  }
-                              data-automation-key="column1"
-                              data-automationid="DetailsRowCell"
-                              role="gridcell"
-                              style={
-                                Object {
-                                  "width": 36,
+                                &:before {
+                                  content: .;
+                                  display: inline-block;
+                                  height: 100%;
+                                  vertical-align: middle;
+                                  visibility: hidden;
+                                  width: 0px;
                                 }
-                              }
-                            >
-                              <img
-                                alt="accdb file icon"
-                                className=
-
-                                    {
-                                      max-height: 16px;
-                                      max-width: 16px;
-                                      vertical-align: middle;
-                                    }
-                                src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/svg/accdb_16x1.svg"
-                              />
-                            </div>
-                            <div
-                              aria-colindex={2}
-                              className=
-                                  is-row-header
-                                  ms-DetailsRow-cell
-                                  {
-                                    color: #323130;
-                                    font-size: 14px;
-                                  }
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 32px;
-                                  }
-                                  &.ms-DetailsRow-cellCheck {
-                                    padding-right: 0px;
-                                  }
-                              data-automation-key="column2"
-                              data-automationid="DetailsRowCell"
-                              role="rowheader"
-                              style={
-                                Object {
-                                  "width": 254,
-                                }
-                              }
-                            >
-                              Duis aute.accdb
-                            </div>
-                            <div
-                              aria-colindex={3}
-                              className=
-                                  ms-DetailsRow-cell
-                                  {
-                                    box-sizing: border-box;
-                                    display: inline-block;
-                                    min-height: 42px;
-                                    outline: transparent;
-                                    overflow: hidden;
-                                    padding-bottom: 11px;
-                                    padding-left: 12px;
-                                    padding-top: 11px;
-                                    position: relative;
-                                    text-overflow: ellipsis;
-                                    vertical-align: top;
-                                    white-space: nowrap;
-                                  }
-                                  &::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  .ms-Fabric--isFocusVisible &:focus:after {
-                                    border: 1px solid #605e5c;
-                                    bottom: 0px;
-                                    content: "";
-                                    left: 0px;
-                                    outline: 1px solid #ffffff;
-                                    position: absolute;
-                                    right: 0px;
-                                    top: 0px;
-                                    z-index: 1;
-                                  }
-                                  & > button {
-                                    max-width: 100%;
-                                  }
-                                  & [data-is-focusable='true'] {
-                                    outline: transparent;
-                                    position: relative;
-                                  }
-                                  & [data-is-focusable='true']::-moz-focus-inner {
-                                    border: 0;
-                                  }
-                                  {
-                                    padding-right: 32px;
-                                  }
-                                  &.ms-DetailsRow-cellCheck {
-                                    padding-right: 0px;
-                                  }
-                              data-automation-key="column3"
-                              data-automationid="DetailsRowCell"
-                              role="gridcell"
-                              style={
-                                Object {
-                                  "width": 114,
-                                }
-                              }
-                            >
-                              <span>
-                                Fri, 06 Jan 2017 04:41:20 GMT
-                              </span>
-                            </div>
-                          </div>
-                          <span
-                            aria-checked={false}
-                            className=
-
                                 {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
                                   bottom: 0px;
-                                  display: none;
+                                  content: "";
                                   left: 0px;
+                                  outline: 1px solid #ffffff;
                                   position: absolute;
                                   right: 0px;
-                                  top: -1px;
+                                  top: 0px;
+                                  z-index: 1;
                                 }
-                            data-selection-toggle={true}
-                            role="checkbox"
-                          />
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 8px;
+                                }
+                            data-automation-key="column1"
+                            data-automationid="DetailsRowCell"
+                            role="gridcell"
+                            style={
+                              Object {
+                                "width": 36,
+                              }
+                            }
+                          >
+                            <img
+                              alt="accdb file icon"
+                              className=
+
+                                  {
+                                    max-height: 16px;
+                                    max-width: 16px;
+                                    vertical-align: middle;
+                                  }
+                              src="https://static2.sharepointonline.com/files/fabric/assets/brand-icons/document/svg/accdb_16x1.svg"
+                            />
+                          </div>
+                          <div
+                            aria-colindex={2}
+                            className=
+                                is-row-header
+                                ms-DetailsRow-cell
+                                {
+                                  color: #323130;
+                                  font-size: 14px;
+                                }
+                                {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
+                                  bottom: 0px;
+                                  content: "";
+                                  left: 0px;
+                                  outline: 1px solid #ffffff;
+                                  position: absolute;
+                                  right: 0px;
+                                  top: 0px;
+                                  z-index: 1;
+                                }
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 32px;
+                                }
+                                &.ms-DetailsRow-cellCheck {
+                                  padding-right: 0px;
+                                }
+                            data-automation-key="column2"
+                            data-automationid="DetailsRowCell"
+                            role="rowheader"
+                            style={
+                              Object {
+                                "width": 254,
+                              }
+                            }
+                          >
+                            Duis aute.accdb
+                          </div>
+                          <div
+                            aria-colindex={3}
+                            className=
+                                ms-DetailsRow-cell
+                                {
+                                  box-sizing: border-box;
+                                  display: inline-block;
+                                  min-height: 42px;
+                                  outline: transparent;
+                                  overflow: hidden;
+                                  padding-bottom: 11px;
+                                  padding-left: 12px;
+                                  padding-top: 11px;
+                                  position: relative;
+                                  text-overflow: ellipsis;
+                                  vertical-align: top;
+                                  white-space: nowrap;
+                                }
+                                &::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                .ms-Fabric--isFocusVisible &:focus:after {
+                                  border: 1px solid #605e5c;
+                                  bottom: 0px;
+                                  content: "";
+                                  left: 0px;
+                                  outline: 1px solid #ffffff;
+                                  position: absolute;
+                                  right: 0px;
+                                  top: 0px;
+                                  z-index: 1;
+                                }
+                                & > button {
+                                  max-width: 100%;
+                                }
+                                & [data-is-focusable='true'] {
+                                  outline: transparent;
+                                  position: relative;
+                                }
+                                & [data-is-focusable='true']::-moz-focus-inner {
+                                  border: 0;
+                                }
+                                {
+                                  padding-right: 32px;
+                                }
+                                &.ms-DetailsRow-cellCheck {
+                                  padding-right: 0px;
+                                }
+                            data-automation-key="column3"
+                            data-automationid="DetailsRowCell"
+                            role="gridcell"
+                            style={
+                              Object {
+                                "width": 114,
+                              }
+                            }
+                          >
+                            <span>
+                              Fri, 06 Jan 2017 04:41:20 GMT
+                            </span>
+                          </div>
                         </div>
+                        <span
+                          aria-checked={false}
+                          className=
+
+                              {
+                                bottom: 0px;
+                                display: none;
+                                left: 0px;
+                                position: absolute;
+                                right: 0px;
+                                top: -1px;
+                              }
+                          data-selection-toggle={true}
+                          role="checkbox"
+                        />
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #10399
- [X] Include a change request file using `$ yarn change`

#### Description of changes

This PR makes one small change in the DetailsList code - it initializes the selection object's mode with `this.props.selectionMode` if it is defined.

It also updates the DetailsList Documents example, which has a toggle to enable modal selection on a list. The DetailsList with no modal selection does not need a custom selection object or a lot of the props that the DetailsList with modal selection does need. In doing so, it fixes the bug where the first row could be selected, even with selection mode set to none.

Before
![DetailsList selection none does select row](https://user-images.githubusercontent.com/14134000/65289457-8d152680-daff-11e9-8120-8403cb801a8d.gif)

After
![DetailsList selection none does not select row](https://user-images.githubusercontent.com/14134000/65289432-740c7580-daff-11e9-807f-9dd15f52d80b.gif)

Let me know if I missed anything or did something questionable.

#### Focus areas to test

Ensure that DetailsList examples all work as expected. There should be no behavior change except for those with selection mode none and no selection object specified.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10548)