### PR TITLE
Fix getDerivedStateFromProps signatures

### DIFF
--- a/change/@uifabric-charting-2019-10-15-15-20-25-derivedstate.json
+++ b/change/@uifabric-charting-2019-10-15-15-20-25-derivedstate.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Fix getDerivedStateFromProps signatures",
+  "packageName": "@uifabric/charting",
+  "email": "elcraig@microsoft.com",
+  "commit": "437c49f055744dc64f13e6ef8c71f5f2d5110d0a",
+  "date": "2019-10-15T22:20:19.578Z",
+  "file": "/Users/elizabeth/git/fabric-react3/change/@uifabric-charting-2019-10-15-15-20-25-derivedstate.json"
+}

--- a/change/@uifabric-date-time-2019-10-15-15-20-25-derivedstate.json
+++ b/change/@uifabric-date-time-2019-10-15-15-20-25-derivedstate.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Fix getDerivedStateFromProps signatures",
+  "packageName": "@uifabric/date-time",
+  "email": "elcraig@microsoft.com",
+  "commit": "437c49f055744dc64f13e6ef8c71f5f2d5110d0a",
+  "date": "2019-10-15T22:20:21.450Z",
+  "file": "/Users/elizabeth/git/fabric-react3/change/@uifabric-date-time-2019-10-15-15-20-25-derivedstate.json"
+}

--- a/change/office-ui-fabric-react-2019-10-15-15-20-25-derivedstate.json
+++ b/change/office-ui-fabric-react-2019-10-15-15-20-25-derivedstate.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Fix getDerivedStateFromProps signatures",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "commit": "437c49f055744dc64f13e6ef8c71f5f2d5110d0a",
+  "date": "2019-10-15T22:20:25.554Z",
+  "file": "/Users/elizabeth/git/fabric-react3/change/office-ui-fabric-react-2019-10-15-15-20-25-derivedstate.json"
+}

