### PR TITLE
Dropdown: Error messages in Dropdown are now linked to the Dropdown (from a programmatic accessibility POV).

### DIFF
--- a/change/@uifabric-utilities-2019-09-24-15-52-15-cliffkoh-10600.json
+++ b/change/@uifabric-utilities-2019-09-24-15-52-15-cliffkoh-10600.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Minor refinement to mergeAriaAttributeValues to correctly handleu false, therefore allowing (`cond && \"something\").",
+  "packageName": "@uifabric/utilities",
+  "email": "cliff.koh@microsoft.com",
+  "commit": "640471f2eb88fec33cbc46a96d60aedd4db8a647",
+  "date": "2019-09-24T22:52:15.667Z"
+}

--- a/change/office-ui-fabric-react-2019-09-24-15-52-15-cliffkoh-10600.json
+++ b/change/office-ui-fabric-react-2019-09-24-15-52-15-cliffkoh-10600.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Drpodown: Error messages in Dropdown are now linked to the Dropdown (from a programmatic accessibility POV).",
+  "comment": "Dropdown: Error messages in Dropdown are now linked to the Dropdown (from a programmatic accessibility POV).",
   "packageName": "office-ui-fabric-react",
   "email": "cliff.koh@microsoft.com",
   "commit": "640471f2eb88fec33cbc46a96d60aedd4db8a647",

--- a/change/office-ui-fabric-react-2019-09-24-15-52-15-cliffkoh-10600.json
+++ b/change/office-ui-fabric-react-2019-09-24-15-52-15-cliffkoh-10600.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Drpodown: Error messages in Dropdown are now linked to the Dropdown (from a programmatic accessibility POV).",
+  "packageName": "office-ui-fabric-react",
+  "email": "cliff.koh@microsoft.com",
+  "commit": "640471f2eb88fec33cbc46a96d60aedd4db8a647",
+  "date": "2019-09-24T22:51:17.487Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -266,7 +266,7 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
               aria-label={ariaLabel}
               aria-labelledby={mergeAriaAttributeValues(label && !ariaLabel ? id + '-label' : undefined)}
               aria-describedby={mergeAriaAttributeValues(optionId, keytipAttributes['aria-describedby'])}
-              aria-activedescendant={ariaAttrs.ariaActiveDescendant}
+              aria-activedescendant={isOpen ? ariaAttrs.ariaActiveDescendant : undefined}
               aria-required={required}
               aria-disabled={disabled}
               aria-owns={isOpen ? id + '-list' : undefined}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -248,6 +248,8 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
       calloutRenderEdge: calloutRenderEdge
     });
 
+    const hasErrorMessage: boolean = !!errorMessage && errorMessage.length > 0;
+
     return (
       <div className={this._classNames.root}>
         {onRenderLabel(this.props, this._onRenderLabel)}
@@ -262,9 +264,9 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
               aria-expanded={isOpen ? 'true' : 'false'}
               role={ariaAttrs.role}
               aria-label={ariaLabel}
-              aria-labelledby={label && !ariaLabel ? id + '-label' : undefined}
+              aria-labelledby={mergeAriaAttributeValues(label && !ariaLabel ? id + '-label' : undefined)}
               aria-describedby={mergeAriaAttributeValues(optionId, keytipAttributes['aria-describedby'])}
-              aria-activedescendant={isOpen ? ariaAttrs.ariaActiveDescendant : undefined}
+              aria-activedescendant={ariaAttrs.ariaActiveDescendant}
               aria-required={required}
               aria-disabled={disabled}
               aria-owns={isOpen ? id + '-list' : undefined}
@@ -283,9 +285,11 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
                 role={ariaAttrs.childRole}
                 aria-live={!hasFocus || disabled || multiSelect || isOpen ? 'off' : 'assertive'}
                 aria-label={selectedOptions.length ? selectedOptions[0].text : this._placeholder}
+                aria-invalid={hasErrorMessage}
                 aria-setsize={ariaAttrs.ariaSetSize}
                 aria-posinset={ariaAttrs.ariaPosInSet}
                 aria-selected={ariaAttrs.ariaSelected}
+                aria-describedby={mergeAriaAttributeValues(hasErrorMessage && id + '-errorMessage')}
               >
                 {// If option is selected render title, otherwise render the placeholder text
                 selectedOptions.length
@@ -297,7 +301,11 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
           )}
         </KeytipData>
         {isOpen && onRenderContainer(props, this._onRenderContainer)}
-        {errorMessage && errorMessage.length > 0 && <div className={this._classNames.errorMessage}>{errorMessage}</div>}
+        {hasErrorMessage && (
+          <div id={id + '-errorMessage'} className={this._classNames.errorMessage}>
+            {errorMessage}
+          </div>
+        )}
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -264,7 +264,7 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
               aria-expanded={isOpen ? 'true' : 'false'}
               role={ariaAttrs.role}
               aria-label={ariaLabel}
-              aria-labelledby={mergeAriaAttributeValues(label && !ariaLabel ? id + '-label' : undefined)}
+              aria-labelledby={label && !ariaLabel ? id + '-label' : undefined}
               aria-describedby={mergeAriaAttributeValues(optionId, keytipAttributes['aria-describedby'])}
               aria-activedescendant={isOpen ? ariaAttrs.ariaActiveDescendant : undefined}
               aria-required={required}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -106,6 +106,7 @@ exports[`Dropdown multi-select Renders multiselect Dropdown correctly 1`] = `
   >
     <span
       aria-atomic={true}
+      aria-invalid={false}
       aria-live="off"
       className=
           ms-Dropdown-title
@@ -282,6 +283,7 @@ exports[`Dropdown single-select Renders single-select Dropdown correctly 1`] = `
   >
     <span
       aria-atomic={true}
+      aria-invalid={false}
       aria-live="off"
       aria-setsize={6}
       className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
@@ -145,6 +145,7 @@ exports[`Component Examples renders Callout.Cover.Example.tsx correctly 1`] = `
       >
         <span
           aria-atomic={true}
+          aria-invalid={false}
           aria-label="Bottom Left Edge"
           aria-live="off"
           aria-posinset={5}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
@@ -830,6 +830,7 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
       >
         <span
           aria-atomic={true}
+          aria-invalid={false}
           aria-label="Bottom Left Edge"
           aria-live="off"
           aria-posinset={5}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -286,6 +286,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
               >
                 <span
                   aria-atomic={true}
+                  aria-invalid={false}
                   aria-label="5 seconds"
                   aria-live="off"
                   className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
@@ -147,6 +147,7 @@ exports[`Component Examples renders Coachmark.Basic.Example.tsx correctly 1`] = 
       >
         <span
           aria-atomic={true}
+          aria-invalid={false}
           aria-label="Bottom Auto Edge"
           aria-live="off"
           aria-posinset={8}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
@@ -291,6 +291,7 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
       >
         <span
           aria-atomic={true}
+          aria-invalid={false}
           aria-label="Bottom Left Edge"
           aria-live="off"
           aria-posinset={5}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
@@ -347,6 +347,7 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
     >
       <span
         aria-atomic={true}
+        aria-invalid={false}
         aria-label="Sunday"
         aria-live="off"
         aria-posinset={1}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
@@ -347,6 +347,7 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
     >
       <span
         aria-atomic={true}
+        aria-invalid={false}
         aria-label="Monday"
         aria-live="off"
         aria-posinset={2}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
@@ -160,6 +160,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
     >
       <span
         aria-atomic={true}
+        aria-invalid={false}
         aria-label="Select an option"
         aria-live="off"
         aria-setsize={7}
@@ -355,6 +356,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
     >
       <span
         aria-atomic={true}
+        aria-invalid={false}
         aria-label="Broccoli"
         aria-live="off"
         className=
@@ -570,6 +572,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
     >
       <span
         aria-atomic={true}
+        aria-invalid={false}
         aria-label="Apple"
         aria-live="off"
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Controlled.Example.tsx.shot
@@ -140,6 +140,7 @@ exports[`Component Examples renders Dropdown.Controlled.Example.tsx correctly 1`
   >
     <span
       aria-atomic={true}
+      aria-invalid={false}
       aria-label="Select an option"
       aria-live="off"
       aria-setsize={7}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.ControlledMulti.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.ControlledMulti.Example.tsx.shot
@@ -139,6 +139,7 @@ exports[`Component Examples renders Dropdown.ControlledMulti.Example.tsx correct
   >
     <span
       aria-atomic={true}
+      aria-invalid={false}
       aria-label="Select options"
       aria-live="off"
       className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
@@ -160,6 +160,7 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
     >
       <span
         aria-atomic={true}
+        aria-invalid={false}
         aria-label="Select an option"
         aria-live="off"
         aria-setsize={10}
@@ -525,6 +526,7 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
     >
       <span
         aria-atomic={true}
+        aria-invalid={false}
         aria-label="Select an option"
         aria-live="off"
         aria-setsize={10}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
@@ -332,6 +332,7 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
     >
       <span
         aria-atomic={true}
+        aria-invalid={false}
         aria-label="Select an option"
         aria-live="off"
         aria-setsize={5}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
@@ -190,6 +190,7 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
       >
         <span
           aria-atomic={true}
+          aria-invalid={false}
           aria-label="Select an option"
           aria-live="off"
           aria-setsize={5}
@@ -512,6 +513,7 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
     >
       <span
         aria-atomic={true}
+        aria-invalid={false}
         aria-label="Required with no label"
         aria-live="off"
         aria-setsize={5}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -868,6 +868,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
       >
         <span
           aria-atomic={true}
+          aria-invalid={false}
           aria-label="size32"
           aria-live="off"
           aria-posinset={4}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
@@ -1066,6 +1066,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
       >
         <span
           aria-atomic={true}
+          aria-invalid={false}
           aria-label="none"
           aria-live="off"
           aria-posinset={1}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
@@ -238,6 +238,7 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
       >
         <span
           aria-atomic={true}
+          aria-invalid={false}
           aria-label="Normal"
           aria-live="off"
           aria-posinset={1}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -4073,6 +4073,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
         >
           <span
             aria-atomic={true}
+            aria-invalid={false}
             aria-label="20"
             aria-live="off"
             aria-posinset={1}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
@@ -3130,6 +3130,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
         >
           <span
             aria-atomic={true}
+            aria-invalid={false}
             aria-label="Left"
             aria-live="off"
             aria-posinset={1}
@@ -3357,6 +3358,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
         >
           <span
             aria-atomic={true}
+            aria-invalid={false}
             aria-label="Top"
             aria-live="off"
             aria-posinset={1}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapAdvanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapAdvanced.Example.tsx.shot
@@ -770,6 +770,7 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
         >
           <span
             aria-atomic={true}
+            aria-invalid={false}
             aria-label="Left"
             aria-live="off"
             aria-posinset={1}
@@ -998,6 +999,7 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
         >
           <span
             aria-atomic={true}
+            aria-invalid={false}
             aria-label="Top"
             aria-live="off"
             aria-posinset={1}
@@ -1226,6 +1228,7 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
         >
           <span
             aria-atomic={true}
+            aria-invalid={false}
             aria-label="Visible"
             aria-live="off"
             aria-posinset={1}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
@@ -1841,6 +1841,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
               >
                 <span
                   aria-atomic={true}
+                  aria-invalid={false}
                   aria-label="Top"
                   aria-live="off"
                   aria-posinset={1}
@@ -2069,6 +2070,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
               >
                 <span
                   aria-atomic={true}
+                  aria-invalid={false}
                   aria-label="Left"
                   aria-live="off"
                   aria-posinset={1}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapAdvanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapAdvanced.Example.tsx.shot
@@ -770,6 +770,7 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
         >
           <span
             aria-atomic={true}
+            aria-invalid={false}
             aria-label="Left"
             aria-live="off"
             aria-posinset={1}
@@ -998,6 +999,7 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
         >
           <span
             aria-atomic={true}
+            aria-invalid={false}
             aria-label="Top"
             aria-live="off"
             aria-posinset={1}
@@ -1226,6 +1228,7 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
         >
           <span
             aria-atomic={true}
+            aria-invalid={false}
             aria-label="Visible"
             aria-live="off"
             aria-posinset={1}

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -925,7 +925,7 @@ export function memoizeFunction<T extends (...args: any[]) => RET_TYPE, RET_TYPE
 export function merge<T = {}>(target: Partial<T>, ...args: (Partial<T> | null | undefined | false)[]): T;
 
 // @public
-export function mergeAriaAttributeValues(...ariaAttributes: (string | undefined)[]): string | undefined;
+export function mergeAriaAttributeValues(...ariaAttributes: (string | undefined | false)[]): string | undefined;
 
 // @public
 export function mergeCustomizations(props: ICustomizerProps, parentContext: ICustomizerContext): ICustomizerContext;

--- a/packages/utilities/src/aria.ts
+++ b/packages/utilities/src/aria.ts
@@ -4,9 +4,9 @@
  *
  * @param ariaAttributes - ARIA attributes to merge
  */
-export function mergeAriaAttributeValues(...ariaAttributes: (string | undefined)[]): string | undefined {
+export function mergeAriaAttributeValues(...ariaAttributes: (string | undefined | false)[]): string | undefined {
   const mergedAttribute = ariaAttributes
-    .filter((arg: string | undefined) => arg !== undefined && arg !== null)
+    .filter((arg: string | undefined | false) => arg !== undefined && arg !== null && arg !== false)
     .join(' ')
     .trim();
   return mergedAttribute === '' ? undefined : mergedAttribute;

--- a/packages/utilities/src/aria.ts
+++ b/packages/utilities/src/aria.ts
@@ -6,7 +6,7 @@
  */
 export function mergeAriaAttributeValues(...ariaAttributes: (string | undefined | false)[]): string | undefined {
   const mergedAttribute = ariaAttributes
-    .filter((arg: string | undefined | false) => arg !== undefined && arg !== null && arg !== false)
+    .filter((arg: string | undefined | false) => arg)
     .join(' ')
     .trim();
   return mergedAttribute === '' ? undefined : mergedAttribute;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10600
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This links the Dropdown to the error message that might potentially be displayed.

I've done considerable reading of specs, looked at various examples on the internet, and tested on Narrator, ChromeVox and NVDA and believe this is the best, most spec-compliant change that is the most semantically correct.

One thing to note is that the various screen reading software differ widely in how they handle aria-labelledby/aria-describedby and when they intersect with roles or if they're both present. David MacDonald (a veteran WCAG member) has an article discussing some of this here: https://www.davidmacd.com/blog/does-aria-label-override-static-text.html


#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10605)