### PR TITLE
SplitButton: High contrast border fix

### DIFF
--- a/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
+++ b/apps/a11y-tests/src/tests/__snapshots__/ComponentExamples.test.tsx.snap
@@ -179,11 +179,11 @@ Array [
         "annotations": Array [
           Object {
             "snippet": Object {
-              "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" aria-disabled=\\"true\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-35\\" tabindex=\\"0\\">",
+              "text": "<div data-automation-id=\\"test\\" aria-roledescription=\\"split button\\" aria-disabled=\\"true\\" data-is-focusable=\\"true\\" role=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" class=\\"css-36\\" tabindex=\\"0\\">",
             },
           },
         ],
-        "fullyQualifiedLogicalName": ".css-35",
+        "fullyQualifiedLogicalName": ".css-36",
         "physicalLocation": Object {
           "fileLocation": Object {
             "uri": "about:blank",
@@ -197,7 +197,7 @@ Array [
       "text": "Fix all of the following: ARIA attribute is not widely supported in screen readers and assistive technologies:  aria-roledescription.",
     },
     "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".css-35",
+      "fullyQualifiedLogicalName": ".css-36",
       "ruleId": "aria-allowed-attr",
     },
     "properties": Object {
@@ -298,11 +298,11 @@ Array [
         "annotations": Array [
           Object {
             "snippet": Object {
-              "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\" class=\\"ms-Button is-disabled root-37\\" aria-disabled=\\"true\\">",
+              "text": "<button type=\\"button\\" aria-haspopup=\\"true\\" aria-expanded=\\"false\\" data-is-focusable=\\"false\\" tabindex=\\"-1\\" class=\\"ms-Button is-disabled root-38\\" aria-disabled=\\"true\\">",
             },
           },
         ],
-        "fullyQualifiedLogicalName": ".is-disabled.root-37",
+        "fullyQualifiedLogicalName": ".root-38",
         "physicalLocation": Object {
           "fileLocation": Object {
             "uri": "about:blank",
@@ -323,7 +323,7 @@ Array [
       "text": "Fix any of the following: Element has a value attribute and the value attribute is empty. Element has no value attribute or the value attribute is empty. Element does not have inner text that is visible to screen readers. aria-label attribute does not exist or is empty. aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty. Element's default semantics were not overridden with role=\\"presentation\\". Element's default semantics were not overridden with role=\\"none\\". Element has no title attribute or the title attribute is empty.",
     },
     "partialFingerprints": Object {
-      "fullyQualifiedLogicalName": ".is-disabled.root-37",
+      "fullyQualifiedLogicalName": ".root-38",
       "ruleId": "button-name",
     },
     "properties": Object {

--- a/change/office-ui-fabric-react-2019-09-27-14-26-14-v-mare-SplitButton-HC-border-fix.json
+++ b/change/office-ui-fabric-react-2019-09-27-14-26-14-v-mare-SplitButton-HC-border-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "SplitButton: Fixed high contrast borders",
+  "packageName": "office-ui-fabric-react",
+  "email": "v-mare@microsoft.com",
+  "commit": "3e9f68c3815f3aba578f4ca4af3b1a707ff2d14a",
+  "date": "2019-09-27T21:26:14.904Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/ButtonThemes.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/ButtonThemes.ts
@@ -1,5 +1,6 @@
 import { IButtonStyles } from './Button.types';
 import { ITheme, HighContrastSelector } from '../../Styling';
+import { IsFocusVisibleClassName } from '../../Utilities';
 
 export function standardStyles(theme: ITheme): IButtonStyles {
   const s = theme.semanticColors;
@@ -70,6 +71,10 @@ export function standardStyles(theme: ITheme): IButtonStyles {
               color: 'Highlight'
             }
           }
+        },
+        [HighContrastSelector]: {
+          border: `1px solid white`,
+          borderLeft: 'none'
         }
       }
     },
@@ -84,7 +89,17 @@ export function standardStyles(theme: ITheme): IButtonStyles {
     },
 
     splitButtonDivider: {
-      backgroundColor: theme.palette.neutralTertiaryAlt
+      backgroundColor: theme.palette.neutralTertiaryAlt,
+      position: 'absolute',
+      width: 1,
+      right: 31,
+      top: 8,
+      bottom: 8,
+      selectors: {
+        [HighContrastSelector]: {
+          backgroundColor: 'WindowText'
+        }
+      }
     },
 
     splitButtonDividerDisabled: {
@@ -181,7 +196,17 @@ export function primaryStyles(theme: ITheme): IButtonStyles {
     },
 
     splitButtonDivider: {
-      backgroundColor: theme.palette.white
+      backgroundColor: theme.palette.white,
+      position: 'absolute',
+      width: 1,
+      right: 31,
+      top: 8,
+      bottom: 8,
+      selectors: {
+        [HighContrastSelector]: {
+          backgroundColor: 'Window'
+        }
+      }
     },
 
     splitButtonDividerDisabled: {
@@ -192,6 +217,9 @@ export function primaryStyles(theme: ITheme): IButtonStyles {
       backgroundColor: theme.palette.themePrimary,
       color: theme.palette.white,
       selectors: {
+        [HighContrastSelector]: {
+          backgroundColor: 'WindowText'
+        },
         ':hover': {
           backgroundColor: theme.palette.themeDark,
           selectors: {

--- a/packages/office-ui-fabric-react/src/components/Button/ButtonThemes.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/ButtonThemes.ts
@@ -1,6 +1,5 @@
 import { IButtonStyles } from './Button.types';
 import { ITheme, HighContrastSelector } from '../../Styling';
-import { IsFocusVisibleClassName } from '../../Utilities';
 
 export function standardStyles(theme: ITheme): IButtonStyles {
   const s = theme.semanticColors;

--- a/packages/office-ui-fabric-react/src/components/Button/ButtonThemes.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/ButtonThemes.ts
@@ -70,10 +70,6 @@ export function standardStyles(theme: ITheme): IButtonStyles {
               color: 'Highlight'
             }
           }
-        },
-        [HighContrastSelector]: {
-          border: `1px solid white`,
-          borderLeft: 'none'
         }
       }
     },

--- a/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -1,5 +1,5 @@
 import { IButtonStyles } from '../Button.types';
-import { ITheme, concatStyleSets, getFocusStyle, IStyle } from '../../../Styling';
+import { HighContrastSelector, ITheme, concatStyleSets, getFocusStyle, IStyle } from '../../../Styling';
 import { memoizeFunction } from '../../../Utilities';
 
 export const getStyles = memoizeFunction(
@@ -20,11 +20,29 @@ export const getStyles = memoizeFunction(
       bottom: 8
     };
 
+    const splitButtonDividerDisabled: IStyle = {
+      position: 'absolute',
+      width: 1,
+      right: 31,
+      top: 8,
+      bottom: 8,
+      selectors: {
+        [HighContrastSelector]: {
+          backgroundColor: 'GrayText'
+        }
+      }
+    };
+
     const splitButtonStyles: IButtonStyles = {
       splitButtonContainer: [
         getFocusStyle(theme, { highContrastStyle: buttonHighContrastFocus }),
         {
-          display: 'inline-flex'
+          display: 'inline-flex',
+          selectors: {
+            '.ms-Button--default, .ms-Button--primary': {
+              borderRight: 'none'
+            }
+          }
         }
       ],
       splitButtonContainerFocused: {
@@ -51,12 +69,17 @@ export const getStyles = memoizeFunction(
       },
 
       splitButtonDivider: splitButtonDivider,
-      splitButtonDividerDisabled: splitButtonDivider,
+      splitButtonDividerDisabled: splitButtonDividerDisabled,
       splitButtonMenuButtonDisabled: {
         pointerEvents: 'none',
         selectors: {
           ':hover': {
             cursor: 'default'
+          },
+          [HighContrastSelector]: {
+            border: `1px solid GrayText`,
+            color: 'GrayText',
+            backgroundColor: 'Window'
           }
         }
       },

--- a/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -65,7 +65,13 @@ export const getStyles = memoizeFunction(
         marginLeft: -1,
         marginTop: 0,
         marginRight: 0,
-        marginBottom: 0
+        marginBottom: 0,
+        selectors: {
+          [HighContrastSelector]: {
+            border: `1px solid white`,
+            borderLeft: 'none'
+          }
+        }
       },
 
       splitButtonDivider: splitButtonDivider,

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CommandBar.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CommandBar.Example.tsx.shot
@@ -226,6 +226,9 @@ exports[`Component Examples renders Button.CommandBar.Example.tsx correctly 1`] 
             right: -2px;
             top: -2px;
           }
+          & .ms-Button--default, & .ms-Button--primary {
+            border-right: none;
+          }
           &:focus {
             outline: none!important;
           }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CommandBar.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CommandBar.Example.tsx.shot
@@ -433,6 +433,10 @@ exports[`Component Examples renders Button.CommandBar.Example.tsx correctly 1`] 
               @media screen and (-ms-high-contrast: active){&:hover {
                 color: Highlight;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-left: none;
+                border: 1px solid white;
+              }
           data-is-focusable={false}
           onClick={[Function]}
           onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Split.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Split.Example.tsx.shot
@@ -77,6 +77,9 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
             right: -2px;
             top: -2px;
           }
+          & .ms-Button--default, & .ms-Button--primary {
+            border-right: none;
+          }
           &:focus {
             outline: none!important;
           }
@@ -257,6 +260,10 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active){&:hover {
                 color: Highlight;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-left: none;
+                border: 1px solid white;
+              }
           data-is-focusable={false}
           onClick={[Function]}
           onKeyDown={[Function]}
@@ -321,6 +328,9 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                 right: 31px;
                 top: 8px;
                 width: 1px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: WindowText;
               }
         />
       </span>
@@ -388,6 +398,9 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
             left: -2px;
             right: -2px;
             top: -2px;
+          }
+          & .ms-Button--default, & .ms-Button--primary {
+            border-right: none;
           }
           &:focus {
             outline: none!important;
@@ -572,6 +585,9 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                 vertical-align: top;
                 width: 32px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: WindowText;
+              }
               &:hover {
                 background-color: #005a9e;
               }
@@ -643,6 +659,9 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                 top: 8px;
                 width: 1px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Window;
+              }
         />
       </span>
     </div>
@@ -709,6 +728,9 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
             left: -2px;
             right: -2px;
             top: -2px;
+          }
+          & .ms-Button--default, & .ms-Button--primary {
+            border-right: none;
           }
           &:focus {
             outline: none!important;
@@ -887,6 +909,9 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                 vertical-align: top;
                 width: 32px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: WindowText;
+              }
               &:hover {
                 background-color: #005a9e;
               }
@@ -958,6 +983,9 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                 top: 8px;
                 width: 1px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: GrayText;
+              }
         />
       </span>
     </div>
@@ -1026,6 +1054,9 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
             left: -2px;
             right: -2px;
             top: -2px;
+          }
+          & .ms-Button--default, & .ms-Button--primary {
+            border-right: none;
           }
       data-automation-id="test"
       data-is-focusable={true}
@@ -1204,6 +1235,11 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                 vertical-align: top;
                 width: 32px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Window;
+                border: 1px solid GrayText;
+                color: GrayText;
+              }
               &:hover {
                 background-color: #f4f4f4;
                 cursor: default;
@@ -1277,6 +1313,9 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                 top: 8px;
                 width: 1px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: GrayText;
+              }
         />
       </span>
     </div>
@@ -1344,6 +1383,9 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 2`] = `
           left: -2px;
           right: -2px;
           top: -2px;
+        }
+        & .ms-Button--default, & .ms-Button--primary {
+          border-right: none;
         }
         @media screen and (-ms-high-contrast: active){& {
           border: none;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Split.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Split.Example.tsx.shot
@@ -587,6 +587,8 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
               }
               @media screen and (-ms-high-contrast: active){& {
                 background-color: WindowText;
+                border-left: none;
+                border: 1px solid white;
               }
               &:hover {
                 background-color: #005a9e;
@@ -911,6 +913,8 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
               }
               @media screen and (-ms-high-contrast: active){& {
                 background-color: WindowText;
+                border-left: none;
+                border: 1px solid white;
               }
               &:hover {
                 background-color: #005a9e;
@@ -1237,6 +1241,7 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
               }
               @media screen and (-ms-high-contrast: active){& {
                 background-color: Window;
+                border-left: none;
                 border: 1px solid GrayText;
                 color: GrayText;
               }
@@ -1566,6 +1571,10 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 2`] = `
               user-select: none;
               vertical-align: top;
               width: 10px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              border-left: none;
+              border: 1px solid white;
             }
         data-is-focusable={false}
         onClick={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
@@ -103,6 +103,9 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                       right: -2px;
                       top: -2px;
                     }
+                    & .ms-Button--default, & .ms-Button--primary {
+                      border-right: none;
+                    }
                     &:focus {
                       outline: none!important;
                     }
@@ -426,6 +429,9 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                       right: -2px;
                       top: -2px;
                     }
+                    & .ms-Button--default, & .ms-Button--primary {
+                      border-right: none;
+                    }
                 data-automation-id="uploadButton"
                 data-is-focusable={true}
                 onFocusCapture={[Function]}
@@ -636,6 +642,11 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                         @media screen and (-ms-high-contrast: active){&:hover {
                           color: Highlight;
                         }
+                        @media screen and (-ms-high-contrast: active){& {
+                          background-color: Window;
+                          border: 1px solid GrayText;
+                          color: GrayText;
+                        }
                     data-is-focusable={false}
                     disabled={false}
                     onClick={[Function]}
@@ -703,6 +714,9 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                           right: 31px;
                           top: 8px;
                           width: 1px;
+                        }
+                        @media screen and (-ms-high-contrast: active){& {
+                          background-color: GrayText;
                         }
                   />
                 </span>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
@@ -314,6 +314,10 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                         @media screen and (-ms-high-contrast: active){&:hover {
                           color: Highlight;
                         }
+                        @media screen and (-ms-high-contrast: active){& {
+                          border-left: none;
+                          border: 1px solid white;
+                        }
                     data-is-focusable={false}
                     onClick={[Function]}
                     onKeyDown={[Function]}
@@ -644,6 +648,7 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                         }
                         @media screen and (-ms-high-contrast: active){& {
                           background-color: Window;
+                          border-left: none;
                           border: 1px solid GrayText;
                           color: GrayText;
                         }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -4,7 +4,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
 <div
   className=
 
-      & .headerDivider-520:hover + .headerDividerBar-521 {
+      & .headerDivider-522:hover + .headerDividerBar-523 {
         display: inline;
       }
 >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
@@ -579,6 +579,9 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
               right: -2px;
               top: -2px;
             }
+            & .ms-Button--default, & .ms-Button--primary {
+              border-right: none;
+            }
             &:focus {
               outline: none!important;
             }
@@ -751,6 +754,10 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                 @media screen and (-ms-high-contrast: active){&:hover {
                   color: Highlight;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-left: none;
+                  border: 1px solid white;
+                }
             data-is-focusable={false}
             onClick={[Function]}
             onKeyDown={[Function]}
@@ -815,6 +822,9 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                   right: 31px;
                   top: 8px;
                   width: 1px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background-color: WindowText;
                 }
           />
         </span>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
@@ -487,6 +487,9 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
             right: -2px;
             top: -2px;
           }
+          & .ms-Button--default, & .ms-Button--primary {
+            border-right: none;
+          }
           &:focus {
             outline: none!important;
           }
@@ -659,6 +662,10 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active){&:hover {
                 color: Highlight;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-left: none;
+                border: 1px solid white;
+              }
           data-is-focusable={false}
           data-ktp-execute-target="ktp-2-b"
           onClick={[Function]}
@@ -724,6 +731,9 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
                 right: 31px;
                 top: 8px;
                 width: 1px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: WindowText;
               }
         />
       </span>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #10299 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Copies over solution from #10364 

#### BEFORE
![image](https://user-images.githubusercontent.com/1434956/63889171-5121f200-c995-11e9-889d-a8d5f2df19b6.png)

#### AFTER
<img width="542" alt="Split button high contrast (1)" src="https://user-images.githubusercontent.com/13246181/64302400-0aee0500-cf38-11e9-98cd-f17d9a0c2685.PNG">


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10656)