### PR TITLE
adding string index sig to IButtonProps

### DIFF
--- a/change/office-ui-fabric-react-2019-10-17-16-53-21-buttonPropsStringIndex.json
+++ b/change/office-ui-fabric-react-2019-10-17-16-53-21-buttonPropsStringIndex.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Adding string index signature to IButtonProps",
+  "packageName": "office-ui-fabric-react",
+  "email": "brandth@microsoft.com",
+  "commit": "2223d173132671f4b73887f07eed8106c1434f85",
+  "date": "2019-10-17T23:53:21.868Z",
+  "file": "C:\\repos\\office-ui-fabric-react\\change\\office-ui-fabric-react-2019-10-17-16-53-21-buttonPropsStringIndex.json"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1880,6 +1880,7 @@ export interface IButton {
 
 // @public (undocumented)
 export interface IButtonProps extends React.AllHTMLAttributes<HTMLAnchorElement | HTMLButtonElement | HTMLDivElement | BaseButton | Button | HTMLSpanElement> {
+    [propertyName: string]: any;
     allowDisabledFocus?: boolean;
     ariaDescription?: string;
     ariaHidden?: boolean;

--- a/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.types.ts
@@ -330,6 +330,11 @@ export interface IButtonProps
    * Optional props to be applied only to the primary action button of SplitButton and not to the overall SplitButton container
    */
   primaryActionButtonProps?: IButtonProps;
+
+  /**
+   * (Optional) Any additional properties to apply to the rendered button.
+   */
+  [propertyName: string]: any;
 }
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10896
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- expose string index signature for IButtonProps.

#### Focus areas to test
That Buttons can take arbitrary props from objects being spread into them. Such examples include aria- and data-

const myObject = {
“data-test-id”: “anId”
}

<Button {...myObject}\>


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10897)