### PR TITLE
Card: Renamed compact prop to horizontal and updated examples and tests accordingly

### DIFF
--- a/apps/vr-tests/src/stories/Card.stories.tsx
+++ b/apps/vr-tests/src/stories/Card.stories.tsx
@@ -100,7 +100,7 @@ const actionButtonStyles: IButtonStyles = {
     fontWeight: FontWeights.semibold
   }
 };
-const footerCompactCardSectionStyles: ICardSectionStyles = {
+const footerHorizontalCardSectionStyles: ICardSectionStyles = {
   root: {
     borderLeft: '1px solid #F3F2F1'
   }
@@ -164,7 +164,7 @@ const addEventButtonTokens: IButtonTokens = {
   textSize: 12,
   textWeight: FontWeights.regular
 };
-const footerCompactCardSectionTokens: ICardSectionTokens = { padding: '0px 0px 0px 12px' };
+const footerHorizontalCardSectionTokens: ICardSectionTokens = { padding: '0px 0px 0px 12px' };
 const cardSectionTokens: ICardSectionTokens = {
   childrenGap: 6,
   padding: 6
@@ -280,27 +280,27 @@ storiesOf('Card', module)
       </Card>
     </Fabric>
   ))
-  .addStory('Compact Card - Basic - Non hoverable', () => (
+  .addStory('Horizontal Card - Basic - Non hoverable', () => (
     <Fabric>
-      <Card compact>
+      <Card horizontal>
         <Card.Item>
-          <Text>Basic compact card</Text>
+          <Text>Basic horizontal card</Text>
         </Card.Item>
       </Card>
     </Fabric>
   ))
-  .addStory('Compact Card - Basic - Hoverable', () => (
+  .addStory('Horizontal Card - Basic - Hoverable', () => (
     <Fabric>
-      <Card compact onClick={cardClicked}>
+      <Card horizontal onClick={cardClicked}>
         <Card.Item>
-          <Text>Basic compact card</Text>
+          <Text>Basic horizontal card</Text>
         </Card.Item>
       </Card>
     </Fabric>
   ))
-  .addStory('Compact Card - Example with contents', () => (
+  .addStory('Horizontal Card - Example with contents', () => (
     <Fabric>
-      <Card compact onClick={cardClicked} tokens={cardTokens}>
+      <Card horizontal onClick={cardClicked} tokens={cardTokens}>
         <Card.Item fill>
           <Image src="https://placehold.it/180x135" alt="Placeholder image." />
         </Card.Item>
@@ -316,8 +316,8 @@ storiesOf('Card', module)
           </Text>
         </Card.Section>
         <Card.Section
-          styles={footerCompactCardSectionStyles}
-          tokens={footerCompactCardSectionTokens}
+          styles={footerHorizontalCardSectionStyles}
+          tokens={footerHorizontalCardSectionTokens}
         >
           <Icon iconName="RedEye" styles={iconStyles} />
           <Icon iconName="SingleBookmark" styles={iconStyles} />

--- a/change/@uifabric-react-cards-2019-10-10-14-37-04-cardHorizontal.json
+++ b/change/@uifabric-react-cards-2019-10-10-14-37-04-cardHorizontal.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Card: Renamed compact prop to horizontal and updated examples and tests accordingly.",
+  "packageName": "@uifabric/react-cards",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "456aebbf657d34609e85800e3d5a8223d454e872",
+  "date": "2019-10-10T21:37:04.526Z",
+  "file": "D:\\office-ui-fabric-react\\change\\@uifabric-react-cards-2019-10-10-14-37-04-cardHorizontal.json"
+}

--- a/change/@uifabric-react-cards-2019-10-10-14-37-04-cardHorizontal.json
+++ b/change/@uifabric-react-cards-2019-10-10-14-37-04-cardHorizontal.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "Card: Renamed compact prop to horizontal and updated examples and tests accordingly.",
   "packageName": "@uifabric/react-cards",
   "email": "Humberto.Morimoto@microsoft.com",

--- a/packages/react-cards/etc/react-cards.api.md
+++ b/packages/react-cards/etc/react-cards.api.md
@@ -75,7 +75,7 @@ export interface ICardItemViewProps extends ICardItemProps {
 
 // @public (undocumented)
 export interface ICardProps extends ICardSlots, IStyleableComponentProps<ICardProps, ICardTokens, ICardStyles>, IBaseProps<ICard>, React.AllHTMLAttributes<HTMLElement> {
-    compact?: boolean;
+    horizontal?: boolean;
     onClick?: (ev: React.MouseEvent<HTMLElement>) => void;
 }
 

--- a/packages/react-cards/src/components/Card/Card.doc.tsx
+++ b/packages/react-cards/src/components/Card/Card.doc.tsx
@@ -3,11 +3,11 @@ import * as React from 'react';
 import { IDocPageProps } from 'office-ui-fabric-react/lib/common/DocPage.types';
 
 import { CardVerticalExample } from './examples/Card.Vertical.Example';
-import { CardCompactExample } from './examples/Card.Compact.Example';
+import { CardHorizontalExample } from './examples/Card.Horizontal.Example';
 import { CardConfigureExample } from './examples/Card.Configure.Example';
 
 const CardVerticalExampleCode = require('!raw-loader!@uifabric/react-cards/src/components/Card/examples/Card.Vertical.Example.tsx') as string;
-const CardCompactExampleCode = require('!raw-loader!@uifabric/react-cards/src/components/Card/examples/Card.Compact.Example.tsx') as string;
+const CardHorizontalExampleCode = require('!raw-loader!@uifabric/react-cards/src/components/Card/examples/Card.Horizontal.Example.tsx') as string;
 const CardConfigureExampleCode = require('!raw-loader!@uifabric/react-cards/src/components/Card/examples/Card.Configure.Example.tsx') as string;
 
 export const CardPageProps: IDocPageProps = {
@@ -21,9 +21,9 @@ export const CardPageProps: IDocPageProps = {
       view: <CardVerticalExample />
     },
     {
-      title: 'Compact Card',
-      code: CardCompactExampleCode,
-      view: <CardCompactExample />
+      title: 'Horizontal Card',
+      code: CardHorizontalExampleCode,
+      view: <CardHorizontalExample />
     },
     {
       title: 'Configure Properties',

--- a/packages/react-cards/src/components/Card/Card.styles.ts
+++ b/packages/react-cards/src/components/Card/Card.styles.ts
@@ -21,7 +21,7 @@ const baseTokens: ICardComponent['tokens'] = (props, theme) => {
   };
 };
 
-const compactTokens: ICardComponent['tokens'] = {
+const horizontalTokens: ICardComponent['tokens'] = {
   height: 'auto',
   minWidth: '300px',
   maxWidth: '500px'
@@ -39,7 +39,7 @@ const clickableTokens: ICardComponent['tokens'] = (props, theme) => {
 
 export const CardTokens: ICardComponent['tokens'] = (props, theme): ICardTokenReturnType => [
   baseTokens,
-  props.compact && compactTokens,
+  props.horizontal && horizontalTokens,
   props.onClick && clickableTokens
 ];
 

--- a/packages/react-cards/src/components/Card/Card.types.ts
+++ b/packages/react-cards/src/components/Card/Card.types.ts
@@ -46,10 +46,10 @@ export interface ICardProps
     IBaseProps<ICard>,
     React.AllHTMLAttributes<HTMLElement> {
   /**
-   * Defines whether to render a regular or a compact Card.
+   * Defines whether to render a vertical or a horizontal Card.
    * @defaultvalue false
    */
-  compact?: boolean;
+  horizontal?: boolean;
 
   /**
    * Defines a callback that is called when the Card is clicked.

--- a/packages/react-cards/src/components/Card/Card.view.test.tsx
+++ b/packages/react-cards/src/components/Card/Card.view.test.tsx
@@ -14,8 +14,8 @@ describe('CardView', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders a Compact Card without contents correctly', () => {
-    const tree = renderer.create(<CardView compact />).toJSON();
+  it('renders a Horizontal Card without contents correctly', () => {
+    const tree = renderer.create(<CardView horizontal />).toJSON();
     expect(tree).toMatchSnapshot();
   });
 
@@ -32,10 +32,10 @@ describe('CardView', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders a Compact Card with contents correctly', () => {
+  it('renders a Horizontal Card with contents correctly', () => {
     const tree = renderer
       .create(
-        <CardView compact>
+        <CardView horizontal>
           <CardItem>This is some content 1</CardItem>
           <CardItem>This is some content 2</CardItem>
           <CardItem>This is some content 3</CardItem>
@@ -56,10 +56,10 @@ describe('CardView', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders a Compact Card with an onClick function specified correctly', () => {
+  it('renders a Horizontal Card with an onClick function specified correctly', () => {
     const tree = renderer
       .create(
-        <CardView compact onClick={alertClicked}>
+        <CardView horizontal onClick={alertClicked}>
           <CardItem>This is some content 1</CardItem>
         </CardView>
       )

--- a/packages/react-cards/src/components/Card/Card.view.tsx
+++ b/packages/react-cards/src/components/Card/Card.view.tsx
@@ -15,7 +15,7 @@ export const CardView: ICardComponent['view'] = props => {
     root: Stack
   });
 
-  const { children, styles, tokens, compact, ...rest } = props;
+  const { children, styles, tokens, horizontal, ...rest } = props;
 
   const nativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(rest, htmlElementProperties);
 
@@ -48,7 +48,7 @@ export const CardView: ICardComponent['view'] = props => {
         let margin: number | string = 0;
 
         /* If childrenMargin has been specified and the fill property is not present, make the appropriate calculations to get the resolved
-         * margin for this specific child depending on the type of Card (vertical vs compact) and the child position in the card (first
+         * margin for this specific child depending on the type of Card (vertical vs horizontal) and the child position in the card (first
          * child, in-between child or last child). */
         if (childrenMargin && !fill) {
           const firstMargin: number = index === 0 ? childrenMargin : 0;
@@ -57,7 +57,7 @@ export const CardView: ICardComponent['view'] = props => {
           const verticalMargin: string = `${firstMargin}px ${childrenMargin}px ${lastMargin}px`;
           const horizontalMargin: string = `${childrenMargin}px ${lastMargin}px ${childrenMargin}px ${firstMargin}px`;
 
-          margin = compact ? horizontalMargin : verticalMargin;
+          margin = horizontal ? horizontalMargin : verticalMargin;
         }
 
         /* Resolve tokens, sending childrenGap only if the child type is CardSection as CardItem doesn't have a childrenGap token in its
@@ -85,11 +85,11 @@ export const CardView: ICardComponent['view'] = props => {
   return (
     <Slots.root
       {...nativeProps}
-      horizontal={compact}
+      horizontal={horizontal}
       tokens={tokens as IStackComponent['tokens']}
       verticalFill
       verticalAlign="start"
-      horizontalAlign={compact ? 'start' : 'stretch'}
+      horizontalAlign={horizontal ? 'start' : 'stretch'}
     >
       {cardChildren}
     </Slots.root>

--- a/packages/react-cards/src/components/Card/CardItem/CardItem.test.tsx
+++ b/packages/react-cards/src/components/Card/CardItem/CardItem.test.tsx
@@ -112,10 +112,10 @@ describe('Card Item', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders correctly when filling up the margins while being the only item in a Compact Card', () => {
+  it('renders correctly when filling up the margins while being the only item in a Horizontal Card', () => {
     const tree = renderer
       .create(
-        <Card compact tokens={{ childrenMargin: 12 }}>
+        <Card horizontal tokens={{ childrenMargin: 12 }}>
           <Card.Item fill>
             <div />
           </Card.Item>
@@ -126,30 +126,10 @@ describe('Card Item', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders correctly when filling up the margins while being the first item in a Compact Card', () => {
+  it('renders correctly when filling up the margins while being the first item in a Horizontal Card', () => {
     const tree = renderer
       .create(
-        <Card compact tokens={{ childrenMargin: 12 }}>
-          <Card.Item fill>
-            <div />
-          </Card.Item>
-          <Card.Item>
-            <div />
-          </Card.Item>
-        </Card>
-      )
-      .toJSON();
-
-    expect(tree).toMatchSnapshot();
-  });
-
-  it('renders correctly when filling up the margins while being the middle item in a Compact Card', () => {
-    const tree = renderer
-      .create(
-        <Card compact tokens={{ childrenMargin: 12 }}>
-          <Card.Item>
-            <div />
-          </Card.Item>
+        <Card horizontal tokens={{ childrenMargin: 12 }}>
           <Card.Item fill>
             <div />
           </Card.Item>
@@ -163,10 +143,30 @@ describe('Card Item', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders correctly when filling up the margins while being the last item in a Compact Card', () => {
+  it('renders correctly when filling up the margins while being the middle item in a Horizontal Card', () => {
     const tree = renderer
       .create(
-        <Card compact tokens={{ childrenMargin: 12 }}>
+        <Card horizontal tokens={{ childrenMargin: 12 }}>
+          <Card.Item>
+            <div />
+          </Card.Item>
+          <Card.Item fill>
+            <div />
+          </Card.Item>
+          <Card.Item>
+            <div />
+          </Card.Item>
+        </Card>
+      )
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders correctly when filling up the margins while being the last item in a Horizontal Card', () => {
+    const tree = renderer
+      .create(
+        <Card horizontal tokens={{ childrenMargin: 12 }}>
           <Card.Item>
             <div />
           </Card.Item>

--- a/packages/react-cards/src/components/Card/CardItem/__snapshots__/CardItem.test.tsx.snap
+++ b/packages/react-cards/src/components/Card/CardItem/__snapshots__/CardItem.test.tsx.snap
@@ -62,7 +62,7 @@ exports[`Card Item renders correctly 1`] = `
 </div>
 `;
 
-exports[`Card Item renders correctly when filling up the margins while being the first item in a Compact Card 1`] = `
+exports[`Card Item renders correctly when filling up the margins while being the first item in a Horizontal Card 1`] = `
 <div
   className=
       ms-Stack
@@ -236,7 +236,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
 </div>
 `;
 
-exports[`Card Item renders correctly when filling up the margins while being the last item in a Compact Card 1`] = `
+exports[`Card Item renders correctly when filling up the margins while being the last item in a Horizontal Card 1`] = `
 <div
   className=
       ms-Stack
@@ -410,7 +410,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
 </div>
 `;
 
-exports[`Card Item renders correctly when filling up the margins while being the middle item in a Compact Card 1`] = `
+exports[`Card Item renders correctly when filling up the margins while being the middle item in a Horizontal Card 1`] = `
 <div
   className=
       ms-Stack
@@ -634,7 +634,7 @@ exports[`Card Item renders correctly when filling up the margins while being the
 </div>
 `;
 
-exports[`Card Item renders correctly when filling up the margins while being the only item in a Compact Card 1`] = `
+exports[`Card Item renders correctly when filling up the margins while being the only item in a Horizontal Card 1`] = `
 <div
   className=
       ms-Stack

--- a/packages/react-cards/src/components/Card/CardPage.tsx
+++ b/packages/react-cards/src/components/Card/CardPage.tsx
@@ -4,8 +4,8 @@ import { ExampleCard, IComponentDemoPageProps, ComponentPage, Markdown, Properti
 import { CardVerticalExample } from './examples/Card.Vertical.Example';
 const CardVerticalExampleCode = require('!raw-loader!@uifabric/react-cards/src/components/Card/examples/Card.Vertical.Example.tsx') as string;
 
-import { CardCompactExample } from './examples/Card.Compact.Example';
-const CardCompactExampleCode = require('!raw-loader!@uifabric/react-cards/src/components/Card/examples/Card.Compact.Example.tsx') as string;
+import { CardHorizontalExample } from './examples/Card.Horizontal.Example';
+const CardHorizontalExampleCode = require('!raw-loader!@uifabric/react-cards/src/components/Card/examples/Card.Horizontal.Example.tsx') as string;
 
 import { CardConfigureExample } from './examples/Card.Configure.Example';
 const CardConfigureExampleCode = require('!raw-loader!@uifabric/react-cards/src/components/Card/examples/Card.Configure.Example.tsx') as string;
@@ -21,8 +21,8 @@ export class CardPage extends React.Component<IComponentDemoPageProps, {}> {
             <ExampleCard title="Vertical Card" code={CardVerticalExampleCode}>
               <CardVerticalExample />
             </ExampleCard>
-            <ExampleCard title="Compact Card" code={CardCompactExampleCode}>
-              <CardCompactExample />
+            <ExampleCard title="Horizontal Card" code={CardHorizontalExampleCode}>
+              <CardHorizontalExample />
             </ExampleCard>
             <ExampleCard title="Configure Properties" code={CardConfigureExampleCode}>
               <CardConfigureExample />

--- a/packages/react-cards/src/components/Card/CardSection/CardSection.test.tsx
+++ b/packages/react-cards/src/components/Card/CardSection/CardSection.test.tsx
@@ -112,10 +112,10 @@ describe('Card Section', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders correctly when filling up the margins while being the only section in a Compact Card', () => {
+  it('renders correctly when filling up the margins while being the only section in a Horizontal Card', () => {
     const tree = renderer
       .create(
-        <Card compact tokens={{ childrenMargin: 12 }}>
+        <Card horizontal tokens={{ childrenMargin: 12 }}>
           <Card.Section fill>
             <div />
           </Card.Section>
@@ -126,30 +126,10 @@ describe('Card Section', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders correctly when filling up the margins while being the first section in a Compact Card', () => {
+  it('renders correctly when filling up the margins while being the first section in a Horizontal Card', () => {
     const tree = renderer
       .create(
-        <Card compact tokens={{ childrenMargin: 12 }}>
-          <Card.Section fill>
-            <div />
-          </Card.Section>
-          <Card.Section>
-            <div />
-          </Card.Section>
-        </Card>
-      )
-      .toJSON();
-
-    expect(tree).toMatchSnapshot();
-  });
-
-  it('renders correctly when filling up the margins while being the middle section in a Compact Card', () => {
-    const tree = renderer
-      .create(
-        <Card compact tokens={{ childrenMargin: 12 }}>
-          <Card.Section>
-            <div />
-          </Card.Section>
+        <Card horizontal tokens={{ childrenMargin: 12 }}>
           <Card.Section fill>
             <div />
           </Card.Section>
@@ -163,10 +143,30 @@ describe('Card Section', () => {
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders correctly when filling up the margins while being the last section in a Compact Card', () => {
+  it('renders correctly when filling up the margins while being the middle section in a Horizontal Card', () => {
     const tree = renderer
       .create(
-        <Card compact tokens={{ childrenMargin: 12 }}>
+        <Card horizontal tokens={{ childrenMargin: 12 }}>
+          <Card.Section>
+            <div />
+          </Card.Section>
+          <Card.Section fill>
+            <div />
+          </Card.Section>
+          <Card.Section>
+            <div />
+          </Card.Section>
+        </Card>
+      )
+      .toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders correctly when filling up the margins while being the last section in a Horizontal Card', () => {
+    const tree = renderer
+      .create(
+        <Card horizontal tokens={{ childrenMargin: 12 }}>
           <Card.Section>
             <div />
           </Card.Section>

--- a/packages/react-cards/src/components/Card/CardSection/__snapshots__/CardSection.test.tsx.snap
+++ b/packages/react-cards/src/components/Card/CardSection/__snapshots__/CardSection.test.tsx.snap
@@ -74,7 +74,7 @@ exports[`Card Section renders correctly 1`] = `
 </div>
 `;
 
-exports[`Card Section renders correctly when filling up the margins while being the first section in a Compact Card 1`] = `
+exports[`Card Section renders correctly when filling up the margins while being the first section in a Horizontal Card 1`] = `
 <div
   className=
       ms-Stack
@@ -296,7 +296,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
 </div>
 `;
 
-exports[`Card Section renders correctly when filling up the margins while being the last section in a Compact Card 1`] = `
+exports[`Card Section renders correctly when filling up the margins while being the last section in a Horizontal Card 1`] = `
 <div
   className=
       ms-Stack
@@ -518,7 +518,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
 </div>
 `;
 
-exports[`Card Section renders correctly when filling up the margins while being the middle section in a Compact Card 1`] = `
+exports[`Card Section renders correctly when filling up the margins while being the middle section in a Horizontal Card 1`] = `
 <div
   className=
       ms-Stack
@@ -814,7 +814,7 @@ exports[`Card Section renders correctly when filling up the margins while being 
 </div>
 `;
 
-exports[`Card Section renders correctly when filling up the margins while being the only section in a Compact Card 1`] = `
+exports[`Card Section renders correctly when filling up the margins while being the only section in a Horizontal Card 1`] = `
 <div
   className=
       ms-Stack

--- a/packages/react-cards/src/components/Card/__snapshots__/Card.view.test.tsx.snap
+++ b/packages/react-cards/src/components/Card/__snapshots__/Card.view.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CardView renders a Compact Card with an onClick function specified correctly 1`] = `
+exports[`CardView renders a Horizontal Card with an onClick function specified correctly 1`] = `
 <div
   className=
       ms-Stack
@@ -49,7 +49,7 @@ exports[`CardView renders a Compact Card with an onClick function specified corr
 </div>
 `;
 
-exports[`CardView renders a Compact Card with contents correctly 1`] = `
+exports[`CardView renders a Horizontal Card with contents correctly 1`] = `
 <div
   className=
       ms-Stack
@@ -139,7 +139,7 @@ exports[`CardView renders a Compact Card with contents correctly 1`] = `
 </div>
 `;
 
-exports[`CardView renders a Compact Card without contents correctly 1`] = `
+exports[`CardView renders a Horizontal Card without contents correctly 1`] = `
 <div
   className=
       ms-Stack

--- a/packages/react-cards/src/components/Card/examples/Card.Horizontal.Example.tsx
+++ b/packages/react-cards/src/components/Card/examples/Card.Horizontal.Example.tsx
@@ -7,7 +7,7 @@ import { Icon, IIconStyles, Image, Stack, IStackTokens, Text, ITextStyles } from
 const alertClicked = (): void => {
   alert('Clicked');
 };
-export class CardCompactExample extends React.Component<{}, {}> {
+export class CardHorizontalExample extends React.Component<{}, {}> {
   public render(): JSX.Element {
     const siteTextStyles: ITextStyles = {
       root: {
@@ -46,13 +46,13 @@ export class CardCompactExample extends React.Component<{}, {}> {
 
     return (
       <Stack tokens={sectionStackTokens}>
-        <Card compact tokens={cardTokens}>
+        <Card horizontal tokens={cardTokens}>
           <Card.Item>
-            <Text>Basic compact card</Text>
+            <Text>Basic horizontal card</Text>
           </Card.Item>
         </Card>
 
-        <Card compact onClick={alertClicked} tokens={cardTokens}>
+        <Card horizontal onClick={alertClicked} tokens={cardTokens}>
           <Card.Item fill>
             <Image src="https://placehold.it/180x135" alt="Placeholder image." />
           </Card.Item>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

One of the biggest pieces of feedback that was received when we did the `Card` hackathon some time ago was to rename the `compact` prop to `horizontal` as it made more sense from an API perspective. This PR takes care of that while also updating examples and tests.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10786)