### PR TITLE
backfixing IE11 datetime focus fix

### DIFF
--- a/change/@uifabric-date-time-2019-09-23-12-21-56-lorejoh12-focusOutlineIE11.json
+++ b/change/@uifabric-date-time-2019-09-23-12-21-56-lorejoh12-focusOutlineIE11.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fixing focus outline in IE11. The outline in IE11 does not show if it overflows the div it's in unless we explicitly set overflow: visible on the div (other browsers have this as the default).",
+  "packageName": "@uifabric/date-time",
+  "email": "jolore@microsoft.com",
+  "commit": "12f8a6108f9a9451745988002902256b6c917536",
+  "date": "2019-09-23T19:21:54.822Z"
+}

--- a/change/office-ui-fabric-react-2019-09-23-12-21-56-lorejoh12-focusOutlineIE11.json
+++ b/change/office-ui-fabric-react-2019-09-23-12-21-56-lorejoh12-focusOutlineIE11.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fixing focus outline in IE11. The outline in IE11 does not show if it overflows the div it's in unless we explicitly set overflow: visible on the div (other browsers have this as the default).",
+  "packageName": "office-ui-fabric-react",
+  "email": "jolore@microsoft.com",
+  "commit": "12f8a6108f9a9451745988002902256b6c917536",
+  "date": "2019-09-23T19:21:56.903Z"
+}

--- a/packages/date-time/src/components/Calendar/Calendar.styles.ts
+++ b/packages/date-time/src/components/Calendar/Calendar.styles.ts
@@ -48,6 +48,7 @@ export const styles = (props: ICalendarStyleProps): ICalendarStyles => {
         marginRight: 16,
         marginTop: 3,
         fontSize: FontSizes.small,
+        overflow: 'visible', // explicitly specify for IE11
         selectors: {
           '& div': {
             fontSize: FontSizes.small

--- a/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.styles.ts
+++ b/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.styles.ts
@@ -43,7 +43,7 @@ export const styles = (props: ICalendarDayStyleProps): ICalendarDayStyles => {
       width: '100%'
     },
     monthAndYear: [
-      getFocusStyle(theme, { inset: -1 }),
+      getFocusStyle(theme, { inset: 1 }),
       {
         alignItems: 'center',
         fontSize: FontSizes.medium,
@@ -104,6 +104,7 @@ export const styles = (props: ICalendarDayStyleProps): ICalendarDayStyles => {
         backgroundColor: 'transparent',
         border: 'none',
         padding: 0,
+        overflow: 'visible', // explicitly specify for IE11
         selectors: {
           '&:hover': {
             color: palette.neutralDark,

--- a/packages/date-time/src/components/Calendar/CalendarPicker/CalendarPicker.styles.ts
+++ b/packages/date-time/src/components/Calendar/CalendarPicker/CalendarPicker.styles.ts
@@ -27,7 +27,8 @@ export const getStyles = (props: ICalendarPickerStyleProps): ICalendarPickerStyl
         backgroundColor: 'transparent',
         flexGrow: 1,
         padding: '0 4px 0 10px',
-        border: 'none'
+        border: 'none',
+        overflow: 'visible' // explicitly specify for IE11
       },
       hasHeaderClickCallback && {
         selectors: {
@@ -61,6 +62,7 @@ export const getStyles = (props: ICalendarPickerStyleProps): ICalendarPickerStyl
         backgroundColor: 'transparent',
         border: 'none',
         padding: 0,
+        overflow: 'visible', // explicitly specify for IE11
         selectors: {
           '&:hover': {
             color: palette.neutralDark,
@@ -97,6 +99,7 @@ export const getStyles = (props: ICalendarPickerStyleProps): ICalendarPickerStyl
         backgroundColor: 'transparent',
         border: 'none',
         borderRadius: 2,
+        overflow: 'visible', // explicitly specify for IE11
         selectors: {
           '&:nth-child(4n + 4)': {
             marginRight: 0

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
@@ -10,6 +10,7 @@ $Calendar-dayPicker-margin: 10px;
   @include ms-normalize;
 
   * {
+    overflow: visible;
     @include focus-border($color: $ms-color-neutralSecondary);
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Cherry picking the accessibility focus changes for IE11 for the DatePicker and Calendar controls back into the 6.0 branch

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10638)