### PR TITLE
Foundation next has @uifabric/merge-styles dependency, should be specified in package.json

### DIFF
--- a/change/@uifabric-foundation-2019-10-02-16-35-20-keco-foundation-merge-styles.json
+++ b/change/@uifabric-foundation-2019-10-02-16-35-20-keco-foundation-merge-styles.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Foundation next requires @uifabric/merge-styles dependency",
+  "packageName": "@uifabric/foundation",
+  "email": "KevinTCoughlin@users.noreply.github.com",
+  "commit": "cd4565bf67647fe0fd6267845b05561f7d6563a2",
+  "date": "2019-10-02T23:35:20.459Z"
+}

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -45,6 +45,7 @@
     "@uifabric/build": "^7.0.0"
   },
   "dependencies": {
+    "@uifabric/merge-styles": "^7.7.0",
     "@uifabric/set-version": "^7.0.2",
     "@uifabric/styling": "^7.7.2",
     "@uifabric/utilities": "^7.3.0",


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Encountered a missing dependency when trying to consume Fabric 7 in ODSP repo using pnpm.

`@uifabric/merge-styles` dependency was introduced in https://github.com/OfficeDev/office-ui-fabric-react/pull/10309/files#diff-36da0b591258dca2ed4c771425d6ff14R2.

`@uifabric/foundation` should specify a dependency on `@uifabric/merge-styles` in its `package.json`. It is my understanding that `pnpm` would have caught this.

#### Focus areas to test

- CI passes.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10695)