### PR TITLE
cherrypick: Remove ReactDOM dependency in utilities.

### DIFF
--- a/change/@uifabric-utilities-2019-10-04-18-04-13-remove-reactdom.json
+++ b/change/@uifabric-utilities-2019-10-04-18-04-13-remove-reactdom.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Reverting dependency on ReactDOM findDOMNode in getWindow and getDocument helpers to avoid bundle problems for partners.",
+  "packageName": "@uifabric/utilities",
+  "email": "dzearing@microsoft.com",
+  "commit": "60e9282babcde13e7ad810d99113a1399e13d479",
+  "date": "2019-10-05T01:04:13.175Z",
+  "file": "/Users/david/fabric/branch0/change/@uifabric-utilities-2019-10-04-18-04-13-remove-reactdom.json"
+}

--- a/change/office-ui-fabric-react-2019-10-04-18-04-13-remove-reactdom.json
+++ b/change/office-ui-fabric-react-2019-10-04-18-04-13-remove-reactdom.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Reverting dependency on ReactDOM findDOMNode in utilities to avoid bundle problems in partners.",
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com",
+  "commit": "60e9282babcde13e7ad810d99113a1399e13d479",
+  "date": "2019-10-05T01:03:47.249Z",
+  "file": "/Users/david/fabric/branch0/change/office-ui-fabric-react-2019-10-04-18-04-13-remove-reactdom.json"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -286,7 +286,7 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
   protected _setInitialFocus = (): void => {
     if (this.props.setInitialFocus && !this._didSetInitialFocus && this.state.positions && this._calloutElement.current) {
       this._didSetInitialFocus = true;
-      this._async.requestAnimationFrame(() => focusFirstChild(this._calloutElement.current!), this);
+      this._async.requestAnimationFrame(() => focusFirstChild(this._calloutElement.current!), this._calloutElement.current);
     }
   };
 
@@ -339,7 +339,7 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
   }
 
   private _updateAsyncPosition(): void {
-    this._async.requestAnimationFrame(() => this._updatePosition(), this);
+    this._async.requestAnimationFrame(() => this._updatePosition(), this._calloutElement.current);
   }
 
   private _getBeakPosition(): React.CSSProperties {
@@ -476,11 +476,13 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
   }
 
   private _setTargetWindowAndElement(target: Element | string | MouseEvent | IPoint | null): void {
+    const currentElement = this._calloutElement.current;
+
     if (target) {
       if (typeof target === 'string') {
-        const currentDoc: Document = getDocument(this)!;
+        const currentDoc: Document = getDocument(currentElement)!;
         this._target = currentDoc ? (currentDoc.querySelector(target) as Element) : null;
-        this._targetWindow = getWindow(this)!;
+        this._targetWindow = getWindow(currentElement)!;
       } else if ((target as MouseEvent).stopPropagation) {
         this._targetWindow = getWindow((target as MouseEvent).toElement as HTMLElement)!;
         this._target = target;
@@ -490,11 +492,11 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
         this._target = target;
         // HTMLImgElements can have x and y values. The check for it being a point must go last.
       } else {
-        this._targetWindow = getWindow(this)!;
+        this._targetWindow = getWindow(currentElement)!;
         this._target = target as IPoint;
       }
     } else {
-      this._targetWindow = getWindow(this)!;
+      this._targetWindow = getWindow(currentElement)!;
     }
   }
 
@@ -518,9 +520,9 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
         if (calloutMainElem.offsetHeight < this.props.finalHeight!) {
           this._setHeightOffsetEveryFrame();
         } else {
-          this._async.cancelAnimationFrame(this._setHeightOffsetTimer, this._target as Element);
+          this._async.cancelAnimationFrame(this._setHeightOffsetTimer, this._calloutElement.current);
         }