--- a/packages/charting/src/components/DonutChart/Arc/Arc.tsx
+++ b/packages/charting/src/components/DonutChart/Arc/Arc.tsx
@@ -16,7 +16,7 @@ export class Arc extends React.Component<IArcProps, IArcState> {
 
   public state: IArcState = {};
 
-  public static getDerivedStateFromProps(nextProps: Readonly<IArcProps>): null {
+  public static getDerivedStateFromProps(nextProps: Readonly<IArcProps>): Partial<IArcState> | null {
     _updateChart(nextProps);
     return null;
   }

--- a/packages/charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/charting/src/components/DonutChart/DonutChart.base.tsx
@@ -31,14 +31,18 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
   private _uniqText: string;
   // tslint:disable:no-any
   private _currentHoverElement: any;
-  public static getDerivedStateFromProps(nextProps: IDonutChartProps, prevState: IDonutChartState): IDonutChartState {
+
+  public static getDerivedStateFromProps(
+    nextProps: Readonly<IDonutChartProps>,
+    prevState: Readonly<IDonutChartState>
+  ): Partial<IDonutChartState> | null {
     if (nextProps.height && nextProps.height !== prevState._height && nextProps.width !== prevState._width) {
       const reducedHeight = nextProps.height / 5;
       return { _width: nextProps.width, _height: nextProps.height - reducedHeight };
-    } else {
-      return prevState;
     }
+    return null;
   }
+
   constructor(props: IDonutChartProps) {
     super(props);
     this.state = {

--- a/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
@@ -17,14 +17,17 @@ export interface ICalendarDayState {
 export class CalendarDayBase extends BaseComponent<ICalendarDayProps, ICalendarDayState> {
   private _dayGrid = React.createRef<ICalendarDayGrid>();
 
-  public static getDerivedStateFromProps(props: ICalendarDayProps, state: ICalendarDayState): ICalendarDayState {
-    const { dateTimeFormatter, strings } = props;
+  public static getDerivedStateFromProps(
+    nextProps: Readonly<ICalendarDayProps>,
+    prevState: Readonly<ICalendarDayState>
+  ): Partial<ICalendarDayState> | null {
+    const { dateTimeFormatter, strings } = nextProps;
 
-    const previousDate = state && state.previousNavigatedDate;
-    const nextDate = props.navigatedDate;
+    const previousDate = prevState && prevState.previousNavigatedDate;
+    const nextDate = nextProps.navigatedDate;
     if (!previousDate) {
       return {
-        previousNavigatedDate: props.navigatedDate
+        previousNavigatedDate: nextProps.navigatedDate
       };
     }
 
@@ -32,18 +35,18 @@ export class CalendarDayBase extends BaseComponent<ICalendarDayProps, ICalendarD
       if (previousDate < nextDate) {
         return {
           animateBackwards: false,
-          previousNavigatedDate: props.navigatedDate
+          previousNavigatedDate: nextProps.navigatedDate
         };
       } else if (previousDate > nextDate) {
         return {
           animateBackwards: true,
-          previousNavigatedDate: props.navigatedDate
+          previousNavigatedDate: nextProps.navigatedDate
         };
       }
     }
 
     return {
-      previousNavigatedDate: props.navigatedDate
+      previousNavigatedDate: nextProps.navigatedDate
     };
   }
 

--- a/packages/date-time/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
@@ -41,9 +41,12 @@ export class CalendarMonthBase extends BaseComponent<ICalendarMonthProps, ICalen
   private _calendarYearRef = React.createRef<ICalendarYear>();
   private _focusOnUpdate: boolean;
 
-  public static getDerivedStateFromProps(props: ICalendarMonthProps, state: ICalendarMonthState): ICalendarMonthState {
-    const previousYear = state.previousNavigatedDate ? state.previousNavigatedDate.getFullYear() : undefined;
-    const nextYear = props.navigatedDate.getFullYear();
+  public static getDerivedStateFromProps(
+    nextProps: Readonly<ICalendarMonthProps>,
+    prevState: Readonly<ICalendarMonthState>
+  ): Partial<ICalendarMonthState> | null {
+    const previousYear = prevState.previousNavigatedDate ? prevState.previousNavigatedDate.getFullYear() : undefined;
+    const nextYear = nextProps.navigatedDate.getFullYear();
     if (!previousYear) {
       return {};
     }
@@ -51,12 +54,12 @@ export class CalendarMonthBase extends BaseComponent<ICalendarMonthProps, ICalen
     if (previousYear < nextYear) {
       return {
         animateBackwards: false,
-        previousNavigatedDate: props.navigatedDate
+        previousNavigatedDate: nextProps.navigatedDate
       };
     } else if (previousYear > nextYear) {
       return {
         animateBackwards: true,
-        previousNavigatedDate: props.navigatedDate
+        previousNavigatedDate: nextProps.navigatedDate
       };
     }
 

--- a/packages/date-time/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
@@ -429,19 +429,23 @@ class CalendarYearHeader extends BaseComponent<ICalendarYearHeaderProps, {}> {
 export class CalendarYearBase extends BaseComponent<ICalendarYearProps, ICalendarYearState> implements ICalendarYear {
   private _gridRef: CalendarYearGrid;
 
-  public static getDerivedStateFromProps(props: ICalendarYearProps, state: ICalendarYearState): ICalendarYearState {
-    if (state && state.internalNavigate) {
+  public static getDerivedStateFromProps(
+    nextProps: Readonly<ICalendarYearProps>,
+    prevState: Readonly<ICalendarYearState>
+  ): Partial<ICalendarYearState> | null {
+    if (prevState && prevState.internalNavigate) {
       return {
-        ...state,
+        ...prevState,
         internalNavigate: false
       };
     }
 
-    const newState = CalendarYearBase._getState(props);
+    const newState = CalendarYearBase._getState(nextProps);
 
     return {
       ...newState,
-      animateBackwards: state && (state.animateBackwards !== undefined ? state.animateBackwards : state.fromYear > newState.fromYear)
+      animateBackwards:
+        prevState && (prevState.animateBackwards !== undefined ? prevState.animateBackwards : prevState.fromYear > newState.fromYear)
     };
   }
 

--- a/packages/date-time/src/components/WeeklyDayPicker/WeeklyDayPicker.base.tsx
+++ b/packages/date-time/src/components/WeeklyDayPicker/WeeklyDayPicker.base.tsx
@@ -79,13 +79,17 @@ export class WeeklyDayPickerBase extends BaseComponent<IWeeklyDayPickerProps, IW
   private _focusOnUpdate: boolean;
   private _initialTouchX: number | undefined;
 
-  public static getDerivedStateFromProps(props: IWeeklyDayPickerProps, state: IWeeklyDayPickerState): IWeeklyDayPickerState {
-    const currentDate = props.initialDate && !isNaN(props.initialDate.getTime()) ? props.initialDate : props.today || new Date();
-    const showFullMonth = !!props.showFullMonth;
+  public static getDerivedStateFromProps(
+    nextProps: Readonly<IWeeklyDayPickerProps>,
+    prevState: Readonly<IWeeklyDayPickerState>
+  ): Partial<IWeeklyDayPickerState> | null {
+    const currentDate =
+      nextProps.initialDate && !isNaN(nextProps.initialDate.getTime()) ? nextProps.initialDate : nextProps.today || new Date();
+    const showFullMonth = !!nextProps.showFullMonth;
     const newAnimationDirection =
-      showFullMonth !== state.previousShowFullMonth ? AnimationDirection.Vertical : AnimationDirection.Horizontal;
+      showFullMonth !== prevState.previousShowFullMonth ? AnimationDirection.Vertical : AnimationDirection.Horizontal;
 
-    if (!compareDates(currentDate, state.selectedDate)) {
+    if (!compareDates(currentDate, prevState.selectedDate)) {
       return {
         selectedDate: currentDate,
         navigatedDate: currentDate,
@@ -96,7 +100,7 @@ export class WeeklyDayPickerBase extends BaseComponent<IWeeklyDayPickerProps, IW
 
     return {
       selectedDate: currentDate,
-      navigatedDate: state.navigatedDate,
+      navigatedDate: prevState.navigatedDate,
       previousShowFullMonth: showFullMonth,
       animationDirection: newAnimationDirection
     };

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -9341,7 +9341,7 @@ export class ToggleBase extends BaseComponent<IToggleProps, IToggleState> implem
     // (undocumented)
     focus(): void;
     // (undocumented)
-    static getDerivedStateFromProps(props: IToggleProps, state: IToggleState): IToggleState;
+    static getDerivedStateFromProps(nextProps: Readonly<IToggleProps>, prevState: Readonly<IToggleState>): Partial<IToggleState> | null;
     // (undocumented)
     render(): JSX.Element;
     }

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -46,17 +46,23 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
   private _scrollableContent: HTMLDivElement | null;
   private _animationCallback: number | null = null;
 
-  public static getDerivedStateFromProps(props: IPanelProps, state: IPanelState): IPanelState {
-    if (props.isOpen === undefined) {
-      return state;
+  public static getDerivedStateFromProps(nextProps: Readonly<IPanelProps>, prevState: Readonly<IPanelState>): Partial<IPanelState> | null {
+    if (nextProps.isOpen === undefined) {
+      return null; // no state update
     }
-    if (props.isOpen && (state.visibility === PanelVisibilityState.closed || state.visibility === PanelVisibilityState.animatingClosed)) {
-      return { ...state, visibility: PanelVisibilityState.animatingOpen };
+    if (
+      nextProps.isOpen &&
+      (prevState.visibility === PanelVisibilityState.closed || prevState.visibility === PanelVisibilityState.animatingClosed)
+    ) {
+      return { visibility: PanelVisibilityState.animatingOpen };
     }
-    if (!props.isOpen && (state.visibility === PanelVisibilityState.open || state.visibility === PanelVisibilityState.animatingOpen)) {
-      return { ...state, visibility: PanelVisibilityState.animatingClosed };
+    if (
+      !nextProps.isOpen &&
+      (prevState.visibility === PanelVisibilityState.open || prevState.visibility === PanelVisibilityState.animatingOpen)
+    ) {
+      return { visibility: PanelVisibilityState.animatingClosed };
     }
-    return state;
+    return null;
   }
 
   constructor(props: IPanelProps) {

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
@@ -14,14 +14,16 @@ export class ToggleBase extends BaseComponent<IToggleProps, IToggleState> implem
   private _id: string;
   private _toggleButton = React.createRef<HTMLButtonElement>();
 
-  public static getDerivedStateFromProps(props: IToggleProps, state: IToggleState): IToggleState {
-    if (props.checked === undefined) {
-      return state;
+  public static getDerivedStateFromProps(
+    nextProps: Readonly<IToggleProps>,
+    prevState: Readonly<IToggleState>
+  ): Partial<IToggleState> | null {
+    if (nextProps.checked === undefined) {
+      return null;
     }
 
     return {
-      ...state,
-      checked: !!props.checked
+      checked: !!nextProps.checked
     };
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Per React typings, the signature of `getDerivedStateFromProps` should be:

```
static getDerivedStateFromProps(
  nextProps: Readonly<IProps>,
  prevState: Readonly<IState>
): Partial<IState> | null
```

Not all of the components followed this signature, and the missing readonly part helped allow me to almost introduce a bug in checkbox in #10644. So I made this PR to fix the signature everywhere.

I also changed places which were returning the entire state to return `null` (no update) instead, and got rid of places which were copying the old state into the returned object (which is unnecessary because React merges in the update automatically, similar to a setState call).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10848)