### PR TITLE
Coachmark: pulseBeacon animation direction fix in RTL

### DIFF
--- a/change/office-ui-fabric-react-2019-09-27-14-39-03-v-mare-Coachmark-RTL-fix.json
+++ b/change/office-ui-fabric-react-2019-09-27-14-39-03-v-mare-Coachmark-RTL-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Coachmark: Fixed pulseBeacon animation direction in RTL",
+  "packageName": "office-ui-fabric-react",
+  "email": "v-mare@microsoft.com",
+  "commit": "31c51d607813abd1c9922d5593037f6e06f13e52",
+  "date": "2019-09-27T21:39:03.123Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.base.tsx
@@ -8,7 +8,8 @@ import {
   getDocument,
   IRectangle,
   KeyCodes,
-  shallowCompare
+  shallowCompare,
+  getRTL
 } from '../../Utilities';
 import { IPositionedData, RectangleEdge, getOppositeEdge } from '../../utilities/positioning';
 
@@ -517,9 +518,19 @@ export class CoachmarkBase extends BaseComponent<ICoachmarkProps, ICoachmarkStat
 
         if (this._beakDirection === RectangleEdge.left) {
           beakLeft = distanceAdjustment;
+          if (getRTL()) {
+            beakRight = distanceAdjustment;
+          } else {
+            beakLeft = distanceAdjustment;
+          }
           transformOriginX = 'left';
         } else {
           beakRight = distanceAdjustment;
+          if (getRTL()) {
+            beakLeft = distanceAdjustment;
+          } else {
+            beakRight = distanceAdjustment;
+          }
           transformOriginX = 'right';
         }
         break;

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.styles.ts
@@ -1,5 +1,6 @@
 import { keyframes, PulsingBeaconAnimationStyles } from '../../Styling';
 import { ICoachmarkStyleProps, ICoachmarkStyles } from './Coachmark.types';
+import { getRTL } from '../../Utilities';
 
 export const COACHMARK_WIDTH = 32;
 export const COACHMARK_HEIGHT = 32;
@@ -166,7 +167,7 @@ export function getStyles(props: ICoachmarkStyleProps): ICoachmarkStyles {
         position: 'absolute',
         top: '50%',
         left: '50%',
-        transform: 'translate(-50%, -50%)',
+        transform: getRTL() ? 'translate(50%, -50%)' : 'translate(-50%, -50%)',
         width: '0px',
         height: '0px',
         borderRadius: '225px',


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: #10314 
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Copied over from #10381 
Fixes issue where the pulse beacon goes flying to the left in RTL mode

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10658)