### PR TITLE
Announced: default aria-live to polite

### DIFF
--- a/change/office-ui-fabric-react-2019-10-08-16-21-44-defaultAnnouncedToPolite.json
+++ b/change/office-ui-fabric-react-2019-10-08-16-21-44-defaultAnnouncedToPolite.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Announced: default aria live to polite",
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com",
+  "commit": "10d61e3f27ff20c0da970f53dddae52f7dfa9b72",
+  "date": "2019-10-08T23:21:44.223Z",
+  "file": "C:\\Users\\naethell\\office-ui-fabric-react\\change\\office-ui-fabric-react-2019-10-08-16-21-44-defaultAnnouncedToPolite.json"
+}

--- a/packages/office-ui-fabric-react/src/components/Announced/Announced.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Announced/Announced.base.tsx
@@ -10,7 +10,7 @@ const getClassNames = classNamesFunction<{}, IAnnouncedStyles>();
  */
 export class AnnouncedBase extends React.Component<IAnnouncedProps> {
   public static defaultProps: Partial<IAnnouncedProps> = {
-    'aria-live': 'assertive'
+    'aria-live': 'polite'
   };
 
   private _classNames: IProcessedStyleSet<IAnnouncedStyles>;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #10742
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Defaults Announced to aria-live="polite". @ecraig12345 @betrue-final-final @cschlechty and I discussed this and believe that it makes more sense.

Out of our current examples, only quick actions, like "item deleted" and "item moved", should be assertive messages, which is already specified in the example.

#### Focus areas to test

Ensure that all of the Announced examples still work as expected in Narrator + Edge.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10752)