### PR TITLE
Facepile: presence example

### DIFF
--- a/change/office-ui-fabric-react-2019-10-16-11-40-24-v-mare-Facepile-presence-example.json
+++ b/change/office-ui-fabric-react-2019-10-16-11-40-24-v-mare-Facepile-presence-example.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Facepile: Added presence example",
+  "packageName": "office-ui-fabric-react",
+  "email": "v-mare@microsoft.com",
+  "commit": "7e5936206eadaafdd2e544e39b520efa0e919823",
+  "date": "2019-10-16T18:40:24.399Z",
+  "file": "/Users/maxrediker/Fabric_UI/office-ui-fabric-react/change/office-ui-fabric-react-2019-10-16-11-40-24-v-mare-Facepile-presence-example.json"
+}

--- a/packages/office-ui-fabric-react/src/components/Facepile/Facepile.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/Facepile.doc.tsx
@@ -14,7 +14,7 @@ export const FacepilePageProps: IDocPageProps = {
   componentUrl: 'https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/office-ui-fabric-react/src/components/Facepile',
   examples: [
     {
-      title: 'Facepile with size and fade in options',
+      title: 'Facepile with size, presence, and fade in options',
       code: FacepileBasicExampleCode,
       view: <FacepileBasicExample />
     },

--- a/packages/office-ui-fabric-react/src/components/Facepile/examples/Facepile.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/examples/Facepile.Basic.Example.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
 import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import { Facepile, IFacepilePersona, IFacepileProps } from 'office-ui-fabric-react/lib/Facepile';
-import { PersonaSize } from 'office-ui-fabric-react/lib/Persona';
+import { PersonaSize, PersonaPresence } from 'office-ui-fabric-react/lib/Persona';
 import { Slider } from 'office-ui-fabric-react/lib/Slider';
 import { facepilePersonas } from '@uifabric/example-data';
 import './Facepile.Examples.scss';
@@ -11,6 +11,7 @@ export interface IFacepileBasicExampleState {
   numberOfFaces: any;
   imagesFadeIn: boolean;
   personaSize: PersonaSize;
+  personaPresence: PersonaPresence;
 }
 
 export class FacepileBasicExample extends React.Component<{}, IFacepileBasicExampleState> {
@@ -20,7 +21,8 @@ export class FacepileBasicExample extends React.Component<{}, IFacepileBasicExam
     this.state = {
       numberOfFaces: 3,
       imagesFadeIn: true,
-      personaSize: PersonaSize.size32
+      personaSize: PersonaSize.size32,
+      personaPresence: PersonaPresence.none
     };
   }
 
@@ -32,7 +34,8 @@ export class FacepileBasicExample extends React.Component<{}, IFacepileBasicExam
       overflowPersonas: facepilePersonas.slice(numberOfFaces),
       getPersonaProps: (persona: IFacepilePersona) => {
         return {
-          imageShouldFadeIn: this.state.imagesFadeIn
+          imageShouldFadeIn: this.state.imagesFadeIn,
+          presence: this.state.personaPresence
         };
       },
       ariaDescription: 'To move through the items use left and right arrow keys.'
@@ -62,6 +65,20 @@ export class FacepileBasicExample extends React.Component<{}, IFacepileBasicExam
               { key: PersonaSize.size40, text: PersonaSize[PersonaSize.size40] }
             ]}
             onChange={this._onChangePersonaSize}
+          />
+          <Dropdown
+            label="Persona Presence:"
+            selectedKey={this.state.personaPresence}
+            options={[
+              { key: PersonaPresence.none, text: PersonaPresence[PersonaPresence.none] },
+              { key: PersonaPresence.away, text: PersonaPresence[PersonaPresence.away] },
+              { key: PersonaPresence.blocked, text: PersonaPresence[PersonaPresence.blocked] },
+              { key: PersonaPresence.busy, text: PersonaPresence[PersonaPresence.busy] },
+              { key: PersonaPresence.dnd, text: PersonaPresence[PersonaPresence.dnd] },
+              { key: PersonaPresence.offline, text: PersonaPresence[PersonaPresence.offline] },
+              { key: PersonaPresence.online, text: PersonaPresence[PersonaPresence.online] }
+            ]}
+            onChange={this._onChangePersonaPresence}
           />
           <Checkbox
             styles={{ root: { margin: '10px 0' } }}
