### PR TITLE
Positioning: Fix issue where anchor edge would flip even if previous positions calculated

### DIFF
--- a/change/office-ui-fabric-react-2019-09-20-11-01-17-fix-calloutjump-forhovercard.json
+++ b/change/office-ui-fabric-react-2019-09-20-11-01-17-fix-calloutjump-forhovercard.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Positioning: Fix issue where anchor edge would flip even if previous positions calculated",
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com",
+  "commit": "52bfddc7567b8f910189142d75c2762358c0e62b",
+  "date": "2019-09-20T18:01:17.186Z"
+}

--- a/packages/office-ui-fabric-react/src/utilities/positioning.test.ts
+++ b/packages/office-ui-fabric-react/src/utilities/positioning.test.ts
@@ -242,12 +242,20 @@ describe('Callout Positioning', () => {
     expect(finalizedPosition.elementPosition.bottom).toBeDefined();
     expect(finalizedPosition.elementPosition.left).toBeUndefined();
 
+    // With bounds introduced, if the elementRectangle is closer to one edge of bounds than another,
+    // but it has already been positioned previously, then don't change the edge
+    // In this case, that's bottom (opposite of target) and left
+    finalizedPosition = __positioningTestPackage._finalizePositionData(pos, host as any, bounds, false, true);
+    expect(finalizedPosition.elementPosition.left).toBeDefined();
+    expect(finalizedPosition.elementPosition.bottom).toBeDefined();
+    expect(finalizedPosition.elementPosition.right).toBeUndefined();
+
     // With bounds introduced, the alignment should apply to the beak as well, aligning it to
     // the edge closest to bounds
     // In this case, that's the bottom (opposite of target) and right (closer to edge of bounds)
     const finalizedBeakPosition = __positioningTestPackage._finalizeBeakPosition(pos, beakPos, bounds);
     expect(finalizedBeakPosition.elementPosition.right).toBeDefined();
     expect(finalizedBeakPosition.elementPosition.bottom).toBeDefined();
-    expect(finalizedPosition.elementPosition.left).toBeUndefined();
+    expect(finalizedBeakPosition.elementPosition.left).toBeUndefined();
   });
 });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #9132
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Positioning: Fix issue where anchor edge would flip even if previous positions calculated

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10557)