### PR TITLE
[Date-Time] Multi-day Day view

### DIFF
--- a/change/@uifabric-date-time-2019-09-26-11-06-20-lorejoh12-dayViewMultiDay.json
+++ b/change/@uifabric-date-time-2019-09-26-11-06-20-lorejoh12-dayViewMultiDay.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "initial commit of multi-day day view implementation. Lots of style updates to allow the hover states to work- previously hover states were always static, but now the classes have to update dynamically as the mouse moves over days",
+  "packageName": "@uifabric/date-time",
+  "email": "jolore@microsoft.com",
+  "commit": "472ab496b3fe9f811b1d4842fec5fdbd2aacbb19",
+  "date": "2019-09-26T18:05:57.908Z"
+}

--- a/change/office-ui-fabric-react-2019-09-26-11-06-20-lorejoh12-dayViewMultiDay.json
+++ b/change/office-ui-fabric-react-2019-09-26-11-06-20-lorejoh12-dayViewMultiDay.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "dateMath change to include extra parameter when calculating date range",
+  "packageName": "office-ui-fabric-react",
+  "email": "jolore@microsoft.com",
+  "commit": "472ab496b3fe9f811b1d4842fec5fdbd2aacbb19",
+  "date": "2019-09-26T18:06:20.515Z"
+}

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Example.scss
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Example.scss
@@ -5,3 +5,7 @@
 .button {
   margin: 17px 10px 0 0;
 }
+
+.dropdown {
+  width: 230px;
+}

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Inline.Example.tsx
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Inline.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { DefaultButton } from 'office-ui-fabric-react';
+import { DefaultButton, Dropdown, IDropdownOption } from 'office-ui-fabric-react';
 import { addDays, getDateRangeArray } from 'office-ui-fabric-react/lib/utilities/dateMath/DateMath';
 import { Calendar, ICalendarProps, DateRangeType, DayOfWeek } from '@uifabric/date-time';
 
@@ -24,10 +24,12 @@ const DayPickerStrings = {
 export interface ICalendarInlineExampleState {
   selectedDate?: Date | null;
   selectedDateRange?: Date[] | null;
+  daysToSelectInDayView?: number;
 }
 
 export interface ICalendarInlineExampleProps extends ICalendarProps {
   showNavigateButtons?: boolean;
+  showDaysToSelectInDayViewDropdown?: boolean;
 }
 
 export class CalendarInlineExample extends React.Component<ICalendarInlineExampleProps, ICalendarInlineExampleState> {
@@ -36,7 +38,8 @@ export class CalendarInlineExample extends React.Component<ICalendarInlineExampl
 
     this.state = {
       selectedDate: null,
-      selectedDateRange: null
+      selectedDateRange: null,
+      daysToSelectInDayView: props.calendarDayProps ? props.calendarDayProps.daysToSelectInDayView : 1
     };
 
     this._onDismiss = this._onDismiss.bind(this);
@@ -105,6 +108,10 @@ export class CalendarInlineExample extends React.Component<ICalendarInlineExampl
           restrictedDates={this.props.restrictedDates}
           showSixWeeksByDefault={this.props.showSixWeeksByDefault}
           workWeekDays={this.props.workWeekDays}
+          calendarDayProps={{
+            ...this.props.calendarDayProps,
+            daysToSelectInDayView: this.state.daysToSelectInDayView
+          }}
         />
         {this.props.showNavigateButtons && (
           <div>
@@ -112,9 +119,36 @@ export class CalendarInlineExample extends React.Component<ICalendarInlineExampl
             <DefaultButton className={styles.button} onClick={this._goNext} text="Next" />
           </div>
         )}
+        {this.props.showDaysToSelectInDayViewDropdown && (
+          <div>
+            <Dropdown
+              className={styles.dropdown}
+              selectedKey={this.state.daysToSelectInDayView && this.state.daysToSelectInDayView}
+              label="Choose days to select"
+              options={[
+                { key: 1, text: '1' },
+                { key: 2, text: '2' },
+                { key: 3, text: '3' },
+                { key: 4, text: '4' },
+                { key: 5, text: '5' },
+                { key: 6, text: '6' }
+              ]}
+              onChange={this._onDaysToSelectInDayViewDropdownChange}
+            />
+          </div>
+        )}
       </div>
     );
   }
