### PR TITLE
Get rid of DetailsList snapshot churn

### DIFF
--- a/change/office-ui-fabric-react-2019-10-17-17-10-25-details-snapshots.json
+++ b/change/office-ui-fabric-react-2019-10-17-17-10-25-details-snapshots.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Get rid of DetailsList example snapshot churn",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "commit": "56290ba7e48a4aab330b6fe65321936d7aa6f99e",
+  "date": "2019-10-18T00:10:25.128Z",
+  "file": "/Users/elizabeth/git/fabric-react3/change/office-ui-fabric-react-2019-10-17-17-10-25-details-snapshots.json"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Advanced.Example.tsx
@@ -19,34 +19,38 @@ import {
 } from 'office-ui-fabric-react/lib/DetailsList';
 import { createListItems, isGroupable, IExampleItem } from '@uifabric/example-data';
 import { memoizeFunction } from 'office-ui-fabric-react/lib/Utilities';
-import { getTheme, mergeStyles, mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
+import { getTheme, mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
 
 const theme = getTheme();
+const headerDividerClass = 'DetailsListAdvancedExample-divider';
 const classNames = mergeStyleSets({
   headerDivider: {
     display: 'inline-block',
     height: '100%'
   },
-  headerDividerBar: {
-    display: 'none',
-    background: theme.palette.themePrimary,
-    position: 'absolute',
-    top: 16,
-    bottom: 0,
-    width: '1px',
-    zIndex: 5
-  },
+  headerDividerBar: [
+    {
+      display: 'none',
+      background: theme.palette.themePrimary,
+      position: 'absolute',
+      top: 16,
+      bottom: 0,
+      width: '1px',
+      zIndex: 5
+    },
+    headerDividerClass
+  ],
   linkField: {
     display: 'block',
     overflow: 'hidden',
     textOverflow: 'ellipsis',
     maxWidth: '100%'
-  }
-});
-const rootClass = mergeStyles({
-  selectors: {
-    [`.${classNames.headerDivider}:hover + .${classNames.headerDividerBar}`]: {
-      display: 'inline'
+  },
+  root: {
+    selectors: {
+      [`.${headerDividerClass}:hover + .${headerDividerClass}`]: {
+        display: 'inline'
+      }
     }
   }
 });
@@ -142,7 +146,7 @@ export class DetailsListAdvancedExample extends React.Component<{}, IDetailsList
     };
 
     return (
-      <div className={rootClass}>
+      <div className={classNames.root}>
         <CommandBar
           styles={{ root: { marginBottom: '40px' } }}
           items={this._getCommandItems(

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -4,7 +4,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
 <div
   className=
 
-      & .headerDivider-522:hover + .headerDividerBar-523 {
+      & .DetailsListAdvancedExample-divider:hover + .DetailsListAdvancedExample-divider {
         display: inline;
       }
 >
@@ -1424,7 +1424,7 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
             </span>
             <span
               className=
-
+                  DetailsListAdvancedExample-divider
                   {
                     background: #0078d4;
                     bottom: 0px;


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

In the DetailsListAdvancedExample, use a static class name instead of the generated one to override hover styles. This gets rid of the snapshot churn from the generated class name updating.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10898)