### PR TITLE
Announced: add `as` prop and root styles

### DIFF
--- a/change/office-ui-fabric-react-2019-10-14-17-36-33-announced.json
+++ b/change/office-ui-fabric-react-2019-10-14-17-36-33-announced.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Announced: add `as` prop and root styles",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "commit": "2e4ea58e204193827ff747b0c661e1ac0701577f",
+  "date": "2019-10-15T00:36:33.041Z",
+  "file": "/Users/elizabeth/git/fabric-react4/change/office-ui-fabric-react-2019-10-14-17-36-33-announced.json"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1513,12 +1513,17 @@ export interface IActivityItemStyles {
 // @public (undocumented)
 export interface IAnnouncedProps extends React.Props<AnnouncedBase>, React.HTMLAttributes<HTMLDivElement> {
     'aria-live'?: 'off' | 'polite' | 'assertive';
+    as?: React.ElementType;
     message?: string;
     styles?: IStyleFunctionOrObject<{}, IAnnouncedStyles>;
 }
 
 // @public (undocumented)
+export type IAnnouncedStyleProps = Pick<IAnnouncedProps, 'className'>;
+
+// @public (undocumented)
 export interface IAnnouncedStyles {
+    root: IStyle;
     screenReaderText: IStyle;
 }
 

--- a/packages/office-ui-fabric-react/src/components/Announced/Announced.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Announced/Announced.base.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { DelayedRender, classNamesFunction, getNativeProps, divProperties } from '../../Utilities';
-import { IProcessedStyleSet } from '../../Styling';
 import { IAnnouncedProps, IAnnouncedStyles } from './Announced.types';
 
 const getClassNames = classNamesFunction<{}, IAnnouncedStyles>();
@@ -13,17 +12,15 @@ export class AnnouncedBase extends React.Component<IAnnouncedProps> {
     'aria-live': 'polite'
   };
 
-  private _classNames: IProcessedStyleSet<IAnnouncedStyles>;
-
   public render(): JSX.Element {
-    const { message, styles, as: Root = 'div' } = this.props;
+    const { message, styles, as: Root = 'div', className } = this.props;
 
-    this._classNames = getClassNames(styles);
+    const classNames = getClassNames(styles, { className });
 
     return (
-      <Root role="status" {...getNativeProps(this.props, divProperties)}>
+      <Root role="status" className={classNames.root} {...getNativeProps(this.props, divProperties, ['className'])}>
         <DelayedRender>
-          <div className={this._classNames.screenReaderText}>{message}</div>
+          <div className={classNames.screenReaderText}>{message}</div>
         </DelayedRender>
       </Root>
     );

--- a/packages/office-ui-fabric-react/src/components/Announced/Announced.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Announced/Announced.base.tsx
@@ -16,16 +16,16 @@ export class AnnouncedBase extends React.Component<IAnnouncedProps> {
   private _classNames: IProcessedStyleSet<IAnnouncedStyles>;
 
   public render(): JSX.Element {
-    const { message, styles } = this.props;
+    const { message, styles, as: Root = 'div' } = this.props;
 
     this._classNames = getClassNames(styles);
 
     return (
-      <div role="status" {...getNativeProps(this.props, divProperties)}>
+      <Root role="status" {...getNativeProps(this.props, divProperties)}>
         <DelayedRender>
           <div className={this._classNames.screenReaderText}>{message}</div>
         </DelayedRender>
-      </div>
+      </Root>
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/Announced/Announced.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Announced/Announced.styles.ts
@@ -1,9 +1,10 @@
 import { hiddenContentStyle } from '../../Styling';
-import { IAnnouncedStyles } from './Announced.types';
+import { IStyleFunction } from '../../Utilities';
+import { IAnnouncedStyles, IAnnouncedStyleProps } from './Announced.types';
 
-export const getStyles = (): IAnnouncedStyles => {
+export const getStyles: IStyleFunction<IAnnouncedStyleProps, IAnnouncedStyles> = props => {
   return {
-    root: {},
+    root: props.className,
     screenReaderText: hiddenContentStyle
   };
 };

--- a/packages/office-ui-fabric-react/src/components/Announced/Announced.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Announced/Announced.styles.ts
@@ -3,6 +3,7 @@ import { IAnnouncedStyles } from './Announced.types';
 
 export const getStyles = (): IAnnouncedStyles => {
   return {
+    root: {},
     screenReaderText: hiddenContentStyle
   };
 };

--- a/packages/office-ui-fabric-react/src/components/Announced/Announced.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Announced/Announced.test.tsx
@@ -1,0 +1,87 @@
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+import { mount, ReactWrapper } from 'enzyme';
+
+import { Announced } from './Announced';
+
+describe('Announced', () => {
+  let component: renderer.ReactTestRenderer | undefined;
+  let wrapper: ReactWrapper | undefined;
+
+  afterEach(() => {
+    jest.useRealTimers();
+    if (component) {
+      component.unmount();
+      component = undefined;
+    }
+    if (wrapper) {
+      wrapper.unmount();
+      wrapper = undefined;
+    }
+  });
+
+  it('does not initially render message', () => {
+    component = renderer.create(<Announced message="hello" />);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders message after delay', () => {
+    jest.useFakeTimers();
+    component = renderer.create(<Announced message="hello" />);
+    jest.runAllTimers();
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders with default settings', () => {
+    wrapper = mount(<Announced message="hello" />);
+    const element = wrapper.getDOMNode() as HTMLElement;
+    expect(element.tagName).toBe('DIV');
+    expect(element.getAttribute('role')).toBe('status');
+    expect(element.getAttribute('aria-live')).toBe('polite');
+  });
+
+  it('delay renders message', () => {
+    jest.useFakeTimers();
+    wrapper = mount(<Announced message="hello" />);
+    expect(wrapper.text()).toBeFalsy();
+
+    jest.runAllTimers();
+    expect(wrapper.text()).toBe('hello');
+  });
+
+  it('renders as custom tag', () => {
+    jest.useFakeTimers();
+    wrapper = mount(<Announced as="span" message="hello" />);
+    expect(wrapper.getDOMNode().tagName).toBe('SPAN');
+
+    jest.runAllTimers();
+    expect(wrapper.text()).toBe('hello'); // still renders children
+  });
+
+  it('can change aria-live', () => {
+    wrapper = mount(<Announced aria-live="assertive" message="hello" />);
+    expect(wrapper.getDOMNode().getAttribute('aria-live')).toBe('assertive');
+  });
+
+  it('can change styles', () => {
+    jest.useFakeTimers();
+    wrapper = mount(
+      <Announced
+        message="hello"
+        className="rootclass1"
+        styles={{
+          root: 'rootclass2',
+          screenReaderText: 'textclass'
+        }}
+      />
+    );
+    jest.runAllTimers();
+
+    const element = wrapper.getDOMNode();
+    expect(element.className).toContain('rootclass1');
+    expect(element.className).toContain('rootclass2');
+    expect(element.firstElementChild!.className).toContain('textclass');
+  });
+});

--- a/packages/office-ui-fabric-react/src/components/Announced/Announced.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Announced/Announced.types.ts
@@ -7,9 +7,6 @@ import { IStyleFunctionOrObject } from '../../Utilities';
  * {@docCategory Announced}
  */
 export interface IAnnouncedProps extends React.Props<AnnouncedBase>, React.HTMLAttributes<HTMLDivElement> {
-  /** Call to provide customized styling that will layer on top of the variant rules. */
-  styles?: IStyleFunctionOrObject<{}, IAnnouncedStyles>;
-
   /**
    * The status message provided as screen reader output
    */
@@ -20,12 +17,27 @@ export interface IAnnouncedProps extends React.Props<AnnouncedBase>, React.HTMLA
    * @default 'polite'
    */
   'aria-live'?: 'off' | 'polite' | 'assertive';
+
+  /**
+   * Optionally render the root of this component as another component type or primitive.
+   * The custom type **must** preserve any children or native props passed in.
+   * @default 'div'
+   */
+  as?: React.ElementType;
+
+  /** Call to provide customized styling that will layer on top of the variant rules. */
+  styles?: IStyleFunctionOrObject<{}, IAnnouncedStyles>;
 }
 
 /**
  * {@docCategory Announced}
  */
 export interface IAnnouncedStyles {
+  /**
+   * Style override for the root element.
+   */
+  root: IStyle;
+
   /**
    * Style override for the screen reader text.
    */

--- a/packages/office-ui-fabric-react/src/components/Announced/Announced.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Announced/Announced.types.ts
@@ -32,6 +32,11 @@ export interface IAnnouncedProps extends React.Props<AnnouncedBase>, React.HTMLA
 /**
  * {@docCategory Announced}
  */
+export type IAnnouncedStyleProps = Pick<IAnnouncedProps, 'className'>;
+
+/**
+ * {@docCategory Announced}
+ */
 export interface IAnnouncedStyles {
   /**
    * Style override for the root element.

--- a/packages/office-ui-fabric-react/src/components/Announced/__snapshots__/Announced.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Announced/__snapshots__/Announced.test.tsx.snap
@@ -1,0 +1,43 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Announced does not initially render message 1`] = `
+<div
+  aria-live="polite"
+  className=
+
+
+  role="status"
+/>
+`;
+
+exports[`Announced renders message after delay 1`] = `
+<div
+  aria-live="polite"
+  className=
+
+
+  role="status"
+>
+  <div
+    className=
+
+        {
+          border: 0px;
+          height: 1px;
+          margin-bottom: -1px;
+          margin-left: -1px;
+          margin-right: -1px;
+          margin-top: -1px;
+          overflow: hidden;
+          padding-bottom: 0px;
+          padding-left: 0px;
+          padding-right: 0px;
+          padding-top: 0px;
+          position: absolute;
+          width: 1px;
+        }
+  >
+    hello
+  </div>
+</div>
+`;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10743
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Currently Announced is always rendered as a `div`, and there's not an idiomatic way to make it render as an `inline-block` element. This PR adds two ways to do that:
1. `styles.root` for styling the root element
2. an `as` prop so the root element can be rendered as anything (such as a `span`)

I definitely think adding `styles.root` makes sense (matches most of our other components), but I'm less certain about adding `as`. Either approach could solve the issue which prompted this PR.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10812)