### PR TITLE
Overflow example - more accessible example

### DIFF
--- a/change/office-ui-fabric-react-2019-09-25-08-53-14-overflow-example.json
+++ b/change/office-ui-fabric-react-2019-09-25-08-53-14-overflow-example.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "changed overflow example to more accessible checkbox example",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "4cc7d0e0d909d4a9dc384d3118d9f40d771d32e4",
+  "date": "2019-09-25T15:53:14.971Z"
+}

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/examples/OverflowSet.Custom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/examples/OverflowSet.Custom.Example.tsx
@@ -1,7 +1,5 @@
 import * as React from 'react';
-import { CommandBarButton, IButtonStyles } from 'office-ui-fabric-react/lib/Button';
-import { SearchBox } from 'office-ui-fabric-react/lib/SearchBox';
-import { IOverflowSetItemProps, OverflowSet } from 'office-ui-fabric-react/lib/OverflowSet';
+import { CommandBarButton, IButtonStyles, IOverflowSetItemProps, OverflowSet, Checkbox } from 'office-ui-fabric-react';
 
 const noOp = () => undefined;
 
@@ -12,9 +10,9 @@ export class OverflowSetCustomExample extends React.PureComponent {
         aria-label="Custom Example"
         items={[
           {
-            key: 'search',
+            key: 'checkbox',
             onRender: () => {
-              return <SearchBox placeholder="Search" styles={{ root: { marginBottom: 0, width: 200 } }} />;
+              return <Checkbox label="A Checkbox" styles={{ root: { marginRight: 5 } }} />;
             }
           },
           {
@@ -101,7 +99,13 @@ export class OverflowSetCustomExample extends React.PureComponent {
       }
     };
     return (
-      <CommandBarButton role="menu" styles={buttonStyles} menuIconProps={{ iconName: 'More' }} menuProps={{ items: overflowItems! }} />
+      <CommandBarButton
+        ariaLabel="More items"
+        role="menu"
+        styles={buttonStyles}
+        menuIconProps={{ iconName: 'More' }}
+        menuProps={{ items: overflowItems! }}
+      />
     );
   };
 }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
@@ -31,137 +31,145 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
   >
     <div
       className=
-          ms-SearchBox
+          ms-Checkbox
+          is-enabled
           {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            align-items: stretch;
-            background-color: #ffffff;
-            border-radius: 2px;
-            border: 1px solid #8a8886;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #323130;
             display: flex;
-            flex-direction: row;
-            flex-wrap: nowrap;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            height: 32px;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 1px;
-            padding-left: 4px;
-            padding-right: 0;
-            padding-top: 1px;
-            width: 200px;
+            margin-right: 5px;
+            position: relative;
           }
-          @media screen and (-ms-high-contrast: active){& {
-            border: 1px solid WindowText;
-          }
-          &:hover {
+          &:hover .ms-Checkbox-checkbox {
             border-color: #323130;
           }
-          @media screen and (-ms-high-contrast: active){&:hover {
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
             border-color: Highlight;
           }
-          &:hover .ms-SearchBox-iconContainer {
-            color: #005a9e;
+          &:focus .ms-Checkbox-checkbox {
+            border-color: #323130;
           }
-      onFocusCapture={[Function]}
-      role="search"
+          &:hover .ms-Checkbox-checkmark {
+            color: #605e5c;
+            opacity: 1;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+            color: Highlight;
+          }
+          &:hover .ms-Checkbox-text {
+            color: #201f1e;
+          }
+          &:focus .ms-Checkbox-text {
+            color: #201f1e;
+          }
     >
-      <div
-        aria-hidden={true}
-        className=
-            ms-SearchBox-iconContainer
-            {
-              color: #0078d4;
-              cursor: text;
-              display: flex;
-              flex-direction: column;
-              flex-shrink: 0;
-              font-size: 16px;
-              justify-content: center;
-              text-align: center;
-              transition: width 0.167s;
-              width: 32px;
-            }
-        onClick={[Function]}
-      >
-        <i
-          aria-hidden={true}
-          className=
-              ms-SearchBox-icon
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                display: inline-block;
-                font-family: "FabricMDL2Icons";
-                font-style: normal;
-                font-weight: normal;
-                opacity: 1;
-                speak: none;
-                transition: opacity 0.167s 0s;
-              }
-          data-icon-name="Search"
-        >
-          
-        </i>
-      </div>
       <input
-        aria-label="Search"
+        aria-checked="false"
+        aria-label="A Checkbox"
         className=
-            ms-SearchBox-field
+
             {
-              background-color: transparent;
-              border: none;
-              box-shadow: none;
-              box-sizing: border-box;
-              color: #323130;
-              flex: 1 1 0px;
-              font-family: inherit;
-              font-size: inherit;
-              font-weight: inherit;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              min-width: 0px;
-              outline: none;
-              overflow: hidden;
-              padding-bottom: 0.5px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
-              text-overflow: ellipsis;
+              background: none;
+              opacity: 0;
+              position: absolute;
             }
-            &::placeholder {
-              color: #605e5c;
-              opacity: 1;
+            .ms-Fabric--isFocusVisible &:focus + label::before {
+              outline-offset: 2px;
+              outline: 1px solid #605e5c;
             }
-            &:-ms-input-placeholder {
-              color: #605e5c;
-              opacity: 1;
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+              outline: 1px solid ActiveBorder;
             }
-            &::-ms-input-placeholder {
-              color: #605e5c;
-              opacity: 1;
-            }
-            &::-ms-clear {
-              display: none;
-            }
-        id="SearchBox1"
+        id="checkbox-1"
+        onBlur={[Function]}
         onChange={[Function]}
-        onInput={[Function]}
-        onKeyDown={[Function]}
-        placeholder="Search"
-        role="searchbox"
-        value=""
+        onFocus={[Function]}
+        type="checkbox"
       />
+      <label
+        className=
+            ms-Checkbox-label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-items: flex-start;
+              cursor: pointer;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              position: relative;
+              text-align: left;
+              user-select: none;
+            }
+            &::before {
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              pointer-events: none;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+            }
+        htmlFor="checkbox-1"
+      >
+        <div
+          className=
+              ms-Checkbox-checkbox
+              {
+                align-items: center;
+                border-radius: 2px;
+                border: 1px solid #323130;
+                box-sizing: border-box;
+                display: flex;
+                flex-shrink: 0;
+                height: 20px;
+                justify-content: center;
+                margin-right: 4px;
+                overflow: hidden;
+                position: relative;
+                transition-duration: 200ms;
+                transition-property: background, border, border-color;
+                transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                width: 20px;
+              }
+        >
+          <i
+            aria-hidden={true}
+            className=
+                ms-Checkbox-checkmark
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #ffffff;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  opacity: 0;
+                  speak: none;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  color: Window;
+                }
+            data-icon-name="CheckMark"
+          >
+            
+          </i>
+        </div>
+        <span
+          aria-hidden="true"
+          className=
+              ms-Checkbox-text
+              {
+                color: #323130;
+                font-size: 14px;
+                line-height: 20px;
+                margin-left: 4px;
+              }
+        >
+          A Checkbox
+        </span>
+      </label>
     </div>
   </div>
   <div
@@ -734,6 +742,7 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
     <button
       aria-expanded={false}
       aria-haspopup={true}
+      aria-label="More items"
       aria-owns={null}
       className=
           ms-Button


### PR DESCRIPTION
fixes #7761 (last item)

Moving to a more simple example that shows off custom overflow set items while working well with scan mode

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10623)