### PR TITLE
Fixed onDismiss passed into Button, made more consistent

### DIFF
--- a/change/office-ui-fabric-react-2019-10-16-10-41-37-button-ondismiss-fix.json
+++ b/change/office-ui-fabric-react-2019-10-16-10-41-37-button-ondismiss-fix.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Button: Fixed logic where onDismiss was replacing internal dismiss function",
+  "comment": "Button: Fixed logic where onDismiss was replacing internal dismiss function.",
   "packageName": "office-ui-fabric-react",
   "email": "mgodbolt@microsoft.com",
   "commit": "30666b87b44be54905478906cb6d76f08d5bb9e2",

--- a/change/office-ui-fabric-react-2019-10-16-10-41-37-button-ondismiss-fix.json
+++ b/change/office-ui-fabric-react-2019-10-16-10-41-37-button-ondismiss-fix.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fixed logic where onDismiss was replacing internal dismiss logic",
+  "comment": "Button: Fixed logic where onDismiss was replacing internal dismiss function",
   "packageName": "office-ui-fabric-react",
   "email": "mgodbolt@microsoft.com",
   "commit": "30666b87b44be54905478906cb6d76f08d5bb9e2",

--- a/change/office-ui-fabric-react-2019-10-16-10-41-37-button-ondismiss-fix.json
+++ b/change/office-ui-fabric-react-2019-10-16-10-41-37-button-ondismiss-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fixed logic where onDismiss was replacing internal dismiss logic",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "30666b87b44be54905478906cb6d76f08d5bb9e2",
+  "date": "2019-10-16T17:41:37.908Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -448,7 +448,6 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
   };
 
   private _onRenderMenu = (menuProps: IContextualMenuProps): JSX.Element => {
-    const { onDismiss = this._dismissMenu } = menuProps;
     const { persistMenu } = this.props;
     const { menuHidden } = this.state;
     const MenuType = this.props.menuAs || (ContextualMenu as React.ReactType<IContextualMenuProps>);
@@ -470,9 +469,20 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
         hidden={persistMenu ? menuHidden : undefined}
         className={css('ms-BaseButton-menuhost', menuProps.className)}
         target={this._isSplitButton ? this._splitButtonContainer.current : this._buttonElement.current}
-        onDismiss={onDismiss}
+        onDismiss={this._onDismissMenu}
       />
     );
+  };
+
+  private _onDismissMenu = (ev: any): void => {
+    const { menuProps } = this.props;
+
+    if (menuProps && menuProps.onDismiss) {
+      menuProps.onDismiss(ev);
+    }
+    if (!ev.defaultPrevented) {
+      this._dismissMenu();
+    }
   };
 
   private _dismissMenu = (): void => {

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.ContextualMenu.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.ContextualMenu.Example.tsx
@@ -8,7 +8,7 @@ export interface IButtonExampleProps {
 }
 
 const menuProps: IContextualMenuProps = {
-  // disable dismiss if shift key is held down while dismissing
+  // For example: disable dismiss if shift key is held down while dismissing
   onDismiss: ev => {
     if (ev.shiftKey) {
       ev.preventDafult();

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.ContextualMenu.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.ContextualMenu.Example.tsx
@@ -8,6 +8,12 @@ export interface IButtonExampleProps {
 }
 
 const menuProps: IContextualMenuProps = {
+  // disable dismiss if shift key is held down while dismissing
+  onDismiss: ev => {
+    if (ev.shiftKey) {
+      ev.preventDafult();
+    }
+  },
   items: [
     {
       key: 'emailMessage',

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.ContextualMenu.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.ContextualMenu.Example.tsx
@@ -11,7 +11,7 @@ const menuProps: IContextualMenuProps = {
   // For example: disable dismiss if shift key is held down while dismissing
   onDismiss: ev => {
     if (ev.shiftKey) {
-      ev.preventDafult();
+      ev.preventDefault();
     }
   },
   items: [


### PR DESCRIPTION
#### Pull request checklist

Currently a custom onDismiss in Button's menuProps will totally replace the internal one, meaning there's no way to even add a console log without breaking the typical dismiss behavior.

This change makes that behavior more consistent with other experiences where it'll always call onDismiss and internal dismiss as long as you don't use `ev.preventDefault()` on the onDismiss function.

https://codepen.io/micahgodbolt/pen/zYYBaRx

I updated the demo to show how shift key could be used to block dismissal. 

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10868)