### PR TITLE
Reversing order of expanded and hasMenu in getClassnames prop function call

### DIFF
--- a/change/office-ui-fabric-react-2019-10-07-17-46-52-BaseButtonReverseArgs.json
+++ b/change/office-ui-fabric-react-2019-10-07-17-46-52-BaseButtonReverseArgs.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Changing order of arguments passed to getClassNames. Until now it was inconsitent with type defined in Button.types.ts",
+  "comment": "Changing order of arguments passed to getClassNames. Until now it was inconsistent with type defined in Button.types.ts",
   "packageName": "office-ui-fabric-react",
   "email": "kushaly@microsoft.com",
   "commit": "93ba0469f7268622bd3d2e4068c6aa4689b3bd19",

--- a/change/office-ui-fabric-react-2019-10-07-17-46-52-BaseButtonReverseArgs.json
+++ b/change/office-ui-fabric-react-2019-10-07-17-46-52-BaseButtonReverseArgs.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Changing order of arguments passed to getClassNames. Until now it was inconsitent with type defined in Button.types.ts",
+  "packageName": "office-ui-fabric-react",
+  "email": "kushaly@microsoft.com",
+  "commit": "93ba0469f7268622bd3d2e4068c6aa4689b3bd19",
+  "date": "2019-10-08T00:46:52.606Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -126,8 +126,8 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
           menuIconProps && menuIconProps.className,
           isPrimaryButtonDisabled!,
           checked!,
-          !!this.props.menuProps,
           !menuHidden,
+          !!this.props.menuProps,
           this.props.split,
           !!allowDisabledFocus
         )


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

In [PR](https://github.com/OfficeDev/office-ui-fabric-react/pull/10580) I think the order of `hasMenu` and `expanded`  in the type definition and the function call of `getClassNames` is inconsistent.

This meant a lot of our menu buttons have a expanded look by default when we update Fabric. This should fix it. 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10733)