### PR TITLE
ColorPicker: adding keyboard accessibility.

### DIFF
--- a/change/office-ui-fabric-react-2019-10-04-17-27-18-colorpicker-keyboard.json
+++ b/change/office-ui-fabric-react-2019-10-04-17-27-18-colorpicker-keyboard.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "ColorPicker: Adding keyboard accessibility to swatch and sliders.",
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com",
+  "commit": "82cf1a015590db75009c0ec312b3909e329407e7",
+  "date": "2019-10-05T00:27:18.419Z",
+  "file": "/Users/david/fabric/branch0/change/office-ui-fabric-react-2019-10-04-17-27-18-colorpicker-keyboard.json"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -2583,7 +2583,7 @@ export interface IColorRectangleProps {
     color: IColor;
     componentRef?: IRefObject<IColorRectangle>;
     minSize?: number;
-    onChange?: (ev: React.MouseEvent<HTMLElement>, color: IColor) => void;
+    onChange?: (ev: React.MouseEvent | React.KeyboardEvent, color: IColor) => void;
     styles?: IStyleFunctionOrObject<IColorRectangleStyleProps, IColorRectangleStyles>;
     theme?: ITheme;
 }
@@ -2614,7 +2614,7 @@ export interface IColorSliderProps {
     isAlpha?: boolean;
     maxValue?: number;
     minValue?: number;
-    onChange?: (event: React.MouseEvent<HTMLElement>, newValue?: number) => void;
+    onChange?: (event: React.MouseEvent | React.KeyboardEvent, newValue?: number) => void;
     overlayStyle?: any;
     styles?: IStyleFunctionOrObject<IColorSliderStyleProps, IColorSliderStyles>;
     theme?: ITheme;

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle/ColorRectangle.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle/ColorRectangle.base.tsx
@@ -1,12 +1,11 @@
 import * as React from 'react';
-import { classNamesFunction, EventGroup, initializeComponentRef } from '../../../Utilities';
+import { classNamesFunction, EventGroup, initializeComponentRef, getRTLSafeKeyCode, KeyCodes } from '../../../Utilities';
 import { IColor } from '../../../utilities/color/interfaces';
 import { MAX_COLOR_SATURATION, MAX_COLOR_VALUE } from '../../../utilities/color/consts';
 import { getFullColorString } from '../../../utilities/color/getFullColorString';
 import { updateSV } from '../../../utilities/color/updateSV';
 import { clamp } from '../../../utilities/color/clamp';
 import { IColorRectangleProps, IColorRectangleStyleProps, IColorRectangleStyles, IColorRectangle } from './ColorRectangle.types';
-import { KeyCodes } from '@uifabric/utilities';
 
 const getClassNames = classNamesFunction<IColorRectangleStyleProps, IColorRectangleStyles>();
 
@@ -91,7 +90,7 @@ export class ColorRectangleBase extends React.Component<IColorRectangleProps, IC
 
     const increment = ev.shiftKey ? 10 : 1;
 
-    switch (ev.which) {
+    switch (getRTLSafeKeyCode(ev.which)) {
       case KeyCodes.up: {
         v = Math.min(100, v + increment);
         break;

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle/ColorRectangle.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle/ColorRectangle.styles.ts
@@ -1,5 +1,6 @@
 import { IColorRectangleStyleProps, IColorRectangleStyles } from './ColorRectangle.types';
 import { HighContrastSelector } from '../../../Styling';
+import { IsFocusVisibleClassName } from '../../../Utilities';
 
 export const getStyles = (props: IColorRectangleStyleProps): IColorRectangleStyles => {
   const { className, theme, minSize } = props;
@@ -15,12 +16,14 @@ export const getStyles = (props: IColorRectangleStyleProps): IColorRectangleStyl
         borderRadius: effects.roundedCorner2,
         minWidth: minSize,
         minHeight: minSize,
+        outline: 'none',
+
         selectors: {
           [HighContrastSelector]: {
             MsHighContrastAdjust: 'none'
           },
 
-          ':focus': {
+          [`.${IsFocusVisibleClassName} &:focus`]: {
             outline: `1px solid ${palette.neutralSecondary}`
           }
         }

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle/ColorRectangle.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle/ColorRectangle.styles.ts
@@ -18,6 +18,10 @@ export const getStyles = (props: IColorRectangleStyleProps): IColorRectangleStyl
         selectors: {
           [HighContrastSelector]: {
             MsHighContrastAdjust: 'none'
+          },
+
+          ':focus': {
+            outline: `1px solid ${palette.neutralSecondary}`
           }
         }
       },

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle/ColorRectangle.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle/ColorRectangle.types.ts
@@ -48,7 +48,7 @@ export interface IColorRectangleProps {
   /**
    * Callback for when the color changes.
    */
-  onChange?: (ev: React.MouseEvent<HTMLElement>, color: IColor) => void;
+  onChange?: (ev: React.MouseEvent | React.KeyboardEvent, color: IColor) => void;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/ColorSlider.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/ColorSlider.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { classNamesFunction, initializeComponentRef, EventGroup, KeyCodes, getWindow } from '../../../Utilities';
+import { classNamesFunction, initializeComponentRef, EventGroup, KeyCodes, getWindow, getRTLSafeKeyCode } from '../../../Utilities';
 import { IColorSliderProps, IColorSliderStyleProps, IColorSliderStyles } from './ColorSlider.types';
 
 const getClassNames = classNamesFunction<IColorSliderStyleProps, IColorSliderStyles>();
@@ -91,7 +91,7 @@ export class ColorSliderBase extends React.Component<IColorSliderProps, IColorSl
     const { minValue = 0, maxValue = 100 } = this.props;
     const increment = ev.shiftKey ? 10 : 1;
 
-    switch (ev.which) {
+    switch (getRTLSafeKeyCode(ev.which)) {
       case KeyCodes.left: {
         currentValue = Math.max(minValue, currentValue - increment);
         break;

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/ColorSlider.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/ColorSlider.styles.ts
@@ -1,4 +1,5 @@
 import { IColorSliderStyleProps, IColorSliderStyles } from './ColorSlider.types';
+import { IsFocusVisibleClassName } from '../../../Utilities';
 
 export const getStyles = (props: IColorSliderStyleProps): IColorSliderStyles => {
   const { theme, className } = props;
@@ -14,9 +15,10 @@ export const getStyles = (props: IColorSliderStyleProps): IColorSliderStyles => 
         border: `1px solid ${palette.neutralLight}`,
         borderRadius: effects.roundedCorner2,
         boxSizing: 'border-box',
+        outline: 'none',
 
         selectors: {
-          ':focus': {
+          [`.${IsFocusVisibleClassName} &:focus`]: {
             outline: `1px solid ${palette.neutralSecondary}`
           }
         }

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/ColorSlider.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/ColorSlider.styles.ts
@@ -13,7 +13,13 @@ export const getStyles = (props: IColorSliderStyleProps): IColorSliderStyles => 
         marginBottom: 8,
         border: `1px solid ${palette.neutralLight}`,
         borderRadius: effects.roundedCorner2,
-        boxSizing: 'border-box'
+        boxSizing: 'border-box',
+
+        selectors: {
+          ':focus': {
+            outline: `1px solid ${palette.neutralSecondary}`
+          }
+        }
       },
       className
     ],

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/ColorSlider.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorSlider/ColorSlider.types.ts
@@ -44,7 +44,7 @@ export interface IColorSliderProps {
   /**
    * Callback issued when the value changes.
    */
-  onChange?: (event: React.MouseEvent<HTMLElement>, newValue?: number) => void;
+  onChange?: (event: React.MouseEvent | React.KeyboardEvent, newValue?: number) => void;
 
   /**
    * If true, the slider represents an alpha slider.


### PR DESCRIPTION
ColorPicker swatch rectangle and sliders were not keyboard accessible; now they are!

* Rectangle: up/down/left/right + shift modifier to go +10 instead of +1.
* Sliders: left/right/home/end + shift modifier
* Focus rect shows up but only when using the keyboard to tab around
* RTL safe


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10725)