### PR TITLE
Fix editor bundling issues and add example error boundary

### DIFF
--- a/change/@uifabric-example-app-base-2019-10-03-22-06-43-editor-bundles.json
+++ b/change/@uifabric-example-app-base-2019-10-03-22-06-43-editor-bundles.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Use latest tsx-editor APIs",
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com",
+  "commit": "5769e0419f9162970898c424da471e8fb9c53ccf",
+  "date": "2019-10-04T05:06:00.317Z"
+}

--- a/change/@uifabric-monaco-editor-2019-10-03-22-06-43-editor-bundles.json
+++ b/change/@uifabric-monaco-editor-2019-10-03-22-06-43-editor-bundles.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Fix monaco bundle paths to use transformed CSS",
+  "packageName": "@uifabric/monaco-editor",
+  "email": "elcraig@microsoft.com",
+  "commit": "5769e0419f9162970898c424da471e8fb9c53ccf",
+  "date": "2019-10-04T05:06:07.516Z"
+}

--- a/change/@uifabric-tsx-editor-2019-10-03-22-06-43-editor-bundles.json
+++ b/change/@uifabric-tsx-editor-2019-10-03-22-06-43-editor-bundles.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Improve bundle structure, and add error boundary around example so errors don't crash the page",
+  "packageName": "@uifabric/tsx-editor",
+  "email": "elcraig@microsoft.com",
+  "commit": "5769e0419f9162970898c424da471e8fb9c53ccf",
+  "date": "2019-10-04T05:06:43.636Z"
+}

--- a/packages/example-app-base/src/components/ExampleCard/ExampleCard.tsx
+++ b/packages/example-app-base/src/components/ExampleCard/ExampleCard.tsx
@@ -18,8 +18,7 @@ import { AppCustomizationsContext, IAppCustomizations, IExampleCardCustomization
 import { CodepenComponent, CONTENT_ID } from '../CodepenComponent/CodepenComponent';
 import { IExampleCardProps, IExampleCardStyleProps, IExampleCardStyles } from './ExampleCard.types';
 import { getStyles } from './ExampleCard.styles';
-import { EditorWrapper, SUPPORTED_PACKAGES, IMonacoTextModel, transformExample } from '@uifabric/tsx-editor/lib/index-min';
-// DO NOT import anything from the root of tsx-editor, to avoid pulling Monaco into the main bundle!
+import { EditorWrapper, SUPPORTED_PACKAGES, IMonacoTextModel, transformExample } from '@uifabric/tsx-editor';
 
 export interface IExampleCardState {
   /** only used if props.isCodeVisible and props.onToggleEditor are undefined */

--- a/packages/example-app-base/src/components/ExampleCard/ExampleCard.tsx
+++ b/packages/example-app-base/src/components/ExampleCard/ExampleCard.tsx
@@ -105,7 +105,9 @@ export class ExampleCardBase extends React.Component<IExampleCardProps, IExample
           const { subComponentStyles } = classNames;
           const { codeButtons: codeButtonStyles } = subComponentStyles;
 
-          const exampleCard = (
+          const ExamplePreview = this._getPreviewComponent(this._activeCustomizations, schemeIndex);
+
+          return (
             <div className={css(classNames.root, isCodeVisible && 'is-codeVisible')}>
               <div className={classNames.header}>
                 <span className={classNames.title}>{title}</span>
@@ -148,22 +150,24 @@ export class ExampleCardBase extends React.Component<IExampleCardProps, IExample
                   )}
                 </div>
               </div>
-              <EditorWrapper
-                code={latestCode}
-                supportedPackages={SUPPORTED_PACKAGES}
-                isCodeVisible={isCodeVisible}
-                editorClassName={classNames.code}
-                editorAriaLabel={`Editor for the example "${title}". The example will be updated as you type.`}
-                previewAs={this._getPreviewComponent(this._activeCustomizations, schemeIndex)}
-                modelRef={this._monacoModelRef}
-              >
-                {children}
-              </EditorWrapper>
+              {isCodeVisible ? (
+                <EditorWrapper
+                  code={latestCode}
+                  supportedPackages={SUPPORTED_PACKAGES}
+                  editorClassName={classNames.code}
+                  editorAriaLabel={`Editor for the example "${title}". The example will be updated as you type.`}
+                  modelRef={this._monacoModelRef}
+                  previewAs={(ExamplePreview as any) as React.FunctionComponent<{}>} // tslint:disable-line:no-any
+                >
+                  {children}
+                </EditorWrapper>
+              ) : (
+                <ExamplePreview>{children}</ExamplePreview>
+              )}
 
               {this._getDosAndDonts()}
             </div>
           );
-          return exampleCard;
         }}
       </AppCustomizationsContext.Consumer>
     );