+
+  private _onDaysToSelectInDayViewDropdownChange = (ev: React.FormEvent<HTMLElement>, option: IDropdownOption | undefined): void => {
+    this.setState((prevState: ICalendarInlineExampleState) => {
+      return {
+        ...prevState,
+        daysToSelectInDayView: option && (option.key as number)
+      };
+    });
+  };
 
   private _onDismiss(): void {
     this.setState((prevState: ICalendarInlineExampleState) => {

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Inline.Example.tsx
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Inline.Example.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DefaultButton } from 'office-ui-fabric-react';
 import { addDays, getDateRangeArray } from 'office-ui-fabric-react/lib/utilities/dateMath/DateMath';
-import { Calendar, DateRangeType, DayOfWeek } from '@uifabric/date-time';
+import { Calendar, ICalendarProps, DateRangeType, DayOfWeek } from '@uifabric/date-time';
 
 import * as styles from './Calendar.Example.scss';
 
@@ -26,23 +26,8 @@ export interface ICalendarInlineExampleState {
   selectedDateRange?: Date[] | null;
 }
 
-export interface ICalendarInlineExampleProps {
-  isMonthPickerVisible?: boolean;
-  dateRangeType: DateRangeType;
-  autoNavigateOnSelection: boolean;
-  showGoToToday: boolean;
+export interface ICalendarInlineExampleProps extends ICalendarProps {
   showNavigateButtons?: boolean;
-  highlightCurrentMonth?: boolean;
-  highlightSelectedMonth?: boolean;
-  isDayPickerVisible?: boolean;
-  showMonthPickerAsOverlay?: boolean;
-  showWeekNumbers?: boolean;
-  minDate?: Date;
-  maxDate?: Date;
-  restrictedDates?: Date[];
-  showSixWeeksByDefault?: boolean;
-  workWeekDays?: DayOfWeek[];
-  firstDayOfWeek?: DayOfWeek;
 }
 
 export class CalendarInlineExample extends React.Component<ICalendarInlineExampleProps, ICalendarInlineExampleState> {
@@ -101,6 +86,7 @@ export class CalendarInlineExample extends React.Component<ICalendarInlineExampl
           </div>
         )}
         <Calendar
+          {...this.props}
           onSelectDate={this._onSelectDate}
           onDismiss={this._onDismiss}
           isMonthPickerVisible={this.props.isMonthPickerVisible}
@@ -139,7 +125,7 @@ export class CalendarInlineExample extends React.Component<ICalendarInlineExampl
   private _goPrevious(): void {
     this.setState((prevState: ICalendarInlineExampleState) => {
       const selectedDate = prevState.selectedDate || new Date();
-      const dateRangeArray = getDateRangeArray(selectedDate, this.props.dateRangeType, DayOfWeek.Sunday);
+      const dateRangeArray = getDateRangeArray(selectedDate, this.props.dateRangeType!, DayOfWeek.Sunday);
 
       let subtractFrom = dateRangeArray[0];
       let daysToSubtract = dateRangeArray.length;
@@ -160,7 +146,7 @@ export class CalendarInlineExample extends React.Component<ICalendarInlineExampl
   private _goNext(): void {
     this.setState((prevState: ICalendarInlineExampleState) => {
       const selectedDate = prevState.selectedDate || new Date();
-      const dateRangeArray = getDateRangeArray(selectedDate, this.props.dateRangeType, DayOfWeek.Sunday);
+      const dateRangeArray = getDateRangeArray(selectedDate, this.props.dateRangeType!, DayOfWeek.Sunday);
       const newSelectedDate = addDays(dateRangeArray.pop()!, 1);
 
       return {

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -667,7 +667,7 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
    *
    */
 
-  private getDayInfosInRangeOfDay = (day: IDayInfo) => {
+  private getDayInfosInRangeOfDay = (day: IDayInfo): IDayInfo[] => {
     const { weeks } = this.state;
     const { dateRangeType, firstDayOfWeek, workWeekDays, daysToSelectInDayView } = this.props;
 
@@ -687,7 +687,7 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
     return dayInfosInRange;
   };
 
-  private getRefsFromDayInfos = (dayInfosInRange: IDayInfo[]) => {
+  private getRefsFromDayInfos = (dayInfosInRange: IDayInfo[]): (HTMLElement | null)[] => {
     let dayRefs: (HTMLElement | null)[] = [];
     if (this.days) {
       dayRefs = dayInfosInRange.map((dayInfo: IDayInfo) => this.days[dayInfo.key]);
@@ -711,14 +711,16 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
             this.props.daysToSelectInDayView > 1
           ) {
             // remove the static classes first to overwrite them
-            dayRef.classList.remove(this.classNames.bottomLeftCornerDate!);
-            dayRef.classList.remove(this.classNames.bottomRightCornerDate!);
-            dayRef.classList.remove(this.classNames.topLeftCornerDate!);
-            dayRef.classList.remove(this.classNames.topRightCornerDate!);
+            dayRef.classList.remove(
+              this.classNames.bottomLeftCornerDate!,
+              this.classNames.bottomRightCornerDate!,
+              this.classNames.topLeftCornerDate!,
+              this.classNames.topRightCornerDate!
+            );
 
             const classNames = this._calculateRoundedStyles(this.classNames, false, false, index > 0, index < dayRefs.length - 1).trim();
             if (classNames) {
-              classNames.split(' ').forEach((c: string) => dayRef.classList.add(c));
+              dayRef.classList.add(...classNames.split(' '));
             }
           }
         }
@@ -769,7 +771,7 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
           ) {
             const classNames = this._calculateRoundedStyles(this.classNames, false, false, index > 0, index < dayRefs.length - 1).trim();
             if (classNames) {
-              classNames.split(' ').forEach((c: string) => dayRef.classList.remove(c));
+              dayRef.classList.remove(...classNames.split(' '));
             }
           }
         }

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -105,7 +105,6 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
       labelledBy,
       lightenDaysOutsideNavigatedMonth,
       animationDirection
-      // daysToSelectInDayView
     } = this.props;
 
     this.classNames = getClassNames(styles, {
@@ -121,9 +120,6 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
 
     // When the month is highlighted get the corner dates so that styles can be added to them
     const weekCorners: IWeekCorners = this._getWeekCornerStyles(classNames, weeks!);
-    // if (!(dateRangeType === DateRangeType.Day && daysToSelectInDayView && daysToSelectInDayView > 1)) {
-    //   weekCorners = this._getWeekCornerStyles(classNames, weeks!);
-    // }
 
     return (
       <FocusZone className={classNames.wrapper}>

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -60,6 +60,7 @@ export interface ICalendarDayGridState {
 export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, ICalendarDayGridState> {
   private navigatedDay: HTMLElement | null;
   private days: { [key: string]: HTMLElement | null } = {};
+  private classNames: IProcessedStyleSet<ICalendarDayGridStyles>;
 
   public constructor(props: ICalendarDayGridProps) {
     super(props);
@@ -104,9 +105,10 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
       labelledBy,
       lightenDaysOutsideNavigatedMonth,
       animationDirection
+      // daysToSelectInDayView
     } = this.props;
 
-    const classNames = getClassNames(styles, {
+    this.classNames = getClassNames(styles, {
       theme: theme!,
       className: className,
       dateRangeType: dateRangeType,
@@ -115,9 +117,13 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
       animationDirection: animationDirection,
       animateBackwards: animateBackwards
     });
+    const classNames = this.classNames;
 
     // When the month is highlighted get the corner dates so that styles can be added to them
     const weekCorners: IWeekCorners = this._getWeekCornerStyles(classNames, weeks!);
+    // if (!(dateRangeType === DateRangeType.Day && daysToSelectInDayView && daysToSelectInDayView > 1)) {
+    //   weekCorners = this._getWeekCornerStyles(classNames, weeks!);
+    // }
 
     return (
       <FocusZone className={classNames.wrapper}>
@@ -194,7 +200,7 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
     classNames: IProcessedStyleSet<ICalendarDayGridStyles>,
     week: IDayInfo[],
     weekIndex: number,
-    weekCorners: IWeekCorners,
+    weekCorners?: IWeekCorners,
     rowClassName?: string,
     ariaRole?: string,
     ariaHidden?: boolean
@@ -222,7 +228,7 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
     day: IDayInfo,
     dayIndex: number,
     weekIndex: number,
-    weekCorners: IWeekCorners,
+    weekCorners?: IWeekCorners,
     ariaHidden?: boolean
   ): JSX.Element => {
     const { navigatedDate, dateTimeFormatter, allFocusable, strings } = this.props;
@@ -234,7 +240,7 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
         key={day.key}
         className={css(
           classNames.dayCell,
-          this._getHighlightedCornerStyle(weekCorners, dayIndex, weekIndex),
+          weekCorners && this._getHighlightedCornerStyle(weekCorners, dayIndex, weekIndex),
           day.isSelected && classNames.daySelected,
           !day.isInBounds && classNames.dayOutsideBounds,
           !day.isInMonth && classNames.dayOutsideNavigatedMonth
@@ -362,12 +368,20 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
   };
 
   private _onSelectDate = (selectedDate: Date): void => {
-    const { onSelectDate, onNavigateDate, dateRangeType, firstDayOfWeek, minDate, maxDate, workWeekDays } = this.props;
+    const {
+      onSelectDate,
+      onNavigateDate,
+      dateRangeType,
+      firstDayOfWeek,
+      minDate,
+      maxDate,
+      workWeekDays,
+      daysToSelectInDayView
+    } = this.props;
 
-    let dateRange = getDateRangeArray(selectedDate, dateRangeType, firstDayOfWeek, workWeekDays);
-    if (dateRangeType !== DateRangeType.Day) {
-      dateRange = this._getBoundedDateRange(dateRange, minDate, maxDate);
-    }
+    let dateRange = getDateRangeArray(selectedDate, dateRangeType, firstDayOfWeek, workWeekDays, daysToSelectInDayView);
+    dateRange = this._getBoundedDateRange(dateRange, minDate, maxDate);
+
     dateRange = dateRange.filter((d: Date) => {
       return !this._getIsRestrictedDate(d);
     });
@@ -392,7 +406,18 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
    * of every day in the grid. Convenient for helping with conversions between day refs and Date objects during callbacks.
    */
   private _getWeeks(propsToUse: ICalendarDayGridProps): IDayInfo[][] {
-    const { navigatedDate, selectedDate, dateRangeType, firstDayOfWeek, today, minDate, maxDate, weeksToShow, workWeekDays } = propsToUse;
+    const {
+      navigatedDate,
+      selectedDate,
+      dateRangeType,
+      firstDayOfWeek,
+      today,
+      minDate,
+      maxDate,
+      weeksToShow,
+      workWeekDays,
+      daysToSelectInDayView
+    } = propsToUse;
 
     let date;
     if (weeksToShow && weeksToShow <= 4) {
@@ -415,12 +440,25 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
     // a flag to indicate whether all days of the week are outside the month
     let isAllDaysOfWeekOutOfMonth = false;
 
-    // in work week view we want to select the whole week
-    const selectedDateRangeType = dateRangeType === DateRangeType.WorkWeek ? DateRangeType.Week : dateRangeType;
-    let selectedDates = getDateRangeArray(selectedDate, selectedDateRangeType, firstDayOfWeek, workWeekDays);
-    if (dateRangeType !== DateRangeType.Day) {
-      selectedDates = this._getBoundedDateRange(selectedDates, minDate, maxDate);
+    // in work week view if the days aren't contiguous we use week view instead
+    let selectedDateRangeType = dateRangeType;
+    if (workWeekDays && dateRangeType === DateRangeType.WorkWeek) {
+      const sortedWWDays = workWeekDays.sort();
+      let isContiguous = true;
+      for (let i = 1; i < sortedWWDays.length; i++) {
+        if (sortedWWDays[i] !== sortedWWDays[i - 1] + 1) {
+          isContiguous = false;
+          break;
+        }
+      }
+
+      if (!isContiguous) {
+        selectedDateRangeType = DateRangeType.Week;
+      }
     }
+
+    let selectedDates = getDateRangeArray(selectedDate, selectedDateRangeType, firstDayOfWeek, workWeekDays, daysToSelectInDayView);
+    selectedDates = this._getBoundedDateRange(selectedDates, minDate, maxDate);
 
     let shouldGetWeeks = true;
 
@@ -504,7 +542,7 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
    *
    */
 
-  private _getWeekCornerStyles(classNames: IProcessedStyleSet<ICalendarDayGridStyles>, weeks: IDayInfo[][]): IWeekCorners {
+  private _getWeekCornerStyles(classNames: IProcessedStyleSet<ICalendarDayGridStyles>, initialWeeks: IDayInfo[][]): IWeekCorners {
     const weekCornersStyled: { [key: string]: string } = {};
     /* need to handle setting all of the corners on arbitrarily shaped blobs
           __
@@ -520,42 +558,48 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
       F needs top right rounding
     */
 
+    // cut off the animation transition weeks
+    const weeks = initialWeeks.slice(1, initialWeeks.length - 1);
+
     // if there's an item above, lose both top corners. Item below, lose both bottom corners, etc.
     weeks.forEach((week: IDayInfo[], weekIndex: number) => {
       week.forEach((day: IDayInfo, dayIndex: number) => {
         const above =
           weeks[weekIndex - 1] &&
           weeks[weekIndex - 1][dayIndex] &&
-          this.isInSameHoverRange(weeks[weekIndex - 1][dayIndex].originalDate, weeks[weekIndex][dayIndex].originalDate);
+          this.isInSameHoverRange(
+            weeks[weekIndex - 1][dayIndex].originalDate,
+            day.originalDate,
+            weeks[weekIndex - 1][dayIndex].isSelected,
+            day.isSelected
+          );
         const below =
           weeks[weekIndex + 1] &&
           weeks[weekIndex + 1][dayIndex] &&
-          this.isInSameHoverRange(weeks[weekIndex + 1][dayIndex].originalDate, weeks[weekIndex][dayIndex].originalDate);
+          this.isInSameHoverRange(
+            weeks[weekIndex + 1][dayIndex].originalDate,
+            day.originalDate,
+            weeks[weekIndex + 1][dayIndex].isSelected,
+            day.isSelected
+          );
         const left =
           weeks[weekIndex][dayIndex - 1] &&
-          this.isInSameHoverRange(weeks[weekIndex][dayIndex - 1].originalDate, weeks[weekIndex][dayIndex].originalDate);
+          this.isInSameHoverRange(
+            weeks[weekIndex][dayIndex - 1].originalDate,
+            day.originalDate,
+            weeks[weekIndex][dayIndex - 1].isSelected,
+            day.isSelected
+          );
         const right =
           weeks[weekIndex][dayIndex + 1] &&
-          this.isInSameHoverRange(weeks[weekIndex][dayIndex + 1].originalDate, weeks[weekIndex][dayIndex].originalDate);
+          this.isInSameHoverRange(
+            weeks[weekIndex][dayIndex + 1].originalDate,
+            day.originalDate,
+            weeks[weekIndex][dayIndex + 1].isSelected,
+            day.isSelected
+          );
 
-        const roundedTopLeft = !above && !left;
-        const roundedTopRight = !above && !right;
-        const roundedBottomLeft = !below && !left;
-        const roundedBottomRight = !below && !right;
-
-        let style = '';
-        if (roundedTopLeft) {
-          style = getRTL() ? style.concat(classNames.topRightCornerDate + ' ') : style.concat(classNames.topLeftCornerDate + ' ');
-        }
-        if (roundedTopRight) {
-          style = getRTL() ? style.concat(classNames.topLeftCornerDate + ' ') : style.concat(classNames.topRightCornerDate + ' ');
-        }
-        if (roundedBottomLeft) {
-          style = getRTL() ? style.concat(classNames.bottomRightCornerDate + ' ') : style.concat(classNames.bottomLeftCornerDate + ' ');
-        }
-        if (roundedBottomRight) {
-          style = getRTL() ? style.concat(classNames.bottomLeftCornerDate + ' ') : style.concat(classNames.bottomRightCornerDate + ' ');
-        }
+        const style = this._calculateRoundedStyles(classNames, above, below, left, right);
 
         weekCornersStyled[weekIndex + '_' + dayIndex] = style;
       });
@@ -564,14 +608,53 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
     return weekCornersStyled;
   }
 
-  private isInSameHoverRange = (date1: Date, date2: Date): boolean => {
+  private _calculateRoundedStyles(
+    classNames: IProcessedStyleSet<ICalendarDayGridStyles>,
+    above: boolean,
+    below: boolean,
+    left: boolean,
+    right: boolean
+  ): string {
+    let style = '';
+    const roundedTopLeft = !above && !left;
+    const roundedTopRight = !above && !right;
+    const roundedBottomLeft = !below && !left;
+    const roundedBottomRight = !below && !right;
+
+    if (roundedTopLeft) {
+      style = getRTL() ? style.concat(classNames.topRightCornerDate + ' ') : style.concat(classNames.topLeftCornerDate + ' ');
+    }
+    if (roundedTopRight) {
+      style = getRTL() ? style.concat(classNames.topLeftCornerDate + ' ') : style.concat(classNames.topRightCornerDate + ' ');
+    }
+    if (roundedBottomLeft) {
+      style = getRTL() ? style.concat(classNames.bottomRightCornerDate + ' ') : style.concat(classNames.bottomLeftCornerDate + ' ');
+    }
+    if (roundedBottomRight) {
+      style = getRTL() ? style.concat(classNames.bottomLeftCornerDate + ' ') : style.concat(classNames.bottomRightCornerDate + ' ');
+    }
+
+    return style;
+  }
+
+  private isInSameHoverRange = (date1: Date, date2: Date, date1Selected: boolean, date2Selected: boolean): boolean => {
     const { dateRangeType, firstDayOfWeek, workWeekDays } = this.props;
 
     // The hover state looks weird with non-contiguous days in work week view. In work week, show week hover state
     const dateRangeHoverType = dateRangeType === DateRangeType.WorkWeek ? DateRangeType.Week : dateRangeType;
 
+    // we do not pass daysToSelectInDayView because we handle setting those styles dyanamically in onMouseOver
     const dateRange = getDateRangeArray(date1, dateRangeHoverType, firstDayOfWeek, workWeekDays);
 
+    if (date1Selected !== date2Selected) {
+      // if one is selected and the other is not, they can't be in the same range
+      return false;
+    } else if (date1Selected && date2Selected) {
+      // if they're both selected at the same time they must be in the same range
+      return true;
+    }
+
+    // otherwise, both must be unselected, so check the dateRange
     return dateRange.filter((date: Date) => date.getTime() === date2.getTime()).length > 0;
   };
 
@@ -588,16 +671,16 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
    *
    */
 
-  private getRefsInRangeOfDay = (day: IDayInfo) => {
+  private getDayInfosInRangeOfDay = (day: IDayInfo) => {
     const { weeks } = this.state;
-    const { dateRangeType, firstDayOfWeek, workWeekDays } = this.props;
+    const { dateRangeType, firstDayOfWeek, workWeekDays, daysToSelectInDayView } = this.props;
 
     // The hover state looks weird with non-contiguous days in work week view. In work week, show week hover state
     const dateRangeHoverType = dateRangeType === DateRangeType.WorkWeek ? DateRangeType.Week : dateRangeType;
 
     // gets all the dates for the given date range type that are in the same date range as the given day
-    const dateRange = getDateRangeArray(day.originalDate, dateRangeHoverType, firstDayOfWeek, workWeekDays).map((date: Date) =>
-      date.getTime()
+    const dateRange = getDateRangeArray(day.originalDate, dateRangeHoverType, firstDayOfWeek, workWeekDays, daysToSelectInDayView).map(
+      (date: Date) => date.getTime()
     );
 
     // gets all the day refs for the given dates
@@ -605,6 +688,10 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
       return accumulatedValue.concat(currentWeek.filter((weekDay: IDayInfo) => dateRange.indexOf(weekDay.originalDate.getTime()) !== -1));
     }, []);
 
+    return dayInfosInRange;
+  };
+
+  private getRefsFromDayInfos = (dayInfosInRange: IDayInfo[]) => {
     let dayRefs: (HTMLElement | null)[] = [];
     if (this.days) {
       dayRefs = dayInfosInRange.map((dayInfo: IDayInfo) => this.days[dayInfo.key]);
@@ -615,11 +702,29 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
 
   private onMouseOverDay = (day: IDayInfo) => {
     return (ev: React.MouseEvent<HTMLElement>) => {
-      const dayRefs = this.getRefsInRangeOfDay(day);
+      const dayInfos = this.getDayInfosInRangeOfDay(day);
+      const dayRefs = this.getRefsFromDayInfos(dayInfos);
 
-      dayRefs.forEach((dayRef: HTMLElement) => {
+      dayRefs.forEach((dayRef: HTMLElement, index: number) => {
         if (dayRef) {
           dayRef.classList.add('ms-CalendarDay-hoverStyle');
+          if (
+            !dayInfos[index].isSelected &&
+            this.props.dateRangeType === DateRangeType.Day &&
+            this.props.daysToSelectInDayView &&
+            this.props.daysToSelectInDayView > 1
+          ) {
+            // remove the static classes first to overwrite them
+            dayRef.classList.remove(this.classNames.bottomLeftCornerDate!);
+            dayRef.classList.remove(this.classNames.bottomRightCornerDate!);
+            dayRef.classList.remove(this.classNames.topLeftCornerDate!);
+            dayRef.classList.remove(this.classNames.topRightCornerDate!);
+
+            const classNames = this._calculateRoundedStyles(this.classNames, false, false, index > 0, index < dayRefs.length - 1).trim();
+            if (classNames) {
+              classNames.split(' ').forEach((c: string) => dayRef.classList.add(c));
+            }
+          }
         }
       });
     };
@@ -627,7 +732,8 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
 
   private onMouseDownDay = (day: IDayInfo) => {
     return (ev: React.MouseEvent<HTMLElement>) => {
-      const dayRefs = this.getRefsInRangeOfDay(day);
+      const dayInfos = this.getDayInfosInRangeOfDay(day);
+      const dayRefs = this.getRefsFromDayInfos(dayInfos);
 
       dayRefs.forEach((dayRef: HTMLElement) => {
         if (dayRef) {
@@ -639,7 +745,8 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
 
   private onMouseUpDay = (day: IDayInfo) => {
     return (ev: React.MouseEvent<HTMLElement>) => {
-      const dayRefs = this.getRefsInRangeOfDay(day);
+      const dayInfos = this.getDayInfosInRangeOfDay(day);
+      const dayRefs = this.getRefsFromDayInfos(dayInfos);
 
       dayRefs.forEach((dayRef: HTMLElement) => {
         if (dayRef) {
@@ -651,12 +758,24 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
 
   private onMouseOutDay = (day: IDayInfo) => {
     return (ev: React.MouseEvent<HTMLElement>) => {
-      const dayRefs = this.getRefsInRangeOfDay(day);
+      const dayInfos = this.getDayInfosInRangeOfDay(day);
+      const dayRefs = this.getRefsFromDayInfos(dayInfos);
 
-      dayRefs.forEach((dayRef: HTMLElement) => {
+      dayRefs.forEach((dayRef: HTMLElement, index: number) => {
         if (dayRef) {
           dayRef.classList.remove('ms-CalendarDay-hoverStyle');
           dayRef.classList.remove('ms-CalendarDay-pressedStyle');
+          if (
+            !dayInfos[index].isSelected &&
+            this.props.dateRangeType === DateRangeType.Day &&
+            this.props.daysToSelectInDayView &&
+            this.props.daysToSelectInDayView > 1
+          ) {
+            const classNames = this._calculateRoundedStyles(this.classNames, false, false, index > 0, index < dayRefs.length - 1).trim();
+            if (classNames) {
+              classNames.split(' ').forEach((c: string) => dayRef.classList.remove(c));
+            }
+          }
         }
       });
     };

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.styles.ts
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.styles.ts
@@ -118,6 +118,8 @@ export const styles = (props: ICalendarDayGridStyleProps): ICalendarDayGridStyle
       padding: 0,
       borderRight: '1px solid',
       borderColor: palette.neutralLight,
+      backgroundColor: palette.neutralLighterAlt,
+      color: palette.neutralSecondary,
       boxSizing: 'border-box',
       width: 28,
       height: 28,

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.types.ts
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.types.ts
@@ -90,6 +90,13 @@ export interface ICalendarDayGridProps extends IBaseProps<ICalendarDayGrid> {
   dateRangeType: DateRangeType;
 
   /**
+   * The number of days to select while dateRangeType === DateRangeType.Day. Used in order to have multi-day
+   * views.
+   * @defaultValue 1
+   */
+  daysToSelectInDayView?: number;
+
+  /**
    * Value of today. If null, current time in client machine will be used.
    */
   today?: Date;

--- a/packages/date-time/src/components/pages/CalendarPage.tsx
+++ b/packages/date-time/src/components/pages/CalendarPage.tsx
@@ -118,6 +118,7 @@ export class CalendarPage extends React.Component<{}, {}> {
                 highlightSelectedMonth={true}
                 showGoToToday={true}
                 calendarDayProps={{ daysToSelectInDayView: 4 }}
+                showDaysToSelectInDayViewDropdown={true}
               />
             </ExampleCard>
             <ExampleCard title="Calendar launched from a button" code={CalendarButtonExampleCode}>

--- a/packages/date-time/src/components/pages/CalendarPage.tsx
+++ b/packages/date-time/src/components/pages/CalendarPage.tsx
@@ -19,12 +19,7 @@ export class CalendarPage extends React.Component<{}, {}> {
         exampleCards={
           <div>
             <ExampleCard title="Inline Calendar" code={CalendarInlineExampleCode}>
-              <CalendarInlineExample
-                isMonthPickerVisible={false}
-                dateRangeType={DateRangeType.Day}
-                autoNavigateOnSelection={false}
-                showGoToToday={true}
-              />
+              <CalendarInlineExample isMonthPickerVisible={false} dateRangeType={DateRangeType.Day} showGoToToday={true} />
             </ExampleCard>
             <ExampleCard title="Inline Calendar with overlayed month picker when header is clicked" code={CalendarInlineExampleCode}>
               <CalendarInlineExample
@@ -32,14 +27,12 @@ export class CalendarPage extends React.Component<{}, {}> {
                 highlightCurrentMonth={false}
                 highlightSelectedMonth={true}
                 dateRangeType={DateRangeType.Day}
-                autoNavigateOnSelection={false}
                 showGoToToday={false}
               />
             </ExampleCard>
             <ExampleCard title="Inline Calendar with month picker" code={CalendarInlineExampleCode}>
               <CalendarInlineExample
                 dateRangeType={DateRangeType.Day}
-                autoNavigateOnSelection={false}
                 highlightCurrentMonth={false}
                 highlightSelectedMonth={true}
                 showGoToToday={true}
@@ -48,7 +41,6 @@ export class CalendarPage extends React.Component<{}, {}> {
             <ExampleCard title="Inline Calendar with week selection" code={CalendarInlineExampleCode}>
               <CalendarInlineExample
                 dateRangeType={DateRangeType.Week}
-                autoNavigateOnSelection={true}
                 highlightCurrentMonth={false}
                 highlightSelectedMonth={true}
                 showGoToToday={true}
@@ -58,7 +50,6 @@ export class CalendarPage extends React.Component<{}, {}> {
             <ExampleCard title="Inline Calendar with month selection" code={CalendarInlineExampleCode}>
               <CalendarInlineExample
                 dateRangeType={DateRangeType.Month}
-                autoNavigateOnSelection={true}
                 highlightCurrentMonth={false}
                 highlightSelectedMonth={true}
                 showGoToToday={true}
@@ -69,7 +60,6 @@ export class CalendarPage extends React.Component<{}, {}> {
               <CalendarInlineExample
                 isMonthPickerVisible={false}
                 dateRangeType={DateRangeType.Day}
-                autoNavigateOnSelection={false}
                 showGoToToday={true}
                 showWeekNumbers={true}
               />
@@ -78,7 +68,6 @@ export class CalendarPage extends React.Component<{}, {}> {
               <CalendarInlineExample
                 isMonthPickerVisible={false}
                 dateRangeType={DateRangeType.Day}
-                autoNavigateOnSelection={false}
                 showGoToToday={true}
                 showSixWeeksByDefault={true}
               />
@@ -86,7 +75,6 @@ export class CalendarPage extends React.Component<{}, {}> {
             <ExampleCard title="Inline Calendar with month picker and no day picker" code={CalendarInlineExampleCode}>
               <CalendarInlineExample
                 dateRangeType={DateRangeType.Month}
-                autoNavigateOnSelection={false}
                 showGoToToday={true}
                 highlightCurrentMonth={false}
                 highlightSelectedMonth={true}
@@ -99,7 +87,6 @@ export class CalendarPage extends React.Component<{}, {}> {
             >
               <CalendarInlineExample
                 dateRangeType={DateRangeType.Day}
-                autoNavigateOnSelection={true}
                 highlightCurrentMonth={false}
                 highlightSelectedMonth={true}
                 showGoToToday={false}
@@ -115,11 +102,22 @@ export class CalendarPage extends React.Component<{}, {}> {
               <CalendarInlineExample
                 dateRangeType={DateRangeType.WorkWeek}
                 firstDayOfWeek={DayOfWeek.Monday}
-                autoNavigateOnSelection={true}
                 highlightCurrentMonth={false}
                 highlightSelectedMonth={true}
                 showGoToToday={true}
                 workWeekDays={[DayOfWeek.Tuesday, DayOfWeek.Saturday, DayOfWeek.Wednesday, DayOfWeek.Friday]}
+              />
+            </ExampleCard>
+            <ExampleCard
+              title="Calendar with multiday view using dateRangeType === DateRangeType.Day and daysToSelectInDayView = 4"
+              code={CalendarInlineExampleCode}
+            >
+              <CalendarInlineExample
+                dateRangeType={DateRangeType.Day}
+                highlightCurrentMonth={false}
+                highlightSelectedMonth={true}
+                showGoToToday={true}
+                calendarDayProps={{ daysToSelectInDayView: 4 }}
               />
             </ExampleCard>
             <ExampleCard title="Calendar launched from a button" code={CalendarButtonExampleCode}>

--- a/packages/office-ui-fabric-react/src/utilities/dateMath/DateMath.ts
+++ b/packages/office-ui-fabric-react/src/utilities/dateMath/DateMath.ts
@@ -150,9 +150,17 @@ export function compareDatePart(date1: Date, date2: Date): Number {
  * @param {DateRangeType} dateRangeType - The desired date range type, i.e., day, week, month, etc.
  * @param {DayOfWeek} firstDayOfWeek - The first day of the week.
  * @param {DayOfWeek[]} workWeekDays - The allowed days in work week. If not provided, assumes all days are allowed.
+ * @param {number} daysToSelectInDayView - The number of days to include when using dateRangeType === DateRangeType.Day
+ * for multiday view. Defaults to 1
  * @returns {Date[]} An array of dates representing the date range containing the specified date.
  */
-export function getDateRangeArray(date: Date, dateRangeType: DateRangeType, firstDayOfWeek: DayOfWeek, workWeekDays?: DayOfWeek[]): Date[] {
+export function getDateRangeArray(
+  date: Date,
+  dateRangeType: DateRangeType,
+  firstDayOfWeek: DayOfWeek,
+  workWeekDays?: DayOfWeek[],
+  daysToSelectInDayView: number = 1
+): Date[] {
   const datesArray = new Array<Date>();
   let startDate: Date;
   let endDate = null;
@@ -164,7 +172,7 @@ export function getDateRangeArray(date: Date, dateRangeType: DateRangeType, firs
   switch (dateRangeType) {
     case DateRangeType.Day:
       startDate = getDatePart(date);
-      endDate = addDays(startDate, 1);
+      endDate = addDays(startDate, daysToSelectInDayView);
       break;
 
     case DateRangeType.Week:

--- a/packages/office-ui-fabric-react/src/utilities/dateMath/DateMath.ts
+++ b/packages/office-ui-fabric-react/src/utilities/dateMath/DateMath.ts
@@ -169,6 +169,8 @@ export function getDateRangeArray(
     workWeekDays = [DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Friday];
   }
 
+  daysToSelectInDayView = Math.max(daysToSelectInDayView, 1);
+
   switch (dateRangeType) {
     case DateRangeType.Day:
       startDate = getDatePart(date);


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Implementation of multiple days with dateRangeType === DateRangeType.Day. This is for something like a 4 day view- it's not really a week based view, so work week days won't work for it, because starting on a Saturday should wrap the remaining days around to the next week.

We explicitly don't try to fix the case where the dates wrap around to the next month and go off the edge of the grid- we don't want to grow the grid unnecessarily large, and showing potentially 7 weeks is bad, so we just don't show the days that go off the edge.

Previously hover states were always static, but now the classes have to update dynamically as the mouse moves over days

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10630)