-      }, this);
+      }, this._calloutElement.current);
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/PositioningContainer/PositioningContainer.tsx
@@ -354,16 +354,18 @@ export class PositioningContainer extends BaseComponent<IPositioningContainerPro
   }
 
   private _setTargetWindowAndElement(target: HTMLElement | string | MouseEvent | IPoint | null): void {
+    const currentElement = this._positionedHost.current;
+
     if (target) {
       if (typeof target === 'string') {
         const currentDoc: Document = getDocument()!;
         this._target = currentDoc ? (currentDoc.querySelector(target) as HTMLElement) : null;
-        this._targetWindow = getWindow(this)!;
+        this._targetWindow = getWindow(currentElement)!;
       } else if ((target as MouseEvent).stopPropagation) {
         this._targetWindow = getWindow((target as MouseEvent).toElement as HTMLElement)!;
         this._target = target;
       } else if ((target as IPoint).x !== undefined && (target as IPoint).y !== undefined) {
-        this._targetWindow = getWindow(this)!;
+        this._targetWindow = getWindow(currentElement)!;
         this._target = target;
       } else {
         const targetElement: HTMLElement = target as HTMLElement;
@@ -371,7 +373,7 @@ export class PositioningContainer extends BaseComponent<IPositioningContainerPro
         this._target = target;
       }
     } else {
-      this._targetWindow = getWindow(this)!;
+      this._targetWindow = getWindow(currentElement)!;
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -1175,16 +1175,18 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
   };
 
   private _setTargetWindowAndElement(target: Element | string | MouseEvent | IPoint): void {
+    const currentElement = this._host;
+
     if (target) {
       if (typeof target === 'string') {
-        const currentDoc: Document = getDocument()!;
+        const currentDoc: Document = getDocument(currentElement)!;
         this._target = currentDoc ? (currentDoc.querySelector(target) as Element) : null;
-        this._targetWindow = getWindow(this)!;
+        this._targetWindow = getWindow(currentElement)!;
       } else if ((target as MouseEvent).stopPropagation) {
         this._targetWindow = getWindow((target as MouseEvent).toElement as HTMLElement)!;
         this._target = target;
       } else if ((target as IPoint).x !== undefined && (target as IPoint).y !== undefined) {
-        this._targetWindow = getWindow(this)!;
+        this._targetWindow = getWindow(currentElement)!;
         this._target = target;
       } else {
         const targetElement: Element = target as Element;
@@ -1192,7 +1194,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
         this._target = target;
       }
     } else {
-      this._targetWindow = getWindow(this)!;
+      this._targetWindow = getWindow(currentElement)!;
     }
   }
 

--- a/packages/office-ui-fabric-react/src/components/Layer/Layer.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Layer/Layer.base.tsx
@@ -80,7 +80,7 @@ export class LayerBase extends React.Component<ILayerProps, ILayerBaseState> {
   private _createLayerElement = () => {
     const { hostId } = this.props;
 
-    const doc = getDocument(this);
+    const doc = getDocument(this._rootRef.current);
     const host = this._getHost();
 
     if (!doc || !host) {
@@ -146,7 +146,7 @@ export class LayerBase extends React.Component<ILayerProps, ILayerBaseState> {
 
   private _getHost(): Node | undefined {
     const { hostId } = this.props;
-    const doc = getDocument(this);
+    const doc = getDocument(this._rootRef.current);
     if (!doc) {
       return undefined;
     }

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -967,7 +967,7 @@ export class List<T = any> extends BaseComponent<IListProps<T>, IListState<T>> i
     // The first time the list gets rendered we need to calculate the rectangle. The width of the list is
     // used to calculate the width of the list items.
     const visibleTop = Math.max(0, -surfaceRect.top);
-    const win = getWindow(this);
+    const win = getWindow(this._root.current);
     const visibleRect = {
       top: visibleTop,
       left: surfaceRect.left,

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withResponsiveMode.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withResponsiveMode.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { findDOMNode } from 'react-dom';
 import { BaseDecorator } from './BaseDecorator';
 import { getWindow, hoistStatics } from '../../Utilities';
 
@@ -69,7 +70,8 @@ export function withResponsiveMode<TProps extends { responsiveMode?: ResponsiveM
 
     private _getResponsiveMode(): ResponsiveMode {
       let responsiveMode = ResponsiveMode.small;
-      const win = getWindow(this);
+      const element = findDOMNode(this) as Element;
+      const win = getWindow(element);
 
       if (typeof win !== 'undefined') {
         try {

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
@@ -69,7 +69,7 @@ export function withViewport<TProps extends { viewport?: IViewport }, TState>(
 
     public componentDidMount(): void {
       const { skipViewportMeasures } = this.props as IWithViewportProps;
-      const win = getWindow(this);
+      const win = getWindow(this._root.current);
 
       this._onAsyncResize = this._async.debounce(this._onAsyncResize, RESIZE_DELAY, {
         leading: false
@@ -93,7 +93,7 @@ export function withViewport<TProps extends { viewport?: IViewport }, TState>(
     public componentDidUpdate(newProps: TProps) {
       const { skipViewportMeasures: oldSkipViewportMeasures } = this.props as IWithViewportProps;
       const { skipViewportMeasures: newSkipViewportMeasures } = newProps as IWithViewportProps;
-      const win = getWindow(this);
+      const win = getWindow(this._root.current);
 
       if (oldSkipViewportMeasures !== newSkipViewportMeasures) {
         if (newSkipViewportMeasures) {
@@ -138,13 +138,13 @@ export function withViewport<TProps extends { viewport?: IViewport }, TState>(
     }
 
     private _isResizeObserverAvailable(): boolean {
-      const win = getWindow(this);
+      const win = getWindow(this._root.current);
 
       return win && (win as any).ResizeObserver;
     }
 
     private _registerResizeObserver = () => {
-      const win = getWindow(this);
+      const win = getWindow(this._root.current);
 
       this._viewportResizeObserver = new (win as any).ResizeObserver(this._onAsyncResize);
       this._viewportResizeObserver.observe(this._root.current);

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { Component } from 'react';
 import { IProcessedStyleSet } from '@uifabric/merge-styles';
 import { IStyleFunction } from '@uifabric/merge-styles';
 import { IStyleFunctionOrObject } from '@uifabric/merge-styles';
@@ -46,8 +45,8 @@ export function assign(target: any, ...args: any[]): any;
 export class Async {
     constructor(parent?: object, onError?: (e: any) => void);
     // (undocumented)
-    cancelAnimationFrame(id: number, targetElement?: Element | Component | null): void;
-    clearImmediate(id: number, targetElement?: Element | Component | null): void;
+    cancelAnimationFrame(id: number, targetElement?: Element | null): void;
+    clearImmediate(id: number, targetElement?: Element | null): void;
     clearInterval(id: number): void;
     clearTimeout(id: number): void;
     debounce<T extends Function>(func: T, wait?: number, options?: {
@@ -59,8 +58,8 @@ export class Async {
     // (undocumented)
     protected _logError(e: any): void;
     // (undocumented)
-    requestAnimationFrame(callback: () => void, targetElement?: Element | Component | null): number;
-    setImmediate(callback: () => void, targetElement?: Element | Component | null): number;
+    requestAnimationFrame(callback: () => void, targetElement?: Element | null): number;
+    setImmediate(callback: () => void, targetElement?: Element | null): number;
     setInterval(callback: () => void, duration: number): number;
     setTimeout(callback: () => void, duration: number): number;
     throttle<T extends Function>(func: T, wait?: number, options?: {
@@ -295,7 +294,7 @@ export function getChildren(parent: HTMLElement, allowVirtualChildren?: boolean)
 export function getDistanceBetweenPoints(point1: IPoint, point2: IPoint): number;
 
 // @public
-export function getDocument(rootElement?: HTMLElement | Component | null): Document | undefined;
+export function getDocument(rootElement?: HTMLElement | null): Document | undefined;
 
 // @public
 export function getElementIndexPath(fromElement: HTMLElement, toElement: HTMLElement): number[];
@@ -355,7 +354,7 @@ export function getScrollbarWidth(): number;
 export function getVirtualParent(child: HTMLElement): HTMLElement | undefined;
 
 // @public
-export function getWindow(rootElement?: Element | Component | null): Window | undefined;
+export function getWindow(rootElement?: Element | null): Window | undefined;
 
 // @public
 export class GlobalSettings {

--- a/packages/utilities/src/Async.ts
+++ b/packages/utilities/src/Async.ts
@@ -1,5 +1,4 @@
 import { getWindow } from './dom/getWindow';
-import { Component } from 'react';
 
 declare function setTimeout(cb: Function, delay: number): number;
 declare function setInterval(cb: Function, delay: number): number;
@@ -143,7 +142,7 @@ export class Async {
    * @param targetElement - Optional target element to use for identifying the correct window.
    * @returns The setTimeout id.
    */
-  public setImmediate(callback: () => void, targetElement?: Element | Component | null): number {
+  public setImmediate(callback: () => void, targetElement?: Element | null): number {
     let immediateId = 0;
     const win = getWindow(targetElement)!;
 
@@ -181,7 +180,7 @@ export class Async {
    * @param id - Id to cancel.
    * @param targetElement - Optional target element to use for identifying the correct window.
    */
-  public clearImmediate(id: number, targetElement?: Element | Component | null): void {
+  public clearImmediate(id: number, targetElement?: Element | null): void {
     const win = getWindow(targetElement)!;
 
     if (this._immediateIds && this._immediateIds[id]) {
@@ -446,7 +445,7 @@ export class Async {
     return resultFunction;
   }
 
-  public requestAnimationFrame(callback: () => void, targetElement?: Element | Component | null): number {
+  public requestAnimationFrame(callback: () => void, targetElement?: Element | null): number {
     let animationFrameId = 0;
     const win = getWindow(targetElement)!;
 
@@ -480,7 +479,7 @@ export class Async {
     return animationFrameId;
   }
 
-  public cancelAnimationFrame(id: number, targetElement?: Element | Component | null): void {
+  public cancelAnimationFrame(id: number, targetElement?: Element | null): void {
     const win = getWindow(targetElement)!;
 
     if (this._animationFrameIds && this._animationFrameIds[id]) {

--- a/packages/utilities/src/dom/getDocument.ts
+++ b/packages/utilities/src/dom/getDocument.ts
@@ -1,6 +1,4 @@
 import { _isSSR } from './setSSR';
-import { Component } from 'react';
-import { findDOMNode } from 'react-dom';
 
 /**
  * Helper to get the document object. Note that in popup window cases, document
@@ -10,11 +8,11 @@ import { findDOMNode } from 'react-dom';
  *
  * @public
  */
-export function getDocument(rootElement?: HTMLElement | Component | null): Document | undefined {
+export function getDocument(rootElement?: HTMLElement | null): Document | undefined {
   if (_isSSR || typeof document === 'undefined') {
     return undefined;
   } else {
-    const el = rootElement && !(rootElement as Element).ownerDocument ? findDOMNode(rootElement) : (rootElement as Element);
+    const el = rootElement as Element;
 
     return el && el.ownerDocument ? el.ownerDocument : document;
   }

--- a/packages/utilities/src/dom/getWindow.ts
+++ b/packages/utilities/src/dom/getWindow.ts
@@ -1,6 +1,4 @@
 import { _isSSR } from './setSSR';
-import { Component } from 'react';
-import { findDOMNode } from 'react-dom';
 
 let _window: Window | undefined = undefined;
 
@@ -21,11 +19,11 @@ try {
  *
  * @public
  */
-export function getWindow(rootElement?: Element | Component | null): Window | undefined {
+export function getWindow(rootElement?: Element | null): Window | undefined {
   if (_isSSR || typeof _window === 'undefined') {
     return undefined;
   } else {
-    const el = rootElement && !(rootElement as Element).ownerDocument ? (findDOMNode(rootElement) as Element) : (rootElement as Element);
+    const el = rootElement as Element;
 
     return el && el.ownerDocument && el.ownerDocument.defaultView ? el.ownerDocument.defaultView : _window;
   }


### PR DESCRIPTION
@KevinTCoughlin 

Here's the cherrypick for the removal of `findDOMNode` from the utilities package.

This should help with bundle concerns for 6.0 users.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10728)