### PR TITLE
DetailsList: ariaLabel for select all checkbox should be dependent on selection mode.

### DIFF
--- a/change/office-ui-fabric-react-2019-09-26-20-04-40-detailslist_aria.json
+++ b/change/office-ui-fabric-react-2019-09-26-20-04-40-detailslist_aria.json
@@ -1,8 +1,8 @@
 {
   "type": "patch",
-  "comment": "Fixing DetailsList ariaLabel - adding selectionMode conditional for the select all toggle",
+  "comment": "DetailsList: ariaLabel for select all checkbox should be dependent on selection mode",
   "packageName": "office-ui-fabric-react",
-  "email": "email not defined",
+  "email": "aneeshak@microsoft.com",
   "commit": "37df5d69b6b259ee236eee68be1c926d733478b7",
   "date": "2019-09-27T03:04:40.271Z"
 }

--- a/change/office-ui-fabric-react-2019-09-26-20-04-40-detailslist_aria.json
+++ b/change/office-ui-fabric-react-2019-09-26-20-04-40-detailslist_aria.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fixing DetailsList ariaLabel - adding selectionMode conditional for the select all toggle",
+  "packageName": "office-ui-fabric-react",
+  "email": "email not defined",
+  "commit": "37df5d69b6b259ee236eee68be1c926d733478b7",
+  "date": "2019-09-27T03:04:40.271Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -142,6 +142,7 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
       onColumnContextMenu,
       onRenderColumnHeaderTooltip = this._onRenderColumnHeaderTooltip,
       styles,
+      selectionMode,
       theme,
       onRenderDetailsCheckbox,
       groupNestingDepth,
@@ -204,7 +205,7 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
                     children: (
                       <DetailsRowCheck
                         id={`${this._id}-check`}
-                        aria-label={ariaLabelForSelectAllCheckbox}
+                        aria-label={selectionMode === SelectionMode.multiple ? ariaLabelForSelectAllCheckbox : ariaLabelForSelectionColumn}
                         aria-describedby={
                           !isCheckboxHidden
                             ? ariaLabelForSelectAllCheckbox && !this.props.onRenderColumnHeaderTooltip


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10519 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

I accidentally put the AutoMerge label on this other PR #10626 before I could push an updated commit addressing a comment. This PR is to fix that.

ariaLabel still verified:
![image](https://user-images.githubusercontent.com/4161791/65739250-6de73d80-e099-11e9-95f2-da9c23e6fd05.png)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10643)