### PR TITLE
Callout & Tooltip: Making background color themable.

### DIFF
--- a/change/office-ui-fabric-react-2019-10-02-17-24-07-tooltipBackgroundHover.json
+++ b/change/office-ui-fabric-react-2019-10-02-17-24-07-tooltipBackgroundHover.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Callout & Tooltip: Making background color themable.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "6aa84713cd454fdab87851df68bc9af845eec00d",
+  "date": "2019-10-03T00:24:07.290Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.styles.ts
@@ -21,7 +21,7 @@ export const getStyles = (props: ICalloutContentStyleProps): ICalloutContentStyl
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
-  const { palette, effects } = theme;
+  const { semanticColors, effects } = theme;
 
   return {
     container: [
@@ -55,7 +55,7 @@ export const getStyles = (props: ICalloutContentStyleProps): ICalloutContentStyl
       classNames.beak,
       {
         position: 'absolute',
-        backgroundColor: palette.white,
+        backgroundColor: semanticColors.menuBackground,
         boxShadow: 'inherit',
         border: 'inherit',
         boxSizing: 'border-box',
@@ -74,14 +74,14 @@ export const getStyles = (props: ICalloutContentStyleProps): ICalloutContentStyl
         right: 0,
         bottom: 0,
         left: 0,
-        backgroundColor: palette.white,
+        backgroundColor: semanticColors.menuBackground,
         borderRadius: effects.roundedCorner2
       }
     ],
     calloutMain: [
       classNames.calloutMain,
       {
-        backgroundColor: palette.white,
+        backgroundColor: semanticColors.menuBackground,
         overflowX: 'hidden',
         overflowY: 'auto',
         position: 'relative',

--- a/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/Tooltip.styles.ts
@@ -3,7 +3,7 @@ import { AnimationClassNames } from '../../Styling';
 
 export const getStyles = (props: ITooltipStyleProps): ITooltipStyles => {
   const { className, beakWidth = 16, gapSpace = 0, maxWidth, theme } = props;
-  const { palette, fonts, effects } = theme;
+  const { palette, semanticColors, fonts, effects } = theme;
 
   // The math here is done to account for the 45 degree rotation of the beak
   const tooltipGapSpace = -(Math.sqrt((beakWidth * beakWidth) / 2) + gapSpace);
@@ -14,7 +14,7 @@ export const getStyles = (props: ITooltipStyleProps): ITooltipStyles => {
       theme.fonts.medium,
       AnimationClassNames.fadeIn200,
       {
-        background: palette.white,
+        background: semanticColors.menuBackground,
         boxShadow: effects.elevation8,
         padding: '8px',
         maxWidth: maxWidth,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10679
- [x] Include a change request file using `$ yarn change`

#### Description of changes

`Tooltip` was using `palette.white` for its background, which was not very friendly for theming so I changed it, after conversations with design, to use `semanticColors.menuBackground` instead. However, I realized that this was not fixing the issue because `Callout` was also using `palette.white` for its background, so I also made the change to use `semanticColors.menuBackground` as part of this PR.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10697)