### PR TITLE
Dropdown: fix wrong open state when is openOnKeyboardFocus and click

### DIFF
--- a/change/office-ui-fabric-react-2019-10-08-14-49-11-xgao-bug-fix-1.json
+++ b/change/office-ui-fabric-react-2019-10-08-14-49-11-xgao-bug-fix-1.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "FIX BUG: dropdown open state wrong when openOnKeyboardFocus to true and click",
+  "comment": "Dropdown: when `openOnKeyboardFocus` prop is set to true, the Dropdown now does not close the options callout immediately.",
   "packageName": "office-ui-fabric-react",
   "email": "xgao@microsoft.com",
   "commit": "575aeee692cd0f947e453ec6aa6ccebf10b25622",

--- a/change/office-ui-fabric-react-2019-10-08-14-49-11-xgao-bug-fix-1.json
+++ b/change/office-ui-fabric-react-2019-10-08-14-49-11-xgao-bug-fix-1.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "FIX BUG: dropdown open state wrong when openOnKeyboardFocus to true and click",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "575aeee692cd0f947e453ec6aa6ccebf10b25622",
+  "date": "2019-10-08T21:49:11.601Z",
+  "file": "/Users/xugao/Projects/office-ui-fabric-react/change/office-ui-fabric-react-2019-10-08-14-49-11-xgao-bug-fix-1.json"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -72,6 +72,9 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
   /** Flag for when we get the first mouseMove */
   private _gotMouseMove: boolean;
 