@@ -96,6 +113,15 @@ export class FacepileBasicExample extends React.Component<{}, IFacepileBasicExam
     this.setState(
       (prevState: IFacepileBasicExampleState): IFacepileBasicExampleState => {
         prevState.personaSize = value.key as PersonaSize;
+        return prevState;
+      }
+    );
+  };
+
+  private _onChangePersonaPresence = (event: React.FormEvent<HTMLDivElement>, value: IDropdownOption): void => {
+    this.setState(
+      (prevState: IFacepileBasicExampleState): IFacepileBasicExampleState => {
+        prevState.personaPresence = value.key as PersonaPresence;
         return prevState;
       }
     );

--- a/packages/office-ui-fabric-react/src/components/Facepile/examples/Facepile.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/examples/Facepile.Basic.Example.tsx
@@ -11,7 +11,6 @@ export interface IFacepileBasicExampleState {
   numberOfFaces: any;
   imagesFadeIn: boolean;
   personaSize: PersonaSize;
-  personaPresence: PersonaPresence;
 }
 
 export class FacepileBasicExample extends React.Component<{}, IFacepileBasicExampleState> {
@@ -21,13 +20,13 @@ export class FacepileBasicExample extends React.Component<{}, IFacepileBasicExam
     this.state = {
       numberOfFaces: 3,
       imagesFadeIn: true,
-      personaSize: PersonaSize.size32,
-      personaPresence: PersonaPresence.none
+      personaSize: PersonaSize.size32
     };
   }
 
   public render(): JSX.Element {
     const { numberOfFaces, personaSize } = this.state;
+
     const facepileProps: IFacepileProps = {
       personaSize: personaSize,
       personas: facepilePersonas.slice(0, numberOfFaces),
@@ -35,7 +34,7 @@ export class FacepileBasicExample extends React.Component<{}, IFacepileBasicExam
       getPersonaProps: (persona: IFacepilePersona) => {
         return {
           imageShouldFadeIn: this.state.imagesFadeIn,
-          presence: this.state.personaPresence
+          presence: this._personaPresence(persona.personaName)
         };
       },
       ariaDescription: 'To move through the items use left and right arrow keys.'
@@ -65,20 +64,6 @@ export class FacepileBasicExample extends React.Component<{}, IFacepileBasicExam
               { key: PersonaSize.size40, text: PersonaSize[PersonaSize.size40] }
             ]}
             onChange={this._onChangePersonaSize}
-          />
-          <Dropdown
-            label="Persona Presence:"
-            selectedKey={this.state.personaPresence}
-            options={[
-              { key: PersonaPresence.none, text: PersonaPresence[PersonaPresence.none] },
-              { key: PersonaPresence.away, text: PersonaPresence[PersonaPresence.away] },
-              { key: PersonaPresence.blocked, text: PersonaPresence[PersonaPresence.blocked] },
-              { key: PersonaPresence.busy, text: PersonaPresence[PersonaPresence.busy] },
-              { key: PersonaPresence.dnd, text: PersonaPresence[PersonaPresence.dnd] },
-              { key: PersonaPresence.offline, text: PersonaPresence[PersonaPresence.offline] },
-              { key: PersonaPresence.online, text: PersonaPresence[PersonaPresence.online] }
-            ]}
-            onChange={this._onChangePersonaPresence}
           />
           <Checkbox
             styles={{ root: { margin: '10px 0' } }}
@@ -118,12 +103,17 @@ export class FacepileBasicExample extends React.Component<{}, IFacepileBasicExam
     );
   };
 
-  private _onChangePersonaPresence = (event: React.FormEvent<HTMLDivElement>, value: IDropdownOption): void => {
-    this.setState(
-      (prevState: IFacepileBasicExampleState): IFacepileBasicExampleState => {
-        prevState.personaPresence = value.key as PersonaPresence;
-        return prevState;
-      }
-    );
+  private _personaPresence = (personaName: any): any => {
+    const presences: any = {
+      0: PersonaPresence.away,
+      1: PersonaPresence.busy,
+      2: PersonaPresence.online,
+      3: PersonaPresence.offline,
+      4: PersonaPresence.offline
+    };
+
+    let str = personaName.charCodeAt(1).toString();
+    let newStr = str.slice(str.length - 1);
+    return presences[Math.floor(newStr / 2)];
   };
 }

