### PR TITLE
ComboBox: Making error messages accessible to screen readers

### DIFF
--- a/change/@uifabric-experiments-2019-10-07-17-26-17-comboBoxErrorMessage.json
+++ b/change/@uifabric-experiments-2019-10-07-17-26-17-comboBoxErrorMessage.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Updating snapshots.",
+  "packageName": "@uifabric/experiments",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "26226b3417d578e0f8573cd67f80e486884440ad",
+  "date": "2019-10-08T00:26:17.879Z",
+  "file": "E:\\office-ui-fabric-react\\change\\@uifabric-experiments-2019-10-07-17-26-17-comboBoxErrorMessage.json"
+}

--- a/change/office-ui-fabric-react-2019-10-04-14-03-17-comboBoxErrorMessage.json
+++ b/change/office-ui-fabric-react-2019-10-04-14-03-17-comboBoxErrorMessage.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "ComboBox: Making error messages accessible to screen readers.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "fb4674198f21545c70ee18e61ddbd3dcb61ad115",
+  "date": "2019-10-04T21:03:17.756Z",
+  "file": "E:\\office-ui-fabric-react\\change\\office-ui-fabric-react-2019-10-04-14-03-17-comboBoxErrorMessage.json"
+}

--- a/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -1671,6 +1671,24 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
         </span>
       </button>
     </div>
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      className=
+
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #a4262c;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
+          }
+      id="ComboBox6-error"
+      role="region"
+    >
+      
+    </div>
   </div>
   <button
     aria-label="next page"

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -311,6 +311,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
   // Primary Render
   public render(): JSX.Element {
     const id = this._id;
+    const errorMessageId = id + '-error';
     const {
       className,
       label,
@@ -393,7 +394,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
                 aria-label={ariaLabel && !label ? ariaLabel : undefined}
                 aria-describedby={
                   errorMessage !== undefined
-                    ? mergeAriaAttributeValues(ariaDescribedBy, keytipAttributes['aria-describedby'], this._id + '-error')
+                    ? mergeAriaAttributeValues(ariaDescribedBy, keytipAttributes['aria-describedby'], errorMessageId)
                     : mergeAriaAttributeValues(ariaDescribedBy, keytipAttributes['aria-describedby'])
                 }
                 aria-activedescendant={this._getAriaActiveDescentValue()}
@@ -439,11 +440,9 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
             },
             this._onRenderContainer
           )}
-        {errorMessage !== undefined && (
-          <div role="region" aria-live="polite" aria-atomic="true" id={this._id + '-error'} className={this._classNames.errorMessage}>
-            {errorMessage}
-          </div>
-        )}
+        <div role="region" aria-live="polite" aria-atomic="true" id={errorMessageId} className={this._classNames.errorMessage}>
+          {errorMessage !== undefined ? errorMessage : ''}
+        </div>
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -133,7 +133,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
   /** The menu item element that is currently selected */
   private _selectedElement = React.createRef<HTMLSpanElement>();
 
