### PR TITLE
DetailsList: Narrator should announce SelectAll Checkbox as a toggle selection for all item

### DIFF
--- a/change/office-ui-fabric-react-2019-09-25-13-40-00-detailslist.json
+++ b/change/office-ui-fabric-react-2019-09-25-13-40-00-detailslist.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "DetailsList: Narrator should announce SelectAll Checkbox should as a toggle selection for all items",
+  "packageName": "office-ui-fabric-react",
+  "email": "email not defined",
+  "commit": "24028884d7f00767de402aa6cb9e2dc9874c8f21",
+  "date": "2019-09-25T20:40:00.190Z"
+}

--- a/change/office-ui-fabric-react-2019-09-25-13-40-00-detailslist.json
+++ b/change/office-ui-fabric-react-2019-09-25-13-40-00-detailslist.json
@@ -1,8 +1,8 @@
 {
   "type": "patch",
-  "comment": "DetailsList: Narrator should announce SelectAll Checkbox should as a toggle selection for all items",
+  "comment": "DetailsList: Narrator should announce SelectAll Checkbox as a toggle selection for all items",
   "packageName": "office-ui-fabric-react",
-  "email": "email not defined",
+  "email": "aneeshak@microsoft.com",
   "commit": "24028884d7f00767de402aa6cb9e2dc9874c8f21",
   "date": "2019-09-25T20:40:00.190Z"
 }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -204,7 +204,7 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
                     children: (
                       <DetailsRowCheck
                         id={`${this._id}-check`}
-                        aria-label={ariaLabelForSelectionColumn}
+                        aria-label={ariaLabelForSelectAllCheckbox}
                         aria-describedby={
                           !isCheckboxHidden
                             ? ariaLabelForSelectAllCheckbox && !this.props.onRenderColumnHeaderTooltip

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.BulkOperations.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.BulkOperations.Example.tsx.shot
@@ -211,7 +211,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                   <div
                     aria-checked={false}
                     aria-describedby="header0-checkTooltip"
-                    aria-label="Toggle selection"
+                    aria-label="Toggle selection for all items"
                     className=
                         ms-DetailsRow-check
                         ms-DetailsHeader-check

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.QuickActions.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.QuickActions.Example.tsx.shot
@@ -157,7 +157,7 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                 <div
                   aria-checked={false}
                   aria-describedby="header0-checkTooltip"
-                  aria-label="Toggle selection"
+                  aria-label="Toggle selection for all items"
                   className=
                       ms-DetailsRow-check
                       ms-DetailsHeader-check

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -944,7 +944,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                 <div
                   aria-checked={false}
                   aria-describedby="header13-checkTooltip"
-                  aria-label="Toggle selection"
+                  aria-label="Toggle selection for all items"
                   className=
                       ms-DetailsRow-check
                       ms-DetailsHeader-check

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Animation.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Animation.Example.tsx.shot
@@ -170,7 +170,7 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                 <div
                   aria-checked={false}
                   aria-describedby="header0-checkTooltip"
-                  aria-label="Toggle selection"
+                  aria-label="Toggle selection for all items"
                   className=
                       ms-DetailsRow-check
                       ms-DetailsHeader-check

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -357,7 +357,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                   <div
                     aria-checked={false}
                     aria-describedby="header3-checkTooltip"
-                    aria-label="Toggle selection"
+                    aria-label="Toggle selection for all items"
                     className=
                         ms-DetailsRow-check
                         ms-DetailsHeader-check

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -358,7 +358,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                   <div
                     aria-checked={false}
                     aria-describedby="header3-checkTooltip"
-                    aria-label="Toggle selection"
+                    aria-label="Toggle selection for all items"
                     className=
                         ms-DetailsRow-check
                         ms-DetailsHeader-check

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
@@ -148,7 +148,7 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
               <div
                 aria-checked={false}
                 aria-describedby="header0-checkTooltip"
-                aria-label="Toggle selection"
+                aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check
                     ms-DetailsHeader-check

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
@@ -148,7 +148,7 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
               <div
                 aria-checked={false}
                 aria-describedby="header0-checkTooltip"
-                aria-label="Toggle selection"
+                aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check
                     ms-DetailsHeader-check

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -148,7 +148,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
               <div
                 aria-checked={false}
                 aria-describedby="header0-checkTooltip"
-                aria-label="Toggle selection"
+                aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check
                     ms-DetailsHeader-check

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -682,7 +682,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                   <div
                     aria-checked={false}
                     aria-describedby="header7-checkTooltip"
-                    aria-label="Toggle selection"
+                    aria-label="Toggle selection for all items"
                     className=
                         ms-DetailsRow-check
                         ms-DetailsHeader-check

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -545,7 +545,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                 <div
                   aria-checked={false}
                   aria-describedby="header5-checkTooltip"
-                  aria-label="Toggle selection"
+                  aria-label="Toggle selection for all items"
                   className=
                       ms-DetailsRow-check
                       ms-DetailsHeader-check

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -148,7 +148,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
               <div
                 aria-checked={false}
                 aria-describedby="header0-checkTooltip"
-                aria-label="Toggle selection"
+                aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check
                     ms-DetailsHeader-check

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -148,7 +148,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
               <div
                 aria-checked={false}
                 aria-describedby="header0-checkTooltip"
-                aria-label="Toggle selection"
+                aria-label="Toggle selection for all items"
                 className=
                     ms-DetailsRow-check
                     ms-DetailsHeader-check


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10519 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Right now, screen reader's interaction with the DetailsList SelectAll checkbox is ambiguous because it simply announces it as "Toggle selection" and when toggled, the states are announced as "checked" and "unchecked" so the user's not aware that all of the items are being checked and unchecked. This is because the `aria-label` on the DetailsRowCheck was set to the ariaLabelForSelectionColumn, not ariaLabelForSelectAllCheckbox. 
Before:
![image](https://user-images.githubusercontent.com/4161791/65638260-963c4280-df9a-11e9-8ade-431bb174e623.png)
After:
![image](https://user-images.githubusercontent.com/4161791/65638311-afdd8a00-df9a-11e9-8131-c0cf4503795e.png)

#### Focus areas to test
Narrator should read out "Toggle selection for all items" when focus is on the select all checkbox.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10626)