### PR TITLE
Breadcrumb: fix accessibility and styling issues

### DIFF
--- a/apps/vr-tests/src/stories/Breadcrumb.stories.tsx
+++ b/apps/vr-tests/src/stories/Breadcrumb.stories.tsx
@@ -72,3 +72,41 @@ storiesOf('Breadcrumb', module)
     ),
     { rtl: true }
   );
+
+// Stories for hovering over actionable and non-actionable items
+storiesOf('Breadcrumb', module)
+  .addDecorator(FabricDecoratorTall)
+  .addDecorator(story => (
+    <Screener
+      steps={new Screener.Steps()
+        .hover('.ms-Breadcrumb-list li:nth-child(2)')
+        .snapshot('non-actionable hover', { cropTo: '.testWrapper' })
+        .hover('.ms-Breadcrumb-list li:nth-child(3)')
+        .snapshot('actionable hover', { cropTo: '.testWrapper' })
+        .hover('.ms-Breadcrumb-overflowButton')
+        .click('.ms-Breadcrumb-overflowButton') // opening the dropdown
+        .hover('.ms-Breadcrumb-overflowButton') // moving the mouse a bit to let dropdown open.
+        .hover('.ms-ContextualMenu-list li:nth-child(2)')
+        .snapshot('actionable overflow hover', { cropTo: '.testWrapper' })
+        .hover('.ms-ContextualMenu-list li:nth-child(3)')
+        .snapshot('non-actionable overflow hover', { cropTo: '.testWrapper' })
+        .end()}
+    >
+      {story()}
+    </Screener>
+  ))
+  .addStory('Hovering items', () => (
+    <Breadcrumb
+      items={[
+        // overflow
+        { text: 'Files', key: 'Files' },
+        { text: 'Folder 1', key: 'l1', onClick: noOp },
+        { text: 'Folder 2 no action', key: 'l2' },
+        // displayed
+        { text: 'Folder 3', key: 'l3', onClick: noOp },
+        { text: 'Folder 4 no action', key: 'l4' },
+        { text: 'Folder 5', key: 'l5', onClick: noOp, isCurrentItem: true }
+      ]}
+      maxDisplayedItems={3}
+    />
+  ));