-  /** The base id for the comboBox */
+  /** The base id for the ComboBox */
   private _id: string;
 
   /**
@@ -391,7 +391,11 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
                 readOnly={disabled || !allowFreeform}
                 aria-labelledby={label && id + '-label'}
                 aria-label={ariaLabel && !label ? ariaLabel : undefined}
-                aria-describedby={mergeAriaAttributeValues(ariaDescribedBy, keytipAttributes['aria-describedby'])}
+                aria-describedby={
+                  errorMessage !== undefined
+                    ? mergeAriaAttributeValues(ariaDescribedBy, keytipAttributes['aria-describedby'], this._id + '-error')
+                    : mergeAriaAttributeValues(ariaDescribedBy, keytipAttributes['aria-describedby'])
+                }
                 aria-activedescendant={this._getAriaActiveDescentValue()}
                 aria-required={required}
                 aria-disabled={disabled}
@@ -435,7 +439,11 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
             },
             this._onRenderContainer
           )}
-        {errorMessage && <div className={this._classNames.errorMessage}>{errorMessage}</div>}
+        {errorMessage !== undefined && (
+          <div role="region" aria-live="polite" aria-atomic="true" id={this._id + '-error'} className={this._classNames.errorMessage}>
+            {errorMessage}
+          </div>
+        )}
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -312,6 +312,24 @@ exports[`ComboBox Renders correctly 1`] = `
       </span>
     </button>
   </div>
+  <div
+    aria-atomic="true"
+    aria-live="polite"
+    className=
+
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          color: #a4262c;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+        }
+    id="ComboBox0-error"
+    role="region"
+  >
+    
+  </div>
 </div>
 `;
 
@@ -629,6 +647,24 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
         </i>
       </span>
     </button>
+  </div>
+  <div
+    aria-atomic="true"
+    aria-live="polite"
+    className=
+
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          color: #a4262c;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 12px;
+          font-weight: 400;
+        }
+    id="ComboBox4-error"
+    role="region"
+  >
+    
   </div>
 </div>
 `;

--- a/packages/office-ui-fabric-react/src/components/ComboBox/docs/ComboBoxDos.md
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/docs/ComboBoxDos.md
@@ -1,3 +1,4 @@
 - Use a ComboBox when there are multiple choices that can be collapsed under one title. Or if the list of items is long or when space is constrained.
 - ComboBoxs contain shortened statements or words.
 - Use a ComboBox when the selected option is more important than the alternatives (in contrast to radio buttons where all the choices are visible putting more emphasis on the other options).
+- Set empty strings values and not `undefined` to the `errorMessage` prop, when trying to spout dynamic error messages so that `aria-live` can work correctly for screen readers.

--- a/packages/office-ui-fabric-react/src/components/ComboBox/docs/ComboBoxDos.md
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/docs/ComboBoxDos.md
@@ -1,4 +1,3 @@
 - Use a ComboBox when there are multiple choices that can be collapsed under one title. Or if the list of items is long or when space is constrained.
 - ComboBoxs contain shortened statements or words.
 - Use a ComboBox when the selected option is more important than the alternatives (in contrast to radio buttons where all the choices are visible putting more emphasis on the other options).
-- Set empty strings values and not `undefined` to the `errorMessage` prop when trying to spout dynamic error messages so that `aria-live` can work correctly for screen readers.

--- a/packages/office-ui-fabric-react/src/components/ComboBox/docs/ComboBoxDos.md
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/docs/ComboBoxDos.md
@@ -1,4 +1,4 @@
 - Use a ComboBox when there are multiple choices that can be collapsed under one title. Or if the list of items is long or when space is constrained.
 - ComboBoxs contain shortened statements or words.
 - Use a ComboBox when the selected option is more important than the alternatives (in contrast to radio buttons where all the choices are visible putting more emphasis on the other options).
-- Set empty strings values and not `undefined` to the `errorMessage` prop, when trying to spout dynamic error messages so that `aria-live` can work correctly for screen readers.
+- Set empty strings values and not `undefined` to the `errorMessage` prop when trying to spout dynamic error messages so that `aria-live` can work correctly for screen readers.

--- a/packages/office-ui-fabric-react/src/components/ComboBox/examples/ComboBox.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/examples/ComboBox.Basic.Example.tsx
@@ -4,6 +4,7 @@ import {
   Fabric,
   IComboBox,
   IComboBoxOption,
+  IComboBoxProps,
   mergeStyles,
   PrimaryButton,
   SelectableOptionMenuItemType
@@ -32,9 +33,20 @@ const wrapperClassName = mergeStyles({
   }
 });
 
+interface IComboBoxBasicExampleState {
+  dynamicErrorValue: number | string;
+}
+
 // tslint:disable:jsx-no-lambda
-export class ComboBoxBasicExample extends React.Component<{}, {}> {
+export class ComboBoxBasicExample extends React.Component<{}, IComboBoxBasicExampleState> {
   private _basicComboBox = React.createRef<IComboBox>();
+
+  constructor(props: {}) {
+    super(props);
+    this.state = {
+      dynamicErrorValue: ''
+    };
+  }
 
   public render(): JSX.Element {
     return (
@@ -94,14 +106,35 @@ export class ComboBoxBasicExample extends React.Component<{}, {}> {
         />
 
         <ComboBox
-          label="ComboBox with error message"
+          label="ComboBox with static error message"
           defaultSelectedKey="B"
           errorMessage="Oh no! This ComboBox has an error!"
+          options={INITIAL_OPTIONS}
+        />
+
+        <ComboBox
+          label="ComboBox with dynamic error message"
+          onChange={this._onChange}
+          selectedKey={this.state.dynamicErrorValue}
+          errorMessage={this._getErrorMessage(this.state.dynamicErrorValue)}
           options={INITIAL_OPTIONS}
         />
 
         <ComboBox disabled label="Disabled ComboBox" defaultSelectedKey="D" options={INITIAL_OPTIONS} />
       </Fabric>
     );
+  }
+
+  private _onChange: IComboBoxProps['onChange'] = (event, option) => {
+    if (option) {
+      this.setState({ dynamicErrorValue: option.key });
+    }
+  };
+
+  private _getErrorMessage(value: number | string) {
+    if (value === 'B') {
+      return 'B is not an allowed option!';
+    }
+    return '';
   }
 }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -372,6 +372,24 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           </span>
         </button>
       </div>
+      <div
+        aria-atomic="true"
+        aria-live="polite"
+        className=
+
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #a4262c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+            }
+        id="ComboBox0-error"
+        role="region"
+      >
+        
+      </div>
     </div>
     <button
       className=
@@ -849,6 +867,24 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         </span>
       </button>
     </div>
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      className=
+
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #a4262c;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
+          }
+      id="ComboBox7-error"
+      role="region"
+    >
+      
+    </div>
   </div>
   <div
     className="ms-ComboBox-container "
@@ -1191,6 +1227,24 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           </i>
         </span>
       </button>
+    </div>
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      className=
+
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #a4262c;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
+          }
+      id="ComboBox11-error"
+      role="region"
+    >
+      
     </div>
   </div>
   <div
@@ -3302,6 +3356,24 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         </div>
       </div>
     </span>
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      className=
+
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #a4262c;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
+          }
+      id="ComboBox15-error"
+      role="region"
+    >
+      
+    </div>
   </div>
   <div
     className="ms-ComboBox-container "
@@ -4276,6 +4348,24 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           </i>
         </span>
       </button>
+    </div>
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      className=
+
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #a4262c;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
+          }
+      id="ComboBox27-error"
+      role="region"
+    >
+      
     </div>
   </div>
 </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -3333,7 +3333,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
       htmlFor="ComboBox19-input"
       id="ComboBox19-label"
     >
-      ComboBox with error message
+      ComboBox with static error message
     </label>
     <div
       className=
@@ -3405,6 +3405,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
     >
       <input
         aria-autocomplete="both"
+        aria-describedby="ComboBox19-error"
         aria-expanded={false}
         aria-labelledby="ComboBox19-label"
         autoCapitalize="off"
@@ -3600,6 +3601,8 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
       </button>
     </div>
     <div
+      aria-atomic="true"
+      aria-live="polite"
       className=
 
           {
@@ -3610,8 +3613,371 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             font-size: 12px;
             font-weight: 400;
           }
+      id="ComboBox19-error"
+      role="region"
     >
       Oh no! This ComboBox has an error!
+    </div>
+  </div>
+  <div
+    className="ms-ComboBox-container "
+  >
+    <label
+      className=
+          ms-Label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 600;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+      htmlFor="ComboBox23-input"
+      id="ComboBox23-label"
+    >
+      ComboBox with dynamic error message
+    </label>
+    <div
+      className=
+          ms-ComboBox
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            background-color: #ffffff;
+            border-color: #8a8886;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
+            cursor: text;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: 32px;
+            margin-left: 0;
+            outline: 0;
+            overflow: hidden;
+            padding-bottom: 1px;
+            padding-left: 8px;
+            padding-right: 32px;
+            padding-top: 1px;
+            position: relative;
+            text-overflow: ellipsis;
+            user-select: none;
+            white-space: nowrap;
+          }
+          & .ms-Label {
+            display: inline-block;
+            margin-bottom: 8px;
+          }
+          &.is-open {
+            border-color: #8a8886;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:hover {
+            border-color: #323130;
+          }
+          &:hover .ms-ComboBox-Input {
+            color: #201f1e;
+          }
+          &:hover .ms-ComboBox-Input::placeholder {
+            color: #201f1e;
+          }
+          &:hover .ms-ComboBox-Input:-ms-input-placeholder {
+            color: #201f1e;
+          }
+          &:hover .ms-ComboBox-Input::-ms-input-placeholder {
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            color: HighlightText;
+          }
+          &:active {
+            border-color: #0078d4;
+          }
+          @media screen and (-ms-high-contrast: active){&:active {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&:active .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+          &:focus {
+            border-color: #0078d4;
+          }
+          &:focus .ms-ComboBox-Input {
+            color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus {
+            -ms-high-contrast-adjust: none;
+            background-color: Window;
+            border-color: Highlight;
+            border-width: 2px;
+            color: HighlightText;
+            padding-bottom: 0;
+            padding-left: 11px;
+            padding-top: 0;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-ComboBox-CaretDown-button {
+            right: -2px;
+            top: -2px;
+          }
+      id="ComboBox23wrapper"
+    >
+      <input
+        aria-autocomplete="both"
+        aria-describedby="ComboBox23-error"
+        aria-expanded={false}
+        aria-labelledby="ComboBox23-label"
+        autoCapitalize="off"
+        autoComplete="off"
+        className=
+            ms-ComboBox-Input
+            {
+              background-color: #ffffff;
+              border-style: none;
+              box-sizing: border-box;
+              color: #323130;
+              font: inherit;
+              height: 28px;
+              outline: none;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              text-overflow: ellipsis;
+              width: 100%;
+            }
+            &::placeholder {
+              color: #605e5c;
+            }
+            &:-ms-input-placeholder {
+              color: #605e5c;
+            }
+            &::-ms-input-placeholder {
+              color: #605e5c;
+            }
+            &::-ms-clear {
+              display: none;
+            }
+        data-is-interactable={true}
+        data-lpignore={true}
+        id="ComboBox23-input"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onCompositionEnd={[Function]}
+        onCompositionStart={[Function]}
+        onCompositionUpdate={[Function]}
+        onFocus={[Function]}
+        onInput={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onTouchStart={[Function]}
+        readOnly={true}
+        role="combobox"
+        spellCheck={false}
+        type="text"
+        value=""
+      />
+      <button
+        aria-hidden={true}
+        className=
+            ms-Button
+            ms-Button--icon
+            ms-ComboBox-CaretDown-button
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 2px;
+              border: none;
+              box-sizing: border-box;
+              color: #605e5c;
+              cursor: default;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+              height: 32px;
+              line-height: 30px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0;
+              position: absolute;
+              right: -1px;
+              text-align: center;
+              text-decoration: none;
+              top: -1px;
+              user-select: none;
+              vertical-align: top;
+              width: 32px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid transparent;
+              bottom: 2px;
+              content: "";
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: absolute;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              -ms-high-contrast-adjust: none;
+              background-color: ButtonFace;
+              border-color: ButtonText;
+              color: ButtonText;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              color: #201f1e;
+              cursor: pointer;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:active {
+              background-color: #edebe9;
+              color: #201f1e;
+            }
+        data-is-focusable={false}
+        onBlur={[Function]}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        role="presentation"
+        tabIndex={-1}
+        type="button"
+      >
+        <span
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
+          data-automationid="splitbuttonprimary"
+        >
+          <i
+            aria-hidden={true}
+            className=
+                ms-Icon
+                ms-Button-icon
+                {
+                  display: inline-block;
+                }
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
+                {
+                  flex-shrink: 0;
+                  font-size: 12px;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  text-align: center;
+                  vertical-align: middle;
+                }
+            data-icon-name="ChevronDown"
+            role="presentation"
+          >
+            
+          </i>
+        </span>
+      </button>
+    </div>
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      className=
+
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #a4262c;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
+          }
+      id="ComboBox23-error"
+      role="region"
+    >
+      
     </div>
   </div>
   <div
@@ -3644,8 +4010,8 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active){& {
             color: GrayText;
           }
-      htmlFor="ComboBox23-input"
-      id="ComboBox23-label"
+      htmlFor="ComboBox27-input"
+      id="ComboBox27-label"
     >
       Disabled ComboBox
     </label>
@@ -3707,13 +4073,13 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             border-color: GrayText;
             color: GrayText;
           }
-      id="ComboBox23wrapper"
+      id="ComboBox27wrapper"
     >
       <input
         aria-autocomplete="none"
         aria-disabled={true}
         aria-expanded={false}
-        aria-labelledby="ComboBox23-label"
+        aria-labelledby="ComboBox27-label"
         autoCapitalize="off"
         autoComplete="off"
         className=
@@ -3753,7 +4119,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             }
         data-is-interactable={false}
         data-lpignore={true}
-        id="ComboBox23-input"
+        id="ComboBox27-input"
         onBlur={[Function]}
         onChange={[Function]}
         onClick={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
@@ -369,6 +369,24 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
         </span>
       </button>
     </div>
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      className=
+
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #a4262c;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
+          }
+      id="ComboBox0-error"
+      role="region"
+    >
+      
+    </div>
   </div>
   <div
     className="ms-ComboBox-container "
@@ -710,6 +728,24 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
           </i>
         </span>
       </button>
+    </div>
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      className=
+
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #a4262c;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
+          }
+      id="ComboBox4-error"
+      role="region"
+    >
+      
     </div>
   </div>
 </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
@@ -373,6 +373,24 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
         </span>
       </button>
     </div>
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      className=
+
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #a4262c;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
+          }
+      id="ComboBox0-error"
+      role="region"
+    >
+      
+    </div>
   </div>
   <div
     className="ms-ComboBox-container "
@@ -714,6 +732,24 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
           </i>
         </span>
       </button>
+    </div>
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      className=
+
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #a4262c;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
+          }
+      id="ComboBox4-error"
+      role="region"
+    >
+      
     </div>
   </div>
 </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -370,6 +370,24 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
         </span>
       </button>
     </div>
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      className=
+
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #a4262c;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
+          }
+      id="ComboBox0-error"
+      role="region"
+    >
+      
+    </div>
   </div>
   <div
     className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
@@ -365,6 +365,24 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
         </span>
       </button>
     </div>
+    <div
+      aria-atomic="true"
+      aria-live="polite"
+      className=
+
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #a4262c;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 12px;
+            font-weight: 400;
+          }
+      id="ComboBox0-error"
+      role="region"
+    >
+      
+    </div>
   </div>
 </div>
 `;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10693
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Error messages in `ComboBox` were not being read by screen readers, which creates an accessibility problem because non-sighted users would not be able to know that there has been an error in their input. To fix that this PR introduces 2 changes:

1. Set `aria-describedby` to the `ComboBox` so that when users focus on the `ComboBox` the screen readers correctly read that an error exists on that input.
2. Set `aria-live` on the `errorMessage` so that if the `ComboBox's` value changes to an invalid one, the error message is announced by screen readers at that moment.

I've added a new example with a dynamic error message to test for the second scenario.

One thing to consider is that we need the `errorMessage` region to be rendered and changed so that `aria-live` can work correctly, but we don't want to always render this if there is no value passed to the `errorMessage` prop. Given this, I've added a `Do` specifying to:

>Set empty strings values and not `undefined` to the `errorMessage` prop when trying to spout dynamic error messages so that aria-live can work correctly for screen readers.

For more info on why we need this:

> Assistive technologies will announce dynamic changes in the content of a live region. The live region must first be present (and usually empty), so that the browser and assistive technologies are aware of it. Any subsequent changes are then announced.
>
>Simply including an aria-live attribute or a specialized live region role (such as role="alert") in the initial markup as it's loaded will have no effect.
>
>Dynamically adding an element with an aria-live attribute or specialized role to the document also won't result in any announcement by assistive technologies (as, at that point, the browser/assistive technologies are not aware of the live region yet, so cannot monitor it for changes).
>
>Always make sure that the live region is present in the document first, and only then dynamically add/change any content.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10720)