### PR TITLE
Dropdown: There is now a visible focus border on Dropdowns in the error state.

### DIFF
--- a/change/office-ui-fabric-react-2019-09-26-16-00-09-cliffkoh-fix10636.json
+++ b/change/office-ui-fabric-react-2019-09-26-16-00-09-cliffkoh-fix10636.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Dropdown: There is now a visible focus border on Dropdowns in the error state.",
+  "packageName": "office-ui-fabric-react",
+  "email": "cliff.koh@microsoft.com",
+  "commit": "3c18ed963ca5d8112a5dfddc56896a47f5dfa125",
+  "date": "2019-09-26T23:00:09.845Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -222,8 +222,7 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
           ['&:active .' + globalClassnames.titleIsPlaceHolder]: !disabled && rootHoverFocusActiveSelectorNeutralPrimaryMixin,
 
           ['&:hover .' + globalClassnames.titleHasError]: borderColorError,
-          ['&:active .' + globalClassnames.titleHasError]: borderColorError,
-          ['&:focus .' + globalClassnames.titleHasError]: borderColorError
+          ['&:active .' + globalClassnames.titleHasError]: borderColorError
         }
       },
       isOpen && 'is-open',

--- a/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -92,9 +92,6 @@ exports[`Dropdown multi-select Renders multiselect Dropdown correctly 1`] = `
         &:active .ms-Dropdown-title--hasError {
           border-color: #a4262c;
         }
-        &:focus .ms-Dropdown-title--hasError {
-          border-color: #a4262c;
-        }
     data-is-focusable={true}
     id="Dropdown0"
     onBlur={[Function]}
@@ -266,9 +263,6 @@ exports[`Dropdown single-select Renders single-select Dropdown correctly 1`] = `
           border-color: #a4262c;
         }
         &:active .ms-Dropdown-title--hasError {
-          border-color: #a4262c;
-        }
-        &:focus .ms-Dropdown-title--hasError {
           border-color: #a4262c;
         }
     data-is-focusable={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
@@ -129,9 +129,6 @@ exports[`Component Examples renders Callout.Cover.Example.tsx correctly 1`] = `
             &:active .ms-Dropdown-title--hasError {
               border-color: #a4262c;
             }
-            &:focus .ms-Dropdown-title--hasError {
-              border-color: #a4262c;
-            }
         data-is-focusable={true}
         id="Dropdown0"
         onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
@@ -814,9 +814,6 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
             &:active .ms-Dropdown-title--hasError {
               border-color: #a4262c;
             }
-            &:focus .ms-Dropdown-title--hasError {
-              border-color: #a4262c;
-            }
         data-is-focusable={true}
         id="Dropdown3"
         onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -272,9 +272,6 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                     &:active .ms-Dropdown-title--hasError {
                       border-color: #a4262c;
                     }
-                    &:focus .ms-Dropdown-title--hasError {
-                      border-color: #a4262c;
-                    }
                 data-is-focusable={false}
                 id="Dropdown2"
                 onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
@@ -131,9 +131,6 @@ exports[`Component Examples renders Coachmark.Basic.Example.tsx correctly 1`] = 
             &:active .ms-Dropdown-title--hasError {
               border-color: #a4262c;
             }
-            &:focus .ms-Dropdown-title--hasError {
-              border-color: #a4262c;
-            }
         data-is-focusable={true}
         id="Dropdown0"
         onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
@@ -275,9 +275,6 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
             &:active .ms-Dropdown-title--hasError {
               border-color: #a4262c;
             }
-            &:focus .ms-Dropdown-title--hasError {
-              border-color: #a4262c;
-            }
         data-is-focusable={true}
         id="Dropdown1"
         onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
@@ -331,9 +331,6 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
           &:active .ms-Dropdown-title--hasError {
             border-color: #a4262c;
           }
-          &:focus .ms-Dropdown-title--hasError {
-            border-color: #a4262c;
-          }
       data-is-focusable={true}
       id="Dropdown5"
       onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
@@ -331,9 +331,6 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
           &:active .ms-Dropdown-title--hasError {
             border-color: #a4262c;
           }
-          &:focus .ms-Dropdown-title--hasError {
-            border-color: #a4262c;
-          }
       data-is-focusable={true}
       id="Dropdown5"
       onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
@@ -145,9 +145,6 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
           &:active .ms-Dropdown-title--hasError {
             border-color: #a4262c;
           }
-          &:focus .ms-Dropdown-title--hasError {
-            border-color: #a4262c;
-          }
       data-is-focusable={true}
       id="Dropdown0"
       onBlur={[Function]}
@@ -340,9 +337,6 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             border-color: #a4262c;
           }
           &:active .ms-Dropdown-title--hasError {
-            border-color: #a4262c;
-          }
-          &:focus .ms-Dropdown-title--hasError {
             border-color: #a4262c;
           }
       data-is-focusable={false}
@@ -556,9 +550,6 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             border-color: #a4262c;
           }
           &:active .ms-Dropdown-title--hasError {
-            border-color: #a4262c;
-          }
-          &:focus .ms-Dropdown-title--hasError {
             border-color: #a4262c;
           }
       data-is-focusable={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Controlled.Example.tsx.shot
@@ -124,9 +124,6 @@ exports[`Component Examples renders Dropdown.Controlled.Example.tsx correctly 1`
         &:active .ms-Dropdown-title--hasError {
           border-color: #a4262c;
         }
-        &:focus .ms-Dropdown-title--hasError {
-          border-color: #a4262c;
-        }
     data-is-focusable={true}
     id="Dropdown0"
     onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.ControlledMulti.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.ControlledMulti.Example.tsx.shot
@@ -124,9 +124,6 @@ exports[`Component Examples renders Dropdown.ControlledMulti.Example.tsx correct
         &:active .ms-Dropdown-title--hasError {
           border-color: #a4262c;
         }
-        &:focus .ms-Dropdown-title--hasError {
-          border-color: #a4262c;
-        }
     data-is-focusable={true}
     id="Dropdown0"
     onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
@@ -145,9 +145,6 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
           &:active .ms-Dropdown-title--hasError {
             border-color: #a4262c;
           }
-          &:focus .ms-Dropdown-title--hasError {
-            border-color: #a4262c;
-          }
       data-is-focusable={true}
       id="Dropdown0"
       onBlur={[Function]}
@@ -509,9 +506,6 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
             border-color: #a4262c;
           }
           &:active .ms-Dropdown-title--hasError {
-            border-color: #a4262c;
-          }
-          &:focus .ms-Dropdown-title--hasError {
             border-color: #a4262c;
           }
       data-is-focusable={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
@@ -317,9 +317,6 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
           &:active .ms-Dropdown-title--hasError {
             border-color: #a4262c;
           }
-          &:focus .ms-Dropdown-title--hasError {
-            border-color: #a4262c;
-          }
       data-is-focusable={true}
       id="Dropdown1"
       onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
@@ -175,9 +175,6 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
             &:active .ms-Dropdown-title--hasError {
               border-color: #a4262c;
             }
-            &:focus .ms-Dropdown-title--hasError {
-              border-color: #a4262c;
-            }
         data-is-focusable={true}
         id="Dropdown0"
         onBlur={[Function]}
@@ -486,9 +483,6 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
             border-color: #a4262c;
           }
           &:active .ms-Dropdown-title--hasError {
-            border-color: #a4262c;
-          }
-          &:focus .ms-Dropdown-title--hasError {
             border-color: #a4262c;
           }
           &:after {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -852,9 +852,6 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
             &:active .ms-Dropdown-title--hasError {
               border-color: #a4262c;
             }
-            &:focus .ms-Dropdown-title--hasError {
-              border-color: #a4262c;
-            }
         data-is-focusable={true}
         id="Dropdown5"
         onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
@@ -1050,9 +1050,6 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
             &:active .ms-Dropdown-title--hasError {
               border-color: #a4262c;
             }
-            &:focus .ms-Dropdown-title--hasError {
-              border-color: #a4262c;
-            }
         data-is-focusable={true}
         id="Dropdown5"
         onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
@@ -222,9 +222,6 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
             &:active .ms-Dropdown-title--hasError {
               border-color: #a4262c;
             }
-            &:focus .ms-Dropdown-title--hasError {
-              border-color: #a4262c;
-            }
         data-is-focusable={true}
         id="Dropdown2"
         onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -4058,9 +4058,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
               &:active .ms-Dropdown-title--hasError {
                 border-color: #a4262c;
               }
-              &:focus .ms-Dropdown-title--hasError {
-                border-color: #a4262c;
-              }
           data-is-focusable={true}
           id="Dropdown64"
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
@@ -3114,9 +3114,6 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
               &:active .ms-Dropdown-title--hasError {
                 border-color: #a4262c;
               }
-              &:focus .ms-Dropdown-title--hasError {
-                border-color: #a4262c;
-              }
           data-is-focusable={true}
           id="Dropdown12"
           onBlur={[Function]}
@@ -3340,9 +3337,6 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 border-color: #a4262c;
               }
               &:active .ms-Dropdown-title--hasError {
-                border-color: #a4262c;
-              }
-              &:focus .ms-Dropdown-title--hasError {
                 border-color: #a4262c;
               }
           data-is-focusable={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapAdvanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapAdvanced.Example.tsx.shot
@@ -754,9 +754,6 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
               &:active .ms-Dropdown-title--hasError {
                 border-color: #a4262c;
               }
-              &:focus .ms-Dropdown-title--hasError {
-                border-color: #a4262c;
-              }
           data-is-focusable={true}
           id="Dropdown2"
           onBlur={[Function]}
@@ -983,9 +980,6 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
               &:active .ms-Dropdown-title--hasError {
                 border-color: #a4262c;
               }
-              &:focus .ms-Dropdown-title--hasError {
-                border-color: #a4262c;
-              }
           data-is-focusable={true}
           id="Dropdown3"
           onBlur={[Function]}
@@ -1210,9 +1204,6 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
                 border-color: #a4262c;
               }
               &:active .ms-Dropdown-title--hasError {
-                border-color: #a4262c;
-              }
-              &:focus .ms-Dropdown-title--hasError {
                 border-color: #a4262c;
               }
           data-is-focusable={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
@@ -1825,9 +1825,6 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     &:active .ms-Dropdown-title--hasError {
                       border-color: #a4262c;
                     }
-                    &:focus .ms-Dropdown-title--hasError {
-                      border-color: #a4262c;
-                    }
                 data-is-focusable={true}
                 id="Dropdown8"
                 onBlur={[Function]}
@@ -2052,9 +2049,6 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       border-color: #a4262c;
                     }
                     &:active .ms-Dropdown-title--hasError {
-                      border-color: #a4262c;
-                    }
-                    &:focus .ms-Dropdown-title--hasError {
                       border-color: #a4262c;
                     }
                 data-is-focusable={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapAdvanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapAdvanced.Example.tsx.shot
@@ -754,9 +754,6 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
               &:active .ms-Dropdown-title--hasError {
                 border-color: #a4262c;
               }
-              &:focus .ms-Dropdown-title--hasError {
-                border-color: #a4262c;
-              }
           data-is-focusable={true}
           id="Dropdown2"
           onBlur={[Function]}
@@ -983,9 +980,6 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
               &:active .ms-Dropdown-title--hasError {
                 border-color: #a4262c;
               }
-              &:focus .ms-Dropdown-title--hasError {
-                border-color: #a4262c;
-              }
           data-is-focusable={true}
           id="Dropdown3"
           onBlur={[Function]}
@@ -1210,9 +1204,6 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
                 border-color: #a4262c;
               }
               &:active .ms-Dropdown-title--hasError {
-                border-color: #a4262c;
-              }
-              &:focus .ms-Dropdown-title--hasError {
                 border-color: #a4262c;
               }
           data-is-focusable={true}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10636 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

@betrue-final-final is out but discussed with @phkuo and agreed with his POV that even in an error state, the Dropdown should go to normal focus since the point of an error is to draw initial attention to it. Once a Dropdown is in the error state, for it to lose the red sharing while it has focus is fine since the user would have already known there is an error (and there is also an error text beneath).

(Thank you @phkuo :))

![dropdown focus](https://user-images.githubusercontent.com/1003246/65730655-63b44780-e077-11e9-82a8-d23768b97922.gif)





###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10640)