--- a/packages/monaco-editor/just.config.js
+++ b/packages/monaco-editor/just.config.js
@@ -21,4 +21,4 @@ task('ts:esm', ts.esm);
 task('ts:commonjs', ts.commonjs);
 task('ts', parallel('ts:esm', 'ts:commonjs'));
 
-task('build', series('clean', 'copy', parallel('transform-css', 'ts'))).cached();
+task('build', series('clean', 'copy', 'transform-css', 'ts')).cached();

--- a/packages/monaco-editor/scripts/addMonacoWebpackConfig.js
+++ b/packages/monaco-editor/scripts/addMonacoWebpackConfig.js
@@ -48,7 +48,9 @@ function addMonacoWebpackConfig(config, includeAllLanguages) {
       ...resolve,
       alias: {
         ...resolve.alias,
-        // Alias monaco-editor imports to either monacoBundle.js (to include all language features)
+        // Alias monaco-editor imports to version with transformed CSS
+        'monaco-editor': '@uifabric/monaco-editor',
+        // Alias @uifabric/monaco-editor imports to either monacoBundle.js (to include all languages)
         // or monacoCoreBundle.js (to include only the editor and TS). Either of these bundle files
         // also attempts to set up the global MonacoEnvironment.
         '@uifabric/monaco-editor$': path.resolve(__dirname, '../lib', includeAllLanguages ? 'monacoBundle.js' : 'monacoCoreBundle.js')

--- a/packages/monaco-editor/src/monacoBundle.ts
+++ b/packages/monaco-editor/src/monacoBundle.ts
@@ -3,7 +3,7 @@
 // @uifabric/monaco-editor root imports here.
 
 // @ts-ignore because monaco doesn't provide typings for this file
-export * from 'monaco-editor/esm/vs/editor/editor.main.js';
+export * from '../esm/vs/editor/editor.main.js';
 
 // If the consumer has set a MonacoConfig global, this will set up Monaco's required
 // MonacoEnvironment globals (otherwise the consumer can manually call this function later)

--- a/packages/monaco-editor/src/monacoCoreBundle.ts
+++ b/packages/monaco-editor/src/monacoCoreBundle.ts
@@ -4,12 +4,12 @@
 
 // Main editor features
 // @ts-ignore because monaco doesn't provide typings for this file
-export * from 'monaco-editor/esm/vs/editor/edcore.main.js';
+export * from '../esm/vs/editor/edcore.main.js';
 
 // TS language features are registered as a side effect of these imports
-import 'monaco-editor/esm/vs/basic-languages/typescript/typescript.contribution.js';
-import 'monaco-editor/esm/vs/basic-languages/javascript/javascript.contribution.js';
-import 'monaco-editor/esm/vs/language/typescript/monaco.contribution.js';
+import '../esm/vs/basic-languages/typescript/typescript.contribution.js';
+import '../esm/vs/basic-languages/javascript/javascript.contribution.js';
+import '../esm/vs/language/typescript/monaco.contribution.js';
 
 // If the consumer has set a MonacoConfig global, this will set up Monaco's required
 // MonacoEnvironment globals (otherwise the consumer can manually call this function later)

--- a/packages/tsx-editor/README.md
+++ b/packages/tsx-editor/README.md
@@ -51,9 +51,10 @@ TODO: add usage example
 
 `TsxEditor` is like `EditorWrapper`, but without the example container, error bar, or read-only fallback. Instead of rendering the example itself, it takes in an `onTransformFinished` callback to pass the example component up to the parent for rendering.
 
-Cautions for this option:
+Notes for this option:
 
-- **Delay load** the `TsxEditor` component to prevent Monaco from being pulled into your main bundle.
+- You should **delay load** the `TsxEditor` component to prevent Monaco from being pulled into your main bundle.
+  - `TsxEditor` isn't included in `@uifabric/tsx-editor/lib/index` due to importing Monaco. It should be imported from `@uifabric/tsx-editor/lib/TsxEditor` instead.
 - When rendering the example component, be sure to wrap it in an error boundary; otherwise **runtime errors in the example will crash the page**. (One option is using `EditorErrorBoundary`, which also handles displaying transform errors.)
 
 TODO: add usage example
@@ -62,7 +63,7 @@ TODO: add usage example
 
 `Editor` renders only Monaco. It works with any language and doesn't do any extra TypeScript setup.
 
-Note that if you choose this option, you should **delay load** the `Editor` component to prevent Monaco from being pulled into your main bundle.
+Note that if you choose this option, you should **delay load** the `Editor` component to prevent Monaco from being pulled into your main bundle. (`Editor` isn't included in `@uifabric/tsx-editor/lib/index` due to importing Monaco. It should be imported from `@uifabric/tsx-editor/lib/Editor` instead.)
 
 TODO: add usage example
 

--- a/packages/tsx-editor/README.md
+++ b/packages/tsx-editor/README.md
@@ -27,7 +27,7 @@ If the user's browser can't support the editor (mainly IE 11 and some mobile bro
 Any project consuming `@uifabric/tsx-editor` should follow the Webpack and runtime configuration instructions from the [`@uifabric/monaco-editor` readme](https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/monaco-editor/README.md). Note that the helpers used are re-exported from this package for convenience:
 
 - `addMonacoWebpackConfig`: import from `@uifabric/tsx-editor/scripts/addMonacoWebpackConfig`
-- `configureEnvironment` and `IMonacoConfig`: import from `@uifabric/tsx-editor/lib/index-min`
+- `configureEnvironment` and `IMonacoConfig`: import from `@uifabric/tsx-editor`
 
 The editor code also assumes that React is available on the page as a global.
 
@@ -44,8 +44,6 @@ Note that these are **still subject to change** until a major release.
 `EditorWrapper` renders a Monaco editor, a container where the example is rendered, and a message bar with errors (when applicable). As the user types, `EditorWrapper` transpiles the updated example component code, evals it, and re-renders the example component.
 
 If the user's browser can't support the editor, the code will be rendered read-only.
-
-Note that if you choose this option, you should **only import from** `@uifabric/tsx-editor/lib/index-min`. This will prevent Monaco from being pulled into your main bundle.
 
 TODO: add usage example
 

--- a/packages/tsx-editor/README.md
+++ b/packages/tsx-editor/README.md
@@ -51,7 +51,10 @@ TODO: add usage example
 
 `TsxEditor` is like `EditorWrapper`, but without the example container, error bar, or read-only fallback. Instead of rendering the example itself, it takes in an `onTransformFinished` callback to pass the example component up to the parent for rendering.
 
-Note that if you choose this option, you should **delay load** the `TsxEditor` component to prevent Monaco from being pulled into your main bundle.
+Cautions for this option:
+
+- **Delay load** the `TsxEditor` component to prevent Monaco from being pulled into your main bundle.
+- When rendering the example component, be sure to wrap it in an error boundary; otherwise **runtime errors in the example will crash the page**. (One option is using `EditorErrorBoundary`, which also handles displaying transform errors.)
 
 TODO: add usage example
 

--- a/packages/tsx-editor/src/Editor.ts
+++ b/packages/tsx-editor/src/Editor.ts
@@ -1,0 +1,2 @@
+export { Editor } from './components/Editor';
+export { IEditorProps } from './components/Editor.types';

--- a/packages/tsx-editor/src/EditorWrapper.ts
+++ b/packages/tsx-editor/src/EditorWrapper.ts
@@ -1,0 +1,2 @@
+export { EditorWrapper } from './components/EditorWrapper';
+export { IEditorWrapperProps } from './components/EditorWrapper.types';

--- a/packages/tsx-editor/src/TsxEditor.ts
+++ b/packages/tsx-editor/src/TsxEditor.ts
@@ -1,0 +1,2 @@
+export { TsxEditor } from './components/TsxEditor';
+export { ITsxEditorProps } from './components/TsxEditor.types';

--- a/packages/tsx-editor/src/components/Editor.tsx
+++ b/packages/tsx-editor/src/components/Editor.tsx
@@ -16,7 +16,7 @@ export const Editor: React.FunctionComponent<IEditorProps> = (props: IEditorProp
     language,
     filename,
     onChange,
-    debounceTime = 500,
+    debounceTime = 1000,
     ariaLabel,
     editorOptions
   } = props;

--- a/packages/tsx-editor/src/components/Editor.tsx
+++ b/packages/tsx-editor/src/components/Editor.tsx
@@ -45,10 +45,6 @@ export const Editor: React.FunctionComponent<IEditorProps> = (props: IEditorProp
       model
     });
 
-    if (internalState.current!.onChange) {
-      internalState.current!.onChange(model.getValue());
-    }
-
     // Handle changes (debounced)
     // tslint:disable-next-line:no-any due to mismatch between Node and browser typings
     let debounceTimeout: any;

--- a/packages/tsx-editor/src/components/Editor.types.ts
+++ b/packages/tsx-editor/src/components/Editor.types.ts
@@ -41,7 +41,7 @@ export interface IEditorProps {
   /**
    * Debounce `onChange` calls by this many milliseconds, or 0 to disable.
    * (Can be changed without re-creating the editor.)
-   * @defaultvalue 500
+   * @defaultvalue 1000
    */
   debounceTime?: number;
 

--- a/packages/tsx-editor/src/components/EditorError.tsx
+++ b/packages/tsx-editor/src/components/EditorError.tsx
@@ -1,25 +1,34 @@
 import * as React from 'react';
 import { MessageBar, MessageBarType } from 'office-ui-fabric-react/lib/MessageBar';
+import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
 
 export interface IEditorErrorProps {
   error?: string | string[];
 }
 
+const indent = 15;
+const lineClass = mergeStyles({
+  marginLeft: indent,
+  paddingLeft: indent,
+  textIndent: `-${indent}px`
+});
+const indentedLineClass = mergeStyles(lineClass, { marginLeft: indent * 2 });
+
+/** Display a message bar with an error. If there's no error, returns null. */
 export const EditorError: React.FunctionComponent<IEditorErrorProps> = props => {
   const { error } = props;
-  const isOneError = !!error && (typeof error === 'string' || error.length === 1);
+  const errorArr = !error ? [] : Array.isArray(error) ? error : error.split('\n');
 
-  return error ? (
-    <MessageBar messageBarType={MessageBarType.error} truncated={true} overflowButtonAriaLabel="Show more">
-      There {isOneError ? 'is an error' : 'are errors'} preventing the code from being rendered:{' '}
-      {typeof error === 'string'
-        ? error
-        : error.map(err => (
-            <span key={err}>
-              <br />
-              {'    ' + err}
-            </span>
-          ))}
+  return errorArr.length ? (
+    <MessageBar messageBarType={MessageBarType.error} truncated overflowButtonAriaLabel="Show more">
+      There {errorArr.length === 1 ? 'is an error' : 'are errors'} preventing the code from being rendered:
+      {errorArr!.map(err => {
+        return (
+          <div key={err} className={/^  +/.test(err) ? indentedLineClass : lineClass}>
+            {err.trim()}
+          </div>
+        );
+      })}
     </MessageBar>
   ) : null;
 };

--- a/packages/tsx-editor/src/components/EditorErrorHandler.tsx
+++ b/packages/tsx-editor/src/components/EditorErrorHandler.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ITransformedExample } from '../interfaces';
+import { ITransformedExample } from '../interfaces/index';
 import { EditorError } from './EditorError';
 
 export interface IEditorErrorBoundaryProps {

--- a/packages/tsx-editor/src/components/EditorErrorHandler.tsx
+++ b/packages/tsx-editor/src/components/EditorErrorHandler.tsx
@@ -1,0 +1,70 @@
+import * as React from 'react';
+import { ITransformedExample } from '../interfaces';
+import { EditorError } from './EditorError';
+
+export interface IEditorErrorBoundaryProps {
+  /**
+   * Result of transforming the code. Used to get the transform error (if any) and to determine
+   * when a previously-caught rendering error should be cleared (because the code has updated and
+   * we should try again).
+   */
+  transformResult: ITransformedExample;
+}
+
+interface IEditorErrorBoundaryState {
+  caughtError?: string;
+}
+
+/**
+ * Error boundary to catch and display any errors thrown while rendering the example component.
+ * It also handles displaying errors from transforming the code.
+ *
+ * The example preview should be rendered as a child of this component. (This component can't just
+ * render the preview directly because error boundaries only catch errors in passed-in children.)
+ */
+export class EditorErrorBoundary extends React.Component<IEditorErrorBoundaryProps, IEditorErrorBoundaryState> {
+  public state: IEditorErrorBoundaryState = {};
+  private _lastGoodChildren: React.ReactNode;
+
+  public static getDerivedStateFromError(error: Error) {
+    return { caughtError: `Error while rendering component: ${error.message || error}` };
+  }
+
+  public componentDidUpdate(prevProps: IEditorErrorBoundaryProps, prevState: IEditorErrorBoundaryState) {
+    const { props, state } = this;
+    // remove the caught error state if:
+    // - the error state is not new (present in both curr/prev state)
+    // - we have an updated result to render
+    if (state.caughtError && prevState.caughtError && props.transformResult !== prevProps.transformResult) {
+      this.setState({ caughtError: undefined });
+    }
+
+    if (!(state.caughtError || props.transformResult.error)) {
+      // keep track of the last known-good children, to reuse if there's an error
+      this._lastGoodChildren = props.children;
+    }
+  }
+
+  public componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    // Log the error to the console so people can see the full stack/etc if they want
+    // (only in production, because React logs these errors itself in dev mode)
+    if (process.env.NODE_ENV === 'production') {
+      console.error(error.stack || error);
+      console.error('In component: ' + errorInfo.componentStack);
+    }
+  }
+
+  public render() {
+    const caughtError = this.state.caughtError;
+    const error = caughtError || this.props.transformResult.error;
+    return (
+      <>
+        <EditorError error={error} />
+        {// If there was an error either transforming or rendering, reuse the most recent
+        // successfully-rendered children (especially important if the error is from rendering,
+        // because attempting to re-render bad children causes the page to crash)
+        error ? this._lastGoodChildren : this.props.children}
+      </>
+    );
+  }
+}

--- a/packages/tsx-editor/src/components/EditorWrapper.tsx
+++ b/packages/tsx-editor/src/components/EditorWrapper.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IEditorWrapperProps } from './EditorWrapper.types';
-import { EditorError } from './EditorError';
+import { EditorErrorBoundary } from './EditorErrorHandler';
 import { TypeScriptSnippet } from './TypeScriptSnippet';
 import { EditorLoading } from './EditorLoading';
 import { isEditorSupported } from '../utilities/index';
@@ -65,9 +65,9 @@ export const EditorWrapper: React.FunctionComponent<IEditorWrapperProps> = props
         )}
       </div>
 
-      <EditorError error={error} />
-
-      <Preview {...previewProps}>{ExampleComponent ? <ExampleComponent /> : children}</Preview>
+      <EditorErrorBoundary transformResult={transformResult}>
+        <Preview {...previewProps}>{ExampleComponent ? <ExampleComponent /> : children}</Preview>
+      </EditorErrorBoundary>
     </div>
   );
 };

