### PR TITLE
ContextualMenu: Removing deprecated check for getMenuClassNames that was stopping callout subComponentStyles from being applied

### DIFF
--- a/change/office-ui-fabric-react-2019-10-03-16-46-42-contextualMenuSubComponentStyles.json
+++ b/change/office-ui-fabric-react-2019-10-03-16-46-42-contextualMenuSubComponentStyles.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "ContextualMenu: Removing deprecated check for getMenuClassNames that was stopping callout subComponentStyles from being applied.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "74b2f0f973bcb377b56dd337f578d7d07388eb83",
+  "date": "2019-10-03T23:46:42.643Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -298,10 +298,9 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
         }
       }
 
-      const calloutStyles =
-        !getMenuClassNames && this._classNames.subComponentStyles
-          ? (this._classNames.subComponentStyles.callout as IStyleFunctionOrObject<ICalloutContentStyleProps, ICalloutContentStyles>)
-          : undefined;
+      const calloutStyles = this._classNames.subComponentStyles
+        ? (this._classNames.subComponentStyles.callout as IStyleFunctionOrObject<ICalloutContentStyleProps, ICalloutContentStyles>)
+        : undefined;
 
       return (
         <Callout


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10710
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Investigating issue #10710 I found that out that `subComponentStyles` were being applied to `menuItem` but not to `callout`. Upon further investigation I found out that there is a condition that says that `subComponentStyles` should only be applied to the `callout` if `getMenuClassNames` has been defined. Since `getMenuClassNames` has been deprecated, I've removed this check in this PR.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10712)