### PR TITLE
filetypeicon mappings for Calendar, Contact, Fluid, PowerBI Data Source - fabric7

### DIFF
--- a/change/@uifabric-file-type-icons-2019-10-08-16-10-05-caperez-oct_filetypeicon_mappings_fabric7.json
+++ b/change/@uifabric-file-type-icons-2019-10-08-16-10-05-caperez-oct_filetypeicon_mappings_fabric7.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Fabric 7 mappings for filetypeicon cal/contact/fluid/pbids",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "caperez@microsoft.com",
+  "commit": "5fbf1010f9b753c9eac17f5565efddcd998a4116",
+  "date": "2019-10-08T23:10:05.409Z",
+  "file": "C:\\Users\\caperez\\Repositories\\office-ui-fabric-react\\change\\@uifabric-file-type-icons-2019-10-08-16-10-05-caperez-oct_filetypeicon_mappings_fabric7.json"
+}

--- a/packages/file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/file-type-icons/src/FileTypeIconMap.ts
@@ -37,6 +37,9 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
     ]
   },
   channelfolder: {},
+  calendar: {
+    extensions: ['ical', 'icalendar', 'ics', 'ifb', 'vcs']
+  },
   code: {
     extensions: [
       'abap',
@@ -243,13 +246,16 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
       'zsh'
     ]
   },
+  contact: {
+    extensions: ['vcf']
+  },
   css: {}, // we dont have the icon yet, but i believe we want it, snapping to 'code' for now
   csv: {
     extensions: ['csv']
   },
   docset: {},
   docx: {
-    extensions: ['b', 'doc', 'docm', 'docx', 'docb']
+    extensions: ['doc', 'docm', 'docx', 'docb']
   },
   dotx: {
     extensions: ['dot', 'dotm', 'dotx']
@@ -263,6 +269,9 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   folder: {},
   font: {
     extensions: ['ttf', 'otf', 'woff']
+  },
+  fluid: {
+    extensions: ['b', 'fluid']
   },
   genericfile: {},
   html: {
@@ -363,7 +372,7 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
     extensions: ['pot', 'potm', 'potx']
   },
   powerbi: {
-    extensions: ['pbix']
+    extensions: ['pbids', 'pbix']
   },
   ppsx: {
     extensions: ['pps', 'ppsm', 'ppsx']


### PR DESCRIPTION
#### Pull request checklist

- [ ] Calendar, Contact, Fluid, PowerBI Data Source filetype icon mappings
- [ ] Equivalent to this PR but for Fabric 7: https://github.com/OfficeDev/office-ui-fabric-react/pull/10749
- [ ] Include a change request file using `$ yarn change`

#### Focus areas to test

- files with the applicable extension


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10751)