### PR TITLE
Fix controlled panel example close button

### DIFF
--- a/change/office-ui-fabric-react-2019-10-14-10-32-08-panel-close.json
+++ b/change/office-ui-fabric-react-2019-10-14-10-32-08-panel-close.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Panel: hide close button for controlled example since it doesn't work",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "commit": "e2fd56e9add58c50ea37ad03c557488b393901b0",
+  "date": "2019-10-14T17:32:08.681Z",
+  "file": "/Users/elizabeth/git/fabric-react4/change/office-ui-fabric-react-2019-10-14-10-32-08-panel-close.json"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Controlled.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Controlled.Example.tsx
@@ -15,7 +15,13 @@ export class PanelControlledExample extends React.Component<{}, IPanelMediumExam
     return (
       <div>
         <DefaultButton secondaryText="Opens the Sample Panel" onClick={this._showPanel} text="Open Panel" />
-        <Panel isOpen={this.state.showPanel} closeButtonAriaLabel="Close" type={PanelType.medium} headerText="Controlled Panel">
+        <Panel
+          isOpen={this.state.showPanel}
+          // The close button won't work on this panel, so it shouldn't be shown
+          hasCloseButton={false}
+          type={PanelType.medium}
+          headerText="Controlled Panel"
+        >
           <p>
             Because <code>isOpen</code> is specified and <code>onDismiss</code> does not modify the example's <code>state</code>, clicking
             the button below is the only way to close this Panel.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10781
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The "Controlled visibility" panel example can only be closed by pressing a dismiss button inside the panel body. Therefore, the non-working normal close button shouldn't be shown.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10805)