### PR TITLE
Textfield: aria-labelledby should be set on mulitine textfields

### DIFF
--- a/change/office-ui-fabric-react-2019-09-25-14-32-36-textfield.json
+++ b/change/office-ui-fabric-react-2019-09-25-14-32-36-textfield.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Textfield: aria-labelledby should be set on multiline textfields too",
+  "packageName": "office-ui-fabric-react",
+  "email": "email not defined",
+  "commit": "44513977f9292c8eb860c6ae35e9420a005cc67b",
+  "date": "2019-09-25T21:32:36.811Z"
+}

--- a/change/office-ui-fabric-react-2019-09-25-14-32-36-textfield.json
+++ b/change/office-ui-fabric-react-2019-09-25-14-32-36-textfield.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Textfield: aria-labelledby should be set on multiline textfields too",
+  "comment": "TextField: Multiline textfields are now correctly associated with their labels with `aria-labelledby`.",
   "packageName": "office-ui-fabric-react",
   "email": "aneeshak@microsoft.com",
   "commit": "44513977f9292c8eb860c6ae35e9420a005cc67b",

--- a/change/office-ui-fabric-react-2019-09-25-14-32-36-textfield.json
+++ b/change/office-ui-fabric-react-2019-09-25-14-32-36-textfield.json
@@ -2,7 +2,7 @@
   "type": "patch",
   "comment": "Textfield: aria-labelledby should be set on multiline textfields too",
   "packageName": "office-ui-fabric-react",
-  "email": "email not defined",
+  "email": "aneeshak@microsoft.com",
   "commit": "44513977f9292c8eb860c6ae35e9420a005cc67b",
   "date": "2019-09-25T21:32:36.811Z"
 }

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -426,7 +426,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
     const textAreaProps = getNativeProps<React.TextareaHTMLAttributes<HTMLTextAreaElement>>(this.props, textAreaProperties, [
       'defaultValue'
     ]);
-
+    const ariaLabelledBy = this.props['aria-labelledby'] || (this.props.label ? this._labelId : undefined);
     return (
       <textarea
         id={this._id}
@@ -436,6 +436,7 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
         onInput={this._onInputChange}
         onChange={this._onInputChange}
         className={this._classNames.field}
+        aria-labelledby={ariaLabelledBy}
         aria-describedby={this._isDescriptionAvailable ? this._descriptionId : this.props['aria-describedby']}
         aria-invalid={!!this._errorMessage}
         aria-label={this.props.ariaLabel}

--- a/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -775,6 +775,7 @@ exports[`TextField snapshots renders multiline resizable correctly 1`] = `
     >
       <textarea
         aria-invalid={false}
+        aria-labelledby="TextFieldLabel2"
         className=
             ms-TextField-field
             {
@@ -950,6 +951,7 @@ exports[`TextField snapshots renders multiline unresizable correctly 1`] = `
     >
       <textarea
         aria-invalid={false}
+        aria-labelledby="TextFieldLabel2"
         className=
             ms-TextField-field
             ms-TextField--unresizable
@@ -1127,6 +1129,7 @@ exports[`TextField snapshots renders multiline with placeholder correctly 1`] = 
     >
       <textarea
         aria-invalid={false}
+        aria-labelledby="TextFieldLabel2"
         className=
             ms-TextField-field
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
@@ -892,6 +892,7 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
         >
           <textarea
             aria-invalid={false}
+            aria-labelledby="TextFieldLabel14"
             className=
                 ms-TextField-field
                 {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
@@ -134,6 +134,7 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
         >
           <textarea
             aria-invalid={false}
+            aria-labelledby="TextFieldLabel2"
             className=
                 ms-TextField-field
                 {
@@ -310,6 +311,7 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
         >
           <textarea
             aria-invalid={false}
+            aria-labelledby="TextFieldLabel5"
             className=
                 ms-TextField-field
                 {
@@ -485,6 +487,7 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
         >
           <textarea
             aria-invalid={false}
+            aria-labelledby="TextFieldLabel8"
             className=
                 ms-TextField-field
                 ms-TextField--unresizable
@@ -681,6 +684,7 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
         >
           <textarea
             aria-invalid={false}
+            aria-labelledby="TextFieldLabel11"
             className=
                 ms-TextField-field
                 {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10551 
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Right now, aria-labelledby isn't set on multiline textfields. I believe this wasn't originally set because the [ARIA spec for `aria-labelledby`](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-labelledby_attribute) says to set it on `input` (single line textfield) but not `<textarea>` (multiline textfield). Makes sense to set it though and found some [other](https://developer.paciellogroup.com/blog/2017/07/short-note-on-aria-label-aria-labelledby-and-aria-describedby/) [documentation](https://thepaciellogroup.github.io/AT-browser-tests/test-files/textarea.html) agreeing with that. 
![image](https://user-images.githubusercontent.com/4161791/65641437-968c0c00-dfa1-11e9-8242-30adc49da936.png)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10627)