### PR TITLE
Editor should include re-exported types

### DIFF
--- a/change/@uifabric-tsx-editor-2019-10-09-17-57-17-icon-types.json
+++ b/change/@uifabric-tsx-editor-2019-10-09-17-57-17-icon-types.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Editor should include re-exported types",
+  "packageName": "@uifabric/tsx-editor",
+  "email": "elcraig@microsoft.com",
+  "commit": "f5d6048b0856ddbe3e20083ada40a9d18588c6bf",
+  "date": "2019-10-10T00:57:17.895Z",
+  "file": "/Users/elizabeth/git/fabric-react3/change/@uifabric-tsx-editor-2019-10-09-17-57-17-icon-types.json"
+}

--- a/packages/tsx-editor/scripts/copyTypes.js
+++ b/packages/tsx-editor/scripts/copyTypes.js
@@ -26,7 +26,7 @@ module.exports = function copyTypes() {
 
       // add any other @uifabric packages it references for processing (ignore React imports and other imports)
       const dtsContents = fs.readFileSync(dtsPath).toString();
-      const importRegex = /import .*? from '(@uifabric\/[\w-]+)/gm;
+      const importRegex = /(?:import|export) .*? from ['"](@uifabric\/[\w-]+)/gm;
       let importMatch;
       while ((importMatch = importRegex.exec(dtsContents))) {
         const packageName = importMatch[1];


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

The live editor was missing types for `@uifabric/icons` because they're only re-exported from Fabric (not referenced in any imports), and the script to copy types was missing a check for dependencies that are only re-exported.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10773)