### PR TITLE
Add `-ms-overflow-style` as a valid CSS property

### DIFF
--- a/change/@uifabric-merge-styles-2019-10-17-16-21-48-ms-overflow-style.json
+++ b/change/@uifabric-merge-styles-2019-10-17-16-21-48-ms-overflow-style.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Add `-ms-overflow-style` as a valid CSS property",
+  "packageName": "@uifabric/merge-styles",
+  "email": "unindented@gmail.com",
+  "commit": "ac7b27aafaa526b44c11d8a2885517a3751ce528",
+  "date": "2019-10-17T23:21:48.970Z",
+  "file": "/Users/dania/Code/office-ui-fabric-react/change/@uifabric-merge-styles-2019-10-17-16-21-48-ms-overflow-style.json"
+}

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -265,6 +265,7 @@ export interface IRawStyleBase extends IRawFontStyle {
     mixBlendMode?: ICSSRule | IMixBlendModes;
     MozOsxFontSmoothing?: 'none' | 'antialiased' | 'grayscale' | 'subpixel-antialiased';
     MsHighContrastAdjust?: ICSSRule | string;
+    MsOverflowStyle?: 'auto' | 'none' | 'scrollbar' | '-ms-autohiding-scrollbar';
     objectFit?: ICSSRule | 'cover' | 'contain' | 'fill' | 'none';
     opacity?: ICSSRule | number | string;
     order?: ICSSRule | number;

--- a/packages/merge-styles/src/IRawStyleBase.ts
+++ b/packages/merge-styles/src/IRawStyleBase.ts
@@ -283,6 +283,11 @@ export interface IRawStyleBase extends IRawFontStyle {
   MsHighContrastAdjust?: ICSSRule | string;
 
   /**
+   * (Ms specific) scrollbar behavior adjust rule.
+   */
+  MsOverflowStyle?: 'auto' | 'none' | 'scrollbar' | '-ms-autohiding-scrollbar';
+
+  /**
    * (Moz specific) font smoothing directive.
    */
   MozOsxFontSmoothing?: 'none' | 'antialiased' | 'grayscale' | 'subpixel-antialiased';


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10893
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Adds `-ms-overflow-style` as a valid CSS property in `IRawStyleBase`.

I'm trying to adjust the way scrollbars are displayed on IE and Edge for my product (Yammer) following the tips in [this article](https://www.filamentgroup.com/lab/scrollbars/), but the type declarations got in the way, so I thought I'd contribute this change.

#### Focus areas to test

Should have no impact on anything.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10895)