### PR TITLE
Customizations: Add applyBatchedUpdates()

### DIFF
--- a/change/@uifabric-utilities-2019-09-20-17-46-49-phkuo-suppressUpdatesPort.json
+++ b/change/@uifabric-utilities-2019-09-20-17-46-49-phkuo-suppressUpdatesPort.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Customizations: add a way to batch updates",
+  "packageName": "@uifabric/utilities",
+  "email": "phkuo@microsoft.com",
+  "commit": "3e60b124b6f072b741a68c5559ed7cf5241fe379",
+  "date": "2019-09-21T00:46:49.523Z"
+}

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -132,9 +132,8 @@ export function customizable(scope: string, fields: string[], concatStyles?: boo
 
 // @public (undocumented)
 export class Customizations {
-    // (undocumented)
+    static applyBatchedUpdates(code: () => void, suppressUpdate?: boolean): void;
     static applyScopedSettings(scopeName: string, settings: ISettings): void;
-    // (undocumented)
     static applySettings(settings: ISettings): void;
     // (undocumented)
     static getSettings(properties: string[], scopeName?: string, localSettings?: ICustomizations): any;

--- a/packages/utilities/src/customizations/Customizer.test.tsx
+++ b/packages/utilities/src/customizations/Customizer.test.tsx
@@ -204,4 +204,42 @@ describe('Customizer', () => {
       }
     );
   });
+
+  it('can suppress updates', () => {
+    Customizations.applySettings({ field: 'globalName' });
+
+    safeMount(
+      <Customizer settings={{ nonMatch: 'customName' }}>
+        <Bar />
+      </Customizer>,
+      wrapper => {
+        // verify base state
+        expect(wrapper.html()).toEqual('<div>globalName</div>');
+
+        // verify it doesn't update during suppressUpdates(), and it works through errors, and it updates after
+        Customizations.applyBatchedUpdates(() => {
+          Customizations.applySettings({ field: 'notGlobalName' });
+          // it should not update inside
+          expect(wrapper.html()).toEqual('<div>globalName</div>');
+          throw new Error();
+        });
+        // afterwards it should have updated
+        expect(wrapper.html()).toEqual('<div>notGlobalName</div>');
+
+        // verify it doesn't update during suppressUpdates(), and it works through errors, and it can suppress final update
+        Customizations.applyBatchedUpdates(() => {
+          Customizations.applySettings({ field: 'notUpdated' });
+          // it should not update inside
+          expect(wrapper.html()).toEqual('<div>notGlobalName</div>');
+          throw new Error();
+        }, true);
+        // afterwards, it should still be on the old value
+        expect(wrapper.html()).toEqual('<div>notGlobalName</div>');
+
+        // verify it updates after suppressUpdates()
+        Customizations.applySettings({ field2: 'lastGlobalName' });
+        expect(wrapper.html()).toEqual('<div>notUpdatedlastGlobalName</div>');
+      }
+    );
+  });
 });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Port of #10549 from v6
Adds applyBatchedUpdates() to Customizations, allowing many Customizations to be applied but only triggering a single update (or optionally, no update at all).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10567)