--- a/packages/office-ui-fabric-react/src/components/Facepile/examples/Facepile.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/examples/Facepile.Basic.Example.tsx
@@ -112,8 +112,8 @@ export class FacepileBasicExample extends React.Component<{}, IFacepileBasicExam
       4: PersonaPresence.offline
     };
 
-    let str = personaName.charCodeAt(1).toString();
-    let newStr = str.slice(str.length - 1);
+    const str = personaName.charCodeAt(1).toString();
+    const newStr = str.slice(str.length - 1);
     return presences[Math.floor(newStr / 2)];
   };
 }

--- a/packages/office-ui-fabric-react/src/components/Facepile/examples/Facepile.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/examples/Facepile.Basic.Example.tsx
@@ -24,6 +24,10 @@ export class FacepileBasicExample extends React.Component<{}, IFacepileBasicExam
     };
   }
 
+  /**
+   * Note: The implementation of presence below is simply for demonstration purposes.
+   * Typically, the persona presence should be included when generating each facepile persona.
+   */
   public render(): JSX.Element {
     const { numberOfFaces, personaSize } = this.state;
 
@@ -104,16 +108,14 @@ export class FacepileBasicExample extends React.Component<{}, IFacepileBasicExam
   };
 
   private _personaPresence = (personaName: any): any => {
-    const presences: any = {
-      0: PersonaPresence.away,
-      1: PersonaPresence.busy,
-      2: PersonaPresence.online,
-      3: PersonaPresence.offline,
-      4: PersonaPresence.offline
-    };
+    const presences: any = [
+      PersonaPresence.away,
+      PersonaPresence.busy,
+      PersonaPresence.online,
+      PersonaPresence.offline,
+      PersonaPresence.offline
+    ];
 
-    const str = personaName.charCodeAt(1).toString();
-    const newStr = str.slice(str.length - 1);
-    return presences[Math.floor(newStr / 2)];
+    return presences[personaName.charCodeAt(1) % 5];
   };
 }

--- a/packages/office-ui-fabric-react/src/components/Facepile/examples/Facepile.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Facepile/examples/Facepile.Basic.Example.tsx
@@ -38,7 +38,7 @@ export class FacepileBasicExample extends React.Component<{}, IFacepileBasicExam
       getPersonaProps: (persona: IFacepilePersona) => {
         return {
           imageShouldFadeIn: this.state.imagesFadeIn,
-          presence: this._personaPresence(persona.personaName)
+          presence: this._personaPresence(persona.personaName!)
         };
       },
       ariaDescription: 'To move through the items use left and right arrow keys.'
@@ -107,7 +107,7 @@ export class FacepileBasicExample extends React.Component<{}, IFacepileBasicExam
     );
   };
 
