### PR TITLE
Type error in GroupedList docs

### DIFF
--- a/change/office-ui-fabric-react-2019-09-24-16-42-44-type-error-groupedlist.json
+++ b/change/office-ui-fabric-react-2019-09-24-16-42-44-type-error-groupedlist.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Use correct type in docs for 'collapseAllVisibility' in 'GroupedList'",
+  "packageName": "office-ui-fabric-react",
+  "email": "thomas.gassmann@hotmail.com",
+  "commit": "279c24fabb91048c9d14e984df68bde7fd44e9b6",
+  "date": "2019-09-24T14:42:44.163Z"
+}

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.types.ts
@@ -230,7 +230,7 @@ export interface IGroupRenderProps {
 
   /**
    * Flag to indicate whether to ignore the collapsing icon on header.
-   * @defaultvalue CheckboxVisibility.visible
+   * @defaultvalue CollapseAllVisibility.visible
    */
   collapseAllVisibility?: CollapseAllVisibility;
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Currently the documentation for `collapseAllVisibility` specifies that `CheckboxVisibility` is the default type, even though `CollapseAllVisibility` is expected. 



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10579)