### PR TITLE
Theme Designer: A11y DetailsList rows should be accessible. 

### DIFF
--- a/apps/theming-designer/src/components/AccessibilityDetailsList.tsx
+++ b/apps/theming-designer/src/components/AccessibilityDetailsList.tsx
@@ -39,15 +39,8 @@ export const AccessibilityDetailsList: React.StatelessComponent<IAccessibilityDe
   const onRenderRow = (detailsRowProps: IDetailsRowProps | undefined): JSX.Element => {
     // Set each row's background and text color to what's specified by its respective slot rule
     if (detailsRowProps && newTheme) {
-      const currentSlotPair = detailsRowProps!.item.slotPair;
-      const pairSplit = currentSlotPair.split(' on ');
-      const currForegroundColor = pairSplit[0];
-      const currBackgroundColor = pairSplit[1];
-
       const rowStyles: Partial<IDetailsRowStyles> = {
         root: {
-          backgroundColor: (newTheme!.palette as any)[currBackgroundColor],
-          color: (newTheme!.palette as any)[currForegroundColor],
           selectors: {
             ':hover': {
               background: 'transparent'


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Right now, the rows of the accessibility details list in the theme designer reflect the foreground and background colors the user chooses but when they have poor color contrast, the rows themselves become inaccessible so removing that styling.

I looked into making another column and individually styling just that one to display to poor color contrast. I thought I could style `<DetailsColumn>` the same way I styled the rows with passing in custom `rowStyles` to create `<DetailsRow>` - I planned on using `IDetailsColumnProps` to get the current slot pair as I do with [`IDetailsRowProps`](https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts#L97). Unfortunately, [`IDetailsColumnProps`](https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.types.ts#L13) doesn't have an `item` prop which I need to get the current slotPair (and thus the correct foreground and background color) and neither `IDetailsColumnStyles` nor `IDetailsColumnStyleProps` have a direct color prop in them either. 

I also looked into using `cellStyleProps` but [this interface](https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.types.ts#L262) doesn't have a color option.

#### Focus areas to test

![image](https://user-images.githubusercontent.com/4161791/66690946-30adae80-ec48-11e9-90bf-f3138a33edf0.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10799)