### PR TITLE
FocusTrapZone: Add aria-modal attribute

### DIFF
--- a/change/office-ui-fabric-react-2019-09-20-12-59-47-jg-6535-ftz-aria-modal.json
+++ b/change/office-ui-fabric-react-2019-09-20-12-59-47-jg-6535-ftz-aria-modal.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "FocusTrapZone: Add aria-modal attribute.",
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com",
+  "commit": "bd8f150e61169ed814584042a59eeef5017154cf",
+  "date": "2019-09-20T19:59:47.600Z"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
@@ -93,6 +93,7 @@ export class FocusTrapZone extends React.Component<IFocusTrapZoneProps, {}> impl
         className={className}
         ref={this._root}
         aria-labelledby={ariaLabelledBy}
+        aria-modal="true"
         onFocusCapture={this._onFocusCapture}
         onFocus={this._onRootFocus}
         onBlur={this._onRootBlur}

--- a/packages/office-ui-fabric-react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
@@ -113,6 +113,7 @@ exports[`HoverCard renders ExpandingCard correctly 1`] = `
           }
         >
           <div
+            aria-modal="true"
             onBlur={[Function]}
             onFocus={[Function]}
             onFocusCapture={[Function]}
@@ -276,6 +277,7 @@ exports[`HoverCard renders PlainCard correctly 1`] = `
           }
         >
           <div
+            aria-modal="true"
             onBlur={[Function]}
             onFocus={[Function]}
             onFocusCapture={[Function]}

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
@@ -221,7 +221,6 @@ export class ModalBase extends BaseComponent<IModalProps, IDialogState> implemen
         <Layer {...mergedLayerProps}>
           <Popup
             role={isModeless || !isBlocking ? 'dialog' : 'alertdialog'}
-            aria-modal={!isModeless}
             ariaLabelledBy={titleAriaId}
             ariaDescribedBy={subtitleAriaId}
             onDismiss={onDismiss}

--- a/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -54,7 +54,6 @@ exports[`Modal renders Draggable Modal correctly 1`] = `
     onSubmit={[Function]}
   >
     <div
-      aria-modal={false}
       onKeyDown={[Function]}
       role="dialog"
       style={
@@ -88,6 +87,7 @@ exports[`Modal renders Draggable Modal correctly 1`] = `
             }
       >
         <div
+          aria-modal="true"
           className=
               ms-Dialog-main
               test-containerClassName
@@ -217,7 +217,6 @@ exports[`Modal renders Modal correctly 1`] = `
     onSubmit={[Function]}
   >
     <div
-      aria-modal={true}
       onKeyDown={[Function]}
       role="dialog"
       style={
@@ -273,6 +272,7 @@ exports[`Modal renders Modal correctly 1`] = `
               }
         />
         <div
+          aria-modal="true"
           className=
               ms-Dialog-main
               test-containerClassName
@@ -389,7 +389,6 @@ exports[`Modal renders Modeless Modal correctly 1`] = `
     onSubmit={[Function]}
   >
     <div
-      aria-modal={false}
       onKeyDown={[Function]}
       role="dialog"
       style={
@@ -423,6 +422,7 @@ exports[`Modal renders Modeless Modal correctly 1`] = `
             }
       >
         <div
+          aria-modal="true"
           className=
               ms-Dialog-main
               test-containerClassName

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -183,7 +183,6 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
       <Layer {...layerProps}>
         <Popup
           role="dialog"
-          aria-modal="true"
           ariaLabelledBy={header ? headerTextId : undefined}
           onDismiss={this.dismiss}
           className={_classNames.hiddenPanel}

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -55,7 +55,6 @@ exports[`Panel renders Panel correctly 1`] = `
   >
     <div
       aria-labelledby="Panel0-headerText"
-      aria-modal="true"
       className=
 
 
@@ -116,6 +115,7 @@ exports[`Panel renders Panel correctly 1`] = `
               }
         />
         <div
+          aria-modal="true"
           className=
               ms-Panel-main
               {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
@@ -849,6 +849,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                                 id="coachmark-desc1"
                               />
                               <div
+                                aria-modal="true"
                                 onBlur={[Function]}
                                 onFocus={[Function]}
                                 onFocusCapture={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -2,6 +2,7 @@
 
 exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctly 1`] = `
 <div
+  aria-modal="true"
   onBlur={[Function]}
   onFocus={[Function]}
   onFocusCapture={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -187,6 +187,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
     </button>
   </div>
   <div
+    aria-modal="true"
     onBlur={[Function]}
     onFocus={[Function]}
     onFocusCapture={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -187,6 +187,7 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
     </button>
   </div>
   <div
+    aria-modal="true"
     onBlur={[Function]}
     onFocus={[Function]}
     onFocusCapture={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
@@ -2,6 +2,7 @@
 
 exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctly 1`] = `
 <div
+  aria-modal="true"
   onBlur={[Function]}
   onFocus={[Function]}
   onFocusCapture={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
@@ -121,6 +121,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
     </span>
   </button>
   <div
+    aria-modal="true"
     onBlur={[Function]}
     onFocus={[Function]}
     onFocusCapture={[Function]}
@@ -450,6 +451,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
         </span>
       </button>
       <div
+        aria-modal="true"
         onBlur={[Function]}
         onFocus={[Function]}
         onFocusCapture={[Function]}
@@ -780,6 +782,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
             </span>
           </button>
           <div
+            aria-modal="true"
             onBlur={[Function]}
             onFocus={[Function]}
             onFocusCapture={[Function]}
@@ -1123,6 +1126,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
             />
           </div>
           <div
+            aria-modal="true"
             onBlur={[Function]}
             onFocus={[Function]}
             onFocusCapture={[Function]}
@@ -1479,6 +1483,7 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
         />
       </div>
       <div
+        aria-modal="true"
         onBlur={[Function]}
         onFocus={[Function]}
         onFocusCapture={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Panel.HiddenOnDismiss.Example.tsx.shot
@@ -173,7 +173,6 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
     >
       <div
         aria-labelledby="Panel3-headerText"
-        aria-modal="true"
         className=
 
             {
@@ -208,6 +207,7 @@ exports[`Component Examples renders Panel.HiddenOnDismiss.Example.tsx correctly 
               }
         >
           <div
+            aria-modal="true"
             className=
                 ms-Panel-main
                 {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6535
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add `aria-modal` attribute to `FocusTrapZone`. Remove `aria-modal` attribute from higher order components (Panel, Modal) since they are now redundant. 

Narrator as yet does not seem to make use of `aria-modal` to affect navigation (per #6535), but this PR more correctly aligns application of `aria-modal` to Fabric's component hierarchy in general. 

#### Focus areas to test

Update snapshots.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10559)