### PR TITLE
SpinButton: Fixing minWidth and having it come from const to be consistent

### DIFF
--- a/change/office-ui-fabric-react-2019-10-10-17-28-29-spinButtonMinWidth.json
+++ b/change/office-ui-fabric-react-2019-10-10-17-28-29-spinButtonMinWidth.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "SpinButton: Fixing minWidth and having it come from const to be consistent.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "e02e44d4313b45a7666346f12b7654db136ede13",
+  "date": "2019-10-11T00:28:29.652Z",
+  "file": "E:\\office-ui-fabric-react\\change\\office-ui-fabric-react-2019-10-10-17-28-29-spinButtonMinWidth.json"
+}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.styles.ts
@@ -6,6 +6,7 @@ import { memoizeFunction } from '../../Utilities';
 const ARROW_BUTTON_WIDTH = 23;
 const ARROW_BUTTON_ICON_SIZE = 8;
 const DEFAULT_HEIGHT = 32;
+const DEFAULT_MIN_WIDTH = 86;
 const LABEL_MARGIN = 10;
 
 const _getDisabledStyles = memoizeFunction(
@@ -136,7 +137,7 @@ export const getStyles = memoizeFunction(
         outline: 'none',
         fontSize: fonts.medium.fontSize,
         width: '100%',
-        minWidth: 86
+        minWidth: DEFAULT_MIN_WIDTH
       },
       labelWrapper: {
         display: 'inline-flex'
@@ -172,7 +173,7 @@ export const getStyles = memoizeFunction(
         display: 'flex',
         boxSizing: 'border-box',
         height: DEFAULT_HEIGHT,
-        minWidth: 86,
+        minWidth: DEFAULT_MIN_WIDTH,
         border: `1px solid ${SpinButtonRootBorderColor}`,
         borderRadius: effects.roundedCorner2
       },
@@ -208,7 +209,7 @@ export const getStyles = memoizeFunction(
         padding: '0 8px',
         outline: 0,
         display: 'block',
-        minWidth: 72,
+        minWidth: DEFAULT_MIN_WIDTH - ARROW_BUTTON_WIDTH - 2,
         whiteSpace: 'nowrap',
         textOverflow: 'ellipsis',
         overflow: 'hidden',

--- a/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
@@ -96,7 +96,7 @@ exports[`SpinButton renders SpinButton correctly 1`] = `
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;
-            min-width: 72px;
+            min-width: 61px;
             outline: 0px;
             overflow: hidden;
             padding-bottom: 0;
@@ -516,7 +516,7 @@ exports[`SpinButton renders SpinButton correctly with values that the user passe
             margin-left: 0px;
             margin-right: 0px;
             margin-top: 0px;
-            min-width: 72px;
+            min-width: 61px;
             outline: 0px;
             overflow: hidden;
             padding-bottom: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -669,7 +669,7 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                       margin-left: 0px;
                       margin-right: 0px;
                       margin-top: 0px;
-                      min-width: 72px;
+                      min-width: 61px;
                       outline: 0px;
                       overflow: hidden;
                       padding-bottom: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Basic.Example.tsx.shot
@@ -125,7 +125,7 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
-              min-width: 72px;
+              min-width: 61px;
               outline: 0px;
               overflow: hidden;
               padding-bottom: 0;
@@ -543,7 +543,7 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
-              min-width: 72px;
+              min-width: 61px;
               outline: 0px;
               overflow: hidden;
               padding-bottom: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
@@ -110,7 +110,7 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
-              min-width: 72px;
+              min-width: 61px;
               outline: 0px;
               overflow: hidden;
               padding-bottom: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithEndPosition.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithEndPosition.Example.tsx.shot
@@ -125,7 +125,7 @@ exports[`Component Examples renders SpinButton.BasicWithEndPosition.Example.tsx 
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
-              min-width: 72px;
+              min-width: 61px;
               outline: 0px;
               overflow: hidden;
               padding-bottom: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIcon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIcon.Example.tsx.shot
@@ -125,7 +125,7 @@ exports[`Component Examples renders SpinButton.BasicWithIcon.Example.tsx correct
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
-              min-width: 72px;
+              min-width: 61px;
               outline: 0px;
               overflow: hidden;
               padding-bottom: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
@@ -133,7 +133,7 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
-              min-width: 72px;
+              min-width: 61px;
               outline: 0px;
               overflow: hidden;
               padding-bottom: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.CustomStyled.Example.tsx.shot
@@ -97,7 +97,7 @@ exports[`Component Examples renders SpinButton.CustomStyled.Example.tsx correctl
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
-              min-width: 72px;
+              min-width: 61px;
               outline: 0px;
               overflow: hidden;
               padding-bottom: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Stateful.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Stateful.Example.tsx.shot
@@ -103,7 +103,7 @@ exports[`Component Examples renders SpinButton.Stateful.Example.tsx correctly 1`
               margin-left: 0px;
               margin-right: 0px;
               margin-top: 0px;
-              min-width: 72px;
+              min-width: 61px;
               outline: 0px;
               overflow: hidden;
               padding-bottom: 0;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10699
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Issue #10699 made it clear that the styling of `minWidths` in the `SpinButton` component was screwing up the component styling when you used a `width` less than what the original `minWidth` was. This PR fixes that issue while at the same time making all style values come from a `const` value and not hardcoded values to preserve consistency.

The main problem here was that `minWidths` were not being calculated in regards to one another, so, when a user specified `widths` that went below the `minWidth`, the parts of the `SpinButton` didn't align anymore.

__Before:__
![image](https://user-images.githubusercontent.com/7798177/66684834-cc7ef080-ec2f-11e9-9556-fab404d4745d.png)

__After:__
![image](https://user-images.githubusercontent.com/7798177/66684845-d30d6800-ec2f-11e9-8009-0ec1c1480c56.png)


#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10788)