### PR TITLE
Hide UHF flightPicker element that causes accessibility issues

### DIFF
--- a/apps/fabric-website/src/components/Site/Site.module.scss
+++ b/apps/fabric-website/src/components/Site/Site.module.scss
@@ -1,26 +1,6 @@
 @import '../../styles/variables';
 @import '../../styles/mixins';
 
-:global {
-  // #headerWrapper is the UHF header wrapper. The p, ul, ol style in _typography.scss was making
-  // the header links larger than they should be, so reset that here.
-  #headerWrapper,
-  #footerWrapper,
-  #socialMediaContainer,
-  .m-back-to-top {
-    p,
-    ul,
-    ol {
-      font-size: inherit;
-    }
-  }
-
-  // Hide UHF back to top button that attempts to go to a nonexistent #main-content page
-  a.m-back-to-top {
-    display: none !important;
-  }
-}
-
 .siteRoot {
   min-height: 100vh;
   display: flex;

--- a/apps/fabric-website/src/styles/_base.scss
+++ b/apps/fabric-website/src/styles/_base.scss
@@ -66,6 +66,25 @@
     @include ms-fontColor-white;
   }
 
+  // #headerWrapper is the UHF header wrapper. The p, ul, ol style in _typography.scss was making
+  // the header links larger than they should be, so reset that here.
+  #headerWrapper,
+  #footerWrapper,
+  #socialMediaContainer {
+    p,
+    ul,
+    ol {
+      font-size: inherit;
+    }
+  }
+
+  // Hide UHF back to top button that attempts to go to a nonexistent #main-content page,
+  // and #flightPicker element which creates accessibility issues
+  a.m-back-to-top,
+  #flightPicker {
+    display: none !important;
+  }
+
   @media screen and (min-width: $uhf-screen-min-mobile) {
     // Align logo with left nav
     .c-uhfh > div {

--- a/change/@uifabric-fabric-website-2019-10-09-16-18-10-flighttools.json
+++ b/change/@uifabric-fabric-website-2019-10-09-16-18-10-flighttools.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Hide UHF flightPicker element that causes accessibility issues",
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com",
+  "commit": "65758fcc9ae1837a6059731219d0c33989b6bb78",
+  "date": "2019-10-09T23:18:10.116Z",
+  "file": "/Users/elizabeth/git/fabric-react3/change/@uifabric-fabric-website-2019-10-09-16-18-10-flighttools.json"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10739
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Hide the UHF-provided `#flightPicker` element on the Fabric website to prevent it from causing accessibility issues (we don't actually use the things inside it, so hiding it is an easy fix).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10771)