### PR TITLE
Fabric website animations shouldn't leave invisible elements behind on fade out.

### DIFF
--- a/change/@uifabric-styling-2019-09-20-17-35-52-animations.json
+++ b/change/@uifabric-styling-2019-09-20-17-35-52-animations.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Animations should not leave invisible elements behind so setting visibility to hidden on fade out to get rid of any interactivity where the faded element was",
+  "packageName": "@uifabric/styling",
+  "email": "email not defined",
+  "commit": "ae723d3294a8e6b55323c80d9a6f57fc9799ec2b",
+  "date": "2019-09-21T00:35:52.564Z"
+}

--- a/packages/styling/src/styles/AnimationStyles.ts
+++ b/packages/styling/src/styles/AnimationStyles.ts
@@ -17,7 +17,7 @@ const FADE_IN: string = keyframes({
 
 const FADE_OUT: string = keyframes({
   from: { opacity: 1 },
-  to: { opacity: 0 }
+  to: { opacity: 0, visibility: 'hidden' }
 });
 
 const SLIDE_RIGHT_IN10: string = _createSlideInX(-10);


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #10512
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Right now, on fade out there are still interact-able elements left behind. Setting visibility to hidden to avoid this. More details in #10512 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10566)