### PR TITLE
Positioning: Fix issue where anchor edge would flip even if previous positions calculated

### DIFF
--- a/change/office-ui-fabric-react-2019-09-20-11-01-17-fix-calloutjump-forhovercard.json
+++ b/change/office-ui-fabric-react-2019-09-20-11-01-17-fix-calloutjump-forhovercard.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Positioning: Fix issue where anchor edge would flip even if previous positions calculated",
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com",
+  "commit": "52bfddc7567b8f910189142d75c2762358c0e62b",
+  "date": "2019-09-20T18:01:17.186Z"
+}

--- a/packages/office-ui-fabric-react/src/utilities/positioning.test.ts
+++ b/packages/office-ui-fabric-react/src/utilities/positioning.test.ts
@@ -218,12 +218,20 @@ describe('Callout Positioning', () => {
     expect(finalizedPosition.elementPosition.bottom).toBeDefined();
     expect(finalizedPosition.elementPosition.left).toBeUndefined();
 
+    // With bounds introduced, if the elementRectangle is closer to one edge of bounds than another,
+    // but it has already been positioned previously, then don't change the edge
+    // In this case, that's bottom (opposite of target) and left
+    finalizedPosition = __positioningTestPackage._finalizePositionData(pos, host as any, bounds, false, true);
+    expect(finalizedPosition.elementPosition.left).toBeDefined();
+    expect(finalizedPosition.elementPosition.bottom).toBeDefined();
+    expect(finalizedPosition.elementPosition.right).toBeUndefined();
+
     // With bounds introduced, the alignment should apply to the beak as well, aligning it to
     // the edge closest to bounds
     // In this case, that's the bottom (opposite of target) and right (closer to edge of bounds)
     const finalizedBeakPosition = __positioningTestPackage._finalizeBeakPosition(pos, beakPos, bounds);
     expect(finalizedBeakPosition.elementPosition.right).toBeDefined();
     expect(finalizedBeakPosition.elementPosition.bottom).toBeDefined();
-    expect(finalizedPosition.elementPosition.left).toBeUndefined();
+    expect(finalizedBeakPosition.elementPosition.left).toBeUndefined();
   });
 });

--- a/packages/office-ui-fabric-react/src/utilities/positioning/positioning.ts
+++ b/packages/office-ui-fabric-react/src/utilities/positioning/positioning.ts
@@ -417,13 +417,22 @@ function _getFlankingEdges(edge: RectangleEdge): { positiveEdge: RectangleEdge; 
 /**
  * Retrieve the final value for the return edge of elementRectangle.
  * If the elementRectangle is closer to one side of the bounds versus the other, the return edge is flipped to grow inward.
+ * The finalized return edge should not flip if the element has already been positiuoned successfully to prevent the callout from
+ * appearing to jump
  *
  * @param elementRectangle
  * @param targetEdge
  * @param bounds
+ * @param previousPositions
  */
-function _finalizeReturnEdge(elementRectangle: Rectangle, returnEdge: RectangleEdge, bounds?: Rectangle): RectangleEdge {
+function _finalizeReturnEdge(
+  elementRectangle: Rectangle,
+  returnEdge: RectangleEdge,
+  bounds?: Rectangle,
+  previousPositions?: boolean
+): RectangleEdge {
   if (
+    !previousPositions &&
     bounds &&
     Math.abs(_getRelativeEdgeDifference(elementRectangle, bounds, returnEdge)) >
       Math.abs(_getRelativeEdgeDifference(elementRectangle, bounds, returnEdge * -1))
@@ -447,6 +456,7 @@ function _finalizeReturnEdge(elementRectangle: Rectangle, returnEdge: RectangleE
  * @param {RectangleEdge} bounds
  * @param {RectangleEdge} [alignmentEdge]
  * @param {boolean} coverTarget
+ * @param {previousPositions} previousPositions
  * @returns {IPartialIRectangle}
  */
 function _finalizeElementPosition(
@@ -455,7 +465,8 @@ function _finalizeElementPosition(
   targetEdge: RectangleEdge,
   bounds?: Rectangle,
   alignmentEdge?: RectangleEdge,
-  coverTarget?: boolean
+  coverTarget?: boolean,
+  previousPositions?: boolean
 ): IPartialIRectangle {
   const returnValue: IPartialIRectangle = {};
 
@@ -465,7 +476,8 @@ function _finalizeElementPosition(
   const returnEdge = _finalizeReturnEdge(
     elementRectangle,
     alignmentEdge ? alignmentEdge : _getFlankingEdges(targetEdge).positiveEdge,
-    bounds
+    bounds,
+    previousPositions
   );
 
   returnValue[elementEdgeString] = _getRelativeEdgeDifference(elementRectangle, hostRect, elementEdge);
@@ -730,11 +742,20 @@ function _positionElementRelative(
   return { ...positionedElement, targetRectangle: targetRect };
 }
 
+/**
+ *
+ * @param positionedElement The elements estimated position, is not page relative yet
+ * @param hostElement The element which is hosting the positioning element
+ * @param bounds The space in which the positioning element can render
+ * @param coverTarget Whether or not the element should cover the target
+ * @param previousPositions If the element has already been positioned before.
+ */
 function _finalizePositionData(
   positionedElement: IElementPosition,
   hostElement: HTMLElement,
   bounds?: Rectangle,
-  coverTarget?: boolean
+  coverTarget?: boolean,
+  previousPositions?: boolean
 ): IPositionedData {
   const finalizedElement: IPartialIRectangle = _finalizeElementPosition(
     positionedElement.elementRectangle,
@@ -742,7 +763,8 @@ function _finalizePositionData(
     positionedElement.targetEdge,
     bounds,
     positionedElement.alignmentEdge,
-    coverTarget
+    coverTarget,
+    previousPositions
   );
   return {
     elementPosition: finalizedElement,
@@ -761,7 +783,7 @@ function _positionElement(
     ? _getRectangleFromIRect(props.bounds)
     : new Rectangle(0, window.innerWidth - getScrollbarWidth(), 0, window.innerHeight);
   const positionedElement: IElementPosition = _positionElementRelative(props, elementToPosition, boundingRect, previousPositions);
-  return _finalizePositionData(positionedElement, hostElement, boundingRect, props.coverTarget);
+  return _finalizePositionData(positionedElement, hostElement, boundingRect, props.coverTarget, !!previousPositions);
 }
 
 function _positionCallout(
@@ -781,7 +803,7 @@ function _positionCallout(
   const beakPositioned: Rectangle = _positionBeak(beakWidth, positionedElement);
   const finalizedBeakPosition: ICalloutBeakPositionedInfo = _finalizeBeakPosition(positionedElement, beakPositioned, boundingRect);
   return {
-    ..._finalizePositionData(positionedElement, hostElement, boundingRect, props.coverTarget),
+    ..._finalizePositionData(positionedElement, hostElement, boundingRect, props.coverTarget, !!previousPositions),
     beakPosition: finalizedBeakPosition
   };
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Positioning: Fix issue where anchor edge would flip even if previous positions calculated

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10562)