### PR TITLE
ContextualMenu: Tightening types of onDismiss callback

### DIFF
--- a/change/office-ui-fabric-react-2019-10-17-13-13-10-buttonMenuEvents.json
+++ b/change/office-ui-fabric-react-2019-10-17-13-13-10-buttonMenuEvents.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "ContextualMenu: Tightening types of onDismiss callback.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "422c0c5b31a2348c3a8f1c94eca91d6a6a776ccd",
+  "date": "2019-10-17T20:13:10.248Z",
+  "file": "D:\\office-ui-fabric-react\\change\\office-ui-fabric-react-2019-10-17-13-13-10-buttonMenuEvents.json"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -3038,7 +3038,7 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
     isSubMenu?: boolean;
     items: IContextualMenuItem[];
     labelElementId?: string;
-    onDismiss?: (ev?: any, dismissAll?: boolean) => void;
+    onDismiss?: (ev?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>, dismissAll?: boolean) => void;
     onItemClick?: (ev?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>, item?: IContextualMenuItem) => boolean | void;
     onMenuDismissed?: (contextualMenu?: IContextualMenuProps) => void;
     onMenuOpened?: (contextualMenu?: IContextualMenuProps) => void;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -3038,7 +3038,7 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
     isSubMenu?: boolean;
     items: IContextualMenuItem[];
     labelElementId?: string;
-    onDismiss?: (ev?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>, dismissAll?: boolean) => void;
+    onDismiss?: (ev?: React.MouseEvent | React.KeyboardEvent, dismissAll?: boolean) => void;
     onItemClick?: (ev?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>, item?: IContextualMenuItem) => boolean | void;
     onMenuDismissed?: (contextualMenu?: IContextualMenuProps) => void;
     onMenuOpened?: (contextualMenu?: IContextualMenuProps) => void;

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -474,7 +474,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     );
   };
 
-  private _onDismissMenu = (ev: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>): void => {
+  private _onDismissMenu = (ev: React.MouseEvent | React.KeyboardEvent): void => {
     const { menuProps } = this.props;
 
     if (menuProps && menuProps.onDismiss) {

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -474,7 +474,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     );
   };
 
-  private _onDismissMenu = (ev: any): void => {
+  private _onDismissMenu = (ev: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>): void => {
     const { menuProps } = this.props;
 
     if (menuProps && menuProps.onDismiss) {

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.ContextualMenu.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.ContextualMenu.Example.tsx
@@ -10,7 +10,7 @@ export interface IButtonExampleProps {
 const menuProps: IContextualMenuProps = {
   // For example: disable dismiss if shift key is held down while dismissing
   onDismiss: ev => {
-    if (ev.shiftKey) {
+    if (ev && ev.shiftKey) {
       ev.preventDefault();
     }
   },

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -145,7 +145,7 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
    * Callback when the ContextualMenu tries to close. If `dismissAll` is true then all
    * submenus will be dismissed.
    */
-  onDismiss?: (ev?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>, dismissAll?: boolean) => void;
+  onDismiss?: (ev?: React.MouseEvent | React.KeyboardEvent, dismissAll?: boolean) => void;
 
   /**
    * Click handler which is invoked if `onClick` is not passed for individual contextual

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -145,7 +145,7 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
    * Callback when the ContextualMenu tries to close. If `dismissAll` is true then all
    * submenus will be dismissed.
    */
-  onDismiss?: (ev?: any, dismissAll?: boolean) => void;
+  onDismiss?: (ev?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>, dismissAll?: boolean) => void;
 
   /**
    * Click handler which is invoked if `onClick` is not passed for individual contextual

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/Items/SelectedItemWithContextMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/Items/SelectedItemWithContextMenu.tsx
@@ -50,7 +50,7 @@ export class SelectedItemWithContextMenu extends BaseComponent<ISelectedItemWith
     }
   };
 
-  private _onCloseContextualMenu = (ev: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>): void => {
+  private _onCloseContextualMenu = (ev: React.MouseEvent | React.KeyboardEvent): void => {
     this.setState({ contextualMenuVisible: false });
   };
 }

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/Items/SelectedItemWithContextMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/Items/SelectedItemWithContextMenu.tsx
@@ -50,7 +50,7 @@ export class SelectedItemWithContextMenu extends BaseComponent<ISelectedItemWith
     }
   };
 
-  private _onCloseContextualMenu = (ev: Event): void => {
+  private _onCloseContextualMenu = (ev: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>): void => {
     this.setState({ contextualMenuVisible: false });
   };
 }

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SelectedItemWithMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SelectedItemWithMenu.tsx
@@ -62,7 +62,7 @@ export class SelectedItemWithMenu extends BaseComponent<IPeoplePickerItemWithMen
     this.setState({ contextualMenuVisible: true });
   };
 
-  private _onCloseContextualMenu = (ev: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
+  private _onCloseContextualMenu = (ev: React.MouseEvent | React.KeyboardEvent) => {
     this.setState({ contextualMenuVisible: false });
   };
 }

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SelectedItemWithMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SelectedItemWithMenu.tsx
@@ -62,7 +62,7 @@ export class SelectedItemWithMenu extends BaseComponent<IPeoplePickerItemWithMen
     this.setState({ contextualMenuVisible: true });
   };
 
-  private _onCloseContextualMenu = (ev: Event) => {
+  private _onCloseContextualMenu = (ev: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>) => {
     this.setState({ contextualMenuVisible: false });
   };
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR tightens the types of the `onDismiss` callback in `ContextualMenus` as discussed in #10868.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10889)