--- a/apps/vr-tests/src/stories/Breadcrumb.stories.tsx
+++ b/apps/vr-tests/src/stories/Breadcrumb.stories.tsx
@@ -80,9 +80,9 @@ storiesOf('Breadcrumb', module)
     <Screener
       steps={new Screener.Steps()
         .hover('.ms-Breadcrumb-list li:nth-child(2)')
-        .snapshot('non-actionable hover', { cropTo: '.testWrapper' })
-        .hover('.ms-Breadcrumb-list li:nth-child(3)')
         .snapshot('actionable hover', { cropTo: '.testWrapper' })
+        .hover('.ms-Breadcrumb-list li:nth-child(3)')
+        .snapshot('non-actionable hover', { cropTo: '.testWrapper' })
         .hover('.ms-Breadcrumb-overflowButton')
         .click('.ms-Breadcrumb-overflowButton') // opening the dropdown
         .hover('.ms-Breadcrumb-overflowButton') // moving the mouse a bit to let dropdown open.

--- a/change/office-ui-fabric-react-2019-10-14-12-36-08-breadcrumb.json
+++ b/change/office-ui-fabric-react-2019-10-14-12-36-08-breadcrumb.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Breadcrumb: fix accessibility and styling issues",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "commit": "7794b431160d816468f248b016e0b7346ffa7bc9",
+  "date": "2019-10-14T19:36:08.850Z",
+  "file": "/Users/elizabeth/git/fabric-react10/change/office-ui-fabric-react-2019-10-14-12-36-08-breadcrumb.json"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -444,7 +444,7 @@ export enum BaseSlots {
 export const Breadcrumb: React.StatelessComponent<IBreadcrumbProps>;
 
 // @public (undocumented)
-export class BreadcrumbBase extends BaseComponent<IBreadcrumbProps, any> {
+export class BreadcrumbBase extends React.Component<IBreadcrumbProps, any> {
     constructor(props: IBreadcrumbProps);
     // (undocumented)
     static defaultProps: IBreadcrumbProps;
@@ -1811,7 +1811,7 @@ export interface IBreadcrumbData {
 
 // @public (undocumented)
 export interface IBreadcrumbItem {
-    as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+    as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'a';
     href?: string;
     isCurrentItem?: boolean;
     key: string;
@@ -2928,6 +2928,7 @@ export interface IContextualMenuItem {
     role?: string;
     secondaryText?: string;
     sectionProps?: IContextualMenuSection;
+    // @deprecated (undocumented)
     shortCut?: string;
     split?: boolean;
     // @deprecated
@@ -3005,7 +3006,7 @@ export interface IContextualMenuListProps {
 
 // Warning: (ae-forgotten-export) The symbol "IWithResponsiveModeState" needs to be exported by the entry point index.d.ts
 // 
-// @public
+// @public (undocumented)
 export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWithResponsiveModeState {
     alignTargetEdge?: boolean;
     ariaLabel?: string;
@@ -3058,7 +3059,7 @@ export interface IContextualMenuRenderItem {
     openSubMenu: () => void;
 }
 
-// @public
+// @public (undocumented)
 export interface IContextualMenuSection extends React.ClassAttributes<any> {
     bottomDivider?: boolean;
     items: IContextualMenuItem[];
@@ -3091,7 +3092,9 @@ export interface IContextualMenuState {
 
 // @public (undocumented)
 export interface IContextualMenuStyleProps {
+    // (undocumented)
     className?: string;
+    // (undocumented)
     theme: ITheme;
 }
 

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.doc.tsx
@@ -1,20 +1,28 @@
 import * as React from 'react';
 
 import { BreadcrumbBasicExample } from './examples/Breadcrumb.Basic.Example';
+import { BreadcrumbCollapsingExample } from './examples/Breadcrumb.Collapsing.Example';
 import { BreadcrumbStaticExample } from './examples/Breadcrumb.Static.Example';
 import { IDocPageProps } from '../../common/DocPage.types';
 
 const BreadcrumbBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx') as string;
+const BreadcrumbCollapsingExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Collapsing.Example.tsx') as string;
 const BreadcrumbStaticExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Static.Example.tsx') as string;
+
 export const BreadcrumbPageProps: IDocPageProps = {
   title: 'Breadcrumb',
   componentName: 'Breadcrumb',
   componentUrl: 'https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/office-ui-fabric-react/src/components/Breadcrumb',
   examples: [
     {
-      title: 'Default Breadcrumb',
+      title: 'Breadcrumb rendering options',
       code: BreadcrumbBasicExampleCode,
       view: <BreadcrumbBasicExample />
+    },
+    {
+      title: 'Breadcrumb collapsing options',
+      code: BreadcrumbCollapsingExampleCode,
+      view: <BreadcrumbCollapsingExample />
     },
     {
       title: 'Breadcrumb with static width ',

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.test.tsx
@@ -1,113 +1,138 @@
 import * as React from 'react';
-import { mount } from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
 import * as renderer from 'react-test-renderer';
 import { Breadcrumb, IBreadcrumbItem } from './index';
 import { Icon } from '../Icon/Icon';
 
 describe('Breadcrumb', () => {
+  const items: IBreadcrumbItem[] = [
+    { text: 'TestText1', key: 'TestKey1' },
+    { text: 'TestText2', key: 'TestKey2' },
+    { text: 'TestText3', key: 'TestKey3' },
+    { text: 'TestText4', key: 'TestKey4' }
+  ];
+
+  let component: renderer.ReactTestRenderer | undefined;
+  let wrapper: ReactWrapper | undefined;
+
+  afterEach(() => {
+    if (component) {
+      component.unmount();
+      component = undefined;
+    }
+    if (wrapper) {
+      wrapper.unmount();
+      wrapper = undefined;
+    }
+  });
+
   it('renders empty breadcrumb', () => {
-    const component = renderer.create(<Breadcrumb items={[]} />);
+    component = renderer.create(<Breadcrumb items={[]} />);
 
     const tree = component.toJSON();
 
     expect(tree).toMatchSnapshot();
   });
 
-  describe('basic rendering', () => {
-    const items: IBreadcrumbItem[] = [
-      { text: 'TestText1', key: 'TestKey1' },
-      { text: 'TestText2', key: 'TestKey2' },
-      { text: 'TestText3', key: 'TestKey3' },
-      { text: 'TestText4', key: 'TestKey4' }
-    ];
-
-    const divider = () => <span>*</span>;
-
-    const overflowIcon = () => <Icon iconName={'ChevronDown'} />;
-
-    it('renders breadcumb correctly 1', () => {
-      const component = renderer.create(<Breadcrumb items={items} />);
+  describe('rendering', () => {
+    it('renders correctly', () => {
+      component = renderer.create(<Breadcrumb items={items} />);
 
       const tree = component.toJSON();
       expect(tree).toMatchSnapshot();
     });
 
-    it('renders breadcumb correctly 2', () => {
-      // With overflow
-      const component = renderer.create(<Breadcrumb items={items} maxDisplayedItems={2} />);
+    it('renders correctly with overflow', () => {
+      component = renderer.create(<Breadcrumb items={items} maxDisplayedItems={2} />);
 
       const tree = component.toJSON();
       expect(tree).toMatchSnapshot();
     });
 
-    it('renders breadcumb correctly 3', () => {
-      // With custom divider
-      const component = renderer.create(<Breadcrumb items={items} dividerAs={divider} />);
+    it('renders correctly with custom divider', () => {
+      const divider = () => <span>*</span>;
+      component = renderer.create(<Breadcrumb items={items} dividerAs={divider} />);
 
       const tree = component.toJSON();
       expect(tree).toMatchSnapshot();
     });
 
-    it('renders breadcumb correctly 4', () => {
-      // With overflow and overflowIndex
-      const component = renderer.create(<Breadcrumb items={items} maxDisplayedItems={2} overflowIndex={1} />);
+    it('renders correctly with overflow and overflowIndex', () => {
+      component = renderer.create(<Breadcrumb items={items} maxDisplayedItems={2} overflowIndex={1} />);
 
       const tree = component.toJSON();
       expect(tree).toMatchSnapshot();
     });
 
-    it('renders breadcumb correctly 5', () => {
-      // With maxDisplayedItems and overflowIndex
-      const component = renderer.create(<Breadcrumb items={items} maxDisplayedItems={1} overflowIndex={1} />);
+    it('renders correctly with maxDisplayedItems and overflowIndex', () => {
+      component = renderer.create(<Breadcrumb items={items} maxDisplayedItems={1} overflowIndex={1} />);
 
       const tree = component.toJSON();
       expect(tree).toMatchSnapshot();
     });
 
-    it('renders breadcumb correctly 6', () => {
-      // With maxDisplayedItems and overflowIndex as 0
-      const component = renderer.create(<Breadcrumb items={items} maxDisplayedItems={0} overflowIndex={0} />);
+    it('renders correctly with maxDisplayedItems and overflowIndex as 0', () => {
+      component = renderer.create(<Breadcrumb items={items} maxDisplayedItems={0} overflowIndex={0} />);
 
       const tree = component.toJSON();
       expect(tree).toMatchSnapshot();
     });
 
-    it('renders breadcumb correctly 7', () => {
-      // With custom overflow icon
-      const component = renderer.create(<Breadcrumb items={items} maxDisplayedItems={2} onRenderOverflowIcon={overflowIcon} />);
+    it('renders  correctly with custom overflow icon', () => {
+      const overflowIcon = () => <Icon iconName={'ChevronDown'} />;
+      component = renderer.create(<Breadcrumb items={items} maxDisplayedItems={2} onRenderOverflowIcon={overflowIcon} />);
 
       const tree = component.toJSON();
       expect(tree).toMatchSnapshot();
     });
   });
 
-  it('can call the callback when an item is clicked', () => {
+  it('renders items with expected element type', () => {
+    const items2: IBreadcrumbItem[] = [
+      { text: 'Test1', key: 'Test1', href: 'http://bing.com', onClick: () => undefined },
+      { text: 'Test2', key: 'Test2', onClick: () => undefined },
+      { text: 'Test3', key: 'Test3', as: 'h1' }
+    ];
+
+    wrapper = mount(<Breadcrumb items={items2} />);
+
+    // get the first child of each list item (the actual item content)
+    const renderedItems = wrapper.find('.ms-Breadcrumb-listItem > *:first-child');
+    expect(renderedItems).toHaveLength(3);
+    // should be a link since it has a href (even though it also has onclick)
+    expect(renderedItems.at(0).getDOMNode().tagName).toBe('A');
+    // should be a button since it doesn't have a href
+    // (can't use a link without a href because it won't respond to key events)
+    expect(renderedItems.at(1).getDOMNode().tagName).toBe('BUTTON');
+    // specified type of h1 overrides default
+    expect(renderedItems.at(2).getDOMNode().tagName).toBe('H1');
+  });
+
+  it('calls the callback when an item is clicked', () => {
     let callbackValue;
     const clickCallback = (ev: React.MouseEvent<HTMLElement>, item: IBreadcrumbItem) => {
+      ev.preventDefault(); // in case it's a navigation event
       callbackValue = item.key;
     };
 
-    const items: IBreadcrumbItem[] = [{ text: 'TestText', key: 'TestKey', onClick: clickCallback }];
+    const items2: IBreadcrumbItem[] = [
+      { text: 'Test1', key: 'Test1', href: 'http://bing.com', onClick: clickCallback },
+      { text: 'Test2', key: 'Test2', onClick: clickCallback }
+    ];
 
-    const wrapper = mount(<Breadcrumb items={items} />);
+    wrapper = mount(<Breadcrumb items={items2} />);
 
-    wrapper
-      .find('.ms-Breadcrumb-itemLink')
-      .first()
-      .simulate('click');
+    const renderedItems = wrapper.find('.ms-Breadcrumb-itemLink').hostNodes();
 
-    expect(callbackValue).toEqual('TestKey');
+    renderedItems.at(0).simulate('click');
+    expect(callbackValue).toEqual('Test1');
+
+    renderedItems.at(1).simulate('click');
+    expect(callbackValue).toEqual('Test2');
   });
 
   it('moves items to overflow in the correct order', () => {
-    const items: IBreadcrumbItem[] = [
-      { text: 'TestText1', key: 'TestKey1' },
-      { text: 'TestText2', key: 'TestKey2' },
-      { text: 'TestText3', key: 'TestKey3' },
-      { text: 'TestText4', key: 'TestKey4' }
-    ];
-
-    const wrapper = mount(<Breadcrumb items={items} maxDisplayedItems={2} />);
+    wrapper = mount(<Breadcrumb items={items} maxDisplayedItems={2} />);
 
     expect(
       wrapper
@@ -118,20 +143,21 @@ describe('Breadcrumb', () => {
   });
 
   it('supports native props on the root element', () => {
-    const items: IBreadcrumbItem[] = [
-      { text: 'TestText1', key: 'TestKey1' },
-      { text: 'TestText2', key: 'TestKey2' },
-      { text: 'TestText3', key: 'TestKey3' },
-      { text: 'TestText4', key: 'TestKey4' }
-    ];
+    wrapper = mount(<Breadcrumb items={items} maxDisplayedItems={2} role="region" />);
 
-    const wrapper = mount(<Breadcrumb items={items} maxDisplayedItems={2} role="region" />);
+    expect(wrapper.find('.ms-Breadcrumb').prop('role')).toEqual('region');
+  });
 
-    expect(
-      wrapper
-        .find('.ms-Breadcrumb')
-        .getDOMNode()
-        .getAttribute('role')
-    ).toEqual('region');
+  it('opens the overflow menu on click', () => {
+    wrapper = mount(<Breadcrumb items={items} maxDisplayedItems={2} />);
+
+    const overflowButton = wrapper.find('.ms-Breadcrumb-overflowButton');
+    // without hostNodes it returns the same element x4
+    overflowButton.hostNodes().simulate('click');
+
+    const overfowItems = document.querySelectorAll('.ms-ContextualMenu-item');
+    expect(overfowItems).toHaveLength(2);
+    expect(overfowItems[0].textContent).toEqual('TestText1');
+    expect(overfowItems[1].textContent).toEqual('TestText2');
   });
 });

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
@@ -130,8 +130,10 @@ export interface IBreadcrumbItem {
 
   /**
    * Optional prop to render the item as a heading of your choice.
+   *
    * You can also use this to force items to render as links instead of buttons (by default,
-   * any item with a `href` renders as a link, and any item without a href renders as a button).
+   * any item with a `href` renders as a link, and any item without a `href` renders as a button).
+   * This is not generally recommended because it may prevent activating the link using the keyboard.
    */
   as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'a';
 }

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.types.ts
@@ -41,7 +41,7 @@ export interface IBreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
   items: IBreadcrumbItem[];
 
   /**
-   * Optional root classname for the root breadcrumb element.
+   * Optional class for the root breadcrumb element.
    */
   className?: string;
 
@@ -60,23 +60,22 @@ export interface IBreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
    */
   maxDisplayedItems?: number;
 
-  /** Method to call when trying to render an item. */
-
+  /** Custom render function for each breadcrumb item. */
   onRenderItem?: IRenderFunction<IBreadcrumbItem>;
 
   /**
-   * Method to call when reducing the length of the breadcrumb.
-   * Return undefined to never reduce breadcrumb length
+   * Method that determines how to reduce the length of the breadcrumb.
+   * Return undefined to never reduce breadcrumb length.
    */
   onReduceData?: (data: IBreadcrumbData) => IBreadcrumbData | undefined;
 
   /**
-   * Aria label to place on the navigation landmark for breadcrumb
+   * Aria label for the root element of the breadcrumb (which is a navigation landmark).
    */
   ariaLabel?: string;
 
   /**
-   * Optional name to use for aria label on overflow button.
+   * Aria label for the overflow button.
    */
   overflowAriaLabel?: string;
 
@@ -89,12 +88,12 @@ export interface IBreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
   theme?: ITheme;
 
   /**
-   * Focuszone props that will get passed through to the root focus zone.
+   * Extra props for the root FocusZone.
    */
   focusZoneProps?: IFocusZoneProps;
 
   /**
-   * TooltipHost props that will get passed through to overflow tooltips.
+   * Extra props for the TooltipHost which wraps each breadcrumb item.
    */
   tooltipHostProps?: ITooltipHostProps;
 }
@@ -104,35 +103,37 @@ export interface IBreadcrumbProps extends React.HTMLAttributes<HTMLElement> {
  */
 export interface IBreadcrumbItem {
   /**
-   * Text to display to the user for the breadcrumb
+   * Text to display to the user for the breadcrumb item.
    */
   text: string;
 
   /**
-   * Arbitrary unique string associated with the breadcrumb
+   * Arbitrary unique string associated with the breadcrumb item.
    */
   key: string;
 
   /**
-   * Callback issued when the breadcrumb is selected.
+   * Callback issued when the breadcrumb item is selected.
    */
   onClick?: (ev?: React.MouseEvent<HTMLElement>, item?: IBreadcrumbItem) => void;
 
   /**
-   * Url to navigate to when this breadcrumb is clicked.
+   * Url to navigate to when this breadcrumb item is clicked.
    */
   href?: string;
 
   /**
-   * If this breadcrumb item is the item the user is currently on, if set to true, aria-current='page' will be applied to this
-   * breadcrumb link
+   * Whether this is the breadcrumb item the user is currently navigated to.
+   * If true, `aria-current="page"` will be applied to this breadcrumb item.
    */
   isCurrentItem?: boolean;
 
   /**
-   * Optional prop to render item as a heading of your choice.
+   * Optional prop to render the item as a heading of your choice.
+   * You can also use this to force items to render as links instead of buttons (by default,
+   * any item with a `href` renders as a link, and any item without a href renders as a button).
    */
-  as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6';
+  as?: 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | 'a';
 }
 
 /**
@@ -140,8 +141,8 @@ export interface IBreadcrumbItem {
  */
 export interface IDividerAsProps extends IIconProps {
   /**
-   * Optional breadcrumb item corresponds to left of the divider to be passed for custom rendering.
-   * For overflowed items, it will be last item in the list
+   * Breadcrumb item to left of the divider to be passed for custom rendering.
+   * For overflowed items, it will be last item in the list.
    */
   item?: IBreadcrumbItem;
 }

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -1,6 +1,397 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Breadcrumb basic rendering renders breadcumb correctly 1 1`] = `
+exports[`Breadcrumb rendering renders  correctly with custom overflow icon 1`] = `
+<div>
+  <div
+    style={
+      Object {
+        "position": "relative",
+      }
+    }
+  >
+    <div
+      data-automation-id="visibleContent"
+      style={
+        Object {
+          "position": "fixed",
+          "visibility": "hidden",
+        }
+      }
+    >
+      <div
+        className=
+            ms-Breadcrumb
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-bottom: 1px;
+              margin-left: 0;
+              margin-right: 0;
+              margin-top: 11px;
+            }
+        role="navigation"
+      >
+        <div
+          className=
+              ms-FocusZone
+              &:focus {
+                outline: none;
+              }
+          data-focuszone-id="FocusZone32"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+        >
+          <ol
+            className=
+                ms-Breadcrumb-list
+                {
+                  align-items: stretch;
+                  display: flex;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  white-space: nowrap;
+                }
+          >
+            <li
+              className=
+                  ms-Breadcrumb-overflow
+                  {
+                    align-items: center;
+                    display: flex;
+                    position: relative;
+                  }
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                aria-owns={null}
+                className=
+                    ms-Button
+                    ms-Button--icon
+                    ms-Button--hasMenu
+                    ms-Breadcrumb-overflowButton
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 2px;
+                      border: none;
+                      box-sizing: border-box;
+                      color: #605e5c;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 16px;
+                      font-weight: 400;
+                      height: 100%;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: none;
+                      vertical-align: top;
+                      white-space: nowrap;
+                      width: auto;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #323130;
+                      cursor: pointer;
+                      text-decoration: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #323130;
+                      text-decoration: none;
+                    }
+                    &:active:hover {
+                      background-color: #edebe9;
+                      color: #323130;
+                      text-decoration: none;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      padding-bottom: 4px;
+                      padding-left: 6px;
+                      padding-right: 6px;
+                      padding-top: 4px;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 16px;
+                    }
+                data-is-focusable={true}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="button"
+                type="button"
+              >
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: center;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <i
+                    aria-hidden={true}
+                    className=
+
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          display: inline-block;
+                          font-family: "FabricMDL2Icons";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                    data-icon-name="ChevronDown"
+                  >
+                    
+                  </i>
+                </span>
+              </button>
+              <i
+                aria-hidden={true}
+                className=
+                    ms-Breadcrumb-chevron
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      color: WindowText;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 8px;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      font-size: 8px;
+                    }
+                data-icon-name="ChevronRight"
+              >
+                
+              </i>
+            </li>
+            <li
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
+                  &:last-child .ms-Breadcrumb-itemLink {
+                    color: #323130;
+                    font-weight: 600;
+                  }
+                  &:last-child .ms-Breadcrumb-item {
+                    color: #323130;
+                    font-weight: 600;
+                  }
+            >
+              <span
+                className=
+                    ms-Breadcrumb-item
+                    {
+                      color: #605e5c;
+                      font-size: 18px;
+                      font-weight: 400;
+                      line-height: 36px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                    }
+                    &:hover {
+                      cursor: default;
+                    }
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  TestText3
+                </div>
+              </span>
+              <i
+                aria-hidden={true}
+                className=
+                    ms-Breadcrumb-chevron
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      color: WindowText;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 8px;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      font-size: 8px;
+                    }
+                data-icon-name="ChevronRight"
+              >
+                
+              </i>
+            </li>
+            <li
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
+                  &:last-child .ms-Breadcrumb-itemLink {
+                    color: #323130;
+                    font-weight: 600;
+                  }
+                  &:last-child .ms-Breadcrumb-item {
+                    color: #323130;
+                    font-weight: 600;
+                  }
+            >
+              <span
+                className=
+                    ms-Breadcrumb-item
+                    {
+                      color: #605e5c;
+                      font-size: 18px;
+                      font-weight: 400;
+                      line-height: 36px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                    }
+                    &:hover {
+                      cursor: default;
+                    }
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  TestText4
+                </div>
+              </span>
+            </li>
+          </ol>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Breadcrumb rendering renders correctly 1`] = `
 <div>
   <div
     style={
@@ -393,7 +784,872 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 1 1`] = `
 </div>
 `;
 
-exports[`Breadcrumb basic rendering renders breadcumb correctly 2 1`] = `
+exports[`Breadcrumb rendering renders correctly with custom divider 1`] = `
+<div>
+  <div
+    style={
+      Object {
+        "position": "relative",
+      }
+    }
+  >
+    <div
+      data-automation-id="visibleContent"
+      style={
+        Object {
+          "position": "fixed",
+          "visibility": "hidden",
+        }
+      }
+    >
+      <div
+        className=
+            ms-Breadcrumb
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-bottom: 1px;
+              margin-left: 0;
+              margin-right: 0;
+              margin-top: 11px;
+            }
+        role="navigation"
+      >
+        <div
+          className=
+              ms-FocusZone
+              &:focus {
+                outline: none;
+              }
+          data-focuszone-id="FocusZone12"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+        >
+          <ol
+            className=
+                ms-Breadcrumb-list
+                {
+                  align-items: stretch;
+                  display: flex;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  white-space: nowrap;
+                }
+          >
+            <li
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
+                  &:last-child .ms-Breadcrumb-itemLink {
+                    color: #323130;
+                    font-weight: 600;
+                  }
+                  &:last-child .ms-Breadcrumb-item {
+                    color: #323130;
+                    font-weight: 600;
+                  }
+            >
+              <span
+                className=
+                    ms-Breadcrumb-item
+                    {
+                      color: #605e5c;
+                      font-size: 18px;
+                      font-weight: 400;
+                      line-height: 36px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                    }
+                    &:hover {
+                      cursor: default;
+                    }
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  TestText1
+                </div>
+              </span>
+              <span>
+                *
+              </span>
+            </li>
+            <li
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
+                  &:last-child .ms-Breadcrumb-itemLink {
+                    color: #323130;
+                    font-weight: 600;
+                  }
+                  &:last-child .ms-Breadcrumb-item {
+                    color: #323130;
+                    font-weight: 600;
+                  }
+            >
+              <span
+                className=
+                    ms-Breadcrumb-item
+                    {
+                      color: #605e5c;
+                      font-size: 18px;
+                      font-weight: 400;
+                      line-height: 36px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                    }
+                    &:hover {
+                      cursor: default;
+                    }
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  TestText2
+                </div>
+              </span>
+              <span>
+                *
+              </span>
+            </li>
+            <li
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
+                  &:last-child .ms-Breadcrumb-itemLink {
+                    color: #323130;
+                    font-weight: 600;
+                  }
+                  &:last-child .ms-Breadcrumb-item {
+                    color: #323130;
+                    font-weight: 600;
+                  }
+            >
+              <span
+                className=
+                    ms-Breadcrumb-item
+                    {
+                      color: #605e5c;
+                      font-size: 18px;
+                      font-weight: 400;
+                      line-height: 36px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                    }
+                    &:hover {
+                      cursor: default;
+                    }
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  TestText3
+                </div>
+              </span>
+              <span>
+                *
+              </span>
+            </li>
+            <li
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
+                  &:last-child .ms-Breadcrumb-itemLink {
+                    color: #323130;
+                    font-weight: 600;
+                  }
+                  &:last-child .ms-Breadcrumb-item {
+                    color: #323130;
+                    font-weight: 600;
+                  }
+            >
+              <span
+                className=
+                    ms-Breadcrumb-item
+                    {
+                      color: #605e5c;
+                      font-size: 18px;
+                      font-weight: 400;
+                      line-height: 36px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                    }
+                    &:hover {
+                      cursor: default;
+                    }
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  TestText4
+                </div>
+              </span>
+            </li>
+          </ol>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Breadcrumb rendering renders correctly with maxDisplayedItems and overflowIndex 1`] = `
+<div>
+  <div
+    style={
+      Object {
+        "position": "relative",
+      }
+    }
+  >
+    <div
+      data-automation-id="visibleContent"
+      style={
+        Object {
+          "position": "fixed",
+          "visibility": "hidden",
+        }
+      }
+    >
+      <div
+        className=
+            ms-Breadcrumb
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-bottom: 1px;
+              margin-left: 0;
+              margin-right: 0;
+              margin-top: 11px;
+            }
+        role="navigation"
+      >
+        <div
+          className=
+              ms-FocusZone
+              &:focus {
+                outline: none;
+              }
+          data-focuszone-id="FocusZone23"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+        >
+          <ol
+            className=
+                ms-Breadcrumb-list
+                {
+                  align-items: stretch;
+                  display: flex;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  white-space: nowrap;
+                }
+          >
+            <li
+              className=
+                  ms-Breadcrumb-listItem
+                  {
+                    align-items: center;
+                    display: flex;
+                    list-style-type: none;
+                    margin-bottom: 0;
+                    margin-left: 0;
+                    margin-right: 0;
+                    margin-top: 0;
+                    padding-bottom: 0;
+                    padding-left: 0;
+                    padding-right: 0;
+                    padding-top: 0;
+                    position: relative;
+                  }
+                  &:last-child .ms-Breadcrumb-itemLink {
+                    color: #323130;
+                    font-weight: 600;
+                  }
+                  &:last-child .ms-Breadcrumb-item {
+                    color: #323130;
+                    font-weight: 600;
+                  }
+            >
+              <span
+                className=
+                    ms-Breadcrumb-item
+                    {
+                      color: #605e5c;
+                      font-size: 18px;
+                      font-weight: 400;
+                      line-height: 36px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                    }
+                    &:hover {
+                      cursor: default;
+                    }
+              >
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  TestText1
+                </div>
+              </span>
+              <i
+                aria-hidden={true}
+                className=
+                    ms-Breadcrumb-chevron
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-size: 12px;
+                      font-style: normal;
+                      font-weight: normal;
+                      speak: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      color: WindowText;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 8px;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      font-size: 8px;
+                    }
+                data-icon-name="ChevronRight"
+              >
+                
+              </i>
+            </li>
+            <li
+              className=
+                  ms-Breadcrumb-overflow
+                  {
+                    align-items: center;
+                    display: flex;
+                    position: relative;
+                  }
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                aria-owns={null}
+                className=
+                    ms-Button
+                    ms-Button--icon
+                    ms-Button--hasMenu
+                    ms-Breadcrumb-overflowButton
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 2px;
+                      border: none;
+                      box-sizing: border-box;
+                      color: #605e5c;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 16px;
+                      font-weight: 400;
+                      height: 100%;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: none;
+                      vertical-align: top;
+                      white-space: nowrap;
+                      width: auto;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #323130;
+                      cursor: pointer;
+                      text-decoration: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #323130;
+                      text-decoration: none;
+                    }
+                    &:active:hover {
+                      background-color: #edebe9;
+                      color: #323130;
+                      text-decoration: none;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      padding-bottom: 4px;
+                      padding-left: 6px;
+                      padding-right: 6px;
+                      padding-top: 4px;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 16px;
+                    }
+                data-is-focusable={true}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="button"
+                type="button"
+              >
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: center;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon
+                        ms-Button-icon
+                        {
+                          display: inline-block;
+                        }
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          font-family: "FabricMDL2Icons";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                        {
+                          flex-shrink: 0;
+                          font-size: 16px;
+                          height: 16px;
+                          line-height: 16px;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          text-align: center;
+                          vertical-align: middle;
+                        }
+                    data-icon-name="More"
+                    role="presentation"
+                  >
+                    
+                  </i>
+                </span>
+              </button>
+            </li>
+          </ol>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Breadcrumb rendering renders correctly with maxDisplayedItems and overflowIndex as 0 1`] = `
+<div>
+  <div
+    style={
+      Object {
+        "position": "relative",
+      }
+    }
+  >
+    <div
+      data-automation-id="visibleContent"
+      style={
+        Object {
+          "position": "fixed",
+          "visibility": "hidden",
+        }
+      }
+    >
+      <div
+        className=
+            ms-Breadcrumb
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-bottom: 1px;
+              margin-left: 0;
+              margin-right: 0;
+              margin-top: 11px;
+            }
+        role="navigation"
+      >
+        <div
+          className=
+              ms-FocusZone
+              &:focus {
+                outline: none;
+              }
+          data-focuszone-id="FocusZone28"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+        >
+          <ol
+            className=
+                ms-Breadcrumb-list
+                {
+                  align-items: stretch;
+                  display: flex;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  white-space: nowrap;
+                }
+          >
+            <li
+              className=
+                  ms-Breadcrumb-overflow
+                  {
+                    align-items: center;
+                    display: flex;
+                    position: relative;
+                  }
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                aria-owns={null}
+                className=
+                    ms-Button
+                    ms-Button--icon
+                    ms-Button--hasMenu
+                    ms-Breadcrumb-overflowButton
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 2px;
+                      border: none;
+                      box-sizing: border-box;
+                      color: #605e5c;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 16px;
+                      font-weight: 400;
+                      height: 100%;
+                      outline: transparent;
+                      overflow: hidden;
+                      padding-bottom: 0;
+                      padding-left: 4px;
+                      padding-right: 4px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      text-overflow: ellipsis;
+                      user-select: none;
+                      vertical-align: top;
+                      white-space: nowrap;
+                      width: auto;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 1px solid #ffffff;
+                      bottom: 1px;
+                      content: "";
+                      left: 1px;
+                      outline: 1px solid #605e5c;
+                      position: absolute;
+                      right: 1px;
+                      top: 1px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #323130;
+                      cursor: pointer;
+                      text-decoration: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #323130;
+                      text-decoration: none;
+                    }
+                    &:active:hover {
+                      background-color: #edebe9;
+                      color: #323130;
+                      text-decoration: none;
+                    }
+                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                      padding-bottom: 4px;
+                      padding-left: 6px;
+                      padding-right: 6px;
+                      padding-top: 4px;
+                    }
+                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                      font-size: 16px;
+                    }
+                data-is-focusable={true}
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="button"
+                type="button"
+              >
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: center;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <i
+                    aria-hidden={true}
+                    className=
+                        ms-Icon
+                        ms-Button-icon
+                        {
+                          display: inline-block;
+                        }
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          font-family: "FabricMDL2Icons";
+                          font-style: normal;
+                          font-weight: normal;
+                          speak: none;
+                        }
+                        {
+                          flex-shrink: 0;
+                          font-size: 16px;
+                          height: 16px;
+                          line-height: 16px;
+                          margin-bottom: 0;
+                          margin-left: 4px;
+                          margin-right: 4px;
+                          margin-top: 0;
+                          text-align: center;
+                          vertical-align: middle;
+                        }
+                    data-icon-name="More"
+                    role="presentation"
+                  >
+                    
+                  </i>
+                </span>
+              </button>
+            </li>
+          </ol>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Breadcrumb rendering renders correctly with overflow 1`] = `
 <div>
   <div
     style={
@@ -800,322 +2056,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 2 1`] = `
 </div>
 `;
 
-exports[`Breadcrumb basic rendering renders breadcumb correctly 3 1`] = `
-<div>
-  <div
-    style={
-      Object {
-        "position": "relative",
-      }
-    }
-  >
-    <div
-      data-automation-id="visibleContent"
-      style={
-        Object {
-          "position": "fixed",
-          "visibility": "hidden",
-        }
-      }
-    >
-      <div
-        className=
-            ms-Breadcrumb
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              margin-bottom: 1px;
-              margin-left: 0;
-              margin-right: 0;
-              margin-top: 11px;
-            }
-        role="navigation"
-      >
-        <div
-          className=
-              ms-FocusZone
-              &:focus {
-                outline: none;
-              }
-          data-focuszone-id="FocusZone12"
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onMouseDownCapture={[Function]}
-        >
-          <ol
-            className=
-                ms-Breadcrumb-list
-                {
-                  align-items: stretch;
-                  display: flex;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  white-space: nowrap;
-                }
-          >
-            <li
-              className=
-                  ms-Breadcrumb-listItem
-                  {
-                    align-items: center;
-                    display: flex;
-                    list-style-type: none;
-                    margin-bottom: 0;
-                    margin-left: 0;
-                    margin-right: 0;
-                    margin-top: 0;
-                    padding-bottom: 0;
-                    padding-left: 0;
-                    padding-right: 0;
-                    padding-top: 0;
-                    position: relative;
-                  }
-                  &:last-child .ms-Breadcrumb-itemLink {
-                    color: #323130;
-                    font-weight: 600;
-                  }
-                  &:last-child .ms-Breadcrumb-item {
-                    color: #323130;
-                    font-weight: 600;
-                  }
-            >
-              <span
-                className=
-                    ms-Breadcrumb-item
-                    {
-                      color: #605e5c;
-                      font-size: 18px;
-                      font-weight: 400;
-                      line-height: 36px;
-                      padding-bottom: 0;
-                      padding-left: 8px;
-                      padding-right: 8px;
-                      padding-top: 0;
-                    }
-                    &:hover {
-                      cursor: default;
-                    }
-              >
-                <div
-                  className=
-                      ms-TooltipHost
-                      {
-                        display: inline;
-                      }
-                  onBlurCapture={[Function]}
-                  onFocusCapture={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  TestText1
-                </div>
-              </span>
-              <span>
-                *
-              </span>
-            </li>
-            <li
-              className=
-                  ms-Breadcrumb-listItem
-                  {
-                    align-items: center;
-                    display: flex;
-                    list-style-type: none;
-                    margin-bottom: 0;
-                    margin-left: 0;
-                    margin-right: 0;
-                    margin-top: 0;
-                    padding-bottom: 0;
-                    padding-left: 0;
-                    padding-right: 0;
-                    padding-top: 0;
-                    position: relative;
-                  }
-                  &:last-child .ms-Breadcrumb-itemLink {
-                    color: #323130;
-                    font-weight: 600;
-                  }
-                  &:last-child .ms-Breadcrumb-item {
-                    color: #323130;
-                    font-weight: 600;
-                  }
-            >
-              <span
-                className=
-                    ms-Breadcrumb-item
-                    {
-                      color: #605e5c;
-                      font-size: 18px;
-                      font-weight: 400;
-                      line-height: 36px;
-                      padding-bottom: 0;
-                      padding-left: 8px;
-                      padding-right: 8px;
-                      padding-top: 0;
-                    }
-                    &:hover {
-                      cursor: default;
-                    }
-              >
-                <div
-                  className=
-                      ms-TooltipHost
-                      {
-                        display: inline;
-                      }
-                  onBlurCapture={[Function]}
-                  onFocusCapture={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  TestText2
-                </div>
-              </span>
-              <span>
-                *
-              </span>
-            </li>
-            <li
-              className=
-                  ms-Breadcrumb-listItem
-                  {
-                    align-items: center;
-                    display: flex;
-                    list-style-type: none;
-                    margin-bottom: 0;
-                    margin-left: 0;
-                    margin-right: 0;
-                    margin-top: 0;
-                    padding-bottom: 0;
-                    padding-left: 0;
-                    padding-right: 0;
-                    padding-top: 0;
-                    position: relative;
-                  }
-                  &:last-child .ms-Breadcrumb-itemLink {
-                    color: #323130;
-                    font-weight: 600;
-                  }
-                  &:last-child .ms-Breadcrumb-item {
-                    color: #323130;
-                    font-weight: 600;
-                  }
-            >
-              <span
-                className=
-                    ms-Breadcrumb-item
-                    {
-                      color: #605e5c;
-                      font-size: 18px;
-                      font-weight: 400;
-                      line-height: 36px;
-                      padding-bottom: 0;
-                      padding-left: 8px;
-                      padding-right: 8px;
-                      padding-top: 0;
-                    }
-                    &:hover {
-                      cursor: default;
-                    }
-              >
-                <div
-                  className=
-                      ms-TooltipHost
-                      {
-                        display: inline;
-                      }
-                  onBlurCapture={[Function]}
-                  onFocusCapture={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  TestText3
-                </div>
-              </span>
-              <span>
-                *
-              </span>
-            </li>
-            <li
-              className=
-                  ms-Breadcrumb-listItem
-                  {
-                    align-items: center;
-                    display: flex;
-                    list-style-type: none;
-                    margin-bottom: 0;
-                    margin-left: 0;
-                    margin-right: 0;
-                    margin-top: 0;
-                    padding-bottom: 0;
-                    padding-left: 0;
-                    padding-right: 0;
-                    padding-top: 0;
-                    position: relative;
-                  }
-                  &:last-child .ms-Breadcrumb-itemLink {
-                    color: #323130;
-                    font-weight: 600;
-                  }
-                  &:last-child .ms-Breadcrumb-item {
-                    color: #323130;
-                    font-weight: 600;
-                  }
-            >
-              <span
-                className=
-                    ms-Breadcrumb-item
-                    {
-                      color: #605e5c;
-                      font-size: 18px;
-                      font-weight: 400;
-                      line-height: 36px;
-                      padding-bottom: 0;
-                      padding-left: 8px;
-                      padding-right: 8px;
-                      padding-top: 0;
-                    }
-                    &:hover {
-                      cursor: default;
-                    }
-              >
-                <div
-                  className=
-                      ms-TooltipHost
-                      {
-                        display: inline;
-                      }
-                  onBlurCapture={[Function]}
-                  onFocusCapture={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  TestText4
-                </div>
-              </span>
-            </li>
-          </ol>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Breadcrumb basic rendering renders breadcumb correctly 4 1`] = `
+exports[`Breadcrumb rendering renders correctly with overflow and overflowIndex 1`] = `
 <div>
   <div
     style={
@@ -1425,947 +2366,6 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 4 1`] = `
                   </i>
                 </span>
               </button>
-              <i
-                aria-hidden={true}
-                className=
-                    ms-Breadcrumb-chevron
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      color: #605e5c;
-                      display: inline-block;
-                      font-family: "FabricMDL2Icons";
-                      font-size: 12px;
-                      font-style: normal;
-                      font-weight: normal;
-                      speak: none;
-                    }
-                    @media screen and (-ms-high-contrast: active){& {
-                      -ms-high-contrast-adjust: none;
-                      color: WindowText;
-                    }
-                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
-                      font-size: 8px;
-                    }
-                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                      font-size: 8px;
-                    }
-                data-icon-name="ChevronRight"
-              >
-                
-              </i>
-            </li>
-            <li
-              className=
-                  ms-Breadcrumb-listItem
-                  {
-                    align-items: center;
-                    display: flex;
-                    list-style-type: none;
-                    margin-bottom: 0;
-                    margin-left: 0;
-                    margin-right: 0;
-                    margin-top: 0;
-                    padding-bottom: 0;
-                    padding-left: 0;
-                    padding-right: 0;
-                    padding-top: 0;
-                    position: relative;
-                  }
-                  &:last-child .ms-Breadcrumb-itemLink {
-                    color: #323130;
-                    font-weight: 600;
-                  }
-                  &:last-child .ms-Breadcrumb-item {
-                    color: #323130;
-                    font-weight: 600;
-                  }
-            >
-              <span
-                className=
-                    ms-Breadcrumb-item
-                    {
-                      color: #605e5c;
-                      font-size: 18px;
-                      font-weight: 400;
-                      line-height: 36px;
-                      padding-bottom: 0;
-                      padding-left: 8px;
-                      padding-right: 8px;
-                      padding-top: 0;
-                    }
-                    &:hover {
-                      cursor: default;
-                    }
-              >
-                <div
-                  className=
-                      ms-TooltipHost
-                      {
-                        display: inline;
-                      }
-                  onBlurCapture={[Function]}
-                  onFocusCapture={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  TestText4
-                </div>
-              </span>
-            </li>
-          </ol>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Breadcrumb basic rendering renders breadcumb correctly 5 1`] = `
-<div>
-  <div
-    style={
-      Object {
-        "position": "relative",
-      }
-    }
-  >
-    <div
-      data-automation-id="visibleContent"
-      style={
-        Object {
-          "position": "fixed",
-          "visibility": "hidden",
-        }
-      }
-    >
-      <div
-        className=
-            ms-Breadcrumb
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              margin-bottom: 1px;
-              margin-left: 0;
-              margin-right: 0;
-              margin-top: 11px;
-            }
-        role="navigation"
-      >
-        <div
-          className=
-              ms-FocusZone
-              &:focus {
-                outline: none;
-              }
-          data-focuszone-id="FocusZone23"
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onMouseDownCapture={[Function]}
-        >
-          <ol
-            className=
-                ms-Breadcrumb-list
-                {
-                  align-items: stretch;
-                  display: flex;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  white-space: nowrap;
-                }
-          >
-            <li
-              className=
-                  ms-Breadcrumb-listItem
-                  {
-                    align-items: center;
-                    display: flex;
-                    list-style-type: none;
-                    margin-bottom: 0;
-                    margin-left: 0;
-                    margin-right: 0;
-                    margin-top: 0;
-                    padding-bottom: 0;
-                    padding-left: 0;
-                    padding-right: 0;
-                    padding-top: 0;
-                    position: relative;
-                  }
-                  &:last-child .ms-Breadcrumb-itemLink {
-                    color: #323130;
-                    font-weight: 600;
-                  }
-                  &:last-child .ms-Breadcrumb-item {
-                    color: #323130;
-                    font-weight: 600;
-                  }
-            >
-              <span
-                className=
-                    ms-Breadcrumb-item
-                    {
-                      color: #605e5c;
-                      font-size: 18px;
-                      font-weight: 400;
-                      line-height: 36px;
-                      padding-bottom: 0;
-                      padding-left: 8px;
-                      padding-right: 8px;
-                      padding-top: 0;
-                    }
-                    &:hover {
-                      cursor: default;
-                    }
-              >
-                <div
-                  className=
-                      ms-TooltipHost
-                      {
-                        display: inline;
-                      }
-                  onBlurCapture={[Function]}
-                  onFocusCapture={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  TestText1
-                </div>
-              </span>
-              <i
-                aria-hidden={true}
-                className=
-                    ms-Breadcrumb-chevron
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      color: #605e5c;
-                      display: inline-block;
-                      font-family: "FabricMDL2Icons";
-                      font-size: 12px;
-                      font-style: normal;
-                      font-weight: normal;
-                      speak: none;
-                    }
-                    @media screen and (-ms-high-contrast: active){& {
-                      -ms-high-contrast-adjust: none;
-                      color: WindowText;
-                    }
-                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
-                      font-size: 8px;
-                    }
-                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                      font-size: 8px;
-                    }
-                data-icon-name="ChevronRight"
-              >
-                
-              </i>
-            </li>
-            <li
-              className=
-                  ms-Breadcrumb-overflow
-                  {
-                    align-items: center;
-                    display: flex;
-                    position: relative;
-                  }
-            >
-              <button
-                aria-expanded={false}
-                aria-haspopup={true}
-                aria-owns={null}
-                className=
-                    ms-Button
-                    ms-Button--icon
-                    ms-Button--hasMenu
-                    ms-Breadcrumb-overflowButton
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      background-color: transparent;
-                      border-radius: 2px;
-                      border: none;
-                      box-sizing: border-box;
-                      color: #605e5c;
-                      cursor: pointer;
-                      display: inline-block;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 16px;
-                      font-weight: 400;
-                      height: 100%;
-                      outline: transparent;
-                      overflow: hidden;
-                      padding-bottom: 0;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 0;
-                      position: relative;
-                      text-align: center;
-                      text-decoration: none;
-                      text-overflow: ellipsis;
-                      user-select: none;
-                      vertical-align: top;
-                      white-space: nowrap;
-                      width: auto;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 1px;
-                      content: "";
-                      left: 1px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 1px;
-                      top: 1px;
-                      z-index: 1;
-                    }
-                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                      border: none;
-                      bottom: -2px;
-                      left: -2px;
-                      outline-color: ButtonText;
-                      right: -2px;
-                      top: -2px;
-                    }
-                    &:active > * {
-                      left: 0px;
-                      position: relative;
-                      top: 0px;
-                    }
-                    &:hover {
-                      background-color: #f3f2f1;
-                      color: #323130;
-                      cursor: pointer;
-                      text-decoration: none;
-                    }
-                    @media screen and (-ms-high-contrast: active){&:hover {
-                      border-color: Highlight;
-                      color: Highlight;
-                    }
-                    &:active {
-                      background-color: #edebe9;
-                      color: #323130;
-                      text-decoration: none;
-                    }
-                    &:active:hover {
-                      background-color: #edebe9;
-                      color: #323130;
-                      text-decoration: none;
-                    }
-                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                      padding-bottom: 4px;
-                      padding-left: 6px;
-                      padding-right: 6px;
-                      padding-top: 4px;
-                    }
-                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
-                      font-size: 16px;
-                    }
-                data-is-focusable={true}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseUp={[Function]}
-                role="button"
-                type="button"
-              >
-                <span
-                  className=
-                      ms-Button-flexContainer
-                      {
-                        align-items: center;
-                        display: flex;
-                        flex-wrap: nowrap;
-                        height: 100%;
-                        justify-content: center;
-                      }
-                  data-automationid="splitbuttonprimary"
-                >
-                  <i
-                    aria-hidden={true}
-                    className=
-                        ms-Icon
-                        ms-Button-icon
-                        {
-                          display: inline-block;
-                        }
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          font-family: "FabricMDL2Icons";
-                          font-style: normal;
-                          font-weight: normal;
-                          speak: none;
-                        }
-                        {
-                          flex-shrink: 0;
-                          font-size: 16px;
-                          height: 16px;
-                          line-height: 16px;
-                          margin-bottom: 0;
-                          margin-left: 4px;
-                          margin-right: 4px;
-                          margin-top: 0;
-                          text-align: center;
-                          vertical-align: middle;
-                        }
-                    data-icon-name="More"
-                    role="presentation"
-                  >
-                    
-                  </i>
-                </span>
-              </button>
-            </li>
-          </ol>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Breadcrumb basic rendering renders breadcumb correctly 6 1`] = `
-<div>
-  <div
-    style={
-      Object {
-        "position": "relative",
-      }
-    }
-  >
-    <div
-      data-automation-id="visibleContent"
-      style={
-        Object {
-          "position": "fixed",
-          "visibility": "hidden",
-        }
-      }
-    >
-      <div
-        className=
-            ms-Breadcrumb
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              margin-bottom: 1px;
-              margin-left: 0;
-              margin-right: 0;
-              margin-top: 11px;
-            }
-        role="navigation"
-      >
-        <div
-          className=
-              ms-FocusZone
-              &:focus {
-                outline: none;
-              }
-          data-focuszone-id="FocusZone28"
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onMouseDownCapture={[Function]}
-        >
-          <ol
-            className=
-                ms-Breadcrumb-list
-                {
-                  align-items: stretch;
-                  display: flex;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  white-space: nowrap;
-                }
-          >
-            <li
-              className=
-                  ms-Breadcrumb-overflow
-                  {
-                    align-items: center;
-                    display: flex;
-                    position: relative;
-                  }
-            >
-              <button
-                aria-expanded={false}
-                aria-haspopup={true}
-                aria-owns={null}
-                className=
-                    ms-Button
-                    ms-Button--icon
-                    ms-Button--hasMenu
-                    ms-Breadcrumb-overflowButton
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      background-color: transparent;
-                      border-radius: 2px;
-                      border: none;
-                      box-sizing: border-box;
-                      color: #605e5c;
-                      cursor: pointer;
-                      display: inline-block;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 16px;
-                      font-weight: 400;
-                      height: 100%;
-                      outline: transparent;
-                      overflow: hidden;
-                      padding-bottom: 0;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 0;
-                      position: relative;
-                      text-align: center;
-                      text-decoration: none;
-                      text-overflow: ellipsis;
-                      user-select: none;
-                      vertical-align: top;
-                      white-space: nowrap;
-                      width: auto;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 1px;
-                      content: "";
-                      left: 1px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 1px;
-                      top: 1px;
-                      z-index: 1;
-                    }
-                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                      border: none;
-                      bottom: -2px;
-                      left: -2px;
-                      outline-color: ButtonText;
-                      right: -2px;
-                      top: -2px;
-                    }
-                    &:active > * {
-                      left: 0px;
-                      position: relative;
-                      top: 0px;
-                    }
-                    &:hover {
-                      background-color: #f3f2f1;
-                      color: #323130;
-                      cursor: pointer;
-                      text-decoration: none;
-                    }
-                    @media screen and (-ms-high-contrast: active){&:hover {
-                      border-color: Highlight;
-                      color: Highlight;
-                    }
-                    &:active {
-                      background-color: #edebe9;
-                      color: #323130;
-                      text-decoration: none;
-                    }
-                    &:active:hover {
-                      background-color: #edebe9;
-                      color: #323130;
-                      text-decoration: none;
-                    }
-                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                      padding-bottom: 4px;
-                      padding-left: 6px;
-                      padding-right: 6px;
-                      padding-top: 4px;
-                    }
-                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
-                      font-size: 16px;
-                    }
-                data-is-focusable={true}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseUp={[Function]}
-                role="button"
-                type="button"
-              >
-                <span
-                  className=
-                      ms-Button-flexContainer
-                      {
-                        align-items: center;
-                        display: flex;
-                        flex-wrap: nowrap;
-                        height: 100%;
-                        justify-content: center;
-                      }
-                  data-automationid="splitbuttonprimary"
-                >
-                  <i
-                    aria-hidden={true}
-                    className=
-                        ms-Icon
-                        ms-Button-icon
-                        {
-                          display: inline-block;
-                        }
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          font-family: "FabricMDL2Icons";
-                          font-style: normal;
-                          font-weight: normal;
-                          speak: none;
-                        }
-                        {
-                          flex-shrink: 0;
-                          font-size: 16px;
-                          height: 16px;
-                          line-height: 16px;
-                          margin-bottom: 0;
-                          margin-left: 4px;
-                          margin-right: 4px;
-                          margin-top: 0;
-                          text-align: center;
-                          vertical-align: middle;
-                        }
-                    data-icon-name="More"
-                    role="presentation"
-                  >
-                    
-                  </i>
-                </span>
-              </button>
-            </li>
-          </ol>
-        </div>
-      </div>
-    </div>
-  </div>
-</div>
-`;
-
-exports[`Breadcrumb basic rendering renders breadcumb correctly 7 1`] = `
-<div>
-  <div
-    style={
-      Object {
-        "position": "relative",
-      }
-    }
-  >
-    <div
-      data-automation-id="visibleContent"
-      style={
-        Object {
-          "position": "fixed",
-          "visibility": "hidden",
-        }
-      }
-    >
-      <div
-        className=
-            ms-Breadcrumb
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              margin-bottom: 1px;
-              margin-left: 0;
-              margin-right: 0;
-              margin-top: 11px;
-            }
-        role="navigation"
-      >
-        <div
-          className=
-              ms-FocusZone
-              &:focus {
-                outline: none;
-              }
-          data-focuszone-id="FocusZone32"
-          onFocus={[Function]}
-          onKeyDown={[Function]}
-          onMouseDownCapture={[Function]}
-        >
-          <ol
-            className=
-                ms-Breadcrumb-list
-                {
-                  align-items: stretch;
-                  display: flex;
-                  margin-bottom: 0px;
-                  margin-left: 0px;
-                  margin-right: 0px;
-                  margin-top: 0px;
-                  padding-bottom: 0px;
-                  padding-left: 0px;
-                  padding-right: 0px;
-                  padding-top: 0px;
-                  white-space: nowrap;
-                }
-          >
-            <li
-              className=
-                  ms-Breadcrumb-overflow
-                  {
-                    align-items: center;
-                    display: flex;
-                    position: relative;
-                  }
-            >
-              <button
-                aria-expanded={false}
-                aria-haspopup={true}
-                aria-owns={null}
-                className=
-                    ms-Button
-                    ms-Button--icon
-                    ms-Button--hasMenu
-                    ms-Breadcrumb-overflowButton
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      background-color: transparent;
-                      border-radius: 2px;
-                      border: none;
-                      box-sizing: border-box;
-                      color: #605e5c;
-                      cursor: pointer;
-                      display: inline-block;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 16px;
-                      font-weight: 400;
-                      height: 100%;
-                      outline: transparent;
-                      overflow: hidden;
-                      padding-bottom: 0;
-                      padding-left: 4px;
-                      padding-right: 4px;
-                      padding-top: 0;
-                      position: relative;
-                      text-align: center;
-                      text-decoration: none;
-                      text-overflow: ellipsis;
-                      user-select: none;
-                      vertical-align: top;
-                      white-space: nowrap;
-                      width: auto;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 1px solid #ffffff;
-                      bottom: 1px;
-                      content: "";
-                      left: 1px;
-                      outline: 1px solid #605e5c;
-                      position: absolute;
-                      right: 1px;
-                      top: 1px;
-                      z-index: 1;
-                    }
-                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                      border: none;
-                      bottom: -2px;
-                      left: -2px;
-                      outline-color: ButtonText;
-                      right: -2px;
-                      top: -2px;
-                    }
-                    &:active > * {
-                      left: 0px;
-                      position: relative;
-                      top: 0px;
-                    }
-                    &:hover {
-                      background-color: #f3f2f1;
-                      color: #323130;
-                      cursor: pointer;
-                      text-decoration: none;
-                    }
-                    @media screen and (-ms-high-contrast: active){&:hover {
-                      border-color: Highlight;
-                      color: Highlight;
-                    }
-                    &:active {
-                      background-color: #edebe9;
-                      color: #323130;
-                      text-decoration: none;
-                    }
-                    &:active:hover {
-                      background-color: #edebe9;
-                      color: #323130;
-                      text-decoration: none;
-                    }
-                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                      padding-bottom: 4px;
-                      padding-left: 6px;
-                      padding-right: 6px;
-                      padding-top: 4px;
-                    }
-                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
-                      font-size: 16px;
-                    }
-                data-is-focusable={true}
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseUp={[Function]}
-                role="button"
-                type="button"
-              >
-                <span
-                  className=
-                      ms-Button-flexContainer
-                      {
-                        align-items: center;
-                        display: flex;
-                        flex-wrap: nowrap;
-                        height: 100%;
-                        justify-content: center;
-                      }
-                  data-automationid="splitbuttonprimary"
-                >
-                  <i
-                    aria-hidden={true}
-                    className=
-
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          display: inline-block;
-                          font-family: "FabricMDL2Icons";
-                          font-style: normal;
-                          font-weight: normal;
-                          speak: none;
-                        }
-                    data-icon-name="ChevronDown"
-                  >
-                    
-                  </i>
-                </span>
-              </button>
-              <i
-                aria-hidden={true}
-                className=
-                    ms-Breadcrumb-chevron
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      color: #605e5c;
-                      display: inline-block;
-                      font-family: "FabricMDL2Icons";
-                      font-size: 12px;
-                      font-style: normal;
-                      font-weight: normal;
-                      speak: none;
-                    }
-                    @media screen and (-ms-high-contrast: active){& {
-                      -ms-high-contrast-adjust: none;
-                      color: WindowText;
-                    }
-                    @media only screen and (min-width: 480px) and (max-width: 639px){& {
-                      font-size: 8px;
-                    }
-                    @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                      font-size: 8px;
-                    }
-                data-icon-name="ChevronRight"
-              >
-                
-              </i>
-            </li>
-            <li
-              className=
-                  ms-Breadcrumb-listItem
-                  {
-                    align-items: center;
-                    display: flex;
-                    list-style-type: none;
-                    margin-bottom: 0;
-                    margin-left: 0;
-                    margin-right: 0;
-                    margin-top: 0;
-                    padding-bottom: 0;
-                    padding-left: 0;
-                    padding-right: 0;
-                    padding-top: 0;
-                    position: relative;
-                  }
-                  &:last-child .ms-Breadcrumb-itemLink {
-                    color: #323130;
-                    font-weight: 600;
-                  }
-                  &:last-child .ms-Breadcrumb-item {
-                    color: #323130;
-                    font-weight: 600;
-                  }
-            >
-              <span
-                className=
-                    ms-Breadcrumb-item
-                    {
-                      color: #605e5c;
-                      font-size: 18px;
-                      font-weight: 400;
-                      line-height: 36px;
-                      padding-bottom: 0;
-                      padding-left: 8px;
-                      padding-right: 8px;
-                      padding-top: 0;
-                    }
-                    &:hover {
-                      cursor: default;
-                    }
-              >
-                <div
-                  className=
-                      ms-TooltipHost
-                      {
-                        display: inline;
-                      }
-                  onBlurCapture={[Function]}
-                  onFocusCapture={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  TestText3
-                </div>
-              </span>
               <i
                 aria-hidden={true}
                 className=

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx
@@ -8,120 +8,57 @@ import { Icon } from 'office-ui-fabric-react/lib/Icon';
 const labelStyles: Partial<IStyleSet<ILabelStyles>> = {
   root: {
     margin: '10px 0',
-    selectors: {
-      '&:not(:first-child)': { marginTop: 24 }
-    }
+    selectors: { '&:not(:first-child)': { marginTop: 24 } }
   }
 };
+
+const items: IBreadcrumbItem[] = [
+  { text: 'Files', key: 'Files', onClick: _onBreadcrumbItemClicked },
+  { text: 'This is folder 1', key: 'f1', onClick: _onBreadcrumbItemClicked },
+  { text: 'This is folder 2 with a long name', key: 'f2', onClick: _onBreadcrumbItemClicked },
+  { text: 'This is folder 3 long', key: 'f3', onClick: _onBreadcrumbItemClicked },
+  { text: 'This is non-clickable folder 4', key: 'f4' },
+  { text: 'This is folder 5', key: 'f5', onClick: _onBreadcrumbItemClicked, isCurrentItem: true }
+];
+const itemsWithHeadings: IBreadcrumbItem[] = [
+  { text: 'Files', key: 'Files', onClick: _onBreadcrumbItemClicked },
+  { text: 'This is folder 1', key: 'd1', onClick: _onBreadcrumbItemClicked },
+  { text: 'This is folder 2', key: 'd2', isCurrentItem: true, as: 'h4' }
+];
 
 export const BreadcrumbBasicExample: React.FunctionComponent = () => {
   return (
     <div>
       <Label styles={labelStyles}>With no maxDisplayedItems</Label>
-      <Breadcrumb
-        items={[
-          { text: 'Files', key: 'Files', onClick: _onBreadcrumbItemClicked },
-          { text: 'This is folder 1', key: 'f1', onClick: _onBreadcrumbItemClicked },
-          { text: 'This is folder 2 with a long name', key: 'f2', onClick: _onBreadcrumbItemClicked },
-          { text: 'This is folder 3 long', key: 'f3', onClick: _onBreadcrumbItemClicked },
-          { text: 'This is folder 4', key: 'f4', onClick: _onBreadcrumbItemClicked },
-          { text: 'This is folder 5 another', key: 'f5', onClick: _onBreadcrumbItemClicked, isCurrentItem: true }
-        ]}
-        ariaLabel="Breadcrumb with no maxDisplayedItems"
-        overflowAriaLabel="More links"
-      />
+      <Breadcrumb items={items} ariaLabel="Breadcrumb with no maxDisplayedItems" overflowAriaLabel="More links" />
 
-      <Label styles={labelStyles}>With Custom Divider Icon</Label>
+      <Label styles={labelStyles}>With maxDisplayedItems set to 3</Label>
       <Breadcrumb
-        items={[
-          { text: 'Files', key: 'Files', onClick: _onBreadcrumbItemClicked },
-          { text: 'This is folder 1', key: 'f1', onClick: _onBreadcrumbItemClicked },
-          { text: 'This is folder 2', key: 'f2', onClick: _onBreadcrumbItemClicked },
-          { text: 'This is folder 3', key: 'f3', onClick: _onBreadcrumbItemClicked },
-          { text: 'This is folder 4', key: 'f4', onClick: _onBreadcrumbItemClicked },
-          { text: 'This is folder 5', key: 'f5', onClick: _onBreadcrumbItemClicked, isCurrentItem: true }
-        ]}
-        dividerAs={_getCustomDivider}
-        ariaLabel="Breadcrumb with custom divider icon"
-        overflowAriaLabel="More links"
-      />
-
-      <Label styles={labelStyles}>With Custom Overflow Icon</Label>
-      <Breadcrumb
-        items={[
-          { text: 'Files', key: 'Files', onClick: _onBreadcrumbItemClicked },
-          { text: 'This is folder 1', key: 'f1', onClick: _onBreadcrumbItemClicked },
-          { text: 'This is folder 2 with a long name', key: 'f2', onClick: _onBreadcrumbItemClicked },
-          { text: 'This is folder 3 long', key: 'f3', onClick: _onBreadcrumbItemClicked },
-          { text: 'This is folder 4', key: 'f4', onClick: _onBreadcrumbItemClicked },
-          { text: 'This is folder 5 another', key: 'f5', onClick: _onBreadcrumbItemClicked, isCurrentItem: true }
-        ]}
-        ariaLabel={'Breadcrumb with no maxDisplayedItems'}
-        onRenderOverflowIcon={_getCustomOverflowIcon}
-      />
-
-      <Label styles={labelStyles}>With maxDisplayedItems set to three</Label>
-      <Breadcrumb
-        items={[
-          { text: 'Files', key: 'Files', href: '#/examples/breadcrumb', onClick: _onBreadcrumbItemClicked },
-          {
-            text: 'This is link 1',
-            key: 'l1',
-            href: '#/examples/breadcrumb',
-            onClick: _onBreadcrumbItemClicked
-          },
-          {
-            text: 'This is link 2',
-            key: 'l2',
-            href: '#/examples/breadcrumb',
-            onClick: _onBreadcrumbItemClicked
-          },
-          {
-            text: 'This is link 3 with a long name',
-            key: 'l3',
-            href: '#/examples/breadcrumb',
-            onClick: _onBreadcrumbItemClicked
-          },
-          {
-            text: 'This is link 4',
-            key: 'l4',
-            href: '#/examples/breadcrumb',
-            onClick: _onBreadcrumbItemClicked
-          },
-          {
-            text: 'This is link 5',
-            key: 'l5',
-            href: '#/examples/breadcrumb',
-            onClick: _onBreadcrumbItemClicked,
-            isCurrentItem: true
-          }
-        ]}
+        items={items}
         maxDisplayedItems={3}
-        ariaLabel="Breadcrumb with maxDisplayedItems set to three"
+        ariaLabel="Breadcrumb with maxDisplayedItems set to 3"
         overflowAriaLabel="More links"
       />
 
-      <Label styles={labelStyles}>With maxDisplayedItems set to two and overflowIndex set to 1 (second element)</Label>
+      <Label styles={labelStyles}>With maxDisplayedItems set to 2 and overflowIndex set to 1 (second element)</Label>
       <Breadcrumb
-        items={[
-          { text: 'TestText1', key: 'TestKey1' },
-          { text: 'TestText2', key: 'TestKey2' },
-          { text: 'TestText3', key: 'TestKey3' },
-          { text: 'TestText4', key: 'TestKey4' }
-        ]}
+        items={items}
         maxDisplayedItems={2}
         overflowIndex={1}
         ariaLabel="Breadcrumb with maxDisplayedItems set to 2 and overflowIndex set to 1"
         overflowAriaLabel="More links"
       />
-      <Label styles={labelStyles}>With items rendered as a headings</Label>
+
+      <Label styles={labelStyles}>With last item rendered as heading</Label>
+      <Breadcrumb items={itemsWithHeadings} ariaLabel="With last item rendered as heading" overflowAriaLabel="More links" />
+
+      <Label styles={labelStyles}>With custom rendered divider and overflow icon</Label>
       <Breadcrumb
-        items={[
-          { text: 'Files', key: 'Files', onClick: _onBreadcrumbItemClicked, as: 'h4' },
-          { text: 'This is folder 1', key: 'd1', onClick: _onBreadcrumbItemClicked, as: 'h3' },
-          { text: 'This is folder 2', key: 'd2', isCurrentItem: true, as: 'h2' }
-        ]}
-        ariaLabel="Current item rendered as a heading"
+        items={itemsWithHeadings}
+        maxDisplayedItems={3}
+        ariaLabel="With custom rendered divider and overflow icon"
+        dividerAs={_getCustomDivider}
+        onRenderOverflowIcon={_getCustomOverflowIcon}
         overflowAriaLabel="More links"
       />
     </div>
@@ -136,7 +73,7 @@ function _getCustomDivider(dividerProps: IDividerAsProps): JSX.Element {
   const tooltipText = dividerProps.item ? dividerProps.item.text : '';
   return (
     <TooltipHost content={`Show ${tooltipText} contents`} calloutProps={{ gapSpace: 0 }}>
-      <span aria-hidden="true" style={{ cursor: 'pointer' }}>
+      <span aria-hidden="true" style={{ cursor: 'pointer', padding: 5 }}>
         /
       </span>
     </TooltipHost>

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx
@@ -20,23 +20,39 @@ const items: IBreadcrumbItem[] = [
   { text: 'This is non-clickable folder 4', key: 'f4' },
   { text: 'This is folder 5', key: 'f5', onClick: _onBreadcrumbItemClicked, isCurrentItem: true }
 ];
-const itemsWithHeadings: IBreadcrumbItem[] = [
+const itemsWithHref: IBreadcrumbItem[] = [
+  // Normally each breadcrumb would have a unique href, but to make the navigation less disruptive
+  // in the example, it uses the breadcrumb page as the href for all the items
+  { text: 'Files', key: 'Files', href: '#/controls/web/breadcrumb' },
+  { text: 'This is folder 1', key: 'f1', href: '#/controls/web/breadcrumb' },
+  { text: 'This is folder 2 with a long name', key: 'f2', href: '#/controls/web/breadcrumb' },
+  { text: 'This is folder 3 long', key: 'f3', href: '#/controls/web/breadcrumb' },
+  { text: 'This is non-clickable folder 4', key: 'f4' },
+  { text: 'This is folder 5', key: 'f5', href: '#/controls/web/breadcrumb', isCurrentItem: true }
+];
+const itemsWithHeading: IBreadcrumbItem[] = [
   { text: 'Files', key: 'Files', onClick: _onBreadcrumbItemClicked },
   { text: 'This is folder 1', key: 'd1', onClick: _onBreadcrumbItemClicked },
+  // Generally, only the last item should ever be a heading.
+  // It would typically be h1 or h2, but we're using h4 here to better fit the structure of the page.
   { text: 'This is folder 2', key: 'd2', isCurrentItem: true, as: 'h4' }
 ];
 
 export const BreadcrumbBasicExample: React.FunctionComponent = () => {
   return (
     <div>
-      <Label styles={labelStyles}>With no maxDisplayedItems</Label>
-      <Breadcrumb items={items} ariaLabel="Breadcrumb with no maxDisplayedItems" overflowAriaLabel="More links" />
-
-      <Label styles={labelStyles}>With maxDisplayedItems set to 3</Label>
+      <Label styles={labelStyles}>With no maxDisplayedItems, and items rendered as buttons</Label>
       <Breadcrumb
         items={items}
+        ariaLabel="Breadcrumb with no maxDisplayedItems, and items rendered as buttons"
+        overflowAriaLabel="More links"
+      />
+
+      <Label styles={labelStyles}>With maxDisplayedItems set to 3, and items rendered as links</Label>
+      <Breadcrumb
+        items={itemsWithHref}
         maxDisplayedItems={3}
-        ariaLabel="Breadcrumb with maxDisplayedItems set to 3"
+        ariaLabel="Breadcrumb with maxDisplayedItems set to 3, and items rendered as links"
         overflowAriaLabel="More links"
       />
 
@@ -50,11 +66,11 @@ export const BreadcrumbBasicExample: React.FunctionComponent = () => {
       />
 
       <Label styles={labelStyles}>With last item rendered as heading</Label>
-      <Breadcrumb items={itemsWithHeadings} ariaLabel="With last item rendered as heading" overflowAriaLabel="More links" />
+      <Breadcrumb items={itemsWithHeading} ariaLabel="With last item rendered as heading" overflowAriaLabel="More links" />
 
       <Label styles={labelStyles}>With custom rendered divider and overflow icon</Label>
       <Breadcrumb
-        items={itemsWithHeadings}
+        items={itemsWithHeading}
         maxDisplayedItems={3}
         ariaLabel="With custom rendered divider and overflow icon"
         dividerAs={_getCustomDivider}

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Basic.Example.tsx
@@ -2,66 +2,54 @@ import * as React from 'react';
 import { Breadcrumb, IBreadcrumbItem, IDividerAsProps } from 'office-ui-fabric-react/lib/Breadcrumb';
 import { Label, ILabelStyles } from 'office-ui-fabric-react/lib/Label';
 import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
-import { IStyleSet } from 'office-ui-fabric-react/lib/Styling';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 
-const labelStyles: Partial<IStyleSet<ILabelStyles>> = {
-  root: {
-    margin: '10px 0',
-    selectors: { '&:not(:first-child)': { marginTop: 24 } }
-  }
+const labelStyles: Partial<ILabelStyles> = {
+  root: { margin: '10px 0', selectors: { '&:not(:first-child)': { marginTop: 24 } } }
 };
 
 const items: IBreadcrumbItem[] = [
   { text: 'Files', key: 'Files', onClick: _onBreadcrumbItemClicked },
-  { text: 'This is folder 1', key: 'f1', onClick: _onBreadcrumbItemClicked },
-  { text: 'This is folder 2 with a long name', key: 'f2', onClick: _onBreadcrumbItemClicked },
-  { text: 'This is folder 3 long', key: 'f3', onClick: _onBreadcrumbItemClicked },
-  { text: 'This is non-clickable folder 4', key: 'f4' },
-  { text: 'This is folder 5', key: 'f5', onClick: _onBreadcrumbItemClicked, isCurrentItem: true }
+  { text: 'Folder 1', key: 'f1', onClick: _onBreadcrumbItemClicked },
+  { text: 'Folder 2', key: 'f2', onClick: _onBreadcrumbItemClicked },
+  { text: 'Folder 3', key: 'f3', onClick: _onBreadcrumbItemClicked },
+  { text: 'Folder 4 (non-clickable)', key: 'f4' },
+  { text: 'Folder 5', key: 'f5', onClick: _onBreadcrumbItemClicked, isCurrentItem: true }
 ];
 const itemsWithHref: IBreadcrumbItem[] = [
   // Normally each breadcrumb would have a unique href, but to make the navigation less disruptive
   // in the example, it uses the breadcrumb page as the href for all the items
   { text: 'Files', key: 'Files', href: '#/controls/web/breadcrumb' },
-  { text: 'This is folder 1', key: 'f1', href: '#/controls/web/breadcrumb' },
-  { text: 'This is folder 2 with a long name', key: 'f2', href: '#/controls/web/breadcrumb' },
-  { text: 'This is folder 3 long', key: 'f3', href: '#/controls/web/breadcrumb' },
-  { text: 'This is non-clickable folder 4', key: 'f4' },
-  { text: 'This is folder 5', key: 'f5', href: '#/controls/web/breadcrumb', isCurrentItem: true }
+  { text: 'Folder 1', key: 'f1', href: '#/controls/web/breadcrumb' },
+  { text: 'Folder 2', key: 'f2', href: '#/controls/web/breadcrumb' },
+  { text: 'Folder 3', key: 'f3', href: '#/controls/web/breadcrumb' },
+  { text: 'Folder 4 (non-clickable)', key: 'f4' },
+  { text: 'Folder 5', key: 'f5', href: '#/controls/web/breadcrumb', isCurrentItem: true }
 ];
 const itemsWithHeading: IBreadcrumbItem[] = [
   { text: 'Files', key: 'Files', onClick: _onBreadcrumbItemClicked },
-  { text: 'This is folder 1', key: 'd1', onClick: _onBreadcrumbItemClicked },
+  { text: 'Folder 1', key: 'd1', onClick: _onBreadcrumbItemClicked },
   // Generally, only the last item should ever be a heading.
   // It would typically be h1 or h2, but we're using h4 here to better fit the structure of the page.
-  { text: 'This is folder 2', key: 'd2', isCurrentItem: true, as: 'h4' }
+  { text: 'Folder 2', key: 'd2', isCurrentItem: true, as: 'h4' }
 ];
 
 export const BreadcrumbBasicExample: React.FunctionComponent = () => {
   return (
     <div>
-      <Label styles={labelStyles}>With no maxDisplayedItems, and items rendered as buttons</Label>
+      <Label styles={labelStyles}>With items rendered as buttons</Label>
       <Breadcrumb
         items={items}
-        ariaLabel="Breadcrumb with no maxDisplayedItems, and items rendered as buttons"
+        maxDisplayedItems={3}
+        ariaLabel="Breadcrumb with items rendered as buttons"
         overflowAriaLabel="More links"
       />
 
-      <Label styles={labelStyles}>With maxDisplayedItems set to 3, and items rendered as links</Label>
+      <Label styles={labelStyles}>With items rendered as links</Label>
       <Breadcrumb
         items={itemsWithHref}
         maxDisplayedItems={3}
-        ariaLabel="Breadcrumb with maxDisplayedItems set to 3, and items rendered as links"
-        overflowAriaLabel="More links"
-      />
-
-      <Label styles={labelStyles}>With maxDisplayedItems set to 2 and overflowIndex set to 1 (second element)</Label>
-      <Breadcrumb
-        items={items}
-        maxDisplayedItems={2}
-        overflowIndex={1}
-        ariaLabel="Breadcrumb with maxDisplayedItems set to 2 and overflowIndex set to 1"
+        ariaLabel="Breadcrumb with items rendered as links"
         overflowAriaLabel="More links"
       />
 

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Collapsing.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Collapsing.Example.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { Breadcrumb, IBreadcrumbItem } from 'office-ui-fabric-react/lib/Breadcrumb';
+import { Label, ILabelStyles } from 'office-ui-fabric-react/lib/Label';
+
+const labelStyles: Partial<ILabelStyles> = {
+  root: { margin: '10px 0', selectors: { '&:not(:first-child)': { marginTop: 24 } } }
+};
+
+const items: IBreadcrumbItem[] = [
+  { text: 'Files', key: 'Files', onClick: _onBreadcrumbItemClicked },
+  { text: 'This is folder 1', key: 'f1', onClick: _onBreadcrumbItemClicked },
+  { text: 'This is folder 2 with a long name', key: 'f2', onClick: _onBreadcrumbItemClicked },
+  { text: 'This is folder 3 long', key: 'f3', onClick: _onBreadcrumbItemClicked },
+  { text: 'This is non-clickable folder 4', key: 'f4' },
+  { text: 'This is folder 5', key: 'f5', onClick: _onBreadcrumbItemClicked, isCurrentItem: true }
+];
+
+export const BreadcrumbCollapsingExample: React.FunctionComponent = () => {
+  return (
+    <div>
+      <Label styles={labelStyles}>With no maxDisplayedItems</Label>
+      <Breadcrumb items={items} ariaLabel="Breadcrumb with no maxDisplayedItems" overflowAriaLabel="More links" />
+
+      <Label styles={labelStyles}>With maxDisplayedItems set to 3</Label>
+      <Breadcrumb
+        items={items}
+        maxDisplayedItems={3}
+        ariaLabel="Breadcrumb with maxDisplayedItems set to 3"
+        overflowAriaLabel="More links"
+      />
+
+      <Label styles={labelStyles}>With maxDisplayedItems set to 2 and overflowIndex set to 1 (second element)</Label>
+      <Breadcrumb
+        items={items}
+        maxDisplayedItems={2}
+        overflowIndex={1}
+        ariaLabel="Breadcrumb with maxDisplayedItems set to 2 and overflowIndex set to 1"
+        overflowAriaLabel="More links"
+      />
+    </div>
+  );
+};
+
+function _onBreadcrumbItemClicked(ev: React.MouseEvent<HTMLElement>, item: IBreadcrumbItem): void {
+  console.log(`Breadcrumb item with key "${item.key}" has been clicked.`);
+}

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Static.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Static.Example.tsx
@@ -1,28 +1,25 @@
 import * as React from 'react';
 import { Breadcrumb, IBreadcrumbItem } from 'office-ui-fabric-react/lib/Breadcrumb';
 
+const items: IBreadcrumbItem[] = [
+  { text: 'Files', key: 'Files', onClick: _onBreadcrumbItemClicked },
+  { text: 'This is folder 1', key: 'f1', onClick: _onBreadcrumbItemClicked },
+  { text: 'This is folder 2 with a long name', key: 'f2', onClick: _onBreadcrumbItemClicked },
+  { text: 'This is folder 3 long', key: 'f3', onClick: _onBreadcrumbItemClicked },
+  { text: 'This is non-clickable folder 4', key: 'f4' },
+  { text: 'This is folder 5', key: 'f5', onClick: _onBreadcrumbItemClicked, isCurrentItem: true }
+];
+
 export const BreadcrumbStaticExample: React.FunctionComponent = () => {
   return (
     <div style={{ display: 'inline-block' }}>
       <Breadcrumb
-        items={[
-          { text: 'Not a link', key: 'Files' },
-          { text: 'Link', key: 'f1', onClick: _onBreadcrumbItemClicked },
-          { text: 'Link', key: 'f2', onClick: _onBreadcrumbItemClicked },
-          { text: 'Not a link', key: 'f3' },
-          { text: 'Link', key: 'f4', onClick: _onBreadcrumbItemClicked },
-          {
-            text: 'Link',
-            key: 'f5',
-            onClick: _onBreadcrumbItemClicked,
-            isCurrentItem: true
-          }
-        ]}
+        items={items}
         // Returning undefined to OnReduceData tells the breadcrumb not to shrink
         onReduceData={_returnUndefined}
         maxDisplayedItems={3}
-        ariaLabel={'Breadcrumb with static width'}
-        overflowAriaLabel={'More items'}
+        ariaLabel="Breadcrumb with static width"
+        overflowAriaLabel="More items"
       />
     </div>
   );

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Static.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/examples/Breadcrumb.Static.Example.tsx
@@ -1,34 +1,35 @@
 import * as React from 'react';
 import { Breadcrumb, IBreadcrumbItem } from 'office-ui-fabric-react/lib/Breadcrumb';
 
-export class BreadcrumbStaticExample extends React.Component {
-  public render(): JSX.Element {
-    return (
-      <div style={{ display: 'inline-block' }}>
-        <Breadcrumb
-          items={[
-            { text: 'Files', key: 'Files', onClick: this._onBreadcrumbItemClicked },
-            { text: 'This is folder 1', key: 'f1', onClick: this._onBreadcrumbItemClicked },
-            { text: 'This is folder 2', key: 'f2', onClick: this._onBreadcrumbItemClicked },
-            { text: 'This is folder 3', key: 'f3', onClick: this._onBreadcrumbItemClicked },
-            { text: 'This is folder 4', key: 'f4', onClick: this._onBreadcrumbItemClicked },
-            { text: 'This is folder 5', key: 'f5', onClick: this._onBreadcrumbItemClicked, isCurrentItem: true }
-          ]}
-          // Returning undefined to OnReduceData tells the breadcrumb not to shrink
-          onReduceData={this._returnUndefined}
-          maxDisplayedItems={3}
-          ariaLabel={'Breadcrumb with static width'}
-          overflowAriaLabel={'More items'}
-        />
-      </div>
-    );
-  }
+export const BreadcrumbStaticExample: React.FunctionComponent = () => {
+  return (
+    <div style={{ display: 'inline-block' }}>
+      <Breadcrumb
+        items={[
+          { text: 'Not a link', key: 'Files' },
+          { text: 'Link', key: 'f1', onClick: _onBreadcrumbItemClicked },
+          { text: 'Link', key: 'f2', onClick: _onBreadcrumbItemClicked },
+          { text: 'Not a link', key: 'f3' },
+          { text: 'Link', key: 'f4', onClick: _onBreadcrumbItemClicked },
+          {
+            text: 'Link',
+            key: 'f5',
+            onClick: _onBreadcrumbItemClicked,
+            isCurrentItem: true
+          }
+        ]}
+        // Returning undefined to OnReduceData tells the breadcrumb not to shrink
+        onReduceData={_returnUndefined}
+        maxDisplayedItems={3}
+        ariaLabel={'Breadcrumb with static width'}
+        overflowAriaLabel={'More items'}
+      />
+    </div>
+  );
+};
 
-  private _onBreadcrumbItemClicked = (ev: React.MouseEvent<HTMLElement>, item: IBreadcrumbItem): void => {
-    console.log(`Breadcrumb item with key "${item.key}" has been clicked.`);
-  };
-
-  private _returnUndefined(): undefined {
-    return undefined;
-  }
+function _onBreadcrumbItemClicked(ev: React.MouseEvent<HTMLElement>, item: IBreadcrumbItem): void {
+  console.log(`Breadcrumb item with key "${item.key}" has been clicked.`);
 }
+
+const _returnUndefined = () => undefined;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -29,7 +29,6 @@ export enum ContextualMenuItemType {
 export interface IContextualMenu {}
 
 /**
- * React.Props is deprecated and we're removing it in 6.0. Usage of 'any' should go away with it.
  * {@docCategory ContextualMenu}
  */
 export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWithResponsiveModeState {
@@ -45,32 +44,31 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
   styles?: IStyleFunctionOrObject<IContextualMenuStyleProps, IContextualMenuStyles>;
 
   /**
-   * Theme provided by High-Order Component.
+   * Theme provided by higher-order component.
    */
   theme?: ITheme;
 
   /**
-   * Additional css class to apply to the ContextualMenu
-   * @defaultvalue undefined
+   * Additional CSS class to apply to the ContextualMenu.
    */
   className?: string;
 
   /**
    * The target that the ContextualMenu should try to position itself based on.
-   * It can be either an Element a querySelector string of a valid Element
-   * or a MouseEvent. If MouseEvent is given then the origin point of the event will be used.
+   * It can be either an element, a query selector string resolving to a valid element,
+   * or a MouseEvent. If a MouseEvent is given, the origin point of the event will be used.
    */
   target?: Target;
 
   /**
-   * How the element should be positioned
+   * How the menu should be positioned
    * @defaultvalue DirectionalHint.bottomAutoEdge
    */
   directionalHint?: DirectionalHint;
 
   /**
-   * How the element should be positioned in RTL layouts.
-   * If not specified, a mirror of `directionalHint` will be used instead
+   * How the menu should be positioned in RTL layouts.
+   * If not specified, a mirror of `directionalHint` will be used.
    */
   directionalHintForRTL?: DirectionalHint;
 
@@ -99,7 +97,7 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
   useTargetAsMinWidth?: boolean;
 
   /**
-   * The bounding rectangle (or callback that returns a rectangle) for which  the contextual menu can appear in.
+   * The bounding rectangle (or callback that returns a rectangle) which the contextual menu can appear in.
    */
   bounds?: IRectangle | ((target?: Target, targetWindow?: Window) => IRectangle | undefined);
 
@@ -109,11 +107,10 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
   isBeakVisible?: boolean;
 
   /**
-   * If true the position returned will have the menu element cover the target.
-   * If false then it will position next to the target;
+   * If true, the menu will be positioned to cover the target.
+   * If false, it will be positioned next to the target.
    * @defaultvalue false
    */
-
   coverTarget?: boolean;
 
   /**
@@ -123,14 +120,13 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
   alignTargetEdge?: boolean;
 
   /**
-   * Collection of menu items.
+   * Menu items to display.
    * @defaultvalue []
    */
   items: IContextualMenuItem[];
 
   /**
-   * Aria Labelled by labelElementId
-   * @defaultvalue null
+   * Used as `aria-labelledby` for the the menu element inside the callout.
    */
   labelElementId?: string;
 
@@ -142,37 +138,35 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
 
   /**
    * Whether to focus on the contextual menu container (as opposed to the first menu item).
-   * @defaultvalue null
    */
   shouldFocusOnContainer?: boolean;
 
   /**
-   * Callback when the ContextualMenu tries to close. If dismissAll is true then all
+   * Callback when the ContextualMenu tries to close. If `dismissAll` is true then all
    * submenus will be dismissed.
    */
   onDismiss?: (ev?: any, dismissAll?: boolean) => void;
 
   /**
-   * Click handler which is invoked if onClick is not passed for individual contextual
+   * Click handler which is invoked if `onClick` is not passed for individual contextual
    * menu item.
-   * Returning true will dismiss the menu even if ev.preventDefault() was called.
+   * Returning true will dismiss the menu even if `ev.preventDefault()` was called.
    */
   onItemClick?: (ev?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>, item?: IContextualMenuItem) => boolean | void;
 
   /**
-   * Whether this menu is a submenu of another menu or not.
+   * Whether this menu is a submenu of another menu.
    */
   isSubMenu?: boolean;
 
   /**
-   * DOM id to tag the ContextualMenu with, for reference.
-   * Should be used for 'aria-owns' and other such uses, rather than direct reference for programmatic purposes.
+   * ID for the ContextualMenu's root element (inside the callout).
+   * Should be used for `aria-owns` and other such uses, rather than direct reference for programmatic purposes.
    */
   id?: string;
 
   /**
-   * Aria label for accessibility for the ContextualMenu.
-   * If none specified no aria label will be applied to the ContextualMenu.
+   * Accessible label for the ContextualMenu's root element (inside the callout).
    */
   ariaLabel?: string;
 
@@ -190,17 +184,17 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
   directionalHintFixed?: boolean;
 
   /**
-   * Callback for when the contextualmenu has been opened.
+   * Callback for when the menu has been opened.
    */
   onMenuOpened?: (contextualMenu?: IContextualMenuProps) => void;
 
   /**
-   * Callback for when the contextualmenu is being closed (removing from the DOM)
+   * Callback for when the menu is being closed (removing from the DOM).
    */
   onMenuDismissed?: (contextualMenu?: IContextualMenuProps) => void;
 
   /**
-   * Pass in custom callout props
+   * Additional custom props for the Callout.
    */
   calloutProps?: ICalloutProps;
 
@@ -210,14 +204,12 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
   title?: string;
 
   /**
-   * Method to provide the classnames to style the contextual menu. Default value is the getMenuClassnames func
-   * defined in ContextualMenu.classnames.
-   * Deprecated, use `styles` prop of `IContextualMenuProps` to leverage mergeStyles API.
-   * @deprecated Use `styles` prop of `IContextualMenuProps` to leverage mergeStyles API.
+   * Method to provide the classnames to style the contextual menu.
+   * @deprecated Use `styles` instead to leverage mergeStyles API.
    */
   getMenuClassNames?: (theme: ITheme, className?: string) => IContextualMenuClassNames;
 
-  /** Method to call when trying to render a submenu. */
+  /** Custom render function for a submenu. */
   onRenderSubMenu?: IRenderFunction<IContextualMenuProps>;
 
   /**
@@ -240,12 +232,12 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
    * Props to pass down to the FocusZone.
    * NOTE: the default FocusZoneDirection will be used unless a direction
    * is specified in the focusZoneProps (even if other focusZoneProps are defined)
-   * @defaultvalue \{direction: FocusZoneDirection.vertical\}
+   * @defaultvalue \{ direction: FocusZoneDirection.vertical \}
    */
   focusZoneProps?: IFocusZoneProps;
 
   /**
-   * If specified, renders the ContextualMenu in a hidden state.
+   * If true, renders the ContextualMenu in a hidden state.
    * Use this flag, rather than rendering a ContextualMenu conditionally based on visibility,
    * to improve rendering performance when it becomes visible.
    * Note: When ContextualMenu is hidden its content will not be rendered. It will only render
@@ -255,18 +247,17 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
   hidden?: boolean;
 
   /**
-   * If true, the component will be updated even when hidden=true.
+   * If true, the component will be updated even when `hidden=true`.
    * Note that this would consume resources to update even though
    * nothing is being shown to the user.
    * This might be helpful though if your updates are small and you want the
-   * contextual menu to be revealed fast to the user when hidden is set to false.
+   * contextual menu to be revealed fast to the user when `hidden` is set to false.
    */
   shouldUpdateWhenHidden?: boolean;
 
   /**
-   * If true, the contextual menu will not be updated until
-   * focus enters the menu via other means. This will only result
-   * in different behavior when shouldFocusOnMount = false
+   * If true, the contextual menu will not be updated until focus enters the menu via other means.
+   * This will only result in different behavior when `shouldFocusOnMount = false`.
    * @defaultvalue null
    */
   delayUpdateFocusOnHover?: boolean;
@@ -309,7 +300,7 @@ export interface IContextualMenuItem {
   itemType?: ContextualMenuItemType;
 
   /**
-   * Props that go to the IconComponent
+   * Props for the Icon.
    */
   iconProps?: IIconProps;
 
@@ -319,7 +310,7 @@ export interface IContextualMenuItem {
   onRenderIcon?: IRenderFunction<IContextualMenuItemProps>;
 
   /**
-   * Props that go to the IconComponent used for the chevron.
+   * Props for the Icon used for the chevron.
    */
   submenuIconProps?: IIconProps;
 
@@ -336,7 +327,7 @@ export interface IContextualMenuItem {
   primaryDisabled?: boolean;
 
   /**
-   * [TODO] Not Yet Implemented
+   * @deprecated Not used
    */
   shortCut?: string;
 
@@ -364,23 +355,24 @@ export interface IContextualMenuItem {
   data?: any;
 
   /**
-   * Callback issued when the menu item is invoked. If ev.preventDefault() is called in onClick, click will not close menu.
-   * Returning true will dismiss the menu even if ev.preventDefault() was called.
+   * Callback for when the menu item is invoked. If `ev.preventDefault()` is called in `onClick`,
+   * the click will not close the menu.
+   * Returning true will dismiss the menu even if `ev.preventDefault()` was called.
    */
   onClick?: (ev?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>, item?: IContextualMenuItem) => boolean | void;
 
   /**
-   * An optional URL to navigate to upon selection
+   * Navigate to this URL when the menu item is clicked.
    */
   href?: string;
 
   /**
-   * An optional target when using href
+   * Target window when using `href`.
    */
   target?: string;
 
   /**
-   * An optional rel when using href. If target is _blank rel is defaulted to a value to prevent clickjacking.
+   * Link relation setting when using `href`. If `target` is `_blank`, `rel` is defaulted to a value to prevent clickjacking.
    */
   rel?: string;
 
@@ -395,7 +387,6 @@ export interface IContextualMenuItem {
 
   /**
    * Method to provide the classnames to style the individual items inside a menu.
-   * Deprecated, use `styles` prop of `IContextualMenuItemProps` to leverage mergeStyles API.
    * @deprecated Use `styles` prop of `IContextualMenuItemProps` to leverage mergeStyles API.
    */
   getItemClassNames?: (
@@ -419,27 +410,24 @@ export interface IContextualMenuItem {
 
   /**
    * Method to provide the classnames to style the Vertical Divider of a split button inside a menu.
-   * Default value is the getVerticalDividerClassnames func defined in ContextualMenu.classnames
+   * Default value is the `getSplitButtonVerticalDividerClassNames` func defined in `ContextualMenu.classnames.ts`.
    * @defaultvalue getSplitButtonVerticalDividerClassNames
    */
   getSplitButtonVerticalDividerClassNames?: (theme: ITheme) => IVerticalDividerClassNames;
 
   /**
-   *  Properties to apply to render this item as a section.
-   *  This prop is mutually exclusive with subMenuProps.
+   * Properties to apply to render this item as a section.
+   * This prop is mutually exclusive with `subMenuProps`.
    */
   sectionProps?: IContextualMenuSection;
 
   /**
-   * Additional css class to apply to the menu item
-   * @defaultvalue undefined
+   * Additional CSS class to apply to the menu item.
    */
   className?: string;
 
   /**
    * Additional styles to apply to the menu item
-   * Deprecated, use `styles` instead.
-   * @defaultvalue undefined
    * @deprecated in favor of the `styles` prop to leverage mergeStyles API.
    */
   style?: React.CSSProperties;
@@ -462,25 +450,23 @@ export interface IContextualMenuItem {
    *
    * The function receives a function that can be called to dismiss the menu as a second argument.
    *  This can be used to make sure that a custom menu item click dismisses the menu.
-   * @defaultvalue undefined
    */
   onRender?: (item: any, dismissMenu: (ev?: any, dismissAll?: boolean) => void) => React.ReactNode;
 
   /**
-   * A function to be executed onMouseDown. This is executed before an onClick event and can
+   * A function to be executed on mouse down. This is executed before an `onClick` event and can
    * be used to interrupt native on click events as well. The click event should still handle
    * the commands. This should only be used in special cases when react and non-react are mixed.
    */
   onMouseDown?: (item: IContextualMenuItem, event: React.MouseEvent<HTMLElement>) => void;
 
   /**
-   * Optional override for the role attribute on the menu button. If one is not provided, it will
-   * have a value of menuitem or menuitemcheckbox.
+   * Optional override for the menu button's role. Defaults to `menuitem` or `menuitemcheckbox`.
    */
   role?: string;
 
   /**
-   * When rendering a custom component that is passed in, the component might also be a list of
+   * When rendering a custom menu component that is passed in, the component might also be a list of
    * elements. We want to keep track of the correct index our menu is using based off of
    * the length of the custom list. It is up to the user to increment the count for their list.
    */
@@ -504,14 +490,12 @@ export interface IContextualMenuItem {
 
   /**
    * Text description for the menu item to display
-   * Deprecated, use `text` instead.
    * @deprecated Use `text` instead.
    */
   name?: string;
 }
 
 /**
- * React.Props is deprecated and we're removing it in 6.0. Usage of 'any' should go away with it.
  * {@docCategory ContextualMenu}
  */
 export interface IContextualMenuSection extends React.ClassAttributes<any> {
@@ -580,14 +564,8 @@ export interface IMenuItemStyles extends IButtonStyles {
  * {@docCategory ContextualMenu}
  */
 export interface IContextualMenuStyleProps {
-  /**
-   * Theme provided by High-Order Component.
-   */
   theme: ITheme;
 
-  /**
-   * Accept custom classNames
-   */
   className?: string;
 
   // Insert ContextualMenu style props below
@@ -632,9 +610,9 @@ export interface IContextualMenuStyles {
  * {@docCategory ContextualMenu}
  */
 export interface IContextualMenuSubComponentStyles {
-  /** Refers to the callout that hosts the ContextualMenu options */
+  /** Styles for the callout that hosts the ContextualMenu options. */
   callout: IStyleFunctionOrObject<ICalloutContentStyleProps, any>;
 
-  /** Refers to the item in the list */
+  /** Styles for each menu item. */
   menuItem: IStyleFunctionOrObject<IContextualMenuItemStyleProps, any>;
 }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -30,7 +30,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
           margin-top: 24px;
         }
   >
-    With no maxDisplayedItems
+    With no maxDisplayedItems, and items rendered as buttons
   </label>
   <div>
     <div
@@ -50,7 +50,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
         }
       >
         <div
-          aria-label="Breadcrumb with no maxDisplayedItems"
+          aria-label="Breadcrumb with no maxDisplayedItems, and items rendered as buttons"
           className=
               ms-Breadcrumb
               {
@@ -120,7 +120,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       font-weight: 600;
                     }
               >
-                <a
+                <button
                   className=
                       ms-Link
                       ms-Breadcrumb-itemLink
@@ -207,6 +207,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         color: Highlight;
                       }
                   onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=
@@ -222,7 +223,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                   >
                     Files
                   </div>
-                </a>
+                </button>
                 <i
                   aria-hidden={true}
                   className=
@@ -279,7 +280,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       font-weight: 600;
                     }
               >
-                <a
+                <button
                   className=
                       ms-Link
                       ms-Breadcrumb-itemLink
@@ -366,6 +367,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         color: Highlight;
                       }
                   onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=
@@ -381,7 +383,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                   >
                     This is folder 1
                   </div>
-                </a>
+                </button>
                 <i
                   aria-hidden={true}
                   className=
@@ -438,7 +440,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       font-weight: 600;
                     }
               >
-                <a
+                <button
                   className=
                       ms-Link
                       ms-Breadcrumb-itemLink
@@ -525,6 +527,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         color: Highlight;
                       }
                   onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=
@@ -540,7 +543,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                   >
                     This is folder 2 with a long name
                   </div>
-                </a>
+                </button>
                 <i
                   aria-hidden={true}
                   className=
@@ -597,7 +600,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       font-weight: 600;
                     }
               >
-                <a
+                <button
                   className=
                       ms-Link
                       ms-Breadcrumb-itemLink
@@ -683,6 +686,659 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: active){&:hover {
                         color: Highlight;
                       }
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    This is folder 3 long
+                  </div>
+                </button>
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Breadcrumb-chevron
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #605e5c;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        color: WindowText;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        font-size: 8px;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        font-size: 8px;
+                      }
+                  data-icon-name="ChevronRight"
+                >
+                  
+                </i>
+              </li>
+              <li
+                className=
+                    ms-Breadcrumb-listItem
+                    {
+                      align-items: center;
+                      display: flex;
+                      list-style-type: none;
+                      margin-bottom: 0;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 0;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &:last-child .ms-Breadcrumb-itemLink {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+                    &:last-child .ms-Breadcrumb-item {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+              >
+                <span
+                  className=
+                      ms-Breadcrumb-item
+                      {
+                        color: #605e5c;
+                        font-size: 18px;
+                        font-weight: 400;
+                        line-height: 36px;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                      }
+                      &:hover {
+                        cursor: default;
+                      }
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    This is non-clickable folder 4
+                  </div>
+                </span>
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Breadcrumb-chevron
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #605e5c;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        color: WindowText;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        font-size: 8px;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        font-size: 8px;
+                      }
+                  data-icon-name="ChevronRight"
+                >
+                  
+                </i>
+              </li>
+              <li
+                className=
+                    ms-Breadcrumb-listItem
+                    {
+                      align-items: center;
+                      display: flex;
+                      list-style-type: none;
+                      margin-bottom: 0;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 0;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &:last-child .ms-Breadcrumb-itemLink {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+                    &:last-child .ms-Breadcrumb-item {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+              >
+                <button
+                  aria-current="page"
+                  className=
+                      ms-Link
+                      ms-Breadcrumb-itemLink
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        background: none;
+                        border-bottom: 1px solid transparent;
+                        border: none;
+                        color: #605e5c;
+                        cursor: pointer;
+                        display: inline;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 18px;
+                        font-weight: 400;
+                        line-height: 36px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: left;
+                        text-overflow: ellipsis;
+                        user-select: text;
+                        white-space: nowrap;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        box-shadow: 0 0 0 1px #605e5c inset;
+                        outline: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-bottom: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){& {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){& {
+                        color: #00009F;
+                      }
+                      &:active {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:hover {
+                        background-color: #f3f2f1;
+                        color: #323130;
+                        cursor: pointer;
+                        text-decoration: none;
+                      }
+                      &:active:hover {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:focus {
+                        color: #201f1e;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #605e5c;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
+                      }
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    This is folder 5
+                  </div>
+                </button>
+              </li>
+            </ol>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <label
+    className=
+        ms-Label
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 600;
+          margin-bottom: 10px;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 10px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
+        &:not(:first-child) {
+          margin-top: 24px;
+        }
+  >
+    With maxDisplayedItems set to 3, and items rendered as links
+  </label>
+  <div>
+    <div
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+    >
+      <div
+        data-automation-id="visibleContent"
+        style={
+          Object {
+            "position": "fixed",
+            "visibility": "hidden",
+          }
+        }
+      >
+        <div
+          aria-label="Breadcrumb with maxDisplayedItems set to 3, and items rendered as links"
+          className=
+              ms-Breadcrumb
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 1px;
+                margin-left: 0;
+                margin-right: 0;
+                margin-top: 11px;
+              }
+          role="navigation"
+        >
+          <div
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+            data-focuszone-id="FocusZone7"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDownCapture={[Function]}
+          >
+            <ol
+              className=
+                  ms-Breadcrumb-list
+                  {
+                    align-items: stretch;
+                    display: flex;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    white-space: nowrap;
+                  }
+            >
+              <li
+                className=
+                    ms-Breadcrumb-overflow
+                    {
+                      align-items: center;
+                      display: flex;
+                      position: relative;
+                    }
+              >
+                <button
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  aria-label="More links"
+                  aria-owns={null}
+                  className=
+                      ms-Button
+                      ms-Button--icon
+                      ms-Button--hasMenu
+                      ms-Breadcrumb-overflowButton
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        border-radius: 2px;
+                        border: none;
+                        box-sizing: border-box;
+                        color: #605e5c;
+                        cursor: pointer;
+                        display: inline-block;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 16px;
+                        font-weight: 400;
+                        height: 100%;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 4px;
+                        padding-right: 4px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: center;
+                        text-decoration: none;
+                        text-overflow: ellipsis;
+                        user-select: none;
+                        vertical-align: top;
+                        white-space: nowrap;
+                        width: auto;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #605e5c;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                        border: none;
+                        bottom: -2px;
+                        left: -2px;
+                        outline-color: ButtonText;
+                        right: -2px;
+                        top: -2px;
+                      }
+                      &:active > * {
+                        left: 0px;
+                        position: relative;
+                        top: 0px;
+                      }
+                      &:hover {
+                        background-color: #f3f2f1;
+                        color: #323130;
+                        cursor: pointer;
+                        text-decoration: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        border-color: Highlight;
+                        color: Highlight;
+                      }
+                      &:active {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:active:hover {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        padding-bottom: 4px;
+                        padding-left: 6px;
+                        padding-right: 6px;
+                        padding-top: 4px;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        font-size: 16px;
+                      }
+                  data-is-focusable={true}
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  role="button"
+                  type="button"
+                >
+                  <span
+                    className=
+                        ms-Button-flexContainer
+                        {
+                          align-items: center;
+                          display: flex;
+                          flex-wrap: nowrap;
+                          height: 100%;
+                          justify-content: center;
+                        }
+                    data-automationid="splitbuttonprimary"
+                  >
+                    <i
+                      aria-hidden={true}
+                      className=
+                          ms-Icon
+                          ms-Button-icon
+                          {
+                            display: inline-block;
+                          }
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            font-family: "FabricMDL2Icons";
+                            font-style: normal;
+                            font-weight: normal;
+                            speak: none;
+                          }
+                          {
+                            flex-shrink: 0;
+                            font-size: 16px;
+                            height: 16px;
+                            line-height: 16px;
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                            text-align: center;
+                            vertical-align: middle;
+                          }
+                      data-icon-name="More"
+                      role="presentation"
+                    >
+                      
+                    </i>
+                  </span>
+                </button>
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Breadcrumb-chevron
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #605e5c;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        color: WindowText;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        font-size: 8px;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        font-size: 8px;
+                      }
+                  data-icon-name="ChevronRight"
+                >
+                  
+                </i>
+              </li>
+              <li
+                className=
+                    ms-Breadcrumb-listItem
+                    {
+                      align-items: center;
+                      display: flex;
+                      list-style-type: none;
+                      margin-bottom: 0;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 0;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &:last-child .ms-Breadcrumb-itemLink {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+                    &:last-child .ms-Breadcrumb-item {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+              >
+                <a
+                  className=
+                      ms-Link
+                      ms-Breadcrumb-itemLink
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #605e5c;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 18px;
+                        font-weight: 400;
+                        line-height: 36px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-decoration: none;
+                        text-overflow: ellipsis;
+                        white-space: nowrap;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        box-shadow: 0 0 0 1px #605e5c inset;
+                        outline: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-bottom: none;
+                      }
+                      &:active {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:hover {
+                        background-color: #f3f2f1;
+                        color: #323130;
+                        cursor: pointer;
+                        text-decoration: none;
+                      }
+                      &:active:hover {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:focus {
+                        color: #201f1e;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #605e5c;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
+                      }
+                  href="#/controls/web/breadcrumb"
                   onClick={[Function]}
                 >
                   <div
@@ -756,93 +1412,22 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       font-weight: 600;
                     }
               >
-                <a
+                <span
                   className=
-                      ms-Link
-                      ms-Breadcrumb-itemLink
+                      ms-Breadcrumb-item
                       {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        background-color: transparent;
-                        background: none;
-                        border-bottom: 1px solid transparent;
-                        border: none;
                         color: #605e5c;
-                        cursor: pointer;
-                        display: inline;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 18px;
                         font-weight: 400;
                         line-height: 36px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        outline: transparent;
-                        overflow: hidden;
                         padding-bottom: 0;
                         padding-left: 8px;
                         padding-right: 8px;
                         padding-top: 0;
-                        position: relative;
-                        text-align: left;
-                        text-overflow: ellipsis;
-                        user-select: text;
-                        white-space: nowrap;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus {
-                        box-shadow: 0 0 0 1px #605e5c inset;
-                        outline: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
-                        outline: 1px solid WindowText;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
-                      }
-                      &:active {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
                       }
                       &:hover {
-                        background-color: #f3f2f1;
-                        color: #323130;
-                        cursor: pointer;
-                        text-decoration: none;
+                        cursor: default;
                       }
-                      &:active:hover {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:focus {
-                        color: #201f1e;
-                      }
-                      &::-moz-focus-inner {
-                        border: 0;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus:after {
-                        border: 1px solid #ffffff;
-                        bottom: 1px;
-                        content: "";
-                        left: 1px;
-                        outline: 1px solid #605e5c;
-                        position: absolute;
-                        right: 1px;
-                        top: 1px;
-                        z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
-                      }
-                  onClick={[Function]}
                 >
                   <div
                     className=
@@ -856,9 +1441,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    This is folder 4
+                    This is non-clickable folder 4
                   </div>
-                </a>
+                </span>
                 <i
                   aria-hidden={true}
                   className=
@@ -923,21 +1508,11 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
-                        background-color: transparent;
-                        background: none;
-                        border-bottom: 1px solid transparent;
-                        border: none;
                         color: #605e5c;
-                        cursor: pointer;
-                        display: inline;
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 18px;
                         font-weight: 400;
                         line-height: 36px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
                         outline: transparent;
                         overflow: hidden;
                         padding-bottom: 0;
@@ -945,9 +1520,8 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         padding-right: 8px;
                         padding-top: 0;
                         position: relative;
-                        text-align: left;
+                        text-decoration: none;
                         text-overflow: ellipsis;
-                        user-select: text;
                         white-space: nowrap;
                       }
                       .ms-Fabric--isFocusVisible &:focus {
@@ -959,12 +1533,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
                       }
                       &:active {
                         background-color: #edebe9;
@@ -1002,1000 +1570,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: active){&:hover {
                         color: Highlight;
                       }
-                  onClick={[Function]}
-                >
-                  <div
-                    className=
-                        ms-TooltipHost
-                        {
-                          display: inline;
-                        }
-                    onBlurCapture={[Function]}
-                    onFocusCapture={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                  >
-                    This is folder 5 another
-                  </div>
-                </a>
-              </li>
-            </ol>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 10px;
-          margin-left: 0;
-          margin-right: 0;
-          margin-top: 10px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-        &:not(:first-child) {
-          margin-top: 24px;
-        }
-  >
-    With Custom Divider Icon
-  </label>
-  <div>
-    <div
-      style={
-        Object {
-          "position": "relative",
-        }
-      }
-    >
-      <div
-        data-automation-id="visibleContent"
-        style={
-          Object {
-            "position": "fixed",
-            "visibility": "hidden",
-          }
-        }
-      >
-        <div
-          aria-label="Breadcrumb with custom divider icon"
-          className=
-              ms-Breadcrumb
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                margin-bottom: 1px;
-                margin-left: 0;
-                margin-right: 0;
-                margin-top: 11px;
-              }
-          role="navigation"
-        >
-          <div
-            className=
-                ms-FocusZone
-                &:focus {
-                  outline: none;
-                }
-            data-focuszone-id="FocusZone7"
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onMouseDownCapture={[Function]}
-          >
-            <ol
-              className=
-                  ms-Breadcrumb-list
-                  {
-                    align-items: stretch;
-                    display: flex;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    white-space: nowrap;
-                  }
-            >
-              <li
-                className=
-                    ms-Breadcrumb-listItem
-                    {
-                      align-items: center;
-                      display: flex;
-                      list-style-type: none;
-                      margin-bottom: 0;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 0;
-                      padding-bottom: 0;
-                      padding-left: 0;
-                      padding-right: 0;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &:last-child .ms-Breadcrumb-itemLink {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-                    &:last-child .ms-Breadcrumb-item {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-              >
-                <a
-                  className=
-                      ms-Link
-                      ms-Breadcrumb-itemLink
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        background-color: transparent;
-                        background: none;
-                        border-bottom: 1px solid transparent;
-                        border: none;
-                        color: #605e5c;
-                        cursor: pointer;
-                        display: inline;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 18px;
-                        font-weight: 400;
-                        line-height: 36px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        outline: transparent;
-                        overflow: hidden;
-                        padding-bottom: 0;
-                        padding-left: 8px;
-                        padding-right: 8px;
-                        padding-top: 0;
-                        position: relative;
-                        text-align: left;
-                        text-overflow: ellipsis;
-                        user-select: text;
-                        white-space: nowrap;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus {
-                        box-shadow: 0 0 0 1px #605e5c inset;
-                        outline: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
-                        outline: 1px solid WindowText;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
-                      }
-                      &:active {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:hover {
-                        background-color: #f3f2f1;
-                        color: #323130;
-                        cursor: pointer;
-                        text-decoration: none;
-                      }
-                      &:active:hover {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:focus {
-                        color: #201f1e;
-                      }
-                      &::-moz-focus-inner {
-                        border: 0;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus:after {
-                        border: 1px solid #ffffff;
-                        bottom: 1px;
-                        content: "";
-                        left: 1px;
-                        outline: 1px solid #605e5c;
-                        position: absolute;
-                        right: 1px;
-                        top: 1px;
-                        z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
-                      }
-                  onClick={[Function]}
-                >
-                  <div
-                    className=
-                        ms-TooltipHost
-                        {
-                          display: inline;
-                        }
-                    onBlurCapture={[Function]}
-                    onFocusCapture={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                  >
-                    Files
-                  </div>
-                </a>
-                <div
-                  className=
-                      ms-TooltipHost
-                      {
-                        display: inline;
-                      }
-                  onBlurCapture={[Function]}
-                  onFocusCapture={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <span
-                    aria-hidden="true"
-                    style={
-                      Object {
-                        "cursor": "pointer",
-                      }
-                    }
-                  >
-                    /
-                  </span>
-                </div>
-              </li>
-              <li
-                className=
-                    ms-Breadcrumb-listItem
-                    {
-                      align-items: center;
-                      display: flex;
-                      list-style-type: none;
-                      margin-bottom: 0;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 0;
-                      padding-bottom: 0;
-                      padding-left: 0;
-                      padding-right: 0;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &:last-child .ms-Breadcrumb-itemLink {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-                    &:last-child .ms-Breadcrumb-item {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-              >
-                <a
-                  className=
-                      ms-Link
-                      ms-Breadcrumb-itemLink
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        background-color: transparent;
-                        background: none;
-                        border-bottom: 1px solid transparent;
-                        border: none;
-                        color: #605e5c;
-                        cursor: pointer;
-                        display: inline;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 18px;
-                        font-weight: 400;
-                        line-height: 36px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        outline: transparent;
-                        overflow: hidden;
-                        padding-bottom: 0;
-                        padding-left: 8px;
-                        padding-right: 8px;
-                        padding-top: 0;
-                        position: relative;
-                        text-align: left;
-                        text-overflow: ellipsis;
-                        user-select: text;
-                        white-space: nowrap;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus {
-                        box-shadow: 0 0 0 1px #605e5c inset;
-                        outline: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
-                        outline: 1px solid WindowText;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
-                      }
-                      &:active {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:hover {
-                        background-color: #f3f2f1;
-                        color: #323130;
-                        cursor: pointer;
-                        text-decoration: none;
-                      }
-                      &:active:hover {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:focus {
-                        color: #201f1e;
-                      }
-                      &::-moz-focus-inner {
-                        border: 0;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus:after {
-                        border: 1px solid #ffffff;
-                        bottom: 1px;
-                        content: "";
-                        left: 1px;
-                        outline: 1px solid #605e5c;
-                        position: absolute;
-                        right: 1px;
-                        top: 1px;
-                        z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
-                      }
-                  onClick={[Function]}
-                >
-                  <div
-                    className=
-                        ms-TooltipHost
-                        {
-                          display: inline;
-                        }
-                    onBlurCapture={[Function]}
-                    onFocusCapture={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                  >
-                    This is folder 1
-                  </div>
-                </a>
-                <div
-                  className=
-                      ms-TooltipHost
-                      {
-                        display: inline;
-                      }
-                  onBlurCapture={[Function]}
-                  onFocusCapture={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <span
-                    aria-hidden="true"
-                    style={
-                      Object {
-                        "cursor": "pointer",
-                      }
-                    }
-                  >
-                    /
-                  </span>
-                </div>
-              </li>
-              <li
-                className=
-                    ms-Breadcrumb-listItem
-                    {
-                      align-items: center;
-                      display: flex;
-                      list-style-type: none;
-                      margin-bottom: 0;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 0;
-                      padding-bottom: 0;
-                      padding-left: 0;
-                      padding-right: 0;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &:last-child .ms-Breadcrumb-itemLink {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-                    &:last-child .ms-Breadcrumb-item {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-              >
-                <a
-                  className=
-                      ms-Link
-                      ms-Breadcrumb-itemLink
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        background-color: transparent;
-                        background: none;
-                        border-bottom: 1px solid transparent;
-                        border: none;
-                        color: #605e5c;
-                        cursor: pointer;
-                        display: inline;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 18px;
-                        font-weight: 400;
-                        line-height: 36px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        outline: transparent;
-                        overflow: hidden;
-                        padding-bottom: 0;
-                        padding-left: 8px;
-                        padding-right: 8px;
-                        padding-top: 0;
-                        position: relative;
-                        text-align: left;
-                        text-overflow: ellipsis;
-                        user-select: text;
-                        white-space: nowrap;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus {
-                        box-shadow: 0 0 0 1px #605e5c inset;
-                        outline: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
-                        outline: 1px solid WindowText;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
-                      }
-                      &:active {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:hover {
-                        background-color: #f3f2f1;
-                        color: #323130;
-                        cursor: pointer;
-                        text-decoration: none;
-                      }
-                      &:active:hover {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:focus {
-                        color: #201f1e;
-                      }
-                      &::-moz-focus-inner {
-                        border: 0;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus:after {
-                        border: 1px solid #ffffff;
-                        bottom: 1px;
-                        content: "";
-                        left: 1px;
-                        outline: 1px solid #605e5c;
-                        position: absolute;
-                        right: 1px;
-                        top: 1px;
-                        z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
-                      }
-                  onClick={[Function]}
-                >
-                  <div
-                    className=
-                        ms-TooltipHost
-                        {
-                          display: inline;
-                        }
-                    onBlurCapture={[Function]}
-                    onFocusCapture={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                  >
-                    This is folder 2
-                  </div>
-                </a>
-                <div
-                  className=
-                      ms-TooltipHost
-                      {
-                        display: inline;
-                      }
-                  onBlurCapture={[Function]}
-                  onFocusCapture={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <span
-                    aria-hidden="true"
-                    style={
-                      Object {
-                        "cursor": "pointer",
-                      }
-                    }
-                  >
-                    /
-                  </span>
-                </div>
-              </li>
-              <li
-                className=
-                    ms-Breadcrumb-listItem
-                    {
-                      align-items: center;
-                      display: flex;
-                      list-style-type: none;
-                      margin-bottom: 0;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 0;
-                      padding-bottom: 0;
-                      padding-left: 0;
-                      padding-right: 0;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &:last-child .ms-Breadcrumb-itemLink {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-                    &:last-child .ms-Breadcrumb-item {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-              >
-                <a
-                  className=
-                      ms-Link
-                      ms-Breadcrumb-itemLink
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        background-color: transparent;
-                        background: none;
-                        border-bottom: 1px solid transparent;
-                        border: none;
-                        color: #605e5c;
-                        cursor: pointer;
-                        display: inline;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 18px;
-                        font-weight: 400;
-                        line-height: 36px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        outline: transparent;
-                        overflow: hidden;
-                        padding-bottom: 0;
-                        padding-left: 8px;
-                        padding-right: 8px;
-                        padding-top: 0;
-                        position: relative;
-                        text-align: left;
-                        text-overflow: ellipsis;
-                        user-select: text;
-                        white-space: nowrap;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus {
-                        box-shadow: 0 0 0 1px #605e5c inset;
-                        outline: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
-                        outline: 1px solid WindowText;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
-                      }
-                      &:active {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:hover {
-                        background-color: #f3f2f1;
-                        color: #323130;
-                        cursor: pointer;
-                        text-decoration: none;
-                      }
-                      &:active:hover {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:focus {
-                        color: #201f1e;
-                      }
-                      &::-moz-focus-inner {
-                        border: 0;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus:after {
-                        border: 1px solid #ffffff;
-                        bottom: 1px;
-                        content: "";
-                        left: 1px;
-                        outline: 1px solid #605e5c;
-                        position: absolute;
-                        right: 1px;
-                        top: 1px;
-                        z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
-                      }
-                  onClick={[Function]}
-                >
-                  <div
-                    className=
-                        ms-TooltipHost
-                        {
-                          display: inline;
-                        }
-                    onBlurCapture={[Function]}
-                    onFocusCapture={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                  >
-                    This is folder 3
-                  </div>
-                </a>
-                <div
-                  className=
-                      ms-TooltipHost
-                      {
-                        display: inline;
-                      }
-                  onBlurCapture={[Function]}
-                  onFocusCapture={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <span
-                    aria-hidden="true"
-                    style={
-                      Object {
-                        "cursor": "pointer",
-                      }
-                    }
-                  >
-                    /
-                  </span>
-                </div>
-              </li>
-              <li
-                className=
-                    ms-Breadcrumb-listItem
-                    {
-                      align-items: center;
-                      display: flex;
-                      list-style-type: none;
-                      margin-bottom: 0;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 0;
-                      padding-bottom: 0;
-                      padding-left: 0;
-                      padding-right: 0;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &:last-child .ms-Breadcrumb-itemLink {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-                    &:last-child .ms-Breadcrumb-item {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-              >
-                <a
-                  className=
-                      ms-Link
-                      ms-Breadcrumb-itemLink
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        background-color: transparent;
-                        background: none;
-                        border-bottom: 1px solid transparent;
-                        border: none;
-                        color: #605e5c;
-                        cursor: pointer;
-                        display: inline;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 18px;
-                        font-weight: 400;
-                        line-height: 36px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        outline: transparent;
-                        overflow: hidden;
-                        padding-bottom: 0;
-                        padding-left: 8px;
-                        padding-right: 8px;
-                        padding-top: 0;
-                        position: relative;
-                        text-align: left;
-                        text-overflow: ellipsis;
-                        user-select: text;
-                        white-space: nowrap;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus {
-                        box-shadow: 0 0 0 1px #605e5c inset;
-                        outline: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
-                        outline: 1px solid WindowText;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
-                      }
-                      &:active {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:hover {
-                        background-color: #f3f2f1;
-                        color: #323130;
-                        cursor: pointer;
-                        text-decoration: none;
-                      }
-                      &:active:hover {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:focus {
-                        color: #201f1e;
-                      }
-                      &::-moz-focus-inner {
-                        border: 0;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus:after {
-                        border: 1px solid #ffffff;
-                        bottom: 1px;
-                        content: "";
-                        left: 1px;
-                        outline: 1px solid #605e5c;
-                        position: absolute;
-                        right: 1px;
-                        top: 1px;
-                        z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
-                      }
-                  onClick={[Function]}
-                >
-                  <div
-                    className=
-                        ms-TooltipHost
-                        {
-                          display: inline;
-                        }
-                    onBlurCapture={[Function]}
-                    onFocusCapture={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                  >
-                    This is folder 4
-                  </div>
-                </a>
-                <div
-                  className=
-                      ms-TooltipHost
-                      {
-                        display: inline;
-                      }
-                  onBlurCapture={[Function]}
-                  onFocusCapture={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <span
-                    aria-hidden="true"
-                    style={
-                      Object {
-                        "cursor": "pointer",
-                      }
-                    }
-                  >
-                    /
-                  </span>
-                </div>
-              </li>
-              <li
-                className=
-                    ms-Breadcrumb-listItem
-                    {
-                      align-items: center;
-                      display: flex;
-                      list-style-type: none;
-                      margin-bottom: 0;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 0;
-                      padding-bottom: 0;
-                      padding-left: 0;
-                      padding-right: 0;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &:last-child .ms-Breadcrumb-itemLink {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-                    &:last-child .ms-Breadcrumb-item {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-              >
-                <a
-                  aria-current="page"
-                  className=
-                      ms-Link
-                      ms-Breadcrumb-itemLink
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        background-color: transparent;
-                        background: none;
-                        border-bottom: 1px solid transparent;
-                        border: none;
-                        color: #605e5c;
-                        cursor: pointer;
-                        display: inline;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 18px;
-                        font-weight: 400;
-                        line-height: 36px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        outline: transparent;
-                        overflow: hidden;
-                        padding-bottom: 0;
-                        padding-left: 8px;
-                        padding-right: 8px;
-                        padding-top: 0;
-                        position: relative;
-                        text-align: left;
-                        text-overflow: ellipsis;
-                        user-select: text;
-                        white-space: nowrap;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus {
-                        box-shadow: 0 0 0 1px #605e5c inset;
-                        outline: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
-                        outline: 1px solid WindowText;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
-                      }
-                      &:active {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:hover {
-                        background-color: #f3f2f1;
-                        color: #323130;
-                        cursor: pointer;
-                        text-decoration: none;
-                      }
-                      &:active:hover {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:focus {
-                        color: #201f1e;
-                      }
-                      &::-moz-focus-inner {
-                        border: 0;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus:after {
-                        border: 1px solid #ffffff;
-                        bottom: 1px;
-                        content: "";
-                        left: 1px;
-                        outline: 1px solid #605e5c;
-                        position: absolute;
-                        right: 1px;
-                        top: 1px;
-                        z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
-                      }
+                  href="#/controls/web/breadcrumb"
                   onClick={[Function]}
                 >
                   <div
@@ -2048,1721 +1623,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
           margin-top: 24px;
         }
   >
-    With Custom Overflow Icon
-  </label>
-  <div>
-    <div
-      style={
-        Object {
-          "position": "relative",
-        }
-      }
-    >
-      <div
-        data-automation-id="visibleContent"
-        style={
-          Object {
-            "position": "fixed",
-            "visibility": "hidden",
-          }
-        }
-      >
-        <div
-          aria-label="Breadcrumb with no maxDisplayedItems"
-          className=
-              ms-Breadcrumb
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                margin-bottom: 1px;
-                margin-left: 0;
-                margin-right: 0;
-                margin-top: 11px;
-              }
-          role="navigation"
-        >
-          <div
-            className=
-                ms-FocusZone
-                &:focus {
-                  outline: none;
-                }
-            data-focuszone-id="FocusZone19"
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onMouseDownCapture={[Function]}
-          >
-            <ol
-              className=
-                  ms-Breadcrumb-list
-                  {
-                    align-items: stretch;
-                    display: flex;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    white-space: nowrap;
-                  }
-            >
-              <li
-                className=
-                    ms-Breadcrumb-listItem
-                    {
-                      align-items: center;
-                      display: flex;
-                      list-style-type: none;
-                      margin-bottom: 0;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 0;
-                      padding-bottom: 0;
-                      padding-left: 0;
-                      padding-right: 0;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &:last-child .ms-Breadcrumb-itemLink {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-                    &:last-child .ms-Breadcrumb-item {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-              >
-                <a
-                  className=
-                      ms-Link
-                      ms-Breadcrumb-itemLink
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        background-color: transparent;
-                        background: none;
-                        border-bottom: 1px solid transparent;
-                        border: none;
-                        color: #605e5c;
-                        cursor: pointer;
-                        display: inline;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 18px;
-                        font-weight: 400;
-                        line-height: 36px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        outline: transparent;
-                        overflow: hidden;
-                        padding-bottom: 0;
-                        padding-left: 8px;
-                        padding-right: 8px;
-                        padding-top: 0;
-                        position: relative;
-                        text-align: left;
-                        text-overflow: ellipsis;
-                        user-select: text;
-                        white-space: nowrap;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus {
-                        box-shadow: 0 0 0 1px #605e5c inset;
-                        outline: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
-                        outline: 1px solid WindowText;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
-                      }
-                      &:active {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:hover {
-                        background-color: #f3f2f1;
-                        color: #323130;
-                        cursor: pointer;
-                        text-decoration: none;
-                      }
-                      &:active:hover {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:focus {
-                        color: #201f1e;
-                      }
-                      &::-moz-focus-inner {
-                        border: 0;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus:after {
-                        border: 1px solid #ffffff;
-                        bottom: 1px;
-                        content: "";
-                        left: 1px;
-                        outline: 1px solid #605e5c;
-                        position: absolute;
-                        right: 1px;
-                        top: 1px;
-                        z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
-                      }
-                  onClick={[Function]}
-                >
-                  <div
-                    className=
-                        ms-TooltipHost
-                        {
-                          display: inline;
-                        }
-                    onBlurCapture={[Function]}
-                    onFocusCapture={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                  >
-                    Files
-                  </div>
-                </a>
-                <i
-                  aria-hidden={true}
-                  className=
-                      ms-Breadcrumb-chevron
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        color: #605e5c;
-                        display: inline-block;
-                        font-family: "FabricMDL2Icons";
-                        font-size: 12px;
-                        font-style: normal;
-                        font-weight: normal;
-                        speak: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        -ms-high-contrast-adjust: none;
-                        color: WindowText;
-                      }
-                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
-                        font-size: 8px;
-                      }
-                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                        font-size: 8px;
-                      }
-                  data-icon-name="ChevronRight"
-                >
-                  
-                </i>
-              </li>
-              <li
-                className=
-                    ms-Breadcrumb-listItem
-                    {
-                      align-items: center;
-                      display: flex;
-                      list-style-type: none;
-                      margin-bottom: 0;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 0;
-                      padding-bottom: 0;
-                      padding-left: 0;
-                      padding-right: 0;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &:last-child .ms-Breadcrumb-itemLink {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-                    &:last-child .ms-Breadcrumb-item {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-              >
-                <a
-                  className=
-                      ms-Link
-                      ms-Breadcrumb-itemLink
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        background-color: transparent;
-                        background: none;
-                        border-bottom: 1px solid transparent;
-                        border: none;
-                        color: #605e5c;
-                        cursor: pointer;
-                        display: inline;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 18px;
-                        font-weight: 400;
-                        line-height: 36px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        outline: transparent;
-                        overflow: hidden;
-                        padding-bottom: 0;
-                        padding-left: 8px;
-                        padding-right: 8px;
-                        padding-top: 0;
-                        position: relative;
-                        text-align: left;
-                        text-overflow: ellipsis;
-                        user-select: text;
-                        white-space: nowrap;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus {
-                        box-shadow: 0 0 0 1px #605e5c inset;
-                        outline: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
-                        outline: 1px solid WindowText;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
-                      }
-                      &:active {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:hover {
-                        background-color: #f3f2f1;
-                        color: #323130;
-                        cursor: pointer;
-                        text-decoration: none;
-                      }
-                      &:active:hover {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:focus {
-                        color: #201f1e;
-                      }
-                      &::-moz-focus-inner {
-                        border: 0;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus:after {
-                        border: 1px solid #ffffff;
-                        bottom: 1px;
-                        content: "";
-                        left: 1px;
-                        outline: 1px solid #605e5c;
-                        position: absolute;
-                        right: 1px;
-                        top: 1px;
-                        z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
-                      }
-                  onClick={[Function]}
-                >
-                  <div
-                    className=
-                        ms-TooltipHost
-                        {
-                          display: inline;
-                        }
-                    onBlurCapture={[Function]}
-                    onFocusCapture={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                  >
-                    This is folder 1
-                  </div>
-                </a>
-                <i
-                  aria-hidden={true}
-                  className=
-                      ms-Breadcrumb-chevron
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        color: #605e5c;
-                        display: inline-block;
-                        font-family: "FabricMDL2Icons";
-                        font-size: 12px;
-                        font-style: normal;
-                        font-weight: normal;
-                        speak: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        -ms-high-contrast-adjust: none;
-                        color: WindowText;
-                      }
-                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
-                        font-size: 8px;
-                      }
-                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                        font-size: 8px;
-                      }
-                  data-icon-name="ChevronRight"
-                >
-                  
-                </i>
-              </li>
-              <li
-                className=
-                    ms-Breadcrumb-listItem
-                    {
-                      align-items: center;
-                      display: flex;
-                      list-style-type: none;
-                      margin-bottom: 0;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 0;
-                      padding-bottom: 0;
-                      padding-left: 0;
-                      padding-right: 0;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &:last-child .ms-Breadcrumb-itemLink {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-                    &:last-child .ms-Breadcrumb-item {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-              >
-                <a
-                  className=
-                      ms-Link
-                      ms-Breadcrumb-itemLink
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        background-color: transparent;
-                        background: none;
-                        border-bottom: 1px solid transparent;
-                        border: none;
-                        color: #605e5c;
-                        cursor: pointer;
-                        display: inline;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 18px;
-                        font-weight: 400;
-                        line-height: 36px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        outline: transparent;
-                        overflow: hidden;
-                        padding-bottom: 0;
-                        padding-left: 8px;
-                        padding-right: 8px;
-                        padding-top: 0;
-                        position: relative;
-                        text-align: left;
-                        text-overflow: ellipsis;
-                        user-select: text;
-                        white-space: nowrap;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus {
-                        box-shadow: 0 0 0 1px #605e5c inset;
-                        outline: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
-                        outline: 1px solid WindowText;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
-                      }
-                      &:active {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:hover {
-                        background-color: #f3f2f1;
-                        color: #323130;
-                        cursor: pointer;
-                        text-decoration: none;
-                      }
-                      &:active:hover {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:focus {
-                        color: #201f1e;
-                      }
-                      &::-moz-focus-inner {
-                        border: 0;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus:after {
-                        border: 1px solid #ffffff;
-                        bottom: 1px;
-                        content: "";
-                        left: 1px;
-                        outline: 1px solid #605e5c;
-                        position: absolute;
-                        right: 1px;
-                        top: 1px;
-                        z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
-                      }
-                  onClick={[Function]}
-                >
-                  <div
-                    className=
-                        ms-TooltipHost
-                        {
-                          display: inline;
-                        }
-                    onBlurCapture={[Function]}
-                    onFocusCapture={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                  >
-                    This is folder 2 with a long name
-                  </div>
-                </a>
-                <i
-                  aria-hidden={true}
-                  className=
-                      ms-Breadcrumb-chevron
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        color: #605e5c;
-                        display: inline-block;
-                        font-family: "FabricMDL2Icons";
-                        font-size: 12px;
-                        font-style: normal;
-                        font-weight: normal;
-                        speak: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        -ms-high-contrast-adjust: none;
-                        color: WindowText;
-                      }
-                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
-                        font-size: 8px;
-                      }
-                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                        font-size: 8px;
-                      }
-                  data-icon-name="ChevronRight"
-                >
-                  
-                </i>
-              </li>
-              <li
-                className=
-                    ms-Breadcrumb-listItem
-                    {
-                      align-items: center;
-                      display: flex;
-                      list-style-type: none;
-                      margin-bottom: 0;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 0;
-                      padding-bottom: 0;
-                      padding-left: 0;
-                      padding-right: 0;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &:last-child .ms-Breadcrumb-itemLink {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-                    &:last-child .ms-Breadcrumb-item {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-              >
-                <a
-                  className=
-                      ms-Link
-                      ms-Breadcrumb-itemLink
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        background-color: transparent;
-                        background: none;
-                        border-bottom: 1px solid transparent;
-                        border: none;
-                        color: #605e5c;
-                        cursor: pointer;
-                        display: inline;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 18px;
-                        font-weight: 400;
-                        line-height: 36px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        outline: transparent;
-                        overflow: hidden;
-                        padding-bottom: 0;
-                        padding-left: 8px;
-                        padding-right: 8px;
-                        padding-top: 0;
-                        position: relative;
-                        text-align: left;
-                        text-overflow: ellipsis;
-                        user-select: text;
-                        white-space: nowrap;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus {
-                        box-shadow: 0 0 0 1px #605e5c inset;
-                        outline: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
-                        outline: 1px solid WindowText;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
-                      }
-                      &:active {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:hover {
-                        background-color: #f3f2f1;
-                        color: #323130;
-                        cursor: pointer;
-                        text-decoration: none;
-                      }
-                      &:active:hover {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:focus {
-                        color: #201f1e;
-                      }
-                      &::-moz-focus-inner {
-                        border: 0;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus:after {
-                        border: 1px solid #ffffff;
-                        bottom: 1px;
-                        content: "";
-                        left: 1px;
-                        outline: 1px solid #605e5c;
-                        position: absolute;
-                        right: 1px;
-                        top: 1px;
-                        z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
-                      }
-                  onClick={[Function]}
-                >
-                  <div
-                    className=
-                        ms-TooltipHost
-                        {
-                          display: inline;
-                        }
-                    onBlurCapture={[Function]}
-                    onFocusCapture={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                  >
-                    This is folder 3 long
-                  </div>
-                </a>
-                <i
-                  aria-hidden={true}
-                  className=
-                      ms-Breadcrumb-chevron
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        color: #605e5c;
-                        display: inline-block;
-                        font-family: "FabricMDL2Icons";
-                        font-size: 12px;
-                        font-style: normal;
-                        font-weight: normal;
-                        speak: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        -ms-high-contrast-adjust: none;
-                        color: WindowText;
-                      }
-                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
-                        font-size: 8px;
-                      }
-                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                        font-size: 8px;
-                      }
-                  data-icon-name="ChevronRight"
-                >
-                  
-                </i>
-              </li>
-              <li
-                className=
-                    ms-Breadcrumb-listItem
-                    {
-                      align-items: center;
-                      display: flex;
-                      list-style-type: none;
-                      margin-bottom: 0;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 0;
-                      padding-bottom: 0;
-                      padding-left: 0;
-                      padding-right: 0;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &:last-child .ms-Breadcrumb-itemLink {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-                    &:last-child .ms-Breadcrumb-item {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-              >
-                <a
-                  className=
-                      ms-Link
-                      ms-Breadcrumb-itemLink
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        background-color: transparent;
-                        background: none;
-                        border-bottom: 1px solid transparent;
-                        border: none;
-                        color: #605e5c;
-                        cursor: pointer;
-                        display: inline;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 18px;
-                        font-weight: 400;
-                        line-height: 36px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        outline: transparent;
-                        overflow: hidden;
-                        padding-bottom: 0;
-                        padding-left: 8px;
-                        padding-right: 8px;
-                        padding-top: 0;
-                        position: relative;
-                        text-align: left;
-                        text-overflow: ellipsis;
-                        user-select: text;
-                        white-space: nowrap;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus {
-                        box-shadow: 0 0 0 1px #605e5c inset;
-                        outline: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
-                        outline: 1px solid WindowText;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
-                      }
-                      &:active {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:hover {
-                        background-color: #f3f2f1;
-                        color: #323130;
-                        cursor: pointer;
-                        text-decoration: none;
-                      }
-                      &:active:hover {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:focus {
-                        color: #201f1e;
-                      }
-                      &::-moz-focus-inner {
-                        border: 0;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus:after {
-                        border: 1px solid #ffffff;
-                        bottom: 1px;
-                        content: "";
-                        left: 1px;
-                        outline: 1px solid #605e5c;
-                        position: absolute;
-                        right: 1px;
-                        top: 1px;
-                        z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
-                      }
-                  onClick={[Function]}
-                >
-                  <div
-                    className=
-                        ms-TooltipHost
-                        {
-                          display: inline;
-                        }
-                    onBlurCapture={[Function]}
-                    onFocusCapture={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                  >
-                    This is folder 4
-                  </div>
-                </a>
-                <i
-                  aria-hidden={true}
-                  className=
-                      ms-Breadcrumb-chevron
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        color: #605e5c;
-                        display: inline-block;
-                        font-family: "FabricMDL2Icons";
-                        font-size: 12px;
-                        font-style: normal;
-                        font-weight: normal;
-                        speak: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        -ms-high-contrast-adjust: none;
-                        color: WindowText;
-                      }
-                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
-                        font-size: 8px;
-                      }
-                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                        font-size: 8px;
-                      }
-                  data-icon-name="ChevronRight"
-                >
-                  
-                </i>
-              </li>
-              <li
-                className=
-                    ms-Breadcrumb-listItem
-                    {
-                      align-items: center;
-                      display: flex;
-                      list-style-type: none;
-                      margin-bottom: 0;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 0;
-                      padding-bottom: 0;
-                      padding-left: 0;
-                      padding-right: 0;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &:last-child .ms-Breadcrumb-itemLink {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-                    &:last-child .ms-Breadcrumb-item {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-              >
-                <a
-                  aria-current="page"
-                  className=
-                      ms-Link
-                      ms-Breadcrumb-itemLink
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        background-color: transparent;
-                        background: none;
-                        border-bottom: 1px solid transparent;
-                        border: none;
-                        color: #605e5c;
-                        cursor: pointer;
-                        display: inline;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 18px;
-                        font-weight: 400;
-                        line-height: 36px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        outline: transparent;
-                        overflow: hidden;
-                        padding-bottom: 0;
-                        padding-left: 8px;
-                        padding-right: 8px;
-                        padding-top: 0;
-                        position: relative;
-                        text-align: left;
-                        text-overflow: ellipsis;
-                        user-select: text;
-                        white-space: nowrap;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus {
-                        box-shadow: 0 0 0 1px #605e5c inset;
-                        outline: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
-                        outline: 1px solid WindowText;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
-                      }
-                      &:active {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:hover {
-                        background-color: #f3f2f1;
-                        color: #323130;
-                        cursor: pointer;
-                        text-decoration: none;
-                      }
-                      &:active:hover {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:focus {
-                        color: #201f1e;
-                      }
-                      &::-moz-focus-inner {
-                        border: 0;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus:after {
-                        border: 1px solid #ffffff;
-                        bottom: 1px;
-                        content: "";
-                        left: 1px;
-                        outline: 1px solid #605e5c;
-                        position: absolute;
-                        right: 1px;
-                        top: 1px;
-                        z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
-                      }
-                  onClick={[Function]}
-                >
-                  <div
-                    className=
-                        ms-TooltipHost
-                        {
-                          display: inline;
-                        }
-                    onBlurCapture={[Function]}
-                    onFocusCapture={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                  >
-                    This is folder 5 another
-                  </div>
-                </a>
-              </li>
-            </ol>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 10px;
-          margin-left: 0;
-          margin-right: 0;
-          margin-top: 10px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-        &:not(:first-child) {
-          margin-top: 24px;
-        }
-  >
-    With maxDisplayedItems set to three
-  </label>
-  <div>
-    <div
-      style={
-        Object {
-          "position": "relative",
-        }
-      }
-    >
-      <div
-        data-automation-id="visibleContent"
-        style={
-          Object {
-            "position": "fixed",
-            "visibility": "hidden",
-          }
-        }
-      >
-        <div
-          aria-label="Breadcrumb with maxDisplayedItems set to three"
-          className=
-              ms-Breadcrumb
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                margin-bottom: 1px;
-                margin-left: 0;
-                margin-right: 0;
-                margin-top: 11px;
-              }
-          role="navigation"
-        >
-          <div
-            className=
-                ms-FocusZone
-                &:focus {
-                  outline: none;
-                }
-            data-focuszone-id="FocusZone26"
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onMouseDownCapture={[Function]}
-          >
-            <ol
-              className=
-                  ms-Breadcrumb-list
-                  {
-                    align-items: stretch;
-                    display: flex;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    white-space: nowrap;
-                  }
-            >
-              <li
-                className=
-                    ms-Breadcrumb-overflow
-                    {
-                      align-items: center;
-                      display: flex;
-                      position: relative;
-                    }
-              >
-                <button
-                  aria-expanded={false}
-                  aria-haspopup={true}
-                  aria-label="More links"
-                  aria-owns={null}
-                  className=
-                      ms-Button
-                      ms-Button--icon
-                      ms-Button--hasMenu
-                      ms-Breadcrumb-overflowButton
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        background-color: transparent;
-                        border-radius: 2px;
-                        border: none;
-                        box-sizing: border-box;
-                        color: #605e5c;
-                        cursor: pointer;
-                        display: inline-block;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 16px;
-                        font-weight: 400;
-                        height: 100%;
-                        outline: transparent;
-                        overflow: hidden;
-                        padding-bottom: 0;
-                        padding-left: 4px;
-                        padding-right: 4px;
-                        padding-top: 0;
-                        position: relative;
-                        text-align: center;
-                        text-decoration: none;
-                        text-overflow: ellipsis;
-                        user-select: none;
-                        vertical-align: top;
-                        white-space: nowrap;
-                        width: auto;
-                      }
-                      &::-moz-focus-inner {
-                        border: 0;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus:after {
-                        border: 1px solid #ffffff;
-                        bottom: 1px;
-                        content: "";
-                        left: 1px;
-                        outline: 1px solid #605e5c;
-                        position: absolute;
-                        right: 1px;
-                        top: 1px;
-                        z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                        border: none;
-                        bottom: -2px;
-                        left: -2px;
-                        outline-color: ButtonText;
-                        right: -2px;
-                        top: -2px;
-                      }
-                      &:active > * {
-                        left: 0px;
-                        position: relative;
-                        top: 0px;
-                      }
-                      &:hover {
-                        background-color: #f3f2f1;
-                        color: #323130;
-                        cursor: pointer;
-                        text-decoration: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        border-color: Highlight;
-                        color: Highlight;
-                      }
-                      &:active {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:active:hover {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                        padding-bottom: 4px;
-                        padding-left: 6px;
-                        padding-right: 6px;
-                        padding-top: 4px;
-                      }
-                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
-                        font-size: 16px;
-                      }
-                  data-is-focusable={true}
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyPress={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  role="button"
-                  type="button"
-                >
-                  <span
-                    className=
-                        ms-Button-flexContainer
-                        {
-                          align-items: center;
-                          display: flex;
-                          flex-wrap: nowrap;
-                          height: 100%;
-                          justify-content: center;
-                        }
-                    data-automationid="splitbuttonprimary"
-                  >
-                    <i
-                      aria-hidden={true}
-                      className=
-                          ms-Icon
-                          ms-Button-icon
-                          {
-                            display: inline-block;
-                          }
-                          {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            font-family: "FabricMDL2Icons";
-                            font-style: normal;
-                            font-weight: normal;
-                            speak: none;
-                          }
-                          {
-                            flex-shrink: 0;
-                            font-size: 16px;
-                            height: 16px;
-                            line-height: 16px;
-                            margin-bottom: 0;
-                            margin-left: 4px;
-                            margin-right: 4px;
-                            margin-top: 0;
-                            text-align: center;
-                            vertical-align: middle;
-                          }
-                      data-icon-name="More"
-                      role="presentation"
-                    >
-                      
-                    </i>
-                  </span>
-                </button>
-                <i
-                  aria-hidden={true}
-                  className=
-                      ms-Breadcrumb-chevron
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        color: #605e5c;
-                        display: inline-block;
-                        font-family: "FabricMDL2Icons";
-                        font-size: 12px;
-                        font-style: normal;
-                        font-weight: normal;
-                        speak: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        -ms-high-contrast-adjust: none;
-                        color: WindowText;
-                      }
-                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
-                        font-size: 8px;
-                      }
-                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                        font-size: 8px;
-                      }
-                  data-icon-name="ChevronRight"
-                >
-                  
-                </i>
-              </li>
-              <li
-                className=
-                    ms-Breadcrumb-listItem
-                    {
-                      align-items: center;
-                      display: flex;
-                      list-style-type: none;
-                      margin-bottom: 0;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 0;
-                      padding-bottom: 0;
-                      padding-left: 0;
-                      padding-right: 0;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &:last-child .ms-Breadcrumb-itemLink {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-                    &:last-child .ms-Breadcrumb-item {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-              >
-                <a
-                  className=
-                      ms-Link
-                      ms-Breadcrumb-itemLink
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        color: #605e5c;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 18px;
-                        font-weight: 400;
-                        line-height: 36px;
-                        outline: transparent;
-                        overflow: hidden;
-                        padding-bottom: 0;
-                        padding-left: 8px;
-                        padding-right: 8px;
-                        padding-top: 0;
-                        position: relative;
-                        text-decoration: none;
-                        text-overflow: ellipsis;
-                        white-space: nowrap;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus {
-                        box-shadow: 0 0 0 1px #605e5c inset;
-                        outline: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
-                        outline: 1px solid WindowText;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        border-bottom: none;
-                      }
-                      &:active {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:hover {
-                        background-color: #f3f2f1;
-                        color: #323130;
-                        cursor: pointer;
-                        text-decoration: none;
-                      }
-                      &:active:hover {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:focus {
-                        color: #201f1e;
-                      }
-                      &::-moz-focus-inner {
-                        border: 0;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus:after {
-                        border: 1px solid #ffffff;
-                        bottom: 1px;
-                        content: "";
-                        left: 1px;
-                        outline: 1px solid #605e5c;
-                        position: absolute;
-                        right: 1px;
-                        top: 1px;
-                        z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
-                      }
-                  href="#/examples/breadcrumb"
-                  onClick={[Function]}
-                >
-                  <div
-                    className=
-                        ms-TooltipHost
-                        {
-                          display: inline;
-                        }
-                    onBlurCapture={[Function]}
-                    onFocusCapture={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                  >
-                    This is link 3 with a long name
-                  </div>
-                </a>
-                <i
-                  aria-hidden={true}
-                  className=
-                      ms-Breadcrumb-chevron
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        color: #605e5c;
-                        display: inline-block;
-                        font-family: "FabricMDL2Icons";
-                        font-size: 12px;
-                        font-style: normal;
-                        font-weight: normal;
-                        speak: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        -ms-high-contrast-adjust: none;
-                        color: WindowText;
-                      }
-                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
-                        font-size: 8px;
-                      }
-                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                        font-size: 8px;
-                      }
-                  data-icon-name="ChevronRight"
-                >
-                  
-                </i>
-              </li>
-              <li
-                className=
-                    ms-Breadcrumb-listItem
-                    {
-                      align-items: center;
-                      display: flex;
-                      list-style-type: none;
-                      margin-bottom: 0;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 0;
-                      padding-bottom: 0;
-                      padding-left: 0;
-                      padding-right: 0;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &:last-child .ms-Breadcrumb-itemLink {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-                    &:last-child .ms-Breadcrumb-item {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-              >
-                <a
-                  className=
-                      ms-Link
-                      ms-Breadcrumb-itemLink
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        color: #605e5c;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 18px;
-                        font-weight: 400;
-                        line-height: 36px;
-                        outline: transparent;
-                        overflow: hidden;
-                        padding-bottom: 0;
-                        padding-left: 8px;
-                        padding-right: 8px;
-                        padding-top: 0;
-                        position: relative;
-                        text-decoration: none;
-                        text-overflow: ellipsis;
-                        white-space: nowrap;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus {
-                        box-shadow: 0 0 0 1px #605e5c inset;
-                        outline: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
-                        outline: 1px solid WindowText;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        border-bottom: none;
-                      }
-                      &:active {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:hover {
-                        background-color: #f3f2f1;
-                        color: #323130;
-                        cursor: pointer;
-                        text-decoration: none;
-                      }
-                      &:active:hover {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:focus {
-                        color: #201f1e;
-                      }
-                      &::-moz-focus-inner {
-                        border: 0;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus:after {
-                        border: 1px solid #ffffff;
-                        bottom: 1px;
-                        content: "";
-                        left: 1px;
-                        outline: 1px solid #605e5c;
-                        position: absolute;
-                        right: 1px;
-                        top: 1px;
-                        z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
-                      }
-                  href="#/examples/breadcrumb"
-                  onClick={[Function]}
-                >
-                  <div
-                    className=
-                        ms-TooltipHost
-                        {
-                          display: inline;
-                        }
-                    onBlurCapture={[Function]}
-                    onFocusCapture={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                  >
-                    This is link 4
-                  </div>
-                </a>
-                <i
-                  aria-hidden={true}
-                  className=
-                      ms-Breadcrumb-chevron
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        color: #605e5c;
-                        display: inline-block;
-                        font-family: "FabricMDL2Icons";
-                        font-size: 12px;
-                        font-style: normal;
-                        font-weight: normal;
-                        speak: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        -ms-high-contrast-adjust: none;
-                        color: WindowText;
-                      }
-                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
-                        font-size: 8px;
-                      }
-                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                        font-size: 8px;
-                      }
-                  data-icon-name="ChevronRight"
-                >
-                  
-                </i>
-              </li>
-              <li
-                className=
-                    ms-Breadcrumb-listItem
-                    {
-                      align-items: center;
-                      display: flex;
-                      list-style-type: none;
-                      margin-bottom: 0;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 0;
-                      padding-bottom: 0;
-                      padding-left: 0;
-                      padding-right: 0;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &:last-child .ms-Breadcrumb-itemLink {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-                    &:last-child .ms-Breadcrumb-item {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-              >
-                <a
-                  aria-current="page"
-                  className=
-                      ms-Link
-                      ms-Breadcrumb-itemLink
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        color: #605e5c;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 18px;
-                        font-weight: 400;
-                        line-height: 36px;
-                        outline: transparent;
-                        overflow: hidden;
-                        padding-bottom: 0;
-                        padding-left: 8px;
-                        padding-right: 8px;
-                        padding-top: 0;
-                        position: relative;
-                        text-decoration: none;
-                        text-overflow: ellipsis;
-                        white-space: nowrap;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus {
-                        box-shadow: 0 0 0 1px #605e5c inset;
-                        outline: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
-                        outline: 1px solid WindowText;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        border-bottom: none;
-                      }
-                      &:active {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:hover {
-                        background-color: #f3f2f1;
-                        color: #323130;
-                        cursor: pointer;
-                        text-decoration: none;
-                      }
-                      &:active:hover {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:focus {
-                        color: #201f1e;
-                      }
-                      &::-moz-focus-inner {
-                        border: 0;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus:after {
-                        border: 1px solid #ffffff;
-                        bottom: 1px;
-                        content: "";
-                        left: 1px;
-                        outline: 1px solid #605e5c;
-                        position: absolute;
-                        right: 1px;
-                        top: 1px;
-                        z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
-                      }
-                  href="#/examples/breadcrumb"
-                  onClick={[Function]}
-                >
-                  <div
-                    className=
-                        ms-TooltipHost
-                        {
-                          display: inline;
-                        }
-                    onBlurCapture={[Function]}
-                    onFocusCapture={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                  >
-                    This is link 5
-                  </div>
-                </a>
-              </li>
-            </ol>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 10px;
-          margin-left: 0;
-          margin-right: 0;
-          margin-top: 10px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-        &:not(:first-child) {
-          margin-top: 24px;
-        }
-  >
-    With maxDisplayedItems set to two and overflowIndex set to 1 (second element)
+    With maxDisplayedItems set to 2 and overflowIndex set to 1 (second element)
   </label>
   <div>
     <div
@@ -3804,7 +1665,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                 &:focus {
                   outline: none;
                 }
-            data-focuszone-id="FocusZone33"
+            data-focuszone-id="FocusZone14"
             onFocus={[Function]}
             onKeyDown={[Function]}
             onMouseDownCapture={[Function]}
@@ -3852,22 +1713,94 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       font-weight: 600;
                     }
               >
-                <span
+                <button
                   className=
-                      ms-Breadcrumb-item
+                      ms-Link
+                      ms-Breadcrumb-itemLink
                       {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        background: none;
+                        border-bottom: 1px solid transparent;
+                        border: none;
                         color: #605e5c;
+                        cursor: pointer;
+                        display: inline;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 18px;
                         font-weight: 400;
                         line-height: 36px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        outline: transparent;
+                        overflow: hidden;
                         padding-bottom: 0;
                         padding-left: 8px;
                         padding-right: 8px;
                         padding-top: 0;
+                        position: relative;
+                        text-align: left;
+                        text-overflow: ellipsis;
+                        user-select: text;
+                        white-space: nowrap;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        box-shadow: 0 0 0 1px #605e5c inset;
+                        outline: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-bottom: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){& {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){& {
+                        color: #00009F;
+                      }
+                      &:active {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
                       }
                       &:hover {
-                        cursor: default;
+                        background-color: #f3f2f1;
+                        color: #323130;
+                        cursor: pointer;
+                        text-decoration: none;
                       }
+                      &:active:hover {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:focus {
+                        color: #201f1e;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #605e5c;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
+                      }
+                  onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=
@@ -3881,9 +1814,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    TestText1
+                    Files
                   </div>
-                </span>
+                </button>
                 <i
                   aria-hidden={true}
                   className=
@@ -4131,22 +2064,95 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       font-weight: 600;
                     }
               >
-                <span
+                <button
+                  aria-current="page"
                   className=
-                      ms-Breadcrumb-item
+                      ms-Link
+                      ms-Breadcrumb-itemLink
                       {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        background: none;
+                        border-bottom: 1px solid transparent;
+                        border: none;
                         color: #605e5c;
+                        cursor: pointer;
+                        display: inline;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 18px;
                         font-weight: 400;
                         line-height: 36px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        outline: transparent;
+                        overflow: hidden;
                         padding-bottom: 0;
                         padding-left: 8px;
                         padding-right: 8px;
                         padding-top: 0;
+                        position: relative;
+                        text-align: left;
+                        text-overflow: ellipsis;
+                        user-select: text;
+                        white-space: nowrap;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        box-shadow: 0 0 0 1px #605e5c inset;
+                        outline: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-bottom: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){& {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){& {
+                        color: #00009F;
+                      }
+                      &:active {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
                       }
                       &:hover {
-                        cursor: default;
+                        background-color: #f3f2f1;
+                        color: #323130;
+                        cursor: pointer;
+                        text-decoration: none;
                       }
+                      &:active:hover {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:focus {
+                        color: #201f1e;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #605e5c;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
+                      }
+                  onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=
@@ -4160,9 +2166,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    TestText4
+                    This is folder 5
                   </div>
-                </span>
+                </button>
               </li>
             </ol>
           </div>
@@ -4198,7 +2204,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
           margin-top: 24px;
         }
   >
-    With items rendered as a headings
+    With last item rendered as heading
   </label>
   <div>
     <div
@@ -4218,7 +2224,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
         }
       >
         <div
-          aria-label="Current item rendered as a heading"
+          aria-label="With last item rendered as heading"
           className=
               ms-Breadcrumb
               {
@@ -4240,7 +2246,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                 &:focus {
                   outline: none;
                 }
-            data-focuszone-id="FocusZone39"
+            data-focuszone-id="FocusZone20"
             onFocus={[Function]}
             onKeyDown={[Function]}
             onMouseDownCapture={[Function]}
@@ -4288,7 +2294,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       font-weight: 600;
                     }
               >
-                <h4
+                <button
                   className=
                       ms-Link
                       ms-Breadcrumb-itemLink
@@ -4375,6 +2381,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         color: Highlight;
                       }
                   onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=
@@ -4390,7 +2397,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                   >
                     Files
                   </div>
-                </h4>
+                </button>
                 <i
                   aria-hidden={true}
                   className=
@@ -4447,7 +2454,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       font-weight: 600;
                     }
               >
-                <h3
+                <button
                   className=
                       ms-Link
                       ms-Breadcrumb-itemLink
@@ -4534,6 +2541,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         color: Highlight;
                       }
                   onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=
@@ -4549,7 +2557,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                   >
                     This is folder 1
                   </div>
-                </h3>
+                </button>
                 <i
                   aria-hidden={true}
                   className=
@@ -4606,7 +2614,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       font-weight: 600;
                     }
               >
-                <h2
+                <h4
                   className=
                       ms-Breadcrumb-item
                       {
@@ -4637,7 +2645,474 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                   >
                     This is folder 2
                   </div>
-                </h2>
+                </h4>
+              </li>
+            </ol>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <label
+    className=
+        ms-Label
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          box-shadow: none;
+          box-sizing: border-box;
+          color: #323130;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 600;
+          margin-bottom: 10px;
+          margin-left: 0;
+          margin-right: 0;
+          margin-top: 10px;
+          overflow-wrap: break-word;
+          padding-bottom: 5px;
+          padding-left: 0;
+          padding-right: 0;
+          padding-top: 5px;
+          word-wrap: break-word;
+        }
+        &:not(:first-child) {
+          margin-top: 24px;
+        }
+  >
+    With custom rendered divider and overflow icon
+  </label>
+  <div>
+    <div
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
+    >
+      <div
+        data-automation-id="visibleContent"
+        style={
+          Object {
+            "position": "fixed",
+            "visibility": "hidden",
+          }
+        }
+      >
+        <div
+          aria-label="With custom rendered divider and overflow icon"
+          className=
+              ms-Breadcrumb
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 1px;
+                margin-left: 0;
+                margin-right: 0;
+                margin-top: 11px;
+              }
+          role="navigation"
+        >
+          <div
+            className=
+                ms-FocusZone
+                &:focus {
+                  outline: none;
+                }
+            data-focuszone-id="FocusZone24"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDownCapture={[Function]}
+          >
+            <ol
+              className=
+                  ms-Breadcrumb-list
+                  {
+                    align-items: stretch;
+                    display: flex;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    white-space: nowrap;
+                  }
+            >
+              <li
+                className=
+                    ms-Breadcrumb-listItem
+                    {
+                      align-items: center;
+                      display: flex;
+                      list-style-type: none;
+                      margin-bottom: 0;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 0;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &:last-child .ms-Breadcrumb-itemLink {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+                    &:last-child .ms-Breadcrumb-item {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+              >
+                <button
+                  className=
+                      ms-Link
+                      ms-Breadcrumb-itemLink
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        background: none;
+                        border-bottom: 1px solid transparent;
+                        border: none;
+                        color: #605e5c;
+                        cursor: pointer;
+                        display: inline;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 18px;
+                        font-weight: 400;
+                        line-height: 36px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: left;
+                        text-overflow: ellipsis;
+                        user-select: text;
+                        white-space: nowrap;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        box-shadow: 0 0 0 1px #605e5c inset;
+                        outline: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-bottom: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){& {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){& {
+                        color: #00009F;
+                      }
+                      &:active {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:hover {
+                        background-color: #f3f2f1;
+                        color: #323130;
+                        cursor: pointer;
+                        text-decoration: none;
+                      }
+                      &:active:hover {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:focus {
+                        color: #201f1e;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #605e5c;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
+                      }
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Files
+                  </div>
+                </button>
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <span
+                    aria-hidden="true"
+                    style={
+                      Object {
+                        "cursor": "pointer",
+                        "padding": 5,
+                      }
+                    }
+                  >
+                    /
+                  </span>
+                </div>
+              </li>
+              <li
+                className=
+                    ms-Breadcrumb-listItem
+                    {
+                      align-items: center;
+                      display: flex;
+                      list-style-type: none;
+                      margin-bottom: 0;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 0;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &:last-child .ms-Breadcrumb-itemLink {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+                    &:last-child .ms-Breadcrumb-item {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+              >
+                <button
+                  className=
+                      ms-Link
+                      ms-Breadcrumb-itemLink
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        background: none;
+                        border-bottom: 1px solid transparent;
+                        border: none;
+                        color: #605e5c;
+                        cursor: pointer;
+                        display: inline;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 18px;
+                        font-weight: 400;
+                        line-height: 36px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: left;
+                        text-overflow: ellipsis;
+                        user-select: text;
+                        white-space: nowrap;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        box-shadow: 0 0 0 1px #605e5c inset;
+                        outline: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-bottom: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){& {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){& {
+                        color: #00009F;
+                      }
+                      &:active {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:hover {
+                        background-color: #f3f2f1;
+                        color: #323130;
+                        cursor: pointer;
+                        text-decoration: none;
+                      }
+                      &:active:hover {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:focus {
+                        color: #201f1e;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #605e5c;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
+                      }
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    This is folder 1
+                  </div>
+                </button>
+                <div
+                  className=
+                      ms-TooltipHost
+                      {
+                        display: inline;
+                      }
+                  onBlurCapture={[Function]}
+                  onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
+                  onMouseEnter={[Function]}
+                  onMouseLeave={[Function]}
+                >
+                  <span
+                    aria-hidden="true"
+                    style={
+                      Object {
+                        "cursor": "pointer",
+                        "padding": 5,
+                      }
+                    }
+                  >
+                    /
+                  </span>
+                </div>
+              </li>
+              <li
+                className=
+                    ms-Breadcrumb-listItem
+                    {
+                      align-items: center;
+                      display: flex;
+                      list-style-type: none;
+                      margin-bottom: 0;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 0;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &:last-child .ms-Breadcrumb-itemLink {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+                    &:last-child .ms-Breadcrumb-item {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+              >
+                <h4
+                  className=
+                      ms-Breadcrumb-item
+                      {
+                        color: #605e5c;
+                        font-size: 18px;
+                        font-weight: 400;
+                        line-height: 36px;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                      }
+                      &:hover {
+                        cursor: default;
+                      }
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    This is folder 2
+                  </div>
+                </h4>
               </li>
             </ol>
           </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Collapsing.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Collapsing.Example.tsx.shot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] = `
+exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 1`] = `
 <div>
   <label
     className=
@@ -30,7 +30,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
           margin-top: 24px;
         }
   >
-    With items rendered as buttons
+    With no maxDisplayedItems
   </label>
   <div>
     <div
@@ -50,7 +50,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
         }
       >
         <div
-          aria-label="Breadcrumb with items rendered as buttons"
+          aria-label="Breadcrumb with no maxDisplayedItems"
           className=
               ms-Breadcrumb
               {
@@ -96,51 +96,98 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
             >
               <li
                 className=
-                    ms-Breadcrumb-overflow
+                    ms-Breadcrumb-listItem
                     {
                       align-items: center;
                       display: flex;
+                      list-style-type: none;
+                      margin-bottom: 0;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 0;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
                       position: relative;
+                    }
+                    &:last-child .ms-Breadcrumb-itemLink {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+                    &:last-child .ms-Breadcrumb-item {
+                      color: #323130;
+                      font-weight: 600;
                     }
               >
                 <button
-                  aria-expanded={false}
-                  aria-haspopup={true}
-                  aria-label="More links"
-                  aria-owns={null}
                   className=
-                      ms-Button
-                      ms-Button--icon
-                      ms-Button--hasMenu
-                      ms-Breadcrumb-overflowButton
+                      ms-Link
+                      ms-Breadcrumb-itemLink
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
                         background-color: transparent;
-                        border-radius: 2px;
+                        background: none;
+                        border-bottom: 1px solid transparent;
                         border: none;
-                        box-sizing: border-box;
                         color: #605e5c;
                         cursor: pointer;
-                        display: inline-block;
+                        display: inline;
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 16px;
+                        font-size: 18px;
                         font-weight: 400;
-                        height: 100%;
+                        line-height: 36px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
                         outline: transparent;
                         overflow: hidden;
                         padding-bottom: 0;
-                        padding-left: 4px;
-                        padding-right: 4px;
+                        padding-left: 8px;
+                        padding-right: 8px;
                         padding-top: 0;
                         position: relative;
-                        text-align: center;
-                        text-decoration: none;
+                        text-align: left;
                         text-overflow: ellipsis;
-                        user-select: none;
-                        vertical-align: top;
+                        user-select: text;
                         white-space: nowrap;
-                        width: auto;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        box-shadow: 0 0 0 1px #605e5c inset;
+                        outline: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-bottom: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){& {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){& {
+                        color: #00009F;
+                      }
+                      &:active {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:hover {
+                        background-color: #f3f2f1;
+                        color: #323130;
+                        cursor: pointer;
+                        text-decoration: none;
+                      }
+                      &:active:hover {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:focus {
+                        color: #201f1e;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -156,104 +203,26 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         top: 1px;
                         z-index: 1;
                       }
-                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                        border: none;
-                        bottom: -2px;
-                        left: -2px;
-                        outline-color: ButtonText;
-                        right: -2px;
-                        top: -2px;
-                      }
-                      &:active > * {
-                        left: 0px;
-                        position: relative;
-                        top: 0px;
-                      }
-                      &:hover {
-                        background-color: #f3f2f1;
-                        color: #323130;
-                        cursor: pointer;
-                        text-decoration: none;
-                      }
                       @media screen and (-ms-high-contrast: active){&:hover {
-                        border-color: Highlight;
                         color: Highlight;
                       }
-                      &:active {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:active:hover {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                        padding-bottom: 4px;
-                        padding-left: 6px;
-                        padding-right: 6px;
-                        padding-top: 4px;
-                      }
-                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
-                        font-size: 16px;
-                      }
-                  data-is-focusable={true}
                   onClick={[Function]}
-                  onKeyDown={[Function]}
-                  onKeyPress={[Function]}
-                  onKeyUp={[Function]}
-                  onMouseDown={[Function]}
-                  onMouseUp={[Function]}
-                  role="button"
                   type="button"
                 >
-                  <span
+                  <div
                     className=
-                        ms-Button-flexContainer
+                        ms-TooltipHost
                         {
-                          align-items: center;
-                          display: flex;
-                          flex-wrap: nowrap;
-                          height: 100%;
-                          justify-content: center;
+                          display: inline;
                         }
-                    data-automationid="splitbuttonprimary"
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
                   >
-                    <i
-                      aria-hidden={true}
-                      className=
-                          ms-Icon
-                          ms-Button-icon
-                          {
-                            display: inline-block;
-                          }
-                          {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
-                            font-family: "FabricMDL2Icons";
-                            font-style: normal;
-                            font-weight: normal;
-                            speak: none;
-                          }
-                          {
-                            flex-shrink: 0;
-                            font-size: 16px;
-                            height: 16px;
-                            line-height: 16px;
-                            margin-bottom: 0;
-                            margin-left: 4px;
-                            margin-right: 4px;
-                            margin-top: 0;
-                            text-align: center;
-                            vertical-align: middle;
-                          }
-                      data-icon-name="More"
-                      role="presentation"
-                    >
-                      
-                    </i>
-                  </span>
+                    Files
+                  </div>
                 </button>
                 <i
                   aria-hidden={true}
@@ -412,7 +381,327 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    Folder 3
+                    This is folder 1
+                  </div>
+                </button>
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Breadcrumb-chevron
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #605e5c;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        color: WindowText;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        font-size: 8px;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        font-size: 8px;
+                      }
+                  data-icon-name="ChevronRight"
+                >
+                  
+                </i>
+              </li>
+              <li
+                className=
+                    ms-Breadcrumb-listItem
+                    {
+                      align-items: center;
+                      display: flex;
+                      list-style-type: none;
+                      margin-bottom: 0;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 0;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &:last-child .ms-Breadcrumb-itemLink {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+                    &:last-child .ms-Breadcrumb-item {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+              >
+                <button
+                  className=
+                      ms-Link
+                      ms-Breadcrumb-itemLink
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        background: none;
+                        border-bottom: 1px solid transparent;
+                        border: none;
+                        color: #605e5c;
+                        cursor: pointer;
+                        display: inline;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 18px;
+                        font-weight: 400;
+                        line-height: 36px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: left;
+                        text-overflow: ellipsis;
+                        user-select: text;
+                        white-space: nowrap;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        box-shadow: 0 0 0 1px #605e5c inset;
+                        outline: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-bottom: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){& {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){& {
+                        color: #00009F;
+                      }
+                      &:active {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:hover {
+                        background-color: #f3f2f1;
+                        color: #323130;
+                        cursor: pointer;
+                        text-decoration: none;
+                      }
+                      &:active:hover {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:focus {
+                        color: #201f1e;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #605e5c;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
+                      }
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    This is folder 2 with a long name
+                  </div>
+                </button>
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Breadcrumb-chevron
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #605e5c;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        color: WindowText;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        font-size: 8px;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        font-size: 8px;
+                      }
+                  data-icon-name="ChevronRight"
+                >
+                  
+                </i>
+              </li>
+              <li
+                className=
+                    ms-Breadcrumb-listItem
+                    {
+                      align-items: center;
+                      display: flex;
+                      list-style-type: none;
+                      margin-bottom: 0;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 0;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &:last-child .ms-Breadcrumb-itemLink {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+                    &:last-child .ms-Breadcrumb-item {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+              >
+                <button
+                  className=
+                      ms-Link
+                      ms-Breadcrumb-itemLink
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        background: none;
+                        border-bottom: 1px solid transparent;
+                        border: none;
+                        color: #605e5c;
+                        cursor: pointer;
+                        display: inline;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 18px;
+                        font-weight: 400;
+                        line-height: 36px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
+                        outline: transparent;
+                        overflow: hidden;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: left;
+                        text-overflow: ellipsis;
+                        user-select: text;
+                        white-space: nowrap;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        box-shadow: 0 0 0 1px #605e5c inset;
+                        outline: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-bottom: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){& {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){& {
+                        color: #00009F;
+                      }
+                      &:active {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:hover {
+                        background-color: #f3f2f1;
+                        color: #323130;
+                        cursor: pointer;
+                        text-decoration: none;
+                      }
+                      &:active:hover {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:focus {
+                        color: #201f1e;
+                      }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 1px solid #ffffff;
+                        bottom: 1px;
+                        content: "";
+                        left: 1px;
+                        outline: 1px solid #605e5c;
+                        position: absolute;
+                        right: 1px;
+                        top: 1px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        color: Highlight;
+                      }
+                  onClick={[Function]}
+                  type="button"
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    This is folder 3 long
                   </div>
                 </button>
                 <i
@@ -500,7 +789,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    Folder 4 (non-clickable)
+                    This is non-clickable folder 4
                   </div>
                 </span>
                 <i
@@ -661,7 +950,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    Folder 5
+                    This is folder 5
                   </div>
                 </button>
               </li>
@@ -699,7 +988,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
           margin-top: 24px;
         }
   >
-    With items rendered as links
+    With maxDisplayedItems set to 3
   </label>
   <div>
     <div
@@ -719,7 +1008,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
         }
       >
         <div
-          aria-label="Breadcrumb with items rendered as links"
+          aria-label="Breadcrumb with maxDisplayedItems set to 3"
           className=
               ms-Breadcrumb
               {
@@ -980,18 +1269,28 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       font-weight: 600;
                     }
               >
-                <a
+                <button
                   className=
                       ms-Link
                       ms-Breadcrumb-itemLink
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        background: none;
+                        border-bottom: 1px solid transparent;
+                        border: none;
                         color: #605e5c;
+                        cursor: pointer;
+                        display: inline;
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 18px;
                         font-weight: 400;
                         line-height: 36px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
                         outline: transparent;
                         overflow: hidden;
                         padding-bottom: 0;
@@ -999,8 +1298,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         padding-right: 8px;
                         padding-top: 0;
                         position: relative;
-                        text-decoration: none;
+                        text-align: left;
                         text-overflow: ellipsis;
+                        user-select: text;
                         white-space: nowrap;
                       }
                       .ms-Fabric--isFocusVisible &:focus {
@@ -1012,6 +1312,12 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){& {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){& {
+                        color: #00009F;
                       }
                       &:active {
                         background-color: #edebe9;
@@ -1049,8 +1355,8 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: active){&:hover {
                         color: Highlight;
                       }
-                  href="#/controls/web/breadcrumb"
                   onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=
@@ -1064,9 +1370,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    Folder 3
+                    This is folder 3 long
                   </div>
-                </a>
+                </button>
                 <i
                   aria-hidden={true}
                   className=
@@ -1152,7 +1458,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    Folder 4 (non-clickable)
+                    This is non-clickable folder 4
                   </div>
                 </span>
                 <i
@@ -1211,7 +1517,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       font-weight: 600;
                     }
               >
-                <a
+                <button
                   aria-current="page"
                   className=
                       ms-Link
@@ -1219,11 +1525,21 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        background: none;
+                        border-bottom: 1px solid transparent;
+                        border: none;
                         color: #605e5c;
+                        cursor: pointer;
+                        display: inline;
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                         font-size: 18px;
                         font-weight: 400;
                         line-height: 36px;
+                        margin-bottom: 0px;
+                        margin-left: 0px;
+                        margin-right: 0px;
+                        margin-top: 0px;
                         outline: transparent;
                         overflow: hidden;
                         padding-bottom: 0;
@@ -1231,8 +1547,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         padding-right: 8px;
                         padding-top: 0;
                         position: relative;
-                        text-decoration: none;
+                        text-align: left;
                         text-overflow: ellipsis;
+                        user-select: text;
                         white-space: nowrap;
                       }
                       .ms-Fabric--isFocusVisible &:focus {
@@ -1244,6 +1561,12 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                       @media screen and (-ms-high-contrast: active){& {
                         border-bottom: none;
+                      }
+                      @media screen and (-ms-high-contrast: white-on-black){& {
+                        color: #FFFF00;
+                      }
+                      @media screen and (-ms-high-contrast: black-on-white){& {
+                        color: #00009F;
                       }
                       &:active {
                         background-color: #edebe9;
@@ -1281,8 +1604,8 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       @media screen and (-ms-high-contrast: active){&:hover {
                         color: Highlight;
                       }
-                  href="#/controls/web/breadcrumb"
                   onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=
@@ -1296,9 +1619,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    Folder 5
+                    This is folder 5
                   </div>
-                </a>
+                </button>
               </li>
             </ol>
           </div>
@@ -1334,7 +1657,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
           margin-top: 24px;
         }
   >
-    With last item rendered as heading
+    With maxDisplayedItems set to 2 and overflowIndex set to 1 (second element)
   </label>
   <div>
     <div
@@ -1354,7 +1677,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
         }
       >
         <div
-          aria-label="With last item rendered as heading"
+          aria-label="Breadcrumb with maxDisplayedItems set to 2 and overflowIndex set to 1"
           className=
               ms-Breadcrumb
               {
@@ -1560,98 +1883,51 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
               </li>
               <li
                 className=
-                    ms-Breadcrumb-listItem
+                    ms-Breadcrumb-overflow
                     {
                       align-items: center;
                       display: flex;
-                      list-style-type: none;
-                      margin-bottom: 0;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 0;
-                      padding-bottom: 0;
-                      padding-left: 0;
-                      padding-right: 0;
-                      padding-top: 0;
                       position: relative;
-                    }
-                    &:last-child .ms-Breadcrumb-itemLink {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-                    &:last-child .ms-Breadcrumb-item {
-                      color: #323130;
-                      font-weight: 600;
                     }
               >
                 <button
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  aria-label="More links"
+                  aria-owns={null}
                   className=
-                      ms-Link
-                      ms-Breadcrumb-itemLink
+                      ms-Button
+                      ms-Button--icon
+                      ms-Button--hasMenu
+                      ms-Breadcrumb-overflowButton
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
                         background-color: transparent;
-                        background: none;
-                        border-bottom: 1px solid transparent;
+                        border-radius: 2px;
                         border: none;
+                        box-sizing: border-box;
                         color: #605e5c;
                         cursor: pointer;
-                        display: inline;
+                        display: inline-block;
                         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 18px;
+                        font-size: 16px;
                         font-weight: 400;
-                        line-height: 36px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
+                        height: 100%;
                         outline: transparent;
                         overflow: hidden;
                         padding-bottom: 0;
-                        padding-left: 8px;
-                        padding-right: 8px;
+                        padding-left: 4px;
+                        padding-right: 4px;
                         padding-top: 0;
                         position: relative;
-                        text-align: left;
+                        text-align: center;
+                        text-decoration: none;
                         text-overflow: ellipsis;
-                        user-select: text;
+                        user-select: none;
+                        vertical-align: top;
                         white-space: nowrap;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus {
-                        box-shadow: 0 0 0 1px #605e5c inset;
-                        outline: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
-                        outline: 1px solid WindowText;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
-                      }
-                      &:active {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:hover {
-                        background-color: #f3f2f1;
-                        color: #323130;
-                        cursor: pointer;
-                        text-decoration: none;
-                      }
-                      &:active:hover {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:focus {
-                        color: #201f1e;
+                        width: auto;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1667,26 +1943,104 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         top: 1px;
                         z-index: 1;
                       }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                        border: none;
+                        bottom: -2px;
+                        left: -2px;
+                        outline-color: ButtonText;
+                        right: -2px;
+                        top: -2px;
+                      }
+                      &:active > * {
+                        left: 0px;
+                        position: relative;
+                        top: 0px;
+                      }
+                      &:hover {
+                        background-color: #f3f2f1;
+                        color: #323130;
+                        cursor: pointer;
+                        text-decoration: none;
+                      }
                       @media screen and (-ms-high-contrast: active){&:hover {
+                        border-color: Highlight;
                         color: Highlight;
                       }
+                      &:active {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      &:active:hover {
+                        background-color: #edebe9;
+                        color: #323130;
+                        text-decoration: none;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        padding-bottom: 4px;
+                        padding-left: 6px;
+                        padding-right: 6px;
+                        padding-top: 4px;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        font-size: 16px;
+                      }
+                  data-is-focusable={true}
                   onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  role="button"
                   type="button"
                 >
-                  <div
+                  <span
                     className=
-                        ms-TooltipHost
+                        ms-Button-flexContainer
                         {
-                          display: inline;
+                          align-items: center;
+                          display: flex;
+                          flex-wrap: nowrap;
+                          height: 100%;
+                          justify-content: center;
                         }
-                    onBlurCapture={[Function]}
-                    onFocusCapture={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
+                    data-automationid="splitbuttonprimary"
                   >
-                    Folder 1
-                  </div>
+                    <i
+                      aria-hidden={true}
+                      className=
+                          ms-Icon
+                          ms-Button-icon
+                          {
+                            display: inline-block;
+                          }
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            font-family: "FabricMDL2Icons";
+                            font-style: normal;
+                            font-weight: normal;
+                            speak: none;
+                          }
+                          {
+                            flex-shrink: 0;
+                            font-size: 16px;
+                            height: 16px;
+                            line-height: 16px;
+                            margin-bottom: 0;
+                            margin-left: 4px;
+                            margin-right: 4px;
+                            margin-top: 0;
+                            text-align: center;
+                            vertical-align: middle;
+                          }
+                      data-icon-name="More"
+                      role="presentation"
+                    >
+                      
+                    </i>
+                  </span>
                 </button>
                 <i
                   aria-hidden={true}
@@ -1744,164 +2098,8 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       font-weight: 600;
                     }
               >
-                <h4
-                  className=
-                      ms-Breadcrumb-item
-                      {
-                        color: #605e5c;
-                        font-size: 18px;
-                        font-weight: 400;
-                        line-height: 36px;
-                        padding-bottom: 0;
-                        padding-left: 8px;
-                        padding-right: 8px;
-                        padding-top: 0;
-                      }
-                      &:hover {
-                        cursor: default;
-                      }
-                >
-                  <div
-                    className=
-                        ms-TooltipHost
-                        {
-                          display: inline;
-                        }
-                    onBlurCapture={[Function]}
-                    onFocusCapture={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                  >
-                    Folder 2
-                  </div>
-                </h4>
-              </li>
-            </ol>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-  <label
-    className=
-        ms-Label
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          box-shadow: none;
-          box-sizing: border-box;
-          color: #323130;
-          display: block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 600;
-          margin-bottom: 10px;
-          margin-left: 0;
-          margin-right: 0;
-          margin-top: 10px;
-          overflow-wrap: break-word;
-          padding-bottom: 5px;
-          padding-left: 0;
-          padding-right: 0;
-          padding-top: 5px;
-          word-wrap: break-word;
-        }
-        &:not(:first-child) {
-          margin-top: 24px;
-        }
-  >
-    With custom rendered divider and overflow icon
-  </label>
-  <div>
-    <div
-      style={
-        Object {
-          "position": "relative",
-        }
-      }
-    >
-      <div
-        data-automation-id="visibleContent"
-        style={
-          Object {
-            "position": "fixed",
-            "visibility": "hidden",
-          }
-        }
-      >
-        <div
-          aria-label="With custom rendered divider and overflow icon"
-          className=
-              ms-Breadcrumb
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                margin-bottom: 1px;
-                margin-left: 0;
-                margin-right: 0;
-                margin-top: 11px;
-              }
-          role="navigation"
-        >
-          <div
-            className=
-                ms-FocusZone
-                &:focus {
-                  outline: none;
-                }
-            data-focuszone-id="FocusZone18"
-            onFocus={[Function]}
-            onKeyDown={[Function]}
-            onMouseDownCapture={[Function]}
-          >
-            <ol
-              className=
-                  ms-Breadcrumb-list
-                  {
-                    align-items: stretch;
-                    display: flex;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    padding-bottom: 0px;
-                    padding-left: 0px;
-                    padding-right: 0px;
-                    padding-top: 0px;
-                    white-space: nowrap;
-                  }
-            >
-              <li
-                className=
-                    ms-Breadcrumb-listItem
-                    {
-                      align-items: center;
-                      display: flex;
-                      list-style-type: none;
-                      margin-bottom: 0;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 0;
-                      padding-bottom: 0;
-                      padding-left: 0;
-                      padding-right: 0;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &:last-child .ms-Breadcrumb-itemLink {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-                    &:last-child .ms-Breadcrumb-item {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-              >
                 <button
+                  aria-current="page"
                   className=
                       ms-Link
                       ms-Breadcrumb-itemLink
@@ -2002,247 +2200,9 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    Files
+                    This is folder 5
                   </div>
                 </button>
-                <div
-                  className=
-                      ms-TooltipHost
-                      {
-                        display: inline;
-                      }
-                  onBlurCapture={[Function]}
-                  onFocusCapture={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <span
-                    aria-hidden="true"
-                    style={
-                      Object {
-                        "cursor": "pointer",
-                        "padding": 5,
-                      }
-                    }
-                  >
-                    /
-                  </span>
-                </div>
-              </li>
-              <li
-                className=
-                    ms-Breadcrumb-listItem
-                    {
-                      align-items: center;
-                      display: flex;
-                      list-style-type: none;
-                      margin-bottom: 0;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 0;
-                      padding-bottom: 0;
-                      padding-left: 0;
-                      padding-right: 0;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &:last-child .ms-Breadcrumb-itemLink {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-                    &:last-child .ms-Breadcrumb-item {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-              >
-                <button
-                  className=
-                      ms-Link
-                      ms-Breadcrumb-itemLink
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        background-color: transparent;
-                        background: none;
-                        border-bottom: 1px solid transparent;
-                        border: none;
-                        color: #605e5c;
-                        cursor: pointer;
-                        display: inline;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 18px;
-                        font-weight: 400;
-                        line-height: 36px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        outline: transparent;
-                        overflow: hidden;
-                        padding-bottom: 0;
-                        padding-left: 8px;
-                        padding-right: 8px;
-                        padding-top: 0;
-                        position: relative;
-                        text-align: left;
-                        text-overflow: ellipsis;
-                        user-select: text;
-                        white-space: nowrap;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus {
-                        box-shadow: 0 0 0 1px #605e5c inset;
-                        outline: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
-                        outline: 1px solid WindowText;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
-                      }
-                      &:active {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:hover {
-                        background-color: #f3f2f1;
-                        color: #323130;
-                        cursor: pointer;
-                        text-decoration: none;
-                      }
-                      &:active:hover {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:focus {
-                        color: #201f1e;
-                      }
-                      &::-moz-focus-inner {
-                        border: 0;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus:after {
-                        border: 1px solid #ffffff;
-                        bottom: 1px;
-                        content: "";
-                        left: 1px;
-                        outline: 1px solid #605e5c;
-                        position: absolute;
-                        right: 1px;
-                        top: 1px;
-                        z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
-                      }
-                  onClick={[Function]}
-                  type="button"
-                >
-                  <div
-                    className=
-                        ms-TooltipHost
-                        {
-                          display: inline;
-                        }
-                    onBlurCapture={[Function]}
-                    onFocusCapture={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                  >
-                    Folder 1
-                  </div>
-                </button>
-                <div
-                  className=
-                      ms-TooltipHost
-                      {
-                        display: inline;
-                      }
-                  onBlurCapture={[Function]}
-                  onFocusCapture={[Function]}
-                  onKeyDown={[Function]}
-                  onMouseEnter={[Function]}
-                  onMouseLeave={[Function]}
-                >
-                  <span
-                    aria-hidden="true"
-                    style={
-                      Object {
-                        "cursor": "pointer",
-                        "padding": 5,
-                      }
-                    }
-                  >
-                    /
-                  </span>
-                </div>
-              </li>
-              <li
-                className=
-                    ms-Breadcrumb-listItem
-                    {
-                      align-items: center;
-                      display: flex;
-                      list-style-type: none;
-                      margin-bottom: 0;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 0;
-                      padding-bottom: 0;
-                      padding-left: 0;
-                      padding-right: 0;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &:last-child .ms-Breadcrumb-itemLink {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-                    &:last-child .ms-Breadcrumb-item {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-              >
-                <h4
-                  className=
-                      ms-Breadcrumb-item
-                      {
-                        color: #605e5c;
-                        font-size: 18px;
-                        font-weight: 400;
-                        line-height: 36px;
-                        padding-bottom: 0;
-                        padding-left: 8px;
-                        padding-right: 8px;
-                        padding-top: 0;
-                      }
-                      &:hover {
-                        cursor: default;
-                      }
-                >
-                  <div
-                    className=
-                        ms-TooltipHost
-                        {
-                          display: inline;
-                        }
-                    onBlurCapture={[Function]}
-                    onFocusCapture={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                  >
-                    Folder 2
-                  </div>
-                </h4>
               </li>
             </ol>
           </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
@@ -287,94 +287,6 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                       font-weight: 600;
                     }
               >
-                <span
-                  className=
-                      ms-Breadcrumb-item
-                      {
-                        color: #605e5c;
-                        font-size: 18px;
-                        font-weight: 400;
-                        line-height: 36px;
-                        padding-bottom: 0;
-                        padding-left: 8px;
-                        padding-right: 8px;
-                        padding-top: 0;
-                      }
-                      &:hover {
-                        cursor: default;
-                      }
-                >
-                  <div
-                    className=
-                        ms-TooltipHost
-                        {
-                          display: inline;
-                        }
-                    onBlurCapture={[Function]}
-                    onFocusCapture={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                  >
-                    Not a link
-                  </div>
-                </span>
-                <i
-                  aria-hidden={true}
-                  className=
-                      ms-Breadcrumb-chevron
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        color: #605e5c;
-                        display: inline-block;
-                        font-family: "FabricMDL2Icons";
-                        font-size: 12px;
-                        font-style: normal;
-                        font-weight: normal;
-                        speak: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        -ms-high-contrast-adjust: none;
-                        color: WindowText;
-                      }
-                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
-                        font-size: 8px;
-                      }
-                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                        font-size: 8px;
-                      }
-                  data-icon-name="ChevronRight"
-                >
-                  
-                </i>
-              </li>
-              <li
-                className=
-                    ms-Breadcrumb-listItem
-                    {
-                      align-items: center;
-                      display: flex;
-                      list-style-type: none;
-                      margin-bottom: 0;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 0;
-                      padding-bottom: 0;
-                      padding-left: 0;
-                      padding-right: 0;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &:last-child .ms-Breadcrumb-itemLink {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-                    &:last-child .ms-Breadcrumb-item {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-              >
                 <button
                   className=
                       ms-Link
@@ -476,9 +388,97 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    Link
+                    This is folder 3 long
                   </div>
                 </button>
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Breadcrumb-chevron
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #605e5c;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        color: WindowText;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        font-size: 8px;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        font-size: 8px;
+                      }
+                  data-icon-name="ChevronRight"
+                >
+                  
+                </i>
+              </li>
+              <li
+                className=
+                    ms-Breadcrumb-listItem
+                    {
+                      align-items: center;
+                      display: flex;
+                      list-style-type: none;
+                      margin-bottom: 0;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 0;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &:last-child .ms-Breadcrumb-itemLink {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+                    &:last-child .ms-Breadcrumb-item {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+              >
+                <span
+                  className=
+                      ms-Breadcrumb-item
+                      {
+                        color: #605e5c;
+                        font-size: 18px;
+                        font-weight: 400;
+                        line-height: 36px;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                      }
+                      &:hover {
+                        cursor: default;
+                      }
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    This is non-clickable folder 4
+                  </div>
+                </span>
                 <i
                   aria-hidden={true}
                   className=
@@ -637,7 +637,7 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    Link
+                    This is folder 5
                   </div>
                 </button>
               </li>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
@@ -287,7 +287,95 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                       font-weight: 600;
                     }
               >
-                <a
+                <span
+                  className=
+                      ms-Breadcrumb-item
+                      {
+                        color: #605e5c;
+                        font-size: 18px;
+                        font-weight: 400;
+                        line-height: 36px;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                      }
+                      &:hover {
+                        cursor: default;
+                      }
+                >
+                  <div
+                    className=
+                        ms-TooltipHost
+                        {
+                          display: inline;
+                        }
+                    onBlurCapture={[Function]}
+                    onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
+                    onMouseEnter={[Function]}
+                    onMouseLeave={[Function]}
+                  >
+                    Not a link
+                  </div>
+                </span>
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Breadcrumb-chevron
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        color: #605e5c;
+                        display: inline-block;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        speak: none;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        -ms-high-contrast-adjust: none;
+                        color: WindowText;
+                      }
+                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
+                        font-size: 8px;
+                      }
+                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
+                        font-size: 8px;
+                      }
+                  data-icon-name="ChevronRight"
+                >
+                  
+                </i>
+              </li>
+              <li
+                className=
+                    ms-Breadcrumb-listItem
+                    {
+                      align-items: center;
+                      display: flex;
+                      list-style-type: none;
+                      margin-bottom: 0;
+                      margin-left: 0;
+                      margin-right: 0;
+                      margin-top: 0;
+                      padding-bottom: 0;
+                      padding-left: 0;
+                      padding-right: 0;
+                      padding-top: 0;
+                      position: relative;
+                    }
+                    &:last-child .ms-Breadcrumb-itemLink {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+                    &:last-child .ms-Breadcrumb-item {
+                      color: #323130;
+                      font-weight: 600;
+                    }
+              >
+                <button
                   className=
                       ms-Link
                       ms-Breadcrumb-itemLink
@@ -374,6 +462,7 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         color: Highlight;
                       }
                   onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=
@@ -387,9 +476,9 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    This is folder 3
+                    Link
                   </div>
-                </a>
+                </button>
                 <i
                   aria-hidden={true}
                   className=
@@ -446,166 +535,7 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                       font-weight: 600;
                     }
               >
-                <a
-                  className=
-                      ms-Link
-                      ms-Breadcrumb-itemLink
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        background-color: transparent;
-                        background: none;
-                        border-bottom: 1px solid transparent;
-                        border: none;
-                        color: #605e5c;
-                        cursor: pointer;
-                        display: inline;
-                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                        font-size: 18px;
-                        font-weight: 400;
-                        line-height: 36px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
-                        outline: transparent;
-                        overflow: hidden;
-                        padding-bottom: 0;
-                        padding-left: 8px;
-                        padding-right: 8px;
-                        padding-top: 0;
-                        position: relative;
-                        text-align: left;
-                        text-overflow: ellipsis;
-                        user-select: text;
-                        white-space: nowrap;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus {
-                        box-shadow: 0 0 0 1px #605e5c inset;
-                        outline: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
-                        outline: 1px solid WindowText;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        border-bottom: none;
-                      }
-                      @media screen and (-ms-high-contrast: white-on-black){& {
-                        color: #FFFF00;
-                      }
-                      @media screen and (-ms-high-contrast: black-on-white){& {
-                        color: #00009F;
-                      }
-                      &:active {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:hover {
-                        background-color: #f3f2f1;
-                        color: #323130;
-                        cursor: pointer;
-                        text-decoration: none;
-                      }
-                      &:active:hover {
-                        background-color: #edebe9;
-                        color: #323130;
-                        text-decoration: none;
-                      }
-                      &:focus {
-                        color: #201f1e;
-                      }
-                      &::-moz-focus-inner {
-                        border: 0;
-                      }
-                      .ms-Fabric--isFocusVisible &:focus:after {
-                        border: 1px solid #ffffff;
-                        bottom: 1px;
-                        content: "";
-                        left: 1px;
-                        outline: 1px solid #605e5c;
-                        position: absolute;
-                        right: 1px;
-                        top: 1px;
-                        z-index: 1;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:hover {
-                        color: Highlight;
-                      }
-                  onClick={[Function]}
-                >
-                  <div
-                    className=
-                        ms-TooltipHost
-                        {
-                          display: inline;
-                        }
-                    onBlurCapture={[Function]}
-                    onFocusCapture={[Function]}
-                    onKeyDown={[Function]}
-                    onMouseEnter={[Function]}
-                    onMouseLeave={[Function]}
-                  >
-                    This is folder 4
-                  </div>
-                </a>
-                <i
-                  aria-hidden={true}
-                  className=
-                      ms-Breadcrumb-chevron
-                      {
-                        -moz-osx-font-smoothing: grayscale;
-                        -webkit-font-smoothing: antialiased;
-                        color: #605e5c;
-                        display: inline-block;
-                        font-family: "FabricMDL2Icons";
-                        font-size: 12px;
-                        font-style: normal;
-                        font-weight: normal;
-                        speak: none;
-                      }
-                      @media screen and (-ms-high-contrast: active){& {
-                        -ms-high-contrast-adjust: none;
-                        color: WindowText;
-                      }
-                      @media only screen and (min-width: 480px) and (max-width: 639px){& {
-                        font-size: 8px;
-                      }
-                      @media only screen and (min-width: 0px) and (max-width: 479px){& {
-                        font-size: 8px;
-                      }
-                  data-icon-name="ChevronRight"
-                >
-                  
-                </i>
-              </li>
-              <li
-                className=
-                    ms-Breadcrumb-listItem
-                    {
-                      align-items: center;
-                      display: flex;
-                      list-style-type: none;
-                      margin-bottom: 0;
-                      margin-left: 0;
-                      margin-right: 0;
-                      margin-top: 0;
-                      padding-bottom: 0;
-                      padding-left: 0;
-                      padding-right: 0;
-                      padding-top: 0;
-                      position: relative;
-                    }
-                    &:last-child .ms-Breadcrumb-itemLink {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-                    &:last-child .ms-Breadcrumb-item {
-                      color: #323130;
-                      font-weight: 600;
-                    }
-              >
-                <a
+                <button
                   aria-current="page"
                   className=
                       ms-Link
@@ -693,6 +623,7 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         color: Highlight;
                       }
                   onClick={[Function]}
+                  type="button"
                 >
                   <div
                     className=
@@ -706,9 +637,9 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
-                    This is folder 5
+                    Link
                   </div>
-                </a>
+                </button>
               </li>
             </ol>
           </div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10138, fixes an issue introduced by PR #10113, and fixes #10750
- [x] Include a change request file using `$ yarn change`

#### Description of changes

#10113 switched breadcrumb items to always use links instead of buttons, which broke "clicking" `href`-less breadcrumb items using the keyboard. I'm reverting that change since it's such a major accessibility issue, and updating the `IBreadcrumbItem.as` prop to allow forcing individual breadcrumb items to be links (to facilitate whatever the PR author was trying to do).

This change also updates the hover styling for non-clickable breadcrumb items in the overflow menu to match the design spec. The current approach--marking the item as disabled and overriding the disabled text color--isn't ideal, but see https://github.com/OfficeDev/office-ui-fabric-react/issues/10138#issuecomment-539304332 for more about the reasoning and alternatives (and I'm open to suggestions).

Also, per #10750, I'm updating the breadcrumb-as-heading example to have only the last breadcrumb be a heading.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10736)