### PR TITLE
DocumentCard: Adding aria-label descriptions to all examples

### DIFF
--- a/change/office-ui-fabric-react-2019-09-30-11-45-49-documentCardAriaExamples.json
+++ b/change/office-ui-fabric-react-2019-09-30-11-45-49-documentCardAriaExamples.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "DocumentCard: Adding aria-label descriptions to all examples.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "425ce7d7d7d148b1bc7ddc063b0880ed5553f5dd",
+  "date": "2019-09-30T18:45:49.124Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Basic.Example.tsx
@@ -29,7 +29,10 @@ export class DocumentCardBasicExample extends React.PureComponent {
     };
 
     return (
-      <DocumentCard onClickHref="http://bing.com">
+      <DocumentCard
+        aria-label="Default Document Card with large file name. Created by Annie Lindqvist a few minutes ago"
+        onClickHref="http://bing.com"
+      >
         <DocumentCardPreview {...previewProps} />
         <DocumentCardTitle
           title="Large_file_name_with_underscores_used_to_separate_all_of_the_words_and_there_are_so_many_words_it_needs_truncating.pptx"

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Basic.Example.tsx
@@ -30,7 +30,7 @@ export class DocumentCardBasicExample extends React.PureComponent {
 
     return (
       <DocumentCard
-        aria-label="Default Document Card with large file name. Created by Annie Lindqvist a few minutes ago"
+        aria-label="Default Document Card with large file name. Created by Annie Lindqvist a few minutes ago."
         onClickHref="http://bing.com"
       >
         <DocumentCardPreview {...previewProps} />

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Compact.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Compact.Example.tsx
@@ -107,7 +107,11 @@ export class DocumentCardCompactExample extends React.PureComponent {
     return (
       <Stack tokens={stackTokens}>
         {/* Document preview */}
-        <DocumentCard type={DocumentCardType.compact} onClickHref="http://bing.com">
+        <DocumentCard
+          aria-label="Document Card with document preview. Revenue stream proposal fiscal year 2016 version 2. Created by Roko Kolar a few minutes ago"
+          type={DocumentCardType.compact}
+          onClickHref="http://bing.com"
+        >
           <DocumentCardPreview previewImages={[previewProps.previewImages[0]]} />
           <DocumentCardDetails>
             <DocumentCardTitle title="Revenue stream proposal fiscal year 2016 version02.pptx" shouldTruncate={true} />
@@ -115,7 +119,11 @@ export class DocumentCardCompactExample extends React.PureComponent {
           </DocumentCardDetails>
         </DocumentCard>
         {/* Folder or site activity */}
-        <DocumentCard type={DocumentCardType.compact} onClickHref="http://bing.com">
+        <DocumentCard
+          aria-label="Document Card with folder or site activity. 4 files were uploaded. Created by Annie Lindqvist a few minutes ago"
+          type={DocumentCardType.compact}
+          onClickHref="http://bing.com"
+        >
           <DocumentCardPreview {...previewProps} />
           <DocumentCardDetails>
             <DocumentCardTitle title="4 files were uploaded" shouldTruncate={true} />
@@ -123,7 +131,11 @@ export class DocumentCardCompactExample extends React.PureComponent {
           </DocumentCardDetails>
         </DocumentCard>
         {/* Card with icon */}
-        <DocumentCard type={DocumentCardType.compact} onClickHref="http://bing.com">
+        <DocumentCard
+          aria-label="Document Card with icon. View and share files. Created by Aaron Reid a few minutes ago"
+          type={DocumentCardType.compact}
+          onClickHref="http://bing.com"
+        >
           <DocumentCardPreview {...previewPropsUsingIcon} />
           <DocumentCardDetails>
             <DocumentCardTitle title="View and share files" shouldTruncate={true} />
@@ -131,7 +143,11 @@ export class DocumentCardCompactExample extends React.PureComponent {
           </DocumentCardDetails>
         </DocumentCard>
         {/* Email conversation */}
-        <DocumentCard type={DocumentCardType.compact} onClickHref="http://bing.com">
+        <DocumentCard
+          aria-label="Document Card with email conversation. Conversation about takeaways from annual SharePoint conference. Sent by Christian Bergqvist a few minutes ago"
+          type={DocumentCardType.compact}
+          onClickHref="http://bing.com"
+        >
           <DocumentCardPreview {...previewOutlookUsingIcon} />
           <DocumentCardDetails>
             <DocumentCardTitle title="Conversation about takeaways from annual SharePoint conference" shouldTruncate={true} />

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Compact.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Compact.Example.tsx
@@ -108,7 +108,8 @@ export class DocumentCardCompactExample extends React.PureComponent {
       <Stack tokens={stackTokens}>
         {/* Document preview */}
         <DocumentCard
-          aria-label="Document Card with document preview. Revenue stream proposal fiscal year 2016 version 2. Created by Roko Kolar a few minutes ago"
+          aria-label="Document Card with document preview. Revenue stream proposal fiscal year 2016 version 2.
+          Created by Roko Kolar a few minutes ago"
           type={DocumentCardType.compact}
           onClickHref="http://bing.com"
         >
@@ -144,7 +145,8 @@ export class DocumentCardCompactExample extends React.PureComponent {
         </DocumentCard>
         {/* Email conversation */}
         <DocumentCard
-          aria-label="Document Card with email conversation. Conversation about takeaways from annual SharePoint conference. Sent by Christian Bergqvist a few minutes ago"
+          aria-label="Document Card with email conversation. Conversation about takeaways from annual SharePoint conference.
+          Sent by Christian Bergqvist a few minutes ago"
           type={DocumentCardType.compact}
           onClickHref="http://bing.com"
         >

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Complete.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Complete.Example.tsx
@@ -93,7 +93,8 @@ export class DocumentCardCompleteExample extends React.PureComponent {
 
     return (
       <DocumentCard
-        aria-label="Document Card with multiple items, commands and views. Marketing documents. 6 files were uploaded. Created by Annie Lindqvist in February 23, 2016. 432 views."
+        aria-label="Document Card with multiple items, commands and views. Marketing documents. 6 files were uploaded.
+        Created by Annie Lindqvist in February 23, 2016. 432 views."
         onClick={this._onClick}
       >
         <DocumentCardPreview {...previewProps} />

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Complete.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Complete.Example.tsx
@@ -92,7 +92,10 @@ export class DocumentCardCompleteExample extends React.PureComponent {
     };
 
     return (
-      <DocumentCard onClick={this._onClick}>
+      <DocumentCard
+        aria-label="Document Card with multiple items, commands and views. Marketing documents. 6 files were uploaded. Created by Annie Lindqvist in February 23, 2016. 432 views."
+        onClick={this._onClick}
+      >
         <DocumentCardPreview {...previewProps} />
         <DocumentCardLocation
           location="Marketing Documents"

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Conversation.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Conversation.Example.tsx
@@ -36,7 +36,11 @@ export const DocumentCardConversationExample: React.StatelessComponent = () => {
 
   return (
     <div>
-      <DocumentCard styles={cardStyles} onClickHref="http://bing.com">
+      <DocumentCard
+        aria-label="Document Card with logo, text preview, and status. Conversation about annual report. Content preview. 3 attachments. Sent by Annie Lindqvist and 2 others in March 13, 2018."
+        styles={cardStyles}
+        onClickHref="http://bing.com"
+      >
         <DocumentCardLogo {...logoProps} />
         <div className={conversationTileClass}>
           <DocumentCardTitle
@@ -55,7 +59,11 @@ export const DocumentCardConversationExample: React.StatelessComponent = () => {
         </div>
         <DocumentCardActivity activity="Sent March 13, 2018" people={people.slice(0, 3)} />
       </DocumentCard>
-      <DocumentCard styles={cardStyles} onClickHref="http://bing.com">
+      <DocumentCard
+        aria-label="Document Card with logo, text preview, and status. Further annual report conversation. Content preview. 3 attachments. Sent by Christian Bergqvist and 2 others in March 13, 2018."
+        styles={cardStyles}
+        onClickHref="http://bing.com"
+      >
         <DocumentCardLogo {...logoProps} />
         <div className={conversationTileClass}>
           <DocumentCardTitle title="Further annual report conversation" />
@@ -64,7 +72,11 @@ export const DocumentCardConversationExample: React.StatelessComponent = () => {
         </div>
         <DocumentCardActivity activity="Sent March 13, 2018" people={people.slice(3, 6)} />
       </DocumentCard>
-      <DocumentCard styles={cardStyles} onClickHref="http://bing.com">
+      <DocumentCard
+        aria-label="Document Card with logo and text preview. Conversation about annual report. Content preview. Sent by Velatine Lourvric and 1 other in March 13, 2018."
+        styles={cardStyles}
+        onClickHref="http://bing.com"
+      >
         <DocumentCardLogo {...logoProps} />
         <div className={conversationTileClass}>
           <DocumentCardTitle title="Conversation about annual report" shouldTruncate />

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Conversation.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Conversation.Example.tsx
@@ -37,7 +37,8 @@ export const DocumentCardConversationExample: React.StatelessComponent = () => {
   return (
     <div>
       <DocumentCard
-        aria-label="Document Card with logo, text preview, and status. Conversation about annual report. Content preview. 3 attachments. Sent by Annie Lindqvist and 2 others in March 13, 2018."
+        aria-label="Document Card with logo, text preview, and status. Conversation about annual report. Content preview. 3 attachments.
+        Sent by Annie Lindqvist and 2 others in March 13, 2018."
         styles={cardStyles}
         onClickHref="http://bing.com"
       >
@@ -60,7 +61,8 @@ export const DocumentCardConversationExample: React.StatelessComponent = () => {
         <DocumentCardActivity activity="Sent March 13, 2018" people={people.slice(0, 3)} />
       </DocumentCard>
       <DocumentCard
-        aria-label="Document Card with logo, text preview, and status. Further annual report conversation. Content preview. 3 attachments. Sent by Christian Bergqvist and 2 others in March 13, 2018."
+        aria-label="Document Card with logo, text preview, and status. Further annual report conversation. Content preview. 3 attachments.
+        Sent by Christian Bergqvist and 2 others in March 13, 2018."
         styles={cardStyles}
         onClickHref="http://bing.com"
       >
@@ -73,7 +75,8 @@ export const DocumentCardConversationExample: React.StatelessComponent = () => {
         <DocumentCardActivity activity="Sent March 13, 2018" people={people.slice(3, 6)} />
       </DocumentCard>
       <DocumentCard
-        aria-label="Document Card with logo and text preview. Conversation about annual report. Content preview. Sent by Velatine Lourvric and 1 other in March 13, 2018."
+        aria-label="Document Card with logo and text preview. Conversation about annual report. Content preview. Sent by Velatine Lourvric
+        and 1 other in March 13, 2018."
         styles={cardStyles}
         onClickHref="http://bing.com"
       >

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Image.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/examples/DocumentCard.Image.Example.tsx
@@ -25,14 +25,22 @@ export const DocumentCardImageExample: React.StatelessComponent = () => {
 
   return (
     <div>
-      <DocumentCard styles={cardStyles} onClickHref="http://bing.com">
+      <DocumentCard
+        aria-label="Document Card with image. How to make a good design. Last modified by Annie Lindqvist and 2 others in March 13, 2018."
+        styles={cardStyles}
+        onClickHref="http://bing.com"
+      >
         <DocumentCardImage height={150} imageFit={ImageFit.cover} imageSrc={TestImages.documentPreviewTwo} />
         <DocumentCardDetails>
           <DocumentCardTitle title="How to make a good design" shouldTruncate />
         </DocumentCardDetails>
         <DocumentCardActivity activity="Modified March 13, 2018" people={people.slice(0, 3)} />
       </DocumentCard>
-      <DocumentCard styles={cardStyles} onClickHref="http://bing.com">
+      <DocumentCard
+        aria-label="Document Card with icon. How to make a good design. Last modified by Christian Bergqvist in January 1, 2019."
+        styles={cardStyles}
+        onClickHref="http://bing.com"
+      >
         <DocumentCardImage
           height={150}
           imageFit={ImageFit.cover}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Basic.Example.tsx.shot
@@ -2,6 +2,7 @@
 
 exports[`Component Examples renders DocumentCard.Basic.Example.tsx correctly 1`] = `
 <div
+  aria-label="Default Document Card with large file name. Created by Annie Lindqvist a few minutes ago."
   className=
       ms-DocumentCard
       ms-DocumentCard--actionable

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
@@ -23,6 +23,8 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
       }
 >
   <div
+    aria-label="Document Card with document preview. Revenue stream proposal fiscal year 2016 version 2.
+          Created by Roko Kolar a few minutes ago"
     className=
         ms-DocumentCard
         ms-DocumentCard--actionable
@@ -360,6 +362,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
     </div>
   </div>
   <div
+    aria-label="Document Card with folder or site activity. 4 files were uploaded. Created by Annie Lindqvist a few minutes ago"
     className=
         ms-DocumentCard
         ms-DocumentCard--actionable
@@ -943,6 +946,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
     </div>
   </div>
   <div
+    aria-label="Document Card with icon. View and share files. Created by Aaron Reid a few minutes ago"
     className=
         ms-DocumentCard
         ms-DocumentCard--actionable
@@ -1263,6 +1267,8 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
     </div>
   </div>
   <div
+    aria-label="Document Card with email conversation. Conversation about takeaways from annual SharePoint conference.
+          Sent by Christian Bergqvist a few minutes ago"
     className=
         ms-DocumentCard
         ms-DocumentCard--actionable

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
@@ -2,6 +2,8 @@
 
 exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 1`] = `
 <div
+  aria-label="Document Card with multiple items, commands and views. Marketing documents. 6 files were uploaded.
+        Created by Annie Lindqvist in February 23, 2016. 432 views."
   className=
       ms-DocumentCard
       ms-DocumentCard--actionable

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Conversation.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Conversation.Example.tsx.shot
@@ -3,6 +3,8 @@
 exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correctly 1`] = `
 <div>
   <div
+    aria-label="Document Card with logo, text preview, and status. Conversation about annual report. Content preview. 3 attachments.
+        Sent by Annie Lindqvist and 2 others in March 13, 2018."
     className=
         ms-DocumentCard
         ms-DocumentCard--actionable
@@ -433,6 +435,8 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
     </div>
   </div>
   <div
+    aria-label="Document Card with logo, text preview, and status. Further annual report conversation. Content preview. 3 attachments.
+        Sent by Christian Bergqvist and 2 others in March 13, 2018."
     className=
         ms-DocumentCard
         ms-DocumentCard--actionable
@@ -853,6 +857,8 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
     </div>
   </div>
   <div
+    aria-label="Document Card with logo and text preview. Conversation about annual report. Content preview. Sent by Velatine Lourvric
+        and 1 other in March 13, 2018."
     className=
         ms-DocumentCard
         ms-DocumentCard--actionable

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Image.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Image.Example.tsx.shot
@@ -3,6 +3,7 @@
 exports[`Component Examples renders DocumentCard.Image.Example.tsx correctly 1`] = `
 <div>
   <div
+    aria-label="Document Card with image. How to make a good design. Last modified by Annie Lindqvist and 2 others in March 13, 2018."
     className=
         ms-DocumentCard
         ms-DocumentCard--actionable
@@ -419,6 +420,7 @@ exports[`Component Examples renders DocumentCard.Image.Example.tsx correctly 1`]
     </div>
   </div>
   <div
+    aria-label="Document Card with icon. How to make a good design. Last modified by Christian Bergqvist in January 1, 2019."
     className=
         ms-DocumentCard
         ms-DocumentCard--actionable


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10664
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR defines the `aria-label` attribute for all `DocumentCard` examples so that users of screen readers have a better experience when navigating through this portion of the website.

#### Focus areas to test

Go to [the website](https://developer.microsoft.com/en-us/fabric#/controls/web/documentcard) and navigate using Narrator+Edge and then go to the PR deployed site and do the same to notice the difference in the experience.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10667)