--- a/packages/tsx-editor/src/components/EditorWrapper.tsx
+++ b/packages/tsx-editor/src/components/EditorWrapper.tsx
@@ -14,21 +14,21 @@ const TsxEditorLazy = React.lazy(() => import('./TsxEditor'));
 export const EditorWrapper: React.FunctionComponent<IEditorWrapperProps> = props => {
   const {
     code,
-    isCodeVisible,
     previewAs: Preview = EditorPreview,
     editorClassName,
-    previewClassName,
+    previewProps = {},
     height = DEFAULT_HEIGHT,
     width,
     editorAriaLabel,
     modelRef,
     useEditor,
     supportedPackages,
+    onTransformFinished: onTransformFinishedFromProps,
     children
   } = props;
 
-  const [error, setError] = React.useState<string | string[]>();
-  const [ExampleComponent, setExampleComponent] = React.useState<React.ComponentType>();
+  const [transformResult, setTransformResult] = React.useState<ITransformedExample>({});
+  const { component: ExampleComponent } = transformResult;
 
   // Check if editing should be enabled
   const canEdit = React.useMemo(() => {
@@ -38,42 +38,40 @@ export const EditorWrapper: React.FunctionComponent<IEditorWrapperProps> = props
     return isEditorSupported(code, supportedPackages);
   }, [useEditor, code, supportedPackages]);
 
-  const onTransformFinished = (result: ITransformedExample) => {
-    setError(result.error);
-    if (result.component) {
-      setExampleComponent(result.component);
-    }
-    if (props.onTransformFinished) {
-      props.onTransformFinished(result);
-    }
-  };
+  const onTransformFinished = React.useCallback(
+    (result: ITransformedExample) => {
+      setTransformResult(result);
+      if (props.onTransformFinished) {
+        props.onTransformFinished(result);
+      }
+    },
+    [onTransformFinishedFromProps]
+  );
 
   return (
     <div>
-      {isCodeVisible && (
-        <div className={editorClassName}>
-          {canEdit ? (
-            // Editing supported -- render editor module (or loading spinner)
-            <React.Suspense fallback={<EditorLoading height={height} />}>
-              <TsxEditorLazy
-                editorProps={{ code, width, height, modelRef, ariaLabel: editorAriaLabel }}
-                onTransformFinished={onTransformFinished}
-              />
-            </React.Suspense>
-          ) : (
-            // Editing not supported
-            <TypeScriptSnippet>{code}</TypeScriptSnippet>
-          )}
-        </div>
-      )}
+      <div className={editorClassName}>
+        {canEdit ? (
+          // Editing supported -- render editor module (or loading spinner)
+          <React.Suspense fallback={<EditorLoading height={height} />}>
+            <TsxEditorLazy
+              editorProps={{ code, width, height, modelRef, ariaLabel: editorAriaLabel }}
+              onTransformFinished={onTransformFinished}
+            />
+          </React.Suspense>
+        ) : (
+          // Editing not supported
+          <TypeScriptSnippet>{code}</TypeScriptSnippet>
+        )}
+      </div>
 
-      {isCodeVisible && <EditorError error={error} />}
+      <EditorError error={error} />
 
-      <Preview className={previewClassName}>{ExampleComponent ? <ExampleComponent /> : children}</Preview>
+      <Preview {...previewProps}>{ExampleComponent ? <ExampleComponent /> : children}</Preview>
     </div>
   );
 };
 
