### PR TITLE
Announced: explictly add aria-live property for visibility

### DIFF
--- a/change/office-ui-fabric-react-2019-10-09-15-57-38-announcedAriaLiveProp.json
+++ b/change/office-ui-fabric-react-2019-10-09-15-57-38-announcedAriaLiveProp.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Announced: explicitly show aria-live property in Announced types",
+  "packageName": "office-ui-fabric-react",
+  "email": "naethell@microsoft.com",
+  "commit": "f387bd52fabef7244663acb5b0bb5d87518f21d1",
+  "date": "2019-10-09T22:57:38.235Z",
+  "file": "C:\\Users\\naethell\\office-ui-fabric-react\\change\\office-ui-fabric-react-2019-10-09-15-57-38-announcedAriaLiveProp.json"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1509,6 +1509,7 @@ export interface IActivityItemStyles {
 
 // @public (undocumented)
 export interface IAnnouncedProps extends React.Props<AnnouncedBase>, React.HTMLAttributes<HTMLDivElement> {
+    'aria-live'?: 'off' | 'polite' | 'assertive';
     message?: string;
     styles?: IStyleFunctionOrObject<{}, IAnnouncedStyles>;
 }

--- a/packages/office-ui-fabric-react/src/components/Announced/Announced.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Announced/Announced.types.ts
@@ -14,6 +14,12 @@ export interface IAnnouncedProps extends React.Props<AnnouncedBase>, React.HTMLA
    * The status message provided as screen reader output
    */
   message?: string;
+
+  /**
+   * Priority with which the screen reader should treat updates to this region
+   * @default 'polite'
+   */
+  'aria-live'?: string;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Announced/Announced.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Announced/Announced.types.ts
@@ -19,7 +19,7 @@ export interface IAnnouncedProps extends React.Props<AnnouncedBase>, React.HTMLA
    * Priority with which the screen reader should treat updates to this region
    * @default 'polite'
    */
-  'aria-live'?: string;
+  'aria-live'?: 'off' | 'polite' | 'assertive';
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Announced/examples/Announced.BulkOperations.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Announced/examples/Announced.BulkOperations.Example.tsx
@@ -119,7 +119,7 @@ export class AnnouncedBulkOperationsExample extends React.Component<{}, IAnnounc
   private _renderAnnounced(): JSX.Element | undefined {
     const { numberOfItems } = this.state;
     if (numberOfItems > 0) {
-      return <Announced message={`${numberOfItems} item${numberOfItems === 1 ? '' : 's'} moved`} />;
+      return <Announced message={`${numberOfItems} item${numberOfItems === 1 ? '' : 's'} moved`} aria-live={'assertive'} />;
     }
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ yarn change`

#### Description of changes

These changes explicitly add the aria-live property to `IAnnouncedProps` for visibility, although it is already inherited from div props. @ecraig12345 pointed out that it might be good for documentation purposes.

These changes also add `aria-live='assertive'` to the bulk operations example.

I called this a "patch", since the API isn't actually changing, but let me know if you think this is better labeled as a "minor".

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10770)