### PR TITLE
Stack: grow=true shoudn't clip flexbox's children.

### DIFF
--- a/change/office-ui-fabric-react-2019-09-20-17-02-33-stack.json
+++ b/change/office-ui-fabric-react-2019-09-20-17-02-33-stack.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Stack doesn't need to set overflow=hidden when grow=true to restrict size of flexbox children. Users are having to override this with overflow=visible to prevent clipping inner children",
+  "packageName": "office-ui-fabric-react",
+  "email": "email not defined",
+  "commit": "987173b9bb37750ff190850e5a4f85c90a0be7de",
+  "date": "2019-09-21T00:02:33.838Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Stack/Stack.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Stack/Stack.styles.ts
@@ -158,8 +158,7 @@ export const styles: IStackComponent['styles'] = (props, theme, tokens): IStackS
         }
       },
       grow && {
-        flexGrow: grow === true ? 1 : grow,
-        overflow: 'hidden'
+        flexGrow: grow === true ? 1 : grow
       },
       horizontalAlign && {
         [horizontal ? 'justifyContent' : 'alignItems']: nameMap[horizontalAlign] || horizontalAlign

--- a/packages/office-ui-fabric-react/src/components/Stack/__snapshots__/Stack.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Stack/__snapshots__/Stack.test.tsx.snap
@@ -386,7 +386,6 @@ exports[`Stack renders horizontal Stack with grow correctly 1`] = `
           flex-grow: 5;
           flex-wrap: nowrap;
           height: auto;
-          overflow: hidden;
           width: auto;
         }
         & > * {
@@ -411,7 +410,6 @@ exports[`Stack renders horizontal Stack with grow correctly 1`] = `
           flex-grow: 2;
           flex-wrap: nowrap;
           height: auto;
-          overflow: hidden;
           width: auto;
         }
         & > * {
@@ -436,7 +434,6 @@ exports[`Stack renders horizontal Stack with grow correctly 1`] = `
           flex-grow: 1;
           flex-wrap: nowrap;
           height: auto;
-          overflow: hidden;
           width: auto;
         }
         & > * {
@@ -840,7 +837,6 @@ exports[`Stack renders vertical Stack with grow correctly 1`] = `
           flex-grow: 5;
           flex-wrap: nowrap;
           height: auto;
-          overflow: hidden;
           width: auto;
         }
         & > * {
@@ -865,7 +861,6 @@ exports[`Stack renders vertical Stack with grow correctly 1`] = `
           flex-grow: 2;
           flex-wrap: nowrap;
           height: auto;
-          overflow: hidden;
           width: auto;
         }
         & > * {
@@ -890,7 +885,6 @@ exports[`Stack renders vertical Stack with grow correctly 1`] = `
           flex-grow: 1;
           flex-wrap: nowrap;
           height: auto;
-          overflow: hidden;
           width: auto;
         }
         & > * {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.VerticalAlign.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.VerticalAlign.Example.tsx.shot
@@ -54,7 +54,6 @@ exports[`Component Examples renders Stack.Vertical.VerticalAlign.Example.tsx cor
             flex-grow: 1;
             flex-wrap: nowrap;
             height: auto;
-            overflow: hidden;
             width: auto;
           }
           & > * {
@@ -150,7 +149,6 @@ exports[`Component Examples renders Stack.Vertical.VerticalAlign.Example.tsx cor
             flex-grow: 1;
             flex-wrap: nowrap;
             height: auto;
-            overflow: hidden;
             width: auto;
           }
           & > * {
@@ -246,7 +244,6 @@ exports[`Component Examples renders Stack.Vertical.VerticalAlign.Example.tsx cor
             flex-grow: 1;
             flex-wrap: nowrap;
             height: auto;
-            overflow: hidden;
             width: auto;
           }
           & > * {
@@ -365,7 +362,6 @@ exports[`Component Examples renders Stack.Vertical.VerticalAlign.Example.tsx cor
             flex-grow: 1;
             flex-wrap: nowrap;
             height: auto;
-            overflow: hidden;
             width: auto;
           }
           & > * {
@@ -461,7 +457,6 @@ exports[`Component Examples renders Stack.Vertical.VerticalAlign.Example.tsx cor
             flex-grow: 1;
             flex-wrap: nowrap;
             height: auto;
-            overflow: hidden;
             width: auto;
           }
           & > * {
@@ -557,7 +552,6 @@ exports[`Component Examples renders Stack.Vertical.VerticalAlign.Example.tsx cor
             flex-grow: 1;
             flex-wrap: nowrap;
             height: auto;
-            overflow: hidden;
             width: auto;
           }
           & > * {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Right now, the style `overflow: 'hidden'` when `grow` is `true` is causing inner children to be clipped causing users to have to override this with `overflow: 'visible'` so removing this style. More details in #10476 
 
#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10564)