### PR TITLE
Allow custom Overflow icon in Breadcrumb component

### DIFF
--- a/change/office-ui-fabric-react-2019-09-24-19-25-38-madomi-overflow-icon.json
+++ b/change/office-ui-fabric-react-2019-09-24-19-25-38-madomi-overflow-icon.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Allow setting a custom overflow icon on the Breadcrumb component",
+  "packageName": "office-ui-fabric-react",
+  "email": "madomi@microsoft.com",
+  "commit": "f5164fd724812ef0b1877445b0ac825debf96504",
+  "date": "2019-09-25T02:25:38.368Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1803,6 +1803,7 @@ export interface IBreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
     maxDisplayedItems?: number;
     onReduceData?: (data: IBreadcrumbData) => IBreadcrumbData | undefined;
     onRenderItem?: IRenderFunction<IBreadcrumbItem>;
+    onRenderOverflowIcon?: IRenderFunction<IButtonProps>;
     overflowAriaLabel?: string;
     overflowIndex?: number;
     // (undocumented)

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
@@ -90,7 +90,8 @@ export class BreadcrumbBase extends BaseComponent<IBreadcrumbProps, any> {
       dividerAs: DividerType = Icon as React.ReactType<IDividerAsProps>,
       onRenderItem = this._onRenderItem,
       overflowAriaLabel,
-      overflowIndex
+      overflowIndex,
+      onRenderOverflowIcon
     } = data.props;
     const { renderedOverflowItems, renderedItems } = data;
 
