### PR TITLE
ComboBox and Dropdown: Passing correct onDismiss prop in onRenderContainer

### DIFF
--- a/change/office-ui-fabric-react-2019-10-15-14-46-17-dropdownComboBoxOnRenderContainerOnDismiss.json
+++ b/change/office-ui-fabric-react-2019-10-15-14-46-17-dropdownComboBoxOnRenderContainerOnDismiss.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "ComboBox and Dropdown: Passing correct onDismiss prop in onRenderContainer.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "a721b7679188cf72e56d4de72491eaa15af0e360",
+  "date": "2019-10-15T21:46:17.046Z",
+  "file": "D:\\office-ui-fabric-react\\change\\office-ui-fabric-react-2019-10-15-14-46-17-dropdownComboBoxOnRenderContainerOnDismiss.json"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -4313,7 +4313,6 @@ export interface IDropdownProps extends ISelectableDroppableTextProps<IDropdown,
     onChange?: (event: React.FormEvent<HTMLDivElement>, option?: IDropdownOption, index?: number) => void;
     // @deprecated (undocumented)
     onChanged?: (option: IDropdownOption, index?: number) => void;
-    onDismiss?: () => void;
     onRenderCaretDown?: IRenderFunction<IDropdownProps>;
     onRenderLabel?: IRenderFunction<IDropdownProps>;
     // @deprecated
@@ -6556,6 +6555,7 @@ export interface ISelectableDroppableTextProps<TComponent, TListenerElement> ext
     errorMessage?: string;
     id?: string;
     label?: string;
+    onDismiss?: () => void;
     onRenderContainer?: IRenderFunction<ISelectableDroppableTextProps<TComponent, TListenerElement>>;
     onRenderItem?: IRenderFunction<ISelectableOption>;
     onRenderList?: IRenderFunction<ISelectableDroppableTextProps<TComponent, TListenerElement>>;

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -430,13 +430,14 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           )}
         </KeytipData>
         {(persistMenu || isOpen) &&
-          (onRenderContainer as any)(
+          onRenderContainer(
             {
               ...this.props,
               onRenderList,
               onRenderItem,
               onRenderOption,
-              options: this.state.currentOptions.map((item, index) => ({ ...item, index: index }))
+              options: this.state.currentOptions.map((item, index) => ({ ...item, index: index })),
+              onDismiss: this._onDismiss
             },
             this._onRenderContainer
           )}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -302,7 +302,7 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
             </div>
           )}
         </KeytipData>
-        {isOpen && onRenderContainer(props, this._onRenderContainer)}
+        {isOpen && onRenderContainer({ ...props, onDismiss: this._onDismiss }, this._onRenderContainer)}
         {hasErrorMessage && (
           <div id={id + '-errorMessage'} className={this._classNames.errorMessage}>
             {errorMessage}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.types.ts
@@ -53,11 +53,6 @@ export interface IDropdownProps extends ISelectableDroppableTextProps<IDropdown,
   onChanged?: (option: IDropdownOption, index?: number) => void;
 
   /**
-   * Callback issues when the options callout is dismissed
-   */
-  onDismiss?: () => void;
-
-  /**
    * Custom render function for the label.
    */
   onRenderLabel?: IRenderFunction<IDropdownProps>;

--- a/packages/office-ui-fabric-react/src/utilities/selectableOption/SelectableDroppableText.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/selectableOption/SelectableDroppableText.types.ts
@@ -74,6 +74,11 @@ export interface ISelectableDroppableTextProps<TComponent, TListenerElement> ext
   onRenderOption?: IRenderFunction<ISelectableOption>;
 
   /**
+   * Callback that is issued when the options callout is dismissed
+   */
+  onDismiss?: () => void;
+
+  /**
    * Whether or not the ISelectableDroppableText is disabled.
    */
   disabled?: boolean;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10753
- [x] Include a change request file using `$ yarn change`

#### Description of changes

When using `onRenderContainer` on both `ComboBox` and `Dropdown` we weren't passing down the correct `onDismiss` property down. This PR fixes that by resolving that passing. In the process of doing so we've moved the `onDismiss` prop from the component types to `SelectableDroppableText` types, which changes the API but keeps it backwards compatible.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10847)