### PR TITLE
Fix cases where List virtualization causes stale data to render

### DIFF
--- a/change/office-ui-fabric-react-2019-10-15-12-39-20-list-virtualization.json
+++ b/change/office-ui-fabric-react-2019-10-15-12-39-20-list-virtualization.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Fix virtualization state tracking in List and DetailsList",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "commit": "09a835928992fa37838f347cec2d16f97d4fe037",
+  "date": "2019-10-15T19:39:20.931Z",
+  "file": "D:\\Src\\Git\\OfficeDev\\office-ui-fabric-react-1\\change\\office-ui-fabric-react-2019-10-15-12-39-20-list-virtualization.json"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -918,8 +918,6 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
     scrollToIndex(index: number, measureItem?: (itemIndex: number) => number, scrollToMode?: ScrollToMode): void;
     // (undocumented)
     UNSAFE_componentWillReceiveProps(newProps: IDetailsListProps): void;
-    // (undocumented)
-    UNSAFE_componentWillUpdate(): void;
 }
 
 // @public (undocumented)
@@ -3525,6 +3523,7 @@ export interface IDetailsListState {
     lastSelectionMode?: SelectionMode;
     // (undocumented)
     lastWidth?: number;
+    version: {};
 }
 
 // @public (undocumented)
@@ -5333,6 +5332,7 @@ export interface IListProps<T = any> extends React.HTMLAttributes<List<T> | HTML
     role?: string;
     startIndex?: number;
     usePageCache?: boolean;
+    version?: {};
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/List/List.types.ts
+++ b/packages/office-ui-fabric-react/src/components/List/List.types.ts
@@ -179,6 +179,11 @@ export interface IListProps<T = any> extends React.HTMLAttributes<List<T> | HTML
    * Override this to control how cells are rendered within a page.
    */
   onRenderPage?: (pageProps: IPageProps<T>, defaultRender?: IRenderFunction<IPageProps<T>>) => React.ReactNode;
+
+  /**
+   * An object which can be passed in as a fresh instance to 'force update' the list.
+   */
+  version?: {};
 }
 
 /**


### PR DESCRIPTION
The `DetailsList` and `List` have some communication issues which can result in stale data being rendered when the `items` passed to the `List` are updated.
Specifically, if:
1. `DetailsList` is initially rendered with less than 10 items (the default page size)
2. `DetailsList` is subsequently updated to have 30+ items (more than 3 pages)
3. The `renderedWindowsAhead` value is `0`, preventing idle callbacks, or `getItemCountPerPage` has been altered to make the page size the same as the window size.
Then the resulting change can cause only the first page of the content to be rendered, and even worse is that it will have stale item data.

This change addresses these circumstances by eliminating two troublesome behaviors:
1. `DetailsList` no longer calls `forceListUpdates` during `componentWillReceiveProps`, because this caused `List` to render with its previous props, queuing a state update callback with bad data. Now, `DetailsList` simply uses a `version` object which can be revved when `shouldForceListUpdates` is `true`, ensuring that the `List` will always re-render subsequently.
2. `List` no longer captures stale data in the post-update callback within `_updatePages`. What was happening was that the callback contained the original `props` and `state` from the first call, but multiple `setState` calls would be queued, so by the time the callback was fired it would be out-of-date. Now, the callback retrieves the current `state` and `props` and takes its action based on current data.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10819)