@@ -116,17 +117,20 @@ export class BreadcrumbBase extends BaseComponent<IBreadcrumbProps, any> {
     ));
 
     if (hasOverflowItems) {
+      const iconProps = !onRenderOverflowIcon ? { iconName: 'More' } : {};
+      const onRenderMenuIcon = onRenderOverflowIcon ? onRenderOverflowIcon : nullFunction;
+
       itemElements.splice(
         overflowIndex!,
         0,
         <li className={this._classNames.overflow} key={OVERFLOW_KEY}>
           <IconButton
             className={this._classNames.overflowButton}
-            iconProps={{ iconName: 'More' }}
+            iconProps={iconProps}
             role="button"
             aria-haspopup="true"
             ariaLabel={overflowAriaLabel}
-            onRenderMenuIcon={nullFunction}
+            onRenderMenuIcon={onRenderMenuIcon}
             menuProps={{
               items: contextualItems,
               directionalHint: DirectionalHint.bottomLeftEdge

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { mount } from 'enzyme';
 import * as renderer from 'react-test-renderer';
 import { Breadcrumb, IBreadcrumbItem } from './index';
+import { Icon } from '../Icon/Icon';
 
 describe('Breadcrumb', () => {
   it('renders empty breadcrumb', () => {
@@ -21,6 +22,8 @@ describe('Breadcrumb', () => {
     ];
 
     const divider = () => <span>*</span>;
+
+    const overflowIcon = () => <Icon iconName={'ChevronDown'} />;
 
     it('renders breadcumb correctly 1', () => {
       const component = renderer.create(<Breadcrumb items={items} />);
@@ -64,6 +67,14 @@ describe('Breadcrumb', () => {
     it('renders breadcumb correctly 6', () => {
       // With maxDisplayedItems and overflowIndex as 0
       const component = renderer.create(<Breadcrumb items={items} maxDisplayedItems={0} overflowIndex={0} />);
+
+      const tree = component.toJSON();
+      expect(tree).toMatchSnapshot();
+    });
+
+    it('renders breadcumb correctly 7', () => {
+      // With custom overflow icon
+      const component = renderer.create(<Breadcrumb items={items} maxDisplayedItems={2} onRenderOverflowIcon={overflowIcon} />);
 
       const tree = component.toJSON();
       expect(tree).toMatchSnapshot();

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
@@ -4,6 +4,7 @@ import { IRefObject, IRenderFunction, IComponentAs, IStyleFunctionOrObject } fro
 import { ITheme, IStyle } from '../../Styling';
 import { IFocusZoneProps } from '../../FocusZone';
 import { ITooltipHostProps } from '../../Tooltip';
+import { IButtonProps } from '../Button';
 
 /**
  * {@docCategory Breadcrumb}
@@ -49,6 +50,10 @@ export interface IBreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
    */
   dividerAs?: IComponentAs<IDividerAsProps>;
 
+  /**
+   * Render a custom overflow icon in place of the default icon `...`
+   */
+  onRenderOverflowIcon?: IRenderFunction<IButtonProps>;
   /**
    * The maximum number of breadcrumbs to display before coalescing.
    * If not specified, all breadcrumbs will be rendered.
@@ -119,7 +124,7 @@ export interface IBreadcrumbItem {
   href?: string;
 
   /**
-   * If this breadcrumb item is the item the user is currently on, if set to true, aria-current="page" will be applied to this
+   * If this breadcrumb item is the item the user is currently on, if set to true, aria-current='page' will be applied to this
    * breadcrumb link
    */
   isCurrentItem?: boolean;

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
@@ -4,7 +4,7 @@ import { IRefObject, IRenderFunction, IComponentAs, IStyleFunctionOrObject } fro
 import { ITheme, IStyle } from '../../Styling';
 import { IFocusZoneProps } from '../../FocusZone';
 import { ITooltipHostProps } from '../../Tooltip';
-import { IButtonProps } from '../Button';
+import { IButtonProps } from '../Button/Button.types';
 
 /**
  * {@docCategory Breadcrumb}

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -1963,6 +1963,384 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 6 1`] = `
 </div>
 `;
 
+exports[`Breadcrumb basic rendering renders breadcumb correctly 7 1`] = `
+<div>
+  <div
+    style={
+      Object {
+        "position": "relative",
+      }
+    }
+  >
+    <div
+      data-automation-id="visibleContent"
+      style={
+        Object {
+          "position": "fixed",
+          "visibility": "hidden",
+        }
+      }
+    >
+      <div
+        className=
+            ms-Breadcrumb
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-bottom: 1px;
+              margin-left: 0;
+              margin-right: 0;
+              margin-top: 23px;
+            }
+        role="navigation"
+      >
+        <div
+          className=
+              ms-FocusZone
+              &:focus {
+                outline: none;
+              }
+          data-focuszone-id="FocusZone32"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+          role="presentation"
+        >
+          <ol
+            className=
+                ms-Breadcrumb-list
+                {
+                  align-items: stretch;
+                  display: flex;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  white-space: nowrap;
+                }
+          >
+            <li
+              className=
+                  ms-Breadcrumb-overflow
+                  {
+                    align-items: center;
+                    display: flex;
+                    position: relative;
+                  }
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                aria-owns={null}
+                className=
+                    ms-Button
+                    ms-Button--icon
+                    ms-Breadcrumb-overflowButton
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: none;
+                      box-sizing: border-box;
+                      color: #333333;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 16px;
+                      font-weight: 400;
+                      height: 100%;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: none;
+                      vertical-align: top;
+                      white-space: nowrap;
+                      width: 32px;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #666666;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #f4f4f4;
+                      color: #212121;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #c8c8c8;
+                      color: #333333;
+                    }
+                    &:hover:active {
+                      background-color: #d0d0d0;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      padding-bottom: 4px;
+                      padding-left: 6px;
+                      padding-right: 6px;
+                      padding-top: 4px;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 15px;
+                    }
+                data-is-focusable={true}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="button"
+                type="button"
+              >
+                <div
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: center;
+                      }
+                >
+                  <i
+                    aria-hidden={true}
+                    className=
+
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          display: inline-block;
+                          font-family: "FabricMDL2Icons";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                    data-icon-name="ChevronDown"
+                    role="presentation"
+                  >
+                    
+                  </i>
+                </div>
+              </button>
+              <i
+                aria-hidden={true}
+                className=
+                    ms-Breadcrumb-chevron
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #666666;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      color: WindowText;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 8px;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      font-size: 8px;
+                    }
+                data-icon-name="ChevronRight"
+                role="presentation"
+              >
+                
+              </i>
+            </li>
+            <li
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
+            >
+              <span
+                className=
+                    ms-Breadcrumb-item
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #333333;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 21px;
+                      font-weight: 100;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                    }
+                    &:hover {
+                      cursor: default;
+                    }
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  TestText3
+                </div>
+              </span>
+              <i
+                aria-hidden={true}
+                className=
+                    ms-Breadcrumb-chevron
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #666666;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      color: WindowText;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 8px;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      font-size: 8px;
+                    }
+                data-icon-name="ChevronRight"
+                role="presentation"
+              >
+                
+              </i>
+            </li>
+            <li
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
+            >
+              <span
+                className=
+                    ms-Breadcrumb-item
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #333333;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 21px;
+                      font-weight: 100;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                    }
+                    &:hover {
+                      cursor: default;
+                    }
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  TestText4
+                </div>
+              </span>
+            </li>
+          </ol>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Breadcrumb renders empty breadcrumb 1`] = `
 <div>
   <div

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx
@@ -3,6 +3,7 @@ import { Breadcrumb, IBreadcrumbItem, IDividerAsProps } from 'office-ui-fabric-r
 import { Label } from 'office-ui-fabric-react/lib/Label';
 import * as exampleStylesImport from '../../../common/_exampleStyles.scss';
 import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
+import { Icon } from '../../Icon';
 const exampleStyles: any = exampleStylesImport;
 
 export class BreadcrumbBasicExample extends React.Component<any, any> {
@@ -40,6 +41,22 @@ export class BreadcrumbBasicExample extends React.Component<any, any> {
           ]}
           dividerAs={this._getCustomDivider}
           ariaLabel={'Breadcrumb with custom divider icon'}
+        />
+
+        <Label className={exampleStyles.exampleLabel} style={{ marginTop: '24px' }}>
+          With Custom Overflow Icon
+        </Label>
+        <Breadcrumb
+          items={[
+            { text: 'Files', key: 'Files', onClick: this._onBreadcrumbItemClicked },
+            { text: 'This is folder 1', key: 'f1', onClick: this._onBreadcrumbItemClicked },
+            { text: 'This is folder 2 with a long name', key: 'f2', onClick: this._onBreadcrumbItemClicked },
+            { text: 'This is folder 3 long', key: 'f3', onClick: this._onBreadcrumbItemClicked },
+            { text: 'This is folder 4', key: 'f4', onClick: this._onBreadcrumbItemClicked },
+            { text: 'This is folder 5 another', key: 'f5', onClick: this._onBreadcrumbItemClicked, isCurrentItem: true }
+          ]}
+          ariaLabel={'Breadcrumb with no maxDisplayedItems'}
+          onRenderOverflowIcon={this._getCustomOverflowIcon}
         />
 
         <Label className={exampleStyles.exampleLabel} style={{ marginTop: '24px' }}>
@@ -117,5 +134,9 @@ export class BreadcrumbBasicExample extends React.Component<any, any> {
         </span>
       </TooltipHost>
     );
+  };
+
+  private _getCustomOverflowIcon = () => {
+    return <Icon iconName={'ChevronDown'} />;
   };
 }

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx
@@ -3,7 +3,8 @@ import { Breadcrumb, IBreadcrumbItem, IDividerAsProps } from 'office-ui-fabric-r
 import { Label } from 'office-ui-fabric-react/lib/Label';
 import * as exampleStylesImport from '../../../common/_exampleStyles.scss';
 import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
-import { Icon } from '../../Icon';
+import { Icon } from 'office-ui-fabric-react/lib/Icon';
+
 const exampleStyles: any = exampleStylesImport;
 
 export class BreadcrumbBasicExample extends React.Component<any, any> {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -2111,6 +2111,1068 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
       }
     }
   >
+    With Custom Overflow Icon
+  </label>
+  <div>
+    <div
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+    >
+      <div
+        data-automation-id="visibleContent"
+        style={
+          Object {
+            "position": "fixed",
+            "visibility": "hidden",
+          }
+        }
+      >
+        <div
+          aria-label="Breadcrumb with no maxDisplayedItems"
+          className=
+              ms-Breadcrumb
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 1px;
+                margin-left: 0;
+                margin-right: 0;
+                margin-top: 23px;
+              }
+          role="navigation"
+        >
+          <div
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+            data-focuszone-id="FocusZone19"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDownCapture={[Function]}
+            role="presentation"
+          >
+            <ol
+              className=
+                  ms-Breadcrumb-list
+                  {
+                    align-items: stretch;
+                    display: flex;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    white-space: nowrap;
+                  }
+            >
+              <li
+                className=
+                    ms-Breadcrumb-listItem
+                    {
+                      align-items: center;
+                      display: flex;
+                      list-style-type: none;
+                      margin-bottom: 0;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 0;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                    }
+              >
+                <button
+                  className=
+                      ms-Link
+                      ms-Breadcrumb-itemLink
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        background: none;
+                        border-bottom: 1px solid transparent;
+                        border: none;
+                        color: #333333;
+                        cursor: pointer;
+                        display: inline;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 21px;
+                        font-weight: 100;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: left;
+                        text-decoration: none;
+                        text-overflow: ellipsis;
+                        user-select: text;
+                        white-space: nowrap;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        box-shadow: 0 0 0 1px #666666 inset;
+                        outline: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-bottom: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){& {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){& {
+                        color: #00009F;
+                      }
+                      &:active, &:hover, &:active:hover {
+                        color: #004578;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                        text-decoration: underline;
+                      }
+                      &:focus {
+                        color: #212121;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #666666;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      &:hover {
+                        background-color: #f4f4f4;
+                        color: initial;
+                        cursor: pointer;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
+                      }
+                      &:active {
+                        background-color: #c8c8c8;
+                        color: #333333;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 17px;
+                        font-weight: 300;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                      }
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Files
+                  </div>
+                </button>
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Breadcrumb-chevron
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #666666;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        color: WindowText;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        font-size: 8px;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        font-size: 8px;
+                      }
+                  data-icon-name="ChevronRight"
+                  role="presentation"
+                >
+                  
+                </i>
+              </li>
+              <li
+                className=
+                    ms-Breadcrumb-listItem
+                    {
+                      align-items: center;
+                      display: flex;
+                      list-style-type: none;
+                      margin-bottom: 0;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 0;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                    }
+              >
+                <button
+                  className=
+                      ms-Link
+                      ms-Breadcrumb-itemLink
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        background: none;
+                        border-bottom: 1px solid transparent;
+                        border: none;
+                        color: #333333;
+                        cursor: pointer;
+                        display: inline;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 21px;
+                        font-weight: 100;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: left;
+                        text-decoration: none;
+                        text-overflow: ellipsis;
+                        user-select: text;
+                        white-space: nowrap;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        box-shadow: 0 0 0 1px #666666 inset;
+                        outline: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-bottom: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){& {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){& {
+                        color: #00009F;
+                      }
+                      &:active, &:hover, &:active:hover {
+                        color: #004578;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                        text-decoration: underline;
+                      }
+                      &:focus {
+                        color: #212121;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #666666;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      &:hover {
+                        background-color: #f4f4f4;
+                        color: initial;
+                        cursor: pointer;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
+                      }
+                      &:active {
+                        background-color: #c8c8c8;
+                        color: #333333;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 17px;
+                        font-weight: 300;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                      }
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    This is folder 1
+                  </div>
+                </button>
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Breadcrumb-chevron
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #666666;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        color: WindowText;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        font-size: 8px;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        font-size: 8px;
+                      }
+                  data-icon-name="ChevronRight"
+                  role="presentation"
+                >
+                  
+                </i>
+              </li>
+              <li
+                className=
+                    ms-Breadcrumb-listItem
+                    {
+                      align-items: center;
+                      display: flex;
+                      list-style-type: none;
+                      margin-bottom: 0;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 0;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                    }
+              >
+                <button
+                  className=
+                      ms-Link
+                      ms-Breadcrumb-itemLink
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        background: none;
+                        border-bottom: 1px solid transparent;
+                        border: none;
+                        color: #333333;
+                        cursor: pointer;
+                        display: inline;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 21px;
+                        font-weight: 100;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: left;
+                        text-decoration: none;
+                        text-overflow: ellipsis;
+                        user-select: text;
+                        white-space: nowrap;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        box-shadow: 0 0 0 1px #666666 inset;
+                        outline: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-bottom: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){& {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){& {
+                        color: #00009F;
+                      }
+                      &:active, &:hover, &:active:hover {
+                        color: #004578;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                        text-decoration: underline;
+                      }
+                      &:focus {
+                        color: #212121;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #666666;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      &:hover {
+                        background-color: #f4f4f4;
+                        color: initial;
+                        cursor: pointer;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
+                      }
+                      &:active {
+                        background-color: #c8c8c8;
+                        color: #333333;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 17px;
+                        font-weight: 300;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                      }
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    This is folder 2 with a long name
+                  </div>
+                </button>
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Breadcrumb-chevron
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #666666;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        color: WindowText;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        font-size: 8px;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        font-size: 8px;
+                      }
+                  data-icon-name="ChevronRight"
+                  role="presentation"
+                >
+                  
+                </i>
+              </li>
+              <li
+                className=
+                    ms-Breadcrumb-listItem
+                    {
+                      align-items: center;
+                      display: flex;
+                      list-style-type: none;
+                      margin-bottom: 0;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 0;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                    }
+              >
+                <button
+                  className=
+                      ms-Link
+                      ms-Breadcrumb-itemLink
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        background: none;
+                        border-bottom: 1px solid transparent;
+                        border: none;
+                        color: #333333;
+                        cursor: pointer;
+                        display: inline;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 21px;
+                        font-weight: 100;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: left;
+                        text-decoration: none;
+                        text-overflow: ellipsis;
+                        user-select: text;
+                        white-space: nowrap;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        box-shadow: 0 0 0 1px #666666 inset;
+                        outline: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-bottom: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){& {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){& {
+                        color: #00009F;
+                      }
+                      &:active, &:hover, &:active:hover {
+                        color: #004578;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                        text-decoration: underline;
+                      }
+                      &:focus {
+                        color: #212121;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #666666;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      &:hover {
+                        background-color: #f4f4f4;
+                        color: initial;
+                        cursor: pointer;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
+                      }
+                      &:active {
+                        background-color: #c8c8c8;
+                        color: #333333;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 17px;
+                        font-weight: 300;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                      }
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    This is folder 3 long
+                  </div>
+                </button>
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Breadcrumb-chevron
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #666666;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        color: WindowText;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        font-size: 8px;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        font-size: 8px;
+                      }
+                  data-icon-name="ChevronRight"
+                  role="presentation"
+                >
+                  
+                </i>
+              </li>
+              <li
+                className=
+                    ms-Breadcrumb-listItem
+                    {
+                      align-items: center;
+                      display: flex;
+                      list-style-type: none;
+                      margin-bottom: 0;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 0;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                    }
+              >
+                <button
+                  className=
+                      ms-Link
+                      ms-Breadcrumb-itemLink
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        background: none;
+                        border-bottom: 1px solid transparent;
+                        border: none;
+                        color: #333333;
+                        cursor: pointer;
+                        display: inline;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 21px;
+                        font-weight: 100;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: left;
+                        text-decoration: none;
+                        text-overflow: ellipsis;
+                        user-select: text;
+                        white-space: nowrap;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        box-shadow: 0 0 0 1px #666666 inset;
+                        outline: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-bottom: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){& {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){& {
+                        color: #00009F;
+                      }
+                      &:active, &:hover, &:active:hover {
+                        color: #004578;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                        text-decoration: underline;
+                      }
+                      &:focus {
+                        color: #212121;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #666666;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      &:hover {
+                        background-color: #f4f4f4;
+                        color: initial;
+                        cursor: pointer;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
+                      }
+                      &:active {
+                        background-color: #c8c8c8;
+                        color: #333333;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 17px;
+                        font-weight: 300;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                      }
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    This is folder 4
+                  </div>
+                </button>
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Breadcrumb-chevron
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #666666;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        color: WindowText;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        font-size: 8px;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        font-size: 8px;
+                      }
+                  data-icon-name="ChevronRight"
+                  role="presentation"
+                >
+                  
+                </i>
+              </li>
+              <li
+                className=
+                    ms-Breadcrumb-listItem
+                    {
+                      align-items: center;
+                      display: flex;
+                      list-style-type: none;
+                      margin-bottom: 0;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 0;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                    }
+              >
+                <button
+                  aria-current="page"
+                  className=
+                      ms-Link
+                      ms-Breadcrumb-itemLink
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        background: none;
+                        border-bottom: 1px solid transparent;
+                        border: none;
+                        color: #333333;
+                        cursor: pointer;
+                        display: inline;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 21px;
+                        font-weight: 100;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: left;
+                        text-decoration: none;
+                        text-overflow: ellipsis;
+                        user-select: text;
+                        white-space: nowrap;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        box-shadow: 0 0 0 1px #666666 inset;
+                        outline: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-bottom: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){& {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){& {
+                        color: #00009F;
+                      }
+                      &:active, &:hover, &:active:hover {
+                        color: #004578;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:active, &:hover, &:active:hover {
+                        text-decoration: underline;
+                      }
+                      &:focus {
+                        color: #212121;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #666666;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      &:hover {
+                        background-color: #f4f4f4;
+                        color: initial;
+                        cursor: pointer;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
+                      }
+                      &:active {
+                        background-color: #c8c8c8;
+                        color: #333333;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 17px;
+                        font-weight: 300;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                      }
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    This is folder 5 another
+                  </div>
+                </button>
+              </li>
+            </ol>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <label
+    className=
+        ms-Label
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #333333;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 0px;
+          margin-left: 0px;
+          margin-right: 0px;
+          margin-top: 0px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
+    style={
+      Object {
+        "marginTop": "24px",
+      }
+    }
+  >
     With maxDisplayedItems set to three
   </label>
   <div>
@@ -2153,7 +3215,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                 &:focus {
                   outline: none;
                 }
-            data-focuszone-id="FocusZone19"
+            data-focuszone-id="FocusZone26"
             onFocus={[Function]}
             onKeyDown={[Function]}
             onMouseDownCapture={[Function]}
@@ -2850,7 +3912,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                 &:focus {
                   outline: none;
                 }
-            data-focuszone-id="FocusZone26"
+            data-focuszone-id="FocusZone33"
             onFocus={[Function]}
             onKeyDown={[Function]}
             onMouseDownCapture={[Function]}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10612
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The current implementation does not allow to include custom items on the Breadcrumb component, this limits applications where the Icon library is not loaded or the ability to render a custom Icon.

In this PR I just added an IRenderFunction to the Breadcrumb container where you can add a custom function to render the Icon.

Currently, the current icon defined in the IconButton component is being defined by the `{ iconName: 'More' }` prop so we need to conditionally remove this prop and provide a custom  `onRenderMenuIcon`

Another approach would be to still use the `onRenderOverflowIcon` prop and in case it's not defined, define a custom Icon render function for the default (for example: `return <Icon iconName={'More'} />; `) the problem with this is that IconButton currently adds a few extra CSS properties (which seems to not do anything), but I did not want to get rid of them.

Also, this change should also be applied to the 7.x version, but we are currently using 6.x.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10613)