### PR TITLE
Editor: fix examples which use fragments

### DIFF
--- a/change/@uifabric-tsx-editor-2019-10-07-21-21-21-jsx-factory.json
+++ b/change/@uifabric-tsx-editor-2019-10-07-21-21-21-jsx-factory.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Fix examples with fragments and refine diagnostic options",
+  "packageName": "@uifabric/tsx-editor",
+  "email": "elcraig@microsoft.com",
+  "commit": "0ca82fbc0625a093136d5d1ea228466b58834497",
+  "date": "2019-10-08T04:21:21.369Z",
+  "file": "/Users/elizabeth/git/fabric-react10/change/@uifabric-tsx-editor-2019-10-07-21-21-21-jsx-factory.json"
+}

--- a/packages/tsx-editor/src/components/TsxEditor.tsx
+++ b/packages/tsx-editor/src/components/TsxEditor.tsx
@@ -94,16 +94,17 @@ function _useCompilerOptions(compilerOptions: ICompilerOptions | undefined): voi
   React.useEffect(() => {
     const oldCompilerOptions = typescriptDefaults.getCompilerOptions();
     typescriptDefaults.setCompilerOptions({
+      // The compiler options used here generally should *not* be strict, because compile errors
+      // will prevent code from rendering
       experimentalDecorators: true,
       preserveConstEnums: true,
+      noImplicitThis: true,
       // Mix in provided options
       ...compilerOptions,
       // These options are essential to making the transform/eval and types code work (no overriding)
-      noEmitOnError: true,
       allowNonTsExtensions: true,
       target: typescript.ScriptTarget.ES2015,
       jsx: typescript.JsxEmit.React,
-      jsxFactory: 'React.createElement',
       module: typescript.ModuleKind.ESNext,
       baseUrl: filePrefix,
       // This is updated after types are loaded, so preserve the old setting

--- a/packages/tsx-editor/src/components/TsxEditor.tsx
+++ b/packages/tsx-editor/src/components/TsxEditor.tsx
@@ -94,10 +94,10 @@ function _useCompilerOptions(compilerOptions: ICompilerOptions | undefined): voi
   React.useEffect(() => {
     const oldCompilerOptions = typescriptDefaults.getCompilerOptions();
     typescriptDefaults.setCompilerOptions({
-      // The compiler options used here generally should *not* be strict, because compile errors
-      // will prevent code from rendering
+      // The compiler options used here generally should *not* be strict, to make quick edits easier
       experimentalDecorators: true,
       preserveConstEnums: true,
+      // implicit global `this` usage is almost always a bug
       noImplicitThis: true,
       // Mix in provided options
       ...compilerOptions,

--- a/packages/tsx-editor/src/transpiler/transpile.ts
+++ b/packages/tsx-editor/src/transpiler/transpile.ts
@@ -24,31 +24,24 @@ export function transpile(model: IMonacoTextModel): Promise<ITransformedCode> {
     .then((getWorker: (uri: monaco.Uri) => Promise<TypeScriptWorker>) => getWorker(model.uri))
     .then(worker => {
       return worker.getEmitOutput(filename).then((output: EmitOutput) => {
-        if (!output.emitSkipped) {
-          transpiledOutput.output = output.outputFiles[0].text;
-          if (win && win.transpileLogging) {
-            console.log('TRANSPILED:');
-            console.log(transpiledOutput.output);
+        // Get diagnostics to find out if there were any syntax errors (there's also getSemanticDiagnostics
+        // for type errors etc, but it may be better to allow the user to just find and fix those
+        // via intellisense rather than blocking compilation, since they may be non-fatal)
+        return worker.getSyntacticDiagnostics(filename).then(syntacticDiagnostics => {
+          syntacticDiagnostics = syntacticDiagnostics.filter(d => d.category === 1 /*error*/);
+
+          if (syntacticDiagnostics.length) {
+            // Don't try to run the example if there's a syntax error
+            transpiledOutput.error = _getErrorMessages(syntacticDiagnostics, model.getValue());
+          } else {
+            transpiledOutput.output = output.outputFiles[0].text;
+            if (win && win.transpileLogging) {
+              console.log('TRANSPILED:');
+              console.log(transpiledOutput.output);
+            }
           }
           return transpiledOutput;
-        }
-        // There was an error, so get diagnostics
-        return Promise.all([worker.getSyntacticDiagnostics(filename), worker.getSemanticDiagnostics(filename)]).then(
-          ([syntacticDiagnostics, semanticDiagnostics]) => {
-            syntacticDiagnostics = syntacticDiagnostics.filter(d => d.category === 1 /*error*/);
-            semanticDiagnostics = semanticDiagnostics.filter(d => d.category === 1);
-
-            // If there's a syntax error, draw attention to that first and ignore any semantic errors
-            const diagnostics = syntacticDiagnostics.length ? syntacticDiagnostics : semanticDiagnostics;
-            if (diagnostics.length) {
-              transpiledOutput.error = _getErrorMessages(diagnostics, model.getValue());
-            } else {
-              transpiledOutput.error = 'Error transpiling code';
-            }
-
-            return transpiledOutput;
-          }
-        );
+        });
       });
     })
     .catch(ex => {


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Apparently the TS compiler option `jsxFactory: 'React.createElement'` prevents fragments from working, so remove it since it's not necessary. (Only a small number of examples use fragments, which is why I didn't catch this.)

Also switch to treating semantic (type) errors as non-fatal: attempting to render the example anyway and not displaying those errors in the message bar (let people use intellisense instead). Syntax errors are still fatal.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10734)