### PR TITLE
[Pickers] Edge IME Compatibility & IE demo page bug fix

### DIFF
--- a/change/office-ui-fabric-react-2019-09-24-18-35-44-u-anhw-picker-asian-langs.json
+++ b/change/office-ui-fabric-react-2019-09-24-18-35-44-u-anhw-picker-asian-langs.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Prevent suggestion autocomplete without selection",
+  "packageName": "office-ui-fabric-react",
+  "email": "anhw@microsoft.com",
+  "commit": "87c6dca185d61a8ed15782090e5b2f7a30fe7fc4",
+  "date": "2019-09-25T01:35:44.321Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Autofill/Autofill.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Autofill/Autofill.test.tsx
@@ -32,6 +32,20 @@ describe('Autofill', () => {
     expect(autofill.inputElement!.value).toBe('hello');
   });
 
+  it('correctly autofills with composable languages', () => {
+    let updatedText: string | undefined;
+    const onInputValueChange = (text: string | undefined): void => {
+      updatedText = text;
+    };
+
+    component = mount(<Autofill componentRef={autofillRef} onInputValueChange={onInputValueChange} suggestedDisplayValue="こんにちは" />);
+
+    ReactTestUtils.Simulate.input(autofill.inputElement!, mockEvent('こん'));
+    expect(updatedText).toBe('こん');
+    expect(autofill.value).toBe('こん');
+    expect(autofill.inputElement!.value).toBe('こんにちは');
+  });
+
   it('does not autofill if suggestedDisplayValue does not match input', () => {
     let updatedText: string | undefined;
     const onInputValueChange = (text: string | undefined): void => {

--- a/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
+++ b/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
@@ -217,8 +217,9 @@ export class Autofill extends BaseComponent<IAutofillProps, IAutofillState> impl
   private _onInputChanged = (ev: React.FormEvent<HTMLElement>) => {
     const value: string = this._getCurrentInputValue(ev);
 
-    // Right now typing does not have isComposing, once that has been fixed any should be removed.
-    this._tryEnableAutofill(value, this._value, (ev.nativeEvent as any).isComposing);
+    if (!this._isComposing) {
+      this._tryEnableAutofill(value, this._value, (ev.nativeEvent as any).isComposing);
+    }
 
     // If it is not IE11 and currently composing, update the value
     if (!(isIE11() && this._isComposing)) {


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

1. There was a bug where typing inside the picker with a language requiring a composition state for typing characters (ie. Japanese) would not behave as expected in Edge. Specifically...
    - Typing a character that matches a suggestion will fill the text input to match the first suggestion, but the highlight does not occur
2. Demo page selector did not work in IE in most recent build when I was testing. Turns out it was caused due to the RegExp constructor not being supported in IE _iff_ there is a regexp passed in. It only takes a string...

#### Focus areas to test

- Any demo page in IE
- Pickers while testing composition based languages. To test, I will push another commit to add a Japanese string to the example page and provide more details on how to test it in a comment :) I'll be sure to remove the commit before merging.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10610)