### PR TITLE
SwatchColorPicker: Added missing selected-hovered border

### DIFF
--- a/change/office-ui-fabric-react-2019-09-27-12-27-49-v-mare-SwatchColorPicker-update-styles.json
+++ b/change/office-ui-fabric-react-2019-09-27-12-27-49-v-mare-SwatchColorPicker-update-styles.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "SwatchColorPicker: Added missing border for selected-hovered state.",
+  "packageName": "office-ui-fabric-react",
+  "email": "v-mare@microsoft.com",
+  "commit": "cfb9035c7b1f43ce0c8c2a7608bb6e7db1f46a0b",
+  "date": "2019-09-27T19:27:49.043Z"
+}

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.styles.ts
@@ -61,7 +61,19 @@ export const getStyles = (props: IColorPickerGridCellStyleProps): IColorPickerGr
       },
       selected && {
         padding: DIVIDING_PADDING,
-        border: `${calculatedBorderWidth}px solid ${theme.palette.neutralTertiaryAlt}`
+        border: `${calculatedBorderWidth}px solid ${theme.palette.neutralTertiaryAlt}`,
+        selectors: {
+          ['&:hover::before']: {
+            content: '""',
+            height: height,
+            width: width,
+            position: 'absolute',
+            top: -calculatedBorderWidth,
+            left: -calculatedBorderWidth,
+            borderRadius: circle ? '50%' : 'default',
+            boxShadow: `inset 0 0 0 1px ${theme.palette.neutralSecondary}`
+          }
+        }
       },
       !selected && {
         selectors: {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #7069
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Border originally added to Fab 7 in #10130 
Added a border to selected-hover state of the color grid cells. Design approved in previously mentioned Fab 7 PR.

#### New Border

![Screen Shot 2019-09-27 at 11 13 47 AM](https://user-images.githubusercontent.com/13246181/65792171-08866180-e118-11e9-91c3-02f3111ee43d.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10653)