+  /** Flag for identifiying dropdown is opened by getting focus */
+  private _isOpenedByFocus: boolean;
+
   constructor(props: IDropdownProps) {
     super(props);
 
@@ -1033,11 +1036,13 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
     const { isOpen } = this.state;
     const disabled = this._isDisabled();
 
-    if (!disabled) {
+    if (!disabled && !(this._isOpenedByFocus && isOpen)) {
       this.setState({
         isOpen: !isOpen
       });
     }
+
+    this._isOpenedByFocus = false;
   };
 
   private _onFocus = (ev: React.FocusEvent<HTMLDivElement>): void => {
@@ -1057,7 +1062,11 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
       const state: Pick<IDropdownState, 'hasFocus'> | Pick<IDropdownState, 'hasFocus' | 'isOpen'> = { hasFocus: true };
       if (openOnKeyboardFocus && !hasFocus) {
         (state as Pick<IDropdownState, 'hasFocus' | 'isOpen'>).isOpen = true;
+        this._isOpenedByFocus = true;
+      } else {
+        this._isOpenedByFocus = false;
       }
+
       this.setState(state);
     }
   };

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -375,19 +375,13 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
     multiSelect?: boolean
   ) => {
     const { onChange, onChanged } = this.props;
-    if (onChange) {
+    if (onChange || onChanged) {
       // for single-select, option passed in will always be selected.
       // for multi-select, flip the checked value
       const changedOpt = multiSelect ? { ...options[index], selected: !checked } : options[index];
 
-      onChange({ ...event, target: this._dropDown.current as EventTarget }, changedOpt, index);
-    }
-
-    if (onChanged) {
-      // for single-select, option passed in will always be selected.
-      // for multi-select, flip the checked value
-      const changedOpt = multiSelect ? { ...options[index], selected: !checked } : options[index];
-      onChanged(changedOpt, index);
+      onChange && onChange({ ...event, target: this._dropDown.current as EventTarget }, changedOpt, index);
+      onChanged && onChanged(changedOpt, index);
     }
   };
 

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -72,8 +72,8 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
   /** Flag for when we get the first mouseMove */
   private _gotMouseMove: boolean;
 
-  /** Flag for identifiying dropdown is opened by getting focus */
-  private _isOpenedByFocus: boolean;
+  /** Flag for identifiying dropdown is opened by getting focus using keyboard */
+  private _isOpenedByKeyboardFocus: boolean;
 
   constructor(props: IDropdownProps) {
     super(props);
@@ -1036,13 +1036,13 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
     const { isOpen } = this.state;
     const disabled = this._isDisabled();
 
-    if (!disabled && !(this._isOpenedByFocus && isOpen)) {
+    if (!disabled && !(this._isOpenedByKeyboardFocus && isOpen)) {
       this.setState({
         isOpen: !isOpen
       });
     }
 
-    this._isOpenedByFocus = false;
+    this._isOpenedByKeyboardFocus = false;
   };
 
   private _onFocus = (ev: React.FocusEvent<HTMLDivElement>): void => {
@@ -1062,9 +1062,7 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
       const state: Pick<IDropdownState, 'hasFocus'> | Pick<IDropdownState, 'hasFocus' | 'isOpen'> = { hasFocus: true };
       if (openOnKeyboardFocus && !hasFocus) {
         (state as Pick<IDropdownState, 'hasFocus' | 'isOpen'>).isOpen = true;
-        this._isOpenedByFocus = true;
-      } else {
-        this._isOpenedByFocus = false;
+        this._isOpenedByKeyboardFocus = true;
       }
 
       this.setState(state);

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
@@ -38,6 +38,8 @@ describe('Dropdown', () => {
       wrapper.unmount();
       wrapper = undefined;
     }
+
+    document.body.innerHTML = '';
   });
 
   describe('single-select', () => {
@@ -341,6 +343,15 @@ describe('Dropdown', () => {
       wrapper = mount(<Dropdown openOnKeyboardFocus label="testgroup" options={DEFAULT_OPTIONS} />);
 
       wrapper.find('.ms-Dropdown').simulate('focus');
+
+      const secondItemElement = document.querySelector('.ms-Dropdown-item[data-index="2"]') as HTMLElement;
+      expect(secondItemElement).toBeTruthy();
+    });
+
+    it('opens on click if openOnKeyboardFocus is true', () => {
+      wrapper = mount(<Dropdown openOnKeyboardFocus={true} label="testgroup" options={DEFAULT_OPTIONS} />);
+
+      wrapper.find('.ms-Dropdown').simulate('click');
 
       const secondItemElement = document.querySelector('.ms-Dropdown-item[data-index="2"]') as HTMLElement;
       expect(secondItemElement).toBeTruthy();

--- a/packages/office-ui-fabric-react/src/utilities/selectableOption/SelectableDroppableText.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selectableOption/SelectableDroppableText.types.ts
@@ -104,7 +104,7 @@ export interface ISelectableDroppableTextProps<TComponent, TListenerElement> ext
   placeholder?: string;
 
   /**
-   * Whether or not the combobox should expand on keyboard focus
+   * Whether or not the dropdown should expand on keyboard focus
    * @defaultvalue false
    */
   openOnKeyboardFocus?: boolean;

--- a/packages/office-ui-fabric-react/src/utilities/selectableOption/SelectableDroppableText.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selectableOption/SelectableDroppableText.types.ts
@@ -104,7 +104,7 @@ export interface ISelectableDroppableTextProps<TComponent, TListenerElement> ext
   placeholder?: string;
 
   /**
-   * Whether or not the dropdown should expand on keyboard focus
+   * Whether or not the combobox/dropdown should expand on keyboard focus
    * @defaultvalue false
    */
   openOnKeyboardFocus?: boolean;

--- a/packages/office-ui-fabric-react/src/utilities/selectableOption/SelectableDroppableText.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selectableOption/SelectableDroppableText.types.ts
@@ -104,7 +104,7 @@ export interface ISelectableDroppableTextProps<TComponent, TListenerElement> ext
   placeholder?: string;
 
   /**
-   * Whether or not the combobox/dropdown should expand on keyboard focus
+   * Whether or not the ComboBox/Dropdown should expand on keyboard focus.
    * @defaultvalue false
    */
   openOnKeyboardFocus?: boolean;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #10747 
- [X] Include a change request file using `$ yarn change`

#### Description of changes
- `openOnKeyboardFocus` will set `isOpen` to `true` when dropdown first gains focus. If user clicked on the dropdown in its unfocus state, `onFocus` will be called then follow with `onClick` call. `onClick` will toggle the dropdown back to closed state after `onFocus` just opened it.
- minor code refactoring on `_onChange`: simplified it slightly
-  A lot of the dropdown unit tests are not capturing real issue due to DOM is not cleaned up after 
`ReactDOM.render(...)` in couple of the existing tests we have



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10748)