-  private _personaPresence = (personaName: any): any => {
+  private _personaPresence = (personaName: string): PersonaPresence => {
     const presences: any = [
       PersonaPresence.away,
       PersonaPresence.busy,

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -943,6 +943,217 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
     </div>
     <div
       className=
+          ms-Dropdown-container
+
+    >
+      <label
+        className=
+            ms-Label
+            ms-Dropdown-label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 600;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+        htmlFor="Dropdown6"
+        id="Dropdown6-label"
+      >
+        Persona Presence:
+      </label>
+      <div
+        aria-describedby="Dropdown6-option"
+        aria-expanded="false"
+        aria-labelledby="Dropdown6-label"
+        className=
+            ms-Dropdown
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              border-color: #605e5c;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #323130;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              outline: 0px;
+              padding-bottom: 0px;
+              padding-left: 0px;
+              padding-right: 0px;
+              padding-top: 0px;
+              position: relative;
+              user-select: none;
+            }
+            &:hover .ms-Dropdown-title {
+              border-color: #323130;
+              color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Dropdown-title {
+              border-color: Highlight;
+            }
+            &:focus .ms-Dropdown-title {
+              border-color: #0078d4;
+              color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title {
+              background-color: Highlight;
+              border-color: Highlight;
+              color: HighlightText;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
+              color: HighlightText;
+            }
+            @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
+              -ms-high-contrast-adjust: none;
+            }
+            &:active .ms-Dropdown-title {
+              border-color: #0078d4;
+              color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active){&:active .ms-Dropdown-title {
+              border-color: Highlight;
+            }
+            &:hover .ms-Dropdown-caretDown {
+              color: #323130;
+            }
+            &:focus .ms-Dropdown-caretDown {
+              color: #323130;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-caretDown {
+              color: HighlightText;
+            }
+            @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-caretDown {
+              -ms-high-contrast-adjust: none;
+            }
+            &:active .ms-Dropdown-caretDown {
+              color: #323130;
+            }
+            &:hover .ms-Dropdown-titleIsPlaceHolder {
+              color: #323130;
+            }
+            &:focus .ms-Dropdown-titleIsPlaceHolder {
+              color: #323130;
+            }
+            &:active .ms-Dropdown-titleIsPlaceHolder {
+              color: #323130;
+            }
+            &:hover .ms-Dropdown-title--hasError {
+              border-color: #a4262c;
+            }
+            &:active .ms-Dropdown-title--hasError {
+              border-color: #a4262c;
+            }
+        data-is-focusable={true}
+        id="Dropdown6"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onKeyDown={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        role="listbox"
+        tabIndex={0}
+      >
+        <span
+          aria-atomic={true}
+          aria-invalid={false}
+          aria-label="none"
+          aria-live="polite"
+          aria-posinset={1}
+          aria-selected={true}
+          aria-setsize={7}
+          className=
+              ms-Dropdown-title
+              {
+                background-color: #ffffff;
+                border-color: #8a8886;
+                border-radius: 2px;
+                border-style: solid;
+                border-width: 1px;
+                box-shadow: none;
+                box-sizing: border-box;
+                cursor: pointer;
+                display: block;
+                height: 32px;
+                line-height: 30px;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                overflow: hidden;
+                padding-bottom: 0;
+                padding-left: 8px;
+                padding-right: 28px;
+                padding-top: 0;
+                position: relative;
+                text-overflow: ellipsis;
+                white-space: nowrap;
+              }
+          id="Dropdown6-option"
+          role="option"
+        >
+          <span>
+            none
+          </span>
+        </span>
+        <span
+          className=
+              ms-Dropdown-caretDownWrapper
+              {
+                cursor: pointer;
+                height: 32px;
+                line-height: 30px;
+                position: absolute;
+                right: 8px;
+                top: 1px;
+              }
+        >
+          <i
+            aria-hidden={true}
+            className=
+                ms-Dropdown-caretDown
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #605e5c;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-size: 12px;
+                  font-style: normal;
+                  font-weight: normal;
+                  pointer-events: none;
+                  speak: none;
+                }
+            data-icon-name="ChevronDown"
+          >
+            
+          </i>
+        </span>
+      </div>
+    </div>
+    <div
+      className=
           ms-Checkbox
           is-checked
           is-enabled
@@ -1007,7 +1218,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
               outline: 1px solid ActiveBorder;
             }
-        id="checkbox-6"
+        id="checkbox-7"
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -1038,7 +1249,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
               right: 0px;
               top: 0px;
             }
-        htmlFor="checkbox-6"
+        htmlFor="checkbox-7"
       >
         <div
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -334,7 +334,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                       {
                         -ms-high-contrast-adjust: none;
                         background-clip: content-box;
-                        background-color: #ffffff;
+                        background-color: #6BB700;
                         border-radius: 50%;
                         border: 2px solid #ffffff;
                         bottom: -2px;
@@ -347,26 +347,8 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                         width: 8px;
                       }
                       @media screen and (-ms-high-contrast: active){& {
-                        background-color: WindowText;
+                        background-color: Highlight;
                         border-color: Window;
-                      }
-                      &:before {
-                        border-radius: 50%;
-                        border: 1px solid #8A8886;
-                        box-sizing: border-box;
-                        content: "";
-                        height: 100%;
-                        left: 0px;
-                        position: absolute;
-                        top: 0px;
-                        width: 100%;
-                      }
-                      @media screen and (-ms-high-contrast: active){&:before {
-                        border-color: Window;
-                        height: calc(100% - 2px);
-                        left: 1px;
-                        top: 1px;
-                        width: calc(100% - 2px);
                       }
                 />
               </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -182,6 +182,29 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                     src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
                   />
                 </div>
+                <div
+                  className=
+                      ms-Persona-presence
+                      {
+                        -ms-high-contrast-adjust: none;
+                        background-clip: content-box;
+                        background-color: #FFAA44;
+                        border-radius: 50%;
+                        border: 2px solid #ffffff;
+                        bottom: -2px;
+                        box-sizing: content-box;
+                        height: 8px;
+                        position: absolute;
+                        right: -2px;
+                        text-align: center;
+                        top: auto;
+                        width: 8px;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        background-color: WindowText;
+                        border-color: Window;
+                      }
+                />
               </div>
             </div>
           </div>
@@ -305,6 +328,47 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                     src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
                   />
                 </div>
+                <div
+                  className=
+                      ms-Persona-presence
+                      {
+                        -ms-high-contrast-adjust: none;
+                        background-clip: content-box;
+                        background-color: #ffffff;
+                        border-radius: 50%;
+                        border: 2px solid #ffffff;
+                        bottom: -2px;
+                        box-sizing: content-box;
+                        height: 8px;
+                        position: absolute;
+                        right: -2px;
+                        text-align: center;
+                        top: auto;
+                        width: 8px;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        background-color: WindowText;
+                        border-color: Window;
+                      }
+                      &:before {
+                        border-radius: 50%;
+                        border: 1px solid #8A8886;
+                        box-sizing: border-box;
+                        content: "";
+                        height: 100%;
+                        left: 0px;
+                        position: absolute;
+                        top: 0px;
+                        width: 100%;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:before {
+                        border-color: Window;
+                        height: calc(100% - 2px);
+                        left: 1px;
+                        top: 1px;
+                        width: calc(100% - 2px);
+                      }
+                />
               </div>
             </div>
           </div>
@@ -459,6 +523,47 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                       AL
                     </span>
                   </div>
+                  <div
+                    className=
+                        ms-Persona-presence
+                        {
+                          -ms-high-contrast-adjust: none;
+                          background-clip: content-box;
+                          background-color: #ffffff;
+                          border-radius: 50%;
+                          border: 2px solid #ffffff;
+                          bottom: -2px;
+                          box-sizing: content-box;
+                          height: 8px;
+                          position: absolute;
+                          right: -2px;
+                          text-align: center;
+                          top: auto;
+                          width: 8px;
+                        }
+                        @media screen and (-ms-high-contrast: active){& {
+                          background-color: WindowText;
+                          border-color: Window;
+                        }
+                        &:before {
+                          border-radius: 50%;
+                          border: 1px solid #8A8886;
+                          box-sizing: border-box;
+                          content: "";
+                          height: 100%;
+                          left: 0px;
+                          position: absolute;
+                          top: 0px;
+                          width: 100%;
+                        }
+                        @media screen and (-ms-high-contrast: active){&:before {
+                          border-color: Window;
+                          height: calc(100% - 2px);
+                          left: 1px;
+                          top: 1px;
+                          width: calc(100% - 2px);
+                        }
+                  />
                 </div>
               </div>
             </span>
@@ -943,217 +1048,6 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
     </div>
     <div
       className=
-          ms-Dropdown-container
-
-    >
-      <label
-        className=
-            ms-Label
-            ms-Dropdown-label
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              box-shadow: none;
-              box-sizing: border-box;
-              color: #323130;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 600;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              overflow-wrap: break-word;
-              padding-bottom: 5px;
-              padding-left: 0;
-              padding-right: 0;
-              padding-top: 5px;
-              word-wrap: break-word;
-            }
-        htmlFor="Dropdown6"
-        id="Dropdown6-label"
-      >
-        Persona Presence:
-      </label>
-      <div
-        aria-describedby="Dropdown6-option"
-        aria-expanded="false"
-        aria-labelledby="Dropdown6-label"
-        className=
-            ms-Dropdown
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              border-color: #605e5c;
-              box-shadow: none;
-              box-sizing: border-box;
-              color: #323130;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              outline: 0px;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
-              position: relative;
-              user-select: none;
-            }
-            &:hover .ms-Dropdown-title {
-              border-color: #323130;
-              color: #201f1e;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover .ms-Dropdown-title {
-              border-color: Highlight;
-            }
-            &:focus .ms-Dropdown-title {
-              border-color: #0078d4;
-              color: #201f1e;
-            }
-            @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title {
-              background-color: Highlight;
-              border-color: Highlight;
-              color: HighlightText;
-            }
-            @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-              color: HighlightText;
-            }
-            @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
-              -ms-high-contrast-adjust: none;
-            }
-            &:active .ms-Dropdown-title {
-              border-color: #0078d4;
-              color: #201f1e;
-            }
-            @media screen and (-ms-high-contrast: active){&:active .ms-Dropdown-title {
-              border-color: Highlight;
-            }
-            &:hover .ms-Dropdown-caretDown {
-              color: #323130;
-            }
-            &:focus .ms-Dropdown-caretDown {
-              color: #323130;
-            }
-            @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-caretDown {
-              color: HighlightText;
-            }
-            @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-caretDown {
-              -ms-high-contrast-adjust: none;
-            }
-            &:active .ms-Dropdown-caretDown {
-              color: #323130;
-            }
-            &:hover .ms-Dropdown-titleIsPlaceHolder {
-              color: #323130;
-            }
-            &:focus .ms-Dropdown-titleIsPlaceHolder {
-              color: #323130;
-            }
-            &:active .ms-Dropdown-titleIsPlaceHolder {
-              color: #323130;
-            }
-            &:hover .ms-Dropdown-title--hasError {
-              border-color: #a4262c;
-            }
-            &:active .ms-Dropdown-title--hasError {
-              border-color: #a4262c;
-            }
-        data-is-focusable={true}
-        id="Dropdown6"
-        onBlur={[Function]}
-        onChange={[Function]}
-        onClick={[Function]}
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        role="listbox"
-        tabIndex={0}
-      >
-        <span
-          aria-atomic={true}
-          aria-invalid={false}
-          aria-label="none"
-          aria-live="polite"
-          aria-posinset={1}
-          aria-selected={true}
-          aria-setsize={7}
-          className=
-              ms-Dropdown-title
-              {
-                background-color: #ffffff;
-                border-color: #8a8886;
-                border-radius: 2px;
-                border-style: solid;
-                border-width: 1px;
-                box-shadow: none;
-                box-sizing: border-box;
-                cursor: pointer;
-                display: block;
-                height: 32px;
-                line-height: 30px;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                overflow: hidden;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 28px;
-                padding-top: 0;
-                position: relative;
-                text-overflow: ellipsis;
-                white-space: nowrap;
-              }
-          id="Dropdown6-option"
-          role="option"
-        >
-          <span>
-            none
-          </span>
-        </span>
-        <span
-          className=
-              ms-Dropdown-caretDownWrapper
-              {
-                cursor: pointer;
-                height: 32px;
-                line-height: 30px;
-                position: absolute;
-                right: 8px;
-                top: 1px;
-              }
-        >
-          <i
-            aria-hidden={true}
-            className=
-                ms-Dropdown-caretDown
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  color: #605e5c;
-                  display: inline-block;
-                  font-family: "FabricMDL2Icons";
-                  font-size: 12px;
-                  font-style: normal;
-                  font-weight: normal;
-                  pointer-events: none;
-                  speak: none;
-                }
-            data-icon-name="ChevronDown"
-          >
-            
-          </i>
-        </span>
-      </div>
-    </div>
-    <div
-      className=
           ms-Checkbox
           is-checked
           is-enabled
@@ -1218,7 +1112,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
               outline: 1px solid ActiveBorder;
             }
-        id="checkbox-7"
+        id="checkbox-6"
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -1249,7 +1143,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
               right: 0px;
               top: 0px;
             }
-        htmlFor="checkbox-7"
+        htmlFor="checkbox-6"
       >
         <div
           className=


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue discussed with Angela and Matt Cox about whether or not Facepile should advertise this functionality more.
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Added presence icons to the Facepile Basic Example. I simply added it to ALL the coins as an illustration that you CAN use presence icons. I didn't know if it would be useful to add fake individual presences to each icon but I can do that if the current implementation seems potentially confusing to consumer.

#### Screenshot
![Screen Shot 2019-10-17 at 11 14 43 AM](https://user-images.githubusercontent.com/13246181/67035860-59fa8e80-f0cf-11e9-92cc-fcf31cd399a9.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10869)