-const EditorPreview: React.FunctionComponent<{ className?: string }> = props => {
-  return <div className={props.className}>{props.children}</div>;
+const EditorPreview: React.FunctionComponent<{}> = props => {
+  return <div {...props} />;
 };

--- a/packages/tsx-editor/src/components/EditorWrapper.types.ts
+++ b/packages/tsx-editor/src/components/EditorWrapper.types.ts
@@ -8,17 +8,14 @@ export interface IEditorWrapperProps {
    */
   code: string;
 
-  /** Whether the editor (or code viewer) is visible */
-  isCodeVisible?: boolean;
-
   /** Class to use on the div wrapping the editor/loading spinner/code viewer */
   editorClassName?: string;
 
   /** Custom component for the preview. It **must** render the children passed in. */
-  previewAs?: React.ComponentType<{ className?: string }>;
+  previewAs?: React.ComponentType<{}>;
 
-  /** Class to use on the wrapper for the rendered example */
-  previewClassName?: string;
+  /** Props to use on the wrapper for the rendered example. */
+  previewProps?: {};
 
   /**
    * Editor height. (Changing this prop should not re-create the editor, but it might not affect

--- a/packages/tsx-editor/src/components/TsxEditor.tsx
+++ b/packages/tsx-editor/src/components/TsxEditor.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import * as monaco from '@uifabric/monaco-editor';
 import { LanguageServiceDefaultsImpl as TypescriptDefaults } from '@uifabric/monaco-editor/monaco-typescript.d';
 import { ITsxEditorProps } from './TsxEditor.types';
-import { transpileAndEval } from '../transpiler/index';
+import { transpileAndEval } from '../transpiler/transpile';
 import { IMonacoTextModel, ICompilerOptions, IPackageGroup } from '../interfaces/index';
 import { Editor } from './Editor';
 import { EditorLoading } from './EditorLoading';

--- a/packages/tsx-editor/src/components/index-min.ts
+++ b/packages/tsx-editor/src/components/index-min.ts
@@ -1,8 +1,0 @@
-// Public component API, but only the parts which don't import Monaco aside from its types.
-export { EditorWrapper } from './EditorWrapper';
-export { IEditorWrapperProps } from './EditorWrapper.types';
-export { CODE_FONT_FAMILY } from './consts';
-
-// Intentionally not exporting:
-// - EditorError, EditorLoading, and TypeScriptSnippet since they're basically internal helpers.
-// - TsxEditor and Editor because they import Monaco

--- a/packages/tsx-editor/src/components/index.ts
+++ b/packages/tsx-editor/src/components/index.ts
@@ -1,10 +1,8 @@
-export { Editor } from './Editor';
-export { IEditorProps } from './Editor.types';
-export { TsxEditor } from './TsxEditor';
-export { ITsxEditorProps } from './TsxEditor.types';
+// Public component API, but only the parts which don't import Monaco aside from its types.
 export { EditorWrapper } from './EditorWrapper';
 export { IEditorWrapperProps } from './EditorWrapper.types';
 export { CODE_FONT_FAMILY } from './consts';
 
-// Intentionally not exporting EditorError, EditorLoading, and TypeScriptSnippet
-//  since they're basically internal helpers
+// Intentionally not exporting:
+// - EditorError, EditorLoading, and TypeScriptSnippet since they're basically internal helpers.
+// - TsxEditor and Editor because they import Monaco

--- a/packages/tsx-editor/src/components/index.ts
+++ b/packages/tsx-editor/src/components/index.ts
@@ -1,8 +1,10 @@
 // Public component API, but only the parts which don't import Monaco aside from its types.
 export { EditorWrapper } from './EditorWrapper';
 export { IEditorWrapperProps } from './EditorWrapper.types';
+export { EditorError, IEditorErrorProps } from './EditorError';
+export { EditorErrorBoundary, IEditorErrorBoundaryProps } from './EditorErrorHandler';
 export { CODE_FONT_FAMILY } from './consts';
 
 // Intentionally not exporting:
-// - EditorError, EditorLoading, and TypeScriptSnippet since they're basically internal helpers.
+// - EditorLoading and TypeScriptSnippet since they're basically internal helpers.
 // - TsxEditor and Editor because they import Monaco

--- a/packages/tsx-editor/src/demo/App.tsx
+++ b/packages/tsx-editor/src/demo/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { PrimaryButton, mergeStyleSets, Stack, Toggle } from 'office-ui-fabric-react';
+import { mergeStyleSets, Stack, Toggle } from 'office-ui-fabric-react';
 import { EditorWrapper } from '../components/EditorWrapper';
 import { SUPPORTED_PACKAGES } from '../utilities/index';
 
@@ -16,24 +16,17 @@ const classNames = mergeStyleSets({
 const width = 800;
 
 export const App: React.FunctionComponent = () => {
-  const [editorHidden, setEditorHidden] = React.useState<boolean>(true);
   const [useEditor, setUseEditor] = React.useState<boolean>(true);
-
-  const onButtonClick = () => setEditorHidden(!editorHidden);
   const onToggleChange = () => setUseEditor(!useEditor);
 
   return (
     <Stack styles={{ root: { width, margin: '0 auto' } }} tokens={{ childrenGap: 20 }}>
       <h1>Typescript + React editor</h1>
-      <Stack horizontal tokens={{ childrenGap: 40 }}>
-        <PrimaryButton text={editorHidden ? 'Show code' : 'Hide code'} onClick={onButtonClick} />
-        <Toggle inlineLabel label="Use editor" checked={useEditor} onChange={onToggleChange} />
-      </Stack>
+      <Toggle inlineLabel label="Use editor" checked={useEditor} onChange={onToggleChange} />
       <EditorWrapper
         code={example}
         editorClassName={classNames.component}
-        previewClassName={classNames.preview}
-        isCodeVisible={!editorHidden}
+        previewProps={{ className: classNames.preview }}
         useEditor={useEditor}
         supportedPackages={SUPPORTED_PACKAGES}
       />

--- a/packages/tsx-editor/src/imports.test.ts
+++ b/packages/tsx-editor/src/imports.test.ts
@@ -9,7 +9,7 @@ describe('monaco imports', () => {
 
   it('test can detect monaco imports', () => {
     try {
-      require('./index');
+      require('./Editor');
     } catch (ex) {
       // Test passes!
       return;
@@ -21,16 +21,16 @@ describe('monaco imports', () => {
 
   it('does not import monaco in certain basic files', () => {
     try {
-      require('./index-min');
+      require('./index');
     } catch (ex) {
       throw new Error(`
-Error importing index-min in test! This probably means that either:
+Error importing index.ts in test! This probably means that either:
 
 1. You added a reference to a new package
     => Solution: add mapping for package in jest.config.js
 
 2. You added a root import of @uifabric/monaco-editor in a file which shouldn't reference Monaco.
-    => Solution: If you need types from Monaco in a file referenced by index-min, import from:
+    => Solution: If you need types from Monaco in a file referenced by index.ts, import from:
           @uifabric/monaco-editor/esm/vs/editor/editor.api
        For imports besides types, please restructure your code.
 

--- a/packages/tsx-editor/src/index-min.ts
+++ b/packages/tsx-editor/src/index-min.ts
@@ -1,7 +1,0 @@
-// This file exports only things which don't import Monaco aside from its types.
-// So it should be safe to import from a bundle size impact perspective and hopefully should
-// work with Jest (because it only references the .d.ts file, which Jest understands).
-export * from './components/index-min';
-export * from './interfaces/index';
-export * from './transpiler/index-min';
-export * from './utilities/index';

--- a/packages/tsx-editor/src/index.ts
+++ b/packages/tsx-editor/src/index.ts
@@ -1,3 +1,6 @@
+// This file exports only things which don't import Monaco aside from its types.
+// So it should be safe to import from a bundle size impact perspective and hopefully should
+// work with Jest (because it only references the .d.ts file, which Jest understands).
 export * from './components/index';
 export * from './interfaces/index';
 export * from './transpiler/index';

--- a/packages/tsx-editor/src/transpiler/index-min.ts
+++ b/packages/tsx-editor/src/transpiler/index-min.ts
@@ -1,7 +1,0 @@
-// Public transpiler API, but only the parts which don't import Monaco aside from its types.
-export { transformExample, ITransformExampleParams } from './exampleTransform';
-export { isExampleValid } from './exampleParser';
-
-// Intentionally not exporting:
-// - transpile because it imports Monaco
-// - most of exampleParser and transpileHelpers because they're essentially internal helpers

--- a/packages/tsx-editor/src/transpiler/index.ts
+++ b/packages/tsx-editor/src/transpiler/index.ts
@@ -1,4 +1,7 @@
-// Public transpiler API
-export { transpile, transpileAndEval } from './transpile';
+// Public transpiler API, but only the parts which don't import Monaco aside from its types.
 export { transformExample, ITransformExampleParams } from './exampleTransform';
 export { isExampleValid } from './exampleParser';
+
+// Intentionally not exporting:
+// - transpile because it imports Monaco
+// - most of exampleParser and transpileHelpers because they're essentially internal helpers

--- a/packages/tsx-editor/src/transpiler/transpile.ts
+++ b/packages/tsx-editor/src/transpiler/transpile.ts
@@ -35,8 +35,11 @@ export function transpile(model: IMonacoTextModel): Promise<ITransformedCode> {
         // There was an error, so get diagnostics
         return Promise.all([worker.getSyntacticDiagnostics(filename), worker.getSemanticDiagnostics(filename)]).then(
           ([syntacticDiagnostics, semanticDiagnostics]) => {
-            const diagnostics = syntacticDiagnostics.concat(semanticDiagnostics).filter(d => d.category === 1 /*error*/);
-            diagnostics.sort((a, b) => a.start! - b.start!);
+            syntacticDiagnostics = syntacticDiagnostics.filter(d => d.category === 1 /*error*/);
+            semanticDiagnostics = semanticDiagnostics.filter(d => d.category === 1);
+
+            // If there's a syntax error, draw attention to that first and ignore any semantic errors
+            const diagnostics = syntacticDiagnostics.length ? syntacticDiagnostics : semanticDiagnostics;
             if (diagnostics.length) {
               transpiledOutput.error = _getErrorMessages(diagnostics, model.getValue());
             } else {


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Change the `tsx-editor` package to use a more conventional import structure:
- delete `index-min` files
- `index` files only include things which **don't** import Monaco
- add root-level files for public APIs `EditorWrapper`, `TsxEditor`, and `Editor` (the latter two are not exported from the main `index` due to importing Monaco)

Add an error boundary so that runtime errors in the example won't crash the whole page.

Fix a bug which was preventing full type checking from being enabled.

Disable transpiling/rendering example until types are fully loaded. (This reduces the chance of runtime errors and helps with various other edge cases.)

Remove code visibility toggle from tsx-editor and move it to ExampleCard (it's not a generally useful behavior and made the error handling logic more complicated).

Fix monaco-bundle imports and helpers so that consuming packages don't try to load non-transformed CSS. (for some reason this worked okay previously in OUFR, but when I tried to make a package consuming tsx-editor, it didn't work)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10714)