### PR TITLE
Fix return type of onGrowData() in CommandBar.

### DIFF
--- a/change/office-ui-fabric-react-2019-09-22-18-29-44-fix-commandbar-types.json
+++ b/change/office-ui-fabric-react-2019-09-22-18-29-44-fix-commandbar-types.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Fix return type of onGrowData() in CommandBar.",
+  "packageName": "office-ui-fabric-react",
+  "email": "1721514+gordianschuda@users.noreply.github.com",
+  "commit": "fc08a14367ab9f3cbdb306d8bd6bd5f9ed59b4f2",
+  "date": "2019-09-22T16:29:44.667Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -2834,7 +2834,7 @@ export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
     items: ICommandBarItemProps[];
     onDataGrown?: (movedItem: ICommandBarItemProps) => void;
     onDataReduced?: (movedItem: ICommandBarItemProps) => void;
-    onGrowData?: (data: ICommandBarData) => ICommandBarData;
+    onGrowData?: (data: ICommandBarData) => ICommandBarData | undefined;
     onReduceData?: (data: ICommandBarData) => ICommandBarData | undefined;
     overflowButtonAs?: IComponentAs<IButtonProps>;
     overflowButtonProps?: IButtonProps;

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.types.ts
@@ -77,7 +77,7 @@ export interface ICommandBarProps extends React.HTMLAttributes<HTMLDivElement> {
    * Custom function to grow data if items are too small for the given space.
    * Return `undefined` if no more steps can be taken to avoid infinate loop.
    */
-  onGrowData?: (data: ICommandBarData) => ICommandBarData;
+  onGrowData?: (data: ICommandBarData) => ICommandBarData | undefined;
 
   /**
    * Function callback invoked when data has been reduced.


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Related to an existing issue: #8948
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Fixes a wrong return type for onGrowData() in the CommandBar component that was forgotten in #9006.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10568)