### PR TITLE
SpinButton: allow passing data attributes

### DIFF
--- a/change/office-ui-fabric-react-2019-10-14-20-01-21-bug-fix-attribute-passing.json
+++ b/change/office-ui-fabric-react-2019-10-14-20-01-21-bug-fix-attribute-passing.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "pass native props for SpinButton",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "6f96ceaaa0fae594e57e6dea6f2b03f531439bcf",
+  "date": "2019-10-15T03:01:21.461Z",
+  "file": "/Users/xugao/Projects/office-ui-fabric-react/change/office-ui-fabric-react-2019-10-14-20-01-21-bug-fix-attribute-passing.json"
+}

--- a/change/office-ui-fabric-react-2019-10-14-20-01-21-bug-fix-attribute-passing.json
+++ b/change/office-ui-fabric-react-2019-10-14-20-01-21-bug-fix-attribute-passing.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "pass native props for SpinButton",
+  "comment": "Allow data attribute passing for SpinButton",
   "packageName": "office-ui-fabric-react",
   "email": "xgao@microsoft.com",
   "commit": "6f96ceaaa0fae594e57e6dea6f2b03f531439bcf",

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6918,7 +6918,7 @@ export interface ISpinButton {
 }
 
 // @public (undocumented)
-export interface ISpinButtonProps {
+export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement> {
     ariaDescribedBy?: string;
     ariaLabel?: string;
     ariaPositionInSet?: number;

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.test.tsx
@@ -36,7 +36,7 @@ describe('SpinButton', () => {
   });
 
   it('renders SpinButton correctly with values that the user passes in', () => {
-    const component = renderer.create(<SpinButton label="label" value={'0'} ariaValueNow={0} ariaValueText={'0 pt'} />);
+    const component = renderer.create(<SpinButton label="label" value={'0'} ariaValueNow={0} ariaValueText={'0 pt'} data-test="test" />);
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -144,7 +144,6 @@ export class SpinButton extends React.Component<ISpinButtonProps, ISpinButtonSta
       incrementButtonAriaLabel,
       decrementButtonIcon,
       decrementButtonAriaLabel,
-      title,
       ariaLabel,
       ariaDescribedBy,
       styles: customStyles,
@@ -167,7 +166,7 @@ export class SpinButton extends React.Component<ISpinButtonProps, ISpinButtonSta
       ? this.props.getClassNames(theme!, disabled, isFocused, keyboardSpinDirection, labelPosition, className)
       : getClassNames(getStyles(theme!, customStyles), disabled, isFocused, keyboardSpinDirection, labelPosition, className);
 
-    const nativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties, ['onBlur', 'onFocus']);
+    const nativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties, ['onBlur', 'onFocus', 'className']);
 
     return (
       <div className={classNames.root}>
@@ -186,7 +185,6 @@ export class SpinButton extends React.Component<ISpinButtonProps, ISpinButtonSta
             <div
               {...nativeProps}
               className={classNames.spinButtonWrapper}
-              title={title && title}
               aria-label={ariaLabel && ariaLabel}
               aria-posinset={ariaPositionInSet}
               aria-setsize={ariaSetSize}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -12,7 +12,9 @@ import {
   customizable,
   calculatePrecision,
   precisionRound,
-  mergeAriaAttributeValues
+  mergeAriaAttributeValues,
+  getNativeProps,
+  divProperties
 } from '../../Utilities';
 import { ISpinButton, ISpinButtonProps } from './SpinButton.types';
 import { Position } from '../../utilities/positioning';
@@ -165,6 +167,8 @@ export class SpinButton extends React.Component<ISpinButtonProps, ISpinButtonSta
       ? this.props.getClassNames(theme!, disabled, isFocused, keyboardSpinDirection, labelPosition, className)
       : getClassNames(getStyles(theme!, customStyles), disabled, isFocused, keyboardSpinDirection, labelPosition, className);
 
+    const nativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties, ['onBlur', 'onFocus']);
+
     return (
       <div className={classNames.root}>
         {labelPosition !== Position.bottom && (iconProps || label) && (
@@ -180,6 +184,7 @@ export class SpinButton extends React.Component<ISpinButtonProps, ISpinButtonSta
         <KeytipData keytipProps={keytipProps} disabled={disabled}>
           {(keytipAttributes: any): JSX.Element => (
             <div
+              {...nativeProps}
               className={classNames.spinButtonWrapper}
               title={title && title}
               aria-label={ariaLabel && ariaLabel}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
@@ -28,7 +28,7 @@ export interface ISpinButton {
 /**
  * {@docCategory SpinButton}
  */
-export interface ISpinButtonProps {
+export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement> {
   /**
    * Gets the component ref.
    */

--- a/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
@@ -490,6 +490,7 @@ exports[`SpinButton renders SpinButton correctly with values that the user passe
         @media screen and (-ms-high-contrast: active){&:hover {
           border-color: Highlight;
         }
+    data-test="test"
   >
     <input
       aria-disabled={false}


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #10768
- [X] Include a change request file using `$ yarn change`

#### Description of changes
Allow to pass data attributes to `<SpinButton />`
![image](https://user-images.githubusercontent.com/1207059/66796850-d3bb2e00-eebd-11e9-86f7-828751b5ed32.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10813)