### PR TITLE
Add role to FocusZone in BasePickerListBelow

### DIFF
--- a/change/office-ui-fabric-react-2019-10-16-08-58-09-BasePickerListBelowRole.json
+++ b/change/office-ui-fabric-react-2019-10-16-08-58-09-BasePickerListBelowRole.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": " Added role to the selection list for BasePickerListBelow control so screen readers will read off \"n\" of \"m\" when arrowing through the list.",
+  "packageName": "office-ui-fabric-react",
+  "email": "malind@microsoft.com",
+  "commit": "adfbe74c57a96e8b75b16c0ee11397ab06a3fd5f",
+  "date": "2019-10-16T15:58:09.775Z"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -990,6 +990,7 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
             direction={FocusZoneDirection.bidirectional}
             isInnerZoneKeystroke={this._isFocusZoneInnerKeystroke}
             id={this._ariaMap.selectedItems}
+            role={'list'}
           >
             {this.renderItems()}
           </FocusZone>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Added role attribute to the FocusZone that contains the selected items for BasePickerListBelow.  Previously there was no role set so adding a role like "list-item" to an item produced by the onRenderItem callback didn't read out in screen readers as item number n of m.

#### Focus areas to test
- Tested that screen reader now read item "n" of "m" in the sample site: https://developer.microsoft.com/en-us/fabric#/controls/web/peoplepicker


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10867)