### PR TITLE
Rating: Align read-only behavior with ARIA standards

### DIFF
--- a/change/office-ui-fabric-react-2019-09-25-10-36-25-jg-10126-rating-accessibility.json
+++ b/change/office-ui-fabric-react-2019-09-25-10-36-25-jg-10126-rating-accessibility.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Rating: Align read-only functionality with ARIA standards.",
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com",
+  "commit": "2bb4a845d352319c2b0893a63edae063e756331b",
+  "date": "2019-09-25T17:36:25.070Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Rating/Rating.base.tsx
@@ -11,7 +11,7 @@ import {
 } from '../../Utilities';
 import { IProcessedStyleSet } from '../../Styling';
 import { Icon } from '../../Icon';
-import { FocusZone, FocusZoneDirection } from '../../FocusZone';
+import { FocusZone, FocusZoneDirection, IFocusZoneProps } from '../../FocusZone';
 import { IRatingProps, RatingSize, IRatingStyleProps, IRatingStyles } from './Rating.types';
 
 const getClassNames = classNamesFunction<IRatingStyleProps, IRatingStyles>();
@@ -128,7 +128,20 @@ export class RatingBase extends React.Component<IRatingProps, IRatingState> {
       }
     }
 
-    const ariaLabel = getAriaLabel ? getAriaLabel(rating ? rating : 0, max as number) : '';
+    const ariaLabel = getAriaLabel ? getAriaLabel(rating ? rating : 0, max as number) : undefined;
+
+    // When in read-only mode, we allow focus (per ARIA standards) and set up ARIA attributes to indicate element is read-only.
+    // https://www.w3.org/TR/wai-aria-1.1/#aria-readonly
+    const readOnlyProps: IFocusZoneProps | undefined = readOnly
+      ? ({
+          allowFocusRoot: true,
+          disabled: true,
+          'aria-label': ariaLabel,
+          'aria-readonly': true,
+          'data-is-focusable': true,
+          tabIndex: 0
+        } as IFocusZoneProps)
+      : undefined;
 
     return (
       <div
@@ -142,14 +155,12 @@ export class RatingBase extends React.Component<IRatingProps, IRatingState> {
       >
         <FocusZone
           direction={FocusZoneDirection.horizontal}
-          tabIndex={readOnly ? 0 : -1}
           className={css(this._classNames.ratingFocusZone, {
             [this._classNames.rootIsLarge]: size === RatingSize.Large,
             [this._classNames.rootIsSmall]: size !== RatingSize.Large
           })}
-          data-is-focusable={readOnly ? true : false}
           defaultActiveElement={rating ? starIds[Math.ceil(rating) - 1] && '#' + starIds[Math.ceil(rating) - 1] : undefined}
-          aria-label={readOnly ? ariaLabel : ''}
+          {...readOnlyProps}
         >
           {stars}
         </FocusZone>

--- a/packages/office-ui-fabric-react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Rating/__snapshots__/Rating.test.tsx.snap
@@ -2,7 +2,6 @@
 
 exports[`Rating renders correctly. 1`] = `
 <div
-  aria-label=""
   className=
       ms-Rating-star
       ms-RatingStar-root
@@ -26,7 +25,6 @@ exports[`Rating renders correctly. 1`] = `
   id="Rating0"
 >
   <div
-    aria-label=""
     className=
         ms-FocusZone
         ms-Rating-focuszone
@@ -57,11 +55,9 @@ exports[`Rating renders correctly. 1`] = `
           height: 32px;
         }
     data-focuszone-id="FocusZone2"
-    data-is-focusable={false}
     onFocus={[Function]}
     onKeyDown={[Function]}
     onMouseDownCapture={[Function]}
-    tabIndex={-1}
   >
     <button
       className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.Basic.Example.tsx.shot
@@ -33,7 +33,6 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
     onFocus={[Function]}
   >
     <div
-      aria-label=""
       className=
           ms-FocusZone
           ms-Rating-focuszone
@@ -64,11 +63,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             height: 36px;
           }
       data-focuszone-id="FocusZone2"
-      data-is-focusable={false}
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
-      tabIndex={-1}
     >
       <button
         className=
@@ -877,7 +874,6 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
     onFocus={[Function]}
   >
     <div
-      aria-label=""
       className=
           ms-FocusZone
           ms-Rating-focuszone
@@ -908,11 +904,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             height: 32px;
           }
       data-focuszone-id="FocusZone5"
-      data-is-focusable={false}
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
-      tabIndex={-1}
     >
       <button
         className=
@@ -1721,7 +1715,6 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
     onFocus={[Function]}
   >
     <div
-      aria-label=""
       className=
           ms-FocusZone
           ms-Rating-focuszone
@@ -1752,11 +1745,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             height: 32px;
           }
       data-focuszone-id="FocusZone8"
-      data-is-focusable={false}
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
-      tabIndex={-1}
     >
       <button
         className=
@@ -3313,7 +3304,6 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
   </div>
   Disabled:
   <div
-    aria-label=""
     className=
         ms-Rating-star
         ms-RatingStar-root
@@ -3333,7 +3323,6 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
     onFocus={[Function]}
   >
     <div
-      aria-label=""
       className=
           ms-FocusZone
           ms-Rating-focuszone
@@ -3364,11 +3353,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             height: 32px;
           }
       data-focuszone-id="FocusZone11"
-      data-is-focusable={false}
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
-      tabIndex={-1}
     >
       <button
         className=
@@ -3929,6 +3916,7 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
   >
     <div
       aria-label="Rating value is 2.5 of 5"
+      aria-readonly={true}
       className=
           ms-FocusZone
           ms-Rating-focuszone
@@ -4682,7 +4670,6 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
     onFocus={[Function]}
   >
     <div
-      aria-label=""
       className=
           ms-FocusZone
           ms-Rating-focuszone
@@ -4713,11 +4700,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             height: 32px;
           }
       data-focuszone-id="FocusZone17"
-      data-is-focusable={false}
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
-      tabIndex={-1}
     >
       <button
         className=
@@ -5526,7 +5511,6 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
     onFocus={[Function]}
   >
     <div
-      aria-label=""
       className=
           ms-FocusZone
           ms-Rating-focuszone
@@ -5557,11 +5541,9 @@ exports[`Component Examples renders Rating.Basic.Example.tsx correctly 1`] = `
             height: 32px;
           }
       data-focuszone-id="FocusZone20"
-      data-is-focusable={false}
       onFocus={[Function]}
       onKeyDown={[Function]}
       onMouseDownCapture={[Function]}
-      tabIndex={-1}
     >
       <button
         className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.ButtonControlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.ButtonControlled.Example.tsx.shot
@@ -24,6 +24,7 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
   >
     <div
       aria-label="Rating value is 0 of 5"
+      aria-readonly={true}
       className=
           ms-FocusZone
           ms-Rating-focuszone


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10126
- [x] Include a change request file using `$ yarn change`

#### Description of changes

#10126 highlights concerns with `Rating`'s accessibility, but proposed making read-only `Ratings` unfocusable. However, [ARIA's read-only attribute](https://www.w3.org/TR/wai-aria-1.1/#aria-readonly) says that read-only elements that are otherwise operable or indirectly affected by users should be focusable. This PR aligns `Rating`'s `readOnly` prop with the ARIA standards by making read-only `Ratings` focusable. Thge PR also now allows `aria-label` contents to be dictated when users focus on read-only `Ratings`.

In addition, this PR fixes the tabindex focus behavior by applying focusability to the child `FocusZone` in readonly mode.

This PR has a side effect that `Ratings` that were previously unfocusable (such as the "Button Controlled Rating" example) are now focusable. This is consistent with the ARIA standard that read-only components that are otherwise operable should be focusable.

I've also fixed a couple of instances where ARIA attributes were being set to `''` rather than `undefined`. (ARIA attributes should be `undefined` when they have no valid value.)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10625)