### PR TITLE
Export DetailsRowFields for rowFieldsAs 

### DIFF
--- a/change/office-ui-fabric-react-2019-10-09-16-30-56-keco-detailsrowfields.json
+++ b/change/office-ui-fabric-react-2019-10-09-16-30-56-keco-detailsrowfields.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Export DetailsRowFields",
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com",
+  "commit": "bd56a5d2336484622be395eaa0e7c50c7ee91166",
+  "date": "2019-10-09T23:30:56.108Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -956,6 +956,9 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
 // @public (undocumented)
 export const DetailsRowCheck: React.FunctionComponent<IDetailsRowCheckProps>;
 
+// @public
+export const DetailsRowFields: React.FunctionComponent<IDetailsRowFieldsProps>;
+
 // @public (undocumented)
 export const DetailsRowGlobalClassNames: {
     root: string;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/index.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/index.ts
@@ -12,6 +12,7 @@ export * from './DetailsRow.types';
 export { DetailsRowGlobalClassNames } from './DetailsRow.styles';
 export * from './DetailsRowCheck';
 export * from './DetailsRowCheck.types';
+export * from './DetailsRowFields';
 export * from './DetailsRowFields.types';
 export * from './DetailsFooter.types';
 export * from './DetailsColumn.base';


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10731
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Exports `DetailsRowFields` to be used via OUFR public API for `rowFieldsAs` prop.

#### Focus areas to test

- CI should pass.

cc: @brandonthomas 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10772)