### PR TITLE
Dropdown: Making multiselect options clickable outside of the options label

### DIFF
--- a/change/office-ui-fabric-react-2019-09-30-16-54-53-multiSelectDropdownSelection.json
+++ b/change/office-ui-fabric-react-2019-09-30-16-54-53-multiSelectDropdownSelection.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Dropdown: Making multiselect options clickable outside of the options label while still within Dropdown's boundaries.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "0bc0285686046f72721eae5c6730b3717473cc1a",
+  "date": "2019-09-30T23:54:53.190Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -4368,6 +4368,7 @@ export interface IDropdownStyles {
 // @public (undocumented)
 export interface IDropdownSubComponentStyles {
     label: IStyleFunctionOrObject<ILabelStyleProps, any>;
+    multiSelectItem: IStyleFunctionOrObject<ICheckboxStyleProps, any>;
     panel: IStyleFunctionOrObject<IPanelStyleProps, any>;
 }
 

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -630,6 +630,10 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
         role="option"
         aria-selected={isItemSelected ? 'true' : 'false'}
         checked={isItemSelected}
+        // Since the Checkbox is triggered via a click on either the checkbox itself or its label, we need to make the label span the
+        // entire width of the Dropdown so users can select and unselect the checkbox as long as they are clicking in the area adjacent
+        // to it.
+        styles={{ label: { width: '100%' } }}
       />
     );
   };

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -21,7 +21,7 @@ import {
   warnMutuallyExclusive
 } from '../../Utilities';
 import { Callout } from '../../Callout';
-import { Checkbox } from '../../Checkbox';
+import { Checkbox, ICheckboxStyleProps, ICheckboxStyles } from '../../Checkbox';
 import { CommandButton } from '../../Button';
 import { DirectionalHint } from '../../common/DirectionalHint';
 import { DropdownMenuItemType, IDropdownOption, IDropdownProps, IDropdownStyleProps, IDropdownStyles, IDropdown } from './Dropdown.types';
@@ -591,6 +591,10 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
 
     const { title = item.text } = item;
 
+    const multiSelectItemStyles = this._classNames.subComponentStyles
+      ? (this._classNames.subComponentStyles.multiSelectItem as IStyleFunctionOrObject<ICheckboxStyleProps, ICheckboxStyles>)
+      : undefined;
+
     return !this.props.multiSelect ? (
       <CommandButton
         id={id + '-list' + item.index}
@@ -630,10 +634,7 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
         role="option"
         aria-selected={isItemSelected ? 'true' : 'false'}
         checked={isItemSelected}
-        // Since the Checkbox is triggered via a click on either the checkbox itself or its label, we need to make the label span the
-        // entire width of the Dropdown so users can select and unselect the checkbox as long as they are clicking in the area adjacent
-        // to it.
-        styles={{ label: { width: '100%' } }}
+        styles={multiSelectItemStyles}
       />
     );
   };

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -347,6 +347,16 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
     ],
     subComponentStyles: {
       label: { root: { display: 'inline-block' } },
+      multiSelectItem: {
+        root: {
+          padding: 0
+        },
+        label: {
+          alignSelf: 'stretch',
+          padding: '0 8px',
+          width: '100%'
+        }
+      },
       panel: {
         root: [panelClassName],
         main: {

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
@@ -5,8 +5,9 @@ import { ISelectableOption } from '../../utilities/selectableOption/SelectableOp
 import { ISelectableDroppableTextProps } from '../../utilities/selectableOption/SelectableDroppableText.types';
 import { ResponsiveMode } from '../../utilities/decorators/withResponsiveMode';
 import { IKeytipProps } from '../../Keytip';
-import { ILabelStyleProps } from '../../Label';
 import { RectangleEdge } from '../../utilities/positioning';
+import { ICheckboxStyleProps } from '../Checkbox/Checkbox.types';
+import { ILabelStyleProps } from '../Label/Label.types';
 import { IPanelStyleProps } from '../Panel/Panel.types';
 
 export { SelectableOptionMenuItemType as DropdownMenuItemType } from '../../utilities/selectableOption/SelectableOption.types';
@@ -286,5 +287,9 @@ export interface IDropdownSubComponentStyles {
 
   /** Refers to the primary label for the Dropdown. */
   label: IStyleFunctionOrObject<ILabelStyleProps, any>;
+  // #5690: replace any with ILabelStyles in TS 2.9
+
+  /** Refers to the the individual dropdown item when the multiSelect prop is true. */
+  multiSelectItem: IStyleFunctionOrObject<ICheckboxStyleProps, any>;
   // #5690: replace any with ILabelStyles in TS 2.9
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10669 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The behavior between single select and multi select `Dropdowns` was inconsistent because in single select `Dropdowns` one can select/unselect an option by clicking outside of the option's label if you are still within the boundaries of the `Dropdown's` callout, while in multi select `Dropdowns` one cannot select/unselect the option this way. This was happening because multi select `Dropdowns` use `Checkboxes` instead of `Buttons` for the options, which are only selected by clicking on either the checkbox itself or the label associated with it. This PR fixes this scenario by expanding the label inside of the `Checkbox` in multi select `Dropdowns` to cover the entire height width of its container.

__Before:__

![Dropdown](https://user-images.githubusercontent.com/7798177/65925116-557e6800-e3a4-11e9-8707-ab987461ce17.gif)

__After:__

![Dropdown](https://user-images.githubusercontent.com/7798177/65925148-7e9ef880-e3a4-11e9-8864-755aca75789f.gif)


#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10674)