### PR TITLE
Dropdown: do not select first option automatically unless using keyboard navigation (backport of #10755)

### DIFF
--- a/change/office-ui-fabric-react-2019-10-08-21-55-21-dropdown-fix.json
+++ b/change/office-ui-fabric-react-2019-10-08-21-55-21-dropdown-fix.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Fixed dropdown to not select first option automatically unless it's selected using keyboard navigation per aria",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "43f40feb7596224a82cecf98f48121567c883783",
+  "date": "2019-10-09T04:55:21.494Z",
+  "file": "/Users/xugao/Projects/office-ui-fabric-react/change/office-ui-fabric-react-2019-10-08-21-55-21-dropdown-fix.json"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -101,6 +101,7 @@ exports[`Dropdown multi-select Renders multiselect Dropdown correctly 1`] = `
     onFocus={[Function]}
     onKeyDown={[Function]}
     onKeyUp={[Function]}
+    onMouseDown={[Function]}
     tabIndex={0}
   >
     <span
@@ -275,6 +276,7 @@ exports[`Dropdown single-select Renders single-select Dropdown correctly 1`] = `
     onFocus={[Function]}
     onKeyDown={[Function]}
     onKeyUp={[Function]}
+    onMouseDown={[Function]}
     role="listbox"
     tabIndex={0}
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
@@ -139,6 +139,7 @@ exports[`Component Examples renders Callout.Cover.Example.tsx correctly 1`] = `
         onFocus={[Function]}
         onKeyDown={[Function]}
         onKeyUp={[Function]}
+        onMouseDown={[Function]}
         role="listbox"
         tabIndex={0}
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
@@ -800,6 +800,7 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
         onFocus={[Function]}
         onKeyDown={[Function]}
         onKeyUp={[Function]}
+        onMouseDown={[Function]}
         role="listbox"
         tabIndex={0}
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -272,6 +272,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                   onFocus={[Function]}
                   onKeyDown={[Function]}
                   onKeyUp={[Function]}
+                  onMouseDown={[Function]}
                   tabIndex={-1}
                 >
                   <span

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
@@ -141,6 +141,7 @@ exports[`Component Examples renders Coachmark.Basic.Example.tsx correctly 1`] = 
         onFocus={[Function]}
         onKeyDown={[Function]}
         onKeyUp={[Function]}
+        onMouseDown={[Function]}
         role="listbox"
         tabIndex={0}
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
@@ -272,6 +272,7 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
         onFocus={[Function]}
         onKeyDown={[Function]}
         onKeyUp={[Function]}
+        onMouseDown={[Function]}
         role="listbox"
         tabIndex={0}
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
@@ -335,6 +335,7 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
+      onMouseDown={[Function]}
       role="listbox"
       tabIndex={0}
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
@@ -335,6 +335,7 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
+      onMouseDown={[Function]}
       role="listbox"
       tabIndex={0}
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
@@ -154,6 +154,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
+      onMouseDown={[Function]}
       role="listbox"
       tabIndex={0}
     >
@@ -355,6 +356,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
+      onMouseDown={[Function]}
       tabIndex={-1}
     >
       <span
@@ -569,6 +571,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
+      onMouseDown={[Function]}
       tabIndex={0}
     >
       <span

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Controlled.Example.tsx.shot
@@ -134,6 +134,7 @@ exports[`Component Examples renders Dropdown.Controlled.Example.tsx correctly 1`
     onFocus={[Function]}
     onKeyDown={[Function]}
     onKeyUp={[Function]}
+    onMouseDown={[Function]}
     role="listbox"
     tabIndex={0}
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.ControlledMulti.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.ControlledMulti.Example.tsx.shot
@@ -134,6 +134,7 @@ exports[`Component Examples renders Dropdown.ControlledMulti.Example.tsx correct
     onFocus={[Function]}
     onKeyDown={[Function]}
     onKeyUp={[Function]}
+    onMouseDown={[Function]}
     tabIndex={0}
   >
     <span

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
@@ -133,6 +133,7 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
     onFocus={[Function]}
     onKeyDown={[Function]}
     onKeyUp={[Function]}
+    onMouseDown={[Function]}
     role="listbox"
     tabIndex={0}
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
@@ -324,6 +324,7 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
+      onMouseDown={[Function]}
       role="listbox"
       tabIndex={0}
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
@@ -184,6 +184,7 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
         onFocus={[Function]}
         onKeyDown={[Function]}
         onKeyUp={[Function]}
+        onMouseDown={[Function]}
         role="listbox"
         tabIndex={0}
       >
@@ -505,6 +506,7 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
       onFocus={[Function]}
       onKeyDown={[Function]}
       onKeyUp={[Function]}
+      onMouseDown={[Function]}
       role="listbox"
       tabIndex={0}
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -856,6 +856,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
         onFocus={[Function]}
         onKeyDown={[Function]}
         onKeyUp={[Function]}
+        onMouseDown={[Function]}
         role="listbox"
         tabIndex={0}
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
@@ -1046,6 +1046,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
         onFocus={[Function]}
         onKeyDown={[Function]}
         onKeyUp={[Function]}
+        onMouseDown={[Function]}
         role="listbox"
         tabIndex={0}
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
@@ -232,6 +232,7 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
         onFocus={[Function]}
         onKeyDown={[Function]}
         onKeyUp={[Function]}
+        onMouseDown={[Function]}
         role="listbox"
         tabIndex={0}
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -3720,6 +3720,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
           onFocus={[Function]}
           onKeyDown={[Function]}
           onKeyUp={[Function]}
+          onMouseDown={[Function]}
           role="listbox"
           tabIndex={0}
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
@@ -3064,6 +3064,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
           onFocus={[Function]}
           onKeyDown={[Function]}
           onKeyUp={[Function]}
+          onMouseDown={[Function]}
           role="listbox"
           tabIndex={0}
         >
@@ -3290,6 +3291,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
           onFocus={[Function]}
           onKeyDown={[Function]}
           onKeyUp={[Function]}
+          onMouseDown={[Function]}
           role="listbox"
           tabIndex={0}
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapAdvanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapAdvanced.Example.tsx.shot
@@ -758,6 +758,7 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
           onFocus={[Function]}
           onKeyDown={[Function]}
           onKeyUp={[Function]}
+          onMouseDown={[Function]}
           role="listbox"
           tabIndex={0}
         >
@@ -985,6 +986,7 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
           onFocus={[Function]}
           onKeyDown={[Function]}
           onKeyUp={[Function]}
+          onMouseDown={[Function]}
           role="listbox"
           tabIndex={0}
         >
@@ -1212,6 +1214,7 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
           onFocus={[Function]}
           onKeyDown={[Function]}
           onKeyUp={[Function]}
+          onMouseDown={[Function]}
           role="listbox"
           tabIndex={0}
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
@@ -1770,6 +1770,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 onFocus={[Function]}
                 onKeyDown={[Function]}
                 onKeyUp={[Function]}
+                onMouseDown={[Function]}
                 role="listbox"
                 tabIndex={0}
               >
@@ -1997,6 +1998,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 onFocus={[Function]}
                 onKeyDown={[Function]}
                 onKeyUp={[Function]}
+                onMouseDown={[Function]}
                 role="listbox"
                 tabIndex={0}
               >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapAdvanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapAdvanced.Example.tsx.shot
@@ -758,6 +758,7 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
           onFocus={[Function]}
           onKeyDown={[Function]}
           onKeyUp={[Function]}
+          onMouseDown={[Function]}
           role="listbox"
           tabIndex={0}
         >
@@ -985,6 +986,7 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
           onFocus={[Function]}
           onKeyDown={[Function]}
           onKeyUp={[Function]}
+          onMouseDown={[Function]}
           role="listbox"
           tabIndex={0}
         >
@@ -1212,6 +1214,7 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
           onFocus={[Function]}
           onKeyDown={[Function]}
           onKeyUp={[Function]}
+          onMouseDown={[Function]}
           role="listbox"
           tabIndex={0}
         >


### PR DESCRIPTION
backport of PR : #10755 
please refer the [parent](https://github.com/OfficeDev/office-ui-fabric-react/pull/10755#issue-326070138) for details

#### Pull request checklist

- [x] Addresses an existing issue: Fixes  #5473 , Fixes  #10713
- [x] Include a change request file using `$ yarn change`

#### Description of changes

In case of keyboard navigation to dropdown, per aria guidance, dropdown should select first option by default on focus. But we do not want to do this if user clicked and opened the dropdown.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10866)