### PR TITLE
Remove @types from peerDependencies in packages

### DIFF
--- a/apps/fabric-website-resources/package.json
+++ b/apps/fabric-website-resources/package.json
@@ -82,8 +82,6 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <17.0.0",
-    "@types/react-dom": ">=16.8.0 <17.0.0",
     "react": ">=16.8.0 <17.0.0",
     "react-dom": ">=16.8.0 <17.0.0"
   }

--- a/change/@uifabric-charting-2019-10-18-13-33-24-type-dependencies.json
+++ b/change/@uifabric-charting-2019-10-18-13-33-24-type-dependencies.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Remove @types packages from peerDependencies",
+  "packageName": "@uifabric/charting",
+  "email": "tmichon@microsoft.com",
+  "commit": "6ce5d6155c6e8004d2bfbf443c1ff7c2878e697f",
+  "date": "2019-10-18T20:33:13.714Z",
+  "file": "D:\\Src\\Git\\OfficeDev\\office-ui-fabric-react-1\\change\\@uifabric-charting-2019-10-18-13-33-24-type-dependencies.json"
+}

--- a/change/@uifabric-date-time-2019-10-18-13-33-24-type-dependencies.json
+++ b/change/@uifabric-date-time-2019-10-18-13-33-24-type-dependencies.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Remove @types packages from peerDependencies",
+  "packageName": "@uifabric/date-time",
+  "email": "tmichon@microsoft.com",
+  "commit": "6ce5d6155c6e8004d2bfbf443c1ff7c2878e697f",
+  "date": "2019-10-18T20:33:14.762Z",
+  "file": "D:\\Src\\Git\\OfficeDev\\office-ui-fabric-react-1\\change\\@uifabric-date-time-2019-10-18-13-33-24-type-dependencies.json"
+}

--- a/change/@uifabric-example-app-base-2019-10-18-13-33-24-type-dependencies.json
+++ b/change/@uifabric-example-app-base-2019-10-18-13-33-24-type-dependencies.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Remove @types packages from peerDependencies",
+  "packageName": "@uifabric/example-app-base",
+  "email": "tmichon@microsoft.com",
+  "commit": "6ce5d6155c6e8004d2bfbf443c1ff7c2878e697f",
+  "date": "2019-10-18T20:33:15.702Z",
+  "file": "D:\\Src\\Git\\OfficeDev\\office-ui-fabric-react-1\\change\\@uifabric-example-app-base-2019-10-18-13-33-24-type-dependencies.json"
+}

--- a/change/@uifabric-experiments-2019-10-18-13-33-24-type-dependencies.json
+++ b/change/@uifabric-experiments-2019-10-18-13-33-24-type-dependencies.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Remove @types packages from peerDependencies",
+  "packageName": "@uifabric/experiments",
+  "email": "tmichon@microsoft.com",
+  "commit": "6ce5d6155c6e8004d2bfbf443c1ff7c2878e697f",
+  "date": "2019-10-18T20:33:16.685Z",
+  "file": "D:\\Src\\Git\\OfficeDev\\office-ui-fabric-react-1\\change\\@uifabric-experiments-2019-10-18-13-33-24-type-dependencies.json"
+}

--- a/change/@uifabric-fabric-website-resources-2019-10-18-13-33-24-type-dependencies.json
+++ b/change/@uifabric-fabric-website-resources-2019-10-18-13-33-24-type-dependencies.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Remove @types packages from peerDependencies",
+  "packageName": "@uifabric/fabric-website-resources",
+  "email": "tmichon@microsoft.com",
+  "commit": "6ce5d6155c6e8004d2bfbf443c1ff7c2878e697f",
+  "date": "2019-10-18T20:33:12.205Z",
+  "file": "D:\\Src\\Git\\OfficeDev\\office-ui-fabric-react-1\\change\\@uifabric-fabric-website-resources-2019-10-18-13-33-24-type-dependencies.json"
+}

--- a/change/@uifabric-file-type-icons-2019-10-18-13-33-24-type-dependencies.json
+++ b/change/@uifabric-file-type-icons-2019-10-18-13-33-24-type-dependencies.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Remove @types packages from peerDependencies",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "tmichon@microsoft.com",
+  "commit": "6ce5d6155c6e8004d2bfbf443c1ff7c2878e697f",
+  "date": "2019-10-18T20:33:17.580Z",
+  "file": "D:\\Src\\Git\\OfficeDev\\office-ui-fabric-react-1\\change\\@uifabric-file-type-icons-2019-10-18-13-33-24-type-dependencies.json"
+}

--- a/change/@uifabric-foundation-2019-10-18-13-33-24-type-dependencies.json
+++ b/change/@uifabric-foundation-2019-10-18-13-33-24-type-dependencies.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Remove @types packages from peerDependencies",
+  "packageName": "@uifabric/foundation",
+  "email": "tmichon@microsoft.com",
+  "commit": "6ce5d6155c6e8004d2bfbf443c1ff7c2878e697f",
+  "date": "2019-10-18T20:33:19.178Z",
+  "file": "D:\\Src\\Git\\OfficeDev\\office-ui-fabric-react-1\\change\\@uifabric-foundation-2019-10-18-13-33-24-type-dependencies.json"
+}

--- a/change/@uifabric-foundation-scenarios-2019-10-18-13-33-24-type-dependencies.json
+++ b/change/@uifabric-foundation-scenarios-2019-10-18-13-33-24-type-dependencies.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Remove @types packages from peerDependencies",
+  "packageName": "@uifabric/foundation-scenarios",
+  "email": "tmichon@microsoft.com",
+  "commit": "6ce5d6155c6e8004d2bfbf443c1ff7c2878e697f",
+  "date": "2019-10-18T20:33:18.420Z",
+  "file": "D:\\Src\\Git\\OfficeDev\\office-ui-fabric-react-1\\change\\@uifabric-foundation-scenarios-2019-10-18-13-33-24-type-dependencies.json"
+}

--- a/change/@uifabric-react-cards-2019-10-18-13-33-24-type-dependencies.json
+++ b/change/@uifabric-react-cards-2019-10-18-13-33-24-type-dependencies.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Remove @types packages from peerDependencies",
+  "packageName": "@uifabric/react-cards",
+  "email": "tmichon@microsoft.com",
+  "commit": "6ce5d6155c6e8004d2bfbf443c1ff7c2878e697f",
+  "date": "2019-10-18T20:33:20.897Z",
+  "file": "D:\\Src\\Git\\OfficeDev\\office-ui-fabric-react-1\\change\\@uifabric-react-cards-2019-10-18-13-33-24-type-dependencies.json"
+}

--- a/change/@uifabric-react-hooks-2019-10-18-13-33-24-type-dependencies.json
+++ b/change/@uifabric-react-hooks-2019-10-18-13-33-24-type-dependencies.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Remove @types packages from peerDependencies",
+  "packageName": "@uifabric/react-hooks",
+  "email": "tmichon@microsoft.com",
+  "commit": "6ce5d6155c6e8004d2bfbf443c1ff7c2878e697f",
+  "date": "2019-10-18T20:33:21.802Z",
+  "file": "D:\\Src\\Git\\OfficeDev\\office-ui-fabric-react-1\\change\\@uifabric-react-hooks-2019-10-18-13-33-24-type-dependencies.json"
+}

--- a/change/@uifabric-test-utilities-2019-10-18-13-33-24-type-dependencies.json
+++ b/change/@uifabric-test-utilities-2019-10-18-13-33-24-type-dependencies.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Remove @types packages from peerDependencies",
+  "packageName": "@uifabric/test-utilities",
+  "email": "tmichon@microsoft.com",
+  "commit": "6ce5d6155c6e8004d2bfbf443c1ff7c2878e697f",
+  "date": "2019-10-18T20:33:22.701Z",
+  "file": "D:\\Src\\Git\\OfficeDev\\office-ui-fabric-react-1\\change\\@uifabric-test-utilities-2019-10-18-13-33-24-type-dependencies.json"
+}

--- a/change/@uifabric-tsx-editor-2019-10-18-13-33-24-type-dependencies.json
+++ b/change/@uifabric-tsx-editor-2019-10-18-13-33-24-type-dependencies.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Remove @types packages from peerDependencies",
+  "packageName": "@uifabric/tsx-editor",
+  "email": "tmichon@microsoft.com",
+  "commit": "6ce5d6155c6e8004d2bfbf443c1ff7c2878e697f",
+  "date": "2019-10-18T20:33:23.556Z",
+  "file": "D:\\Src\\Git\\OfficeDev\\office-ui-fabric-react-1\\change\\@uifabric-tsx-editor-2019-10-18-13-33-24-type-dependencies.json"
+}

--- a/change/@uifabric-utilities-2019-10-18-13-33-24-type-dependencies.json
+++ b/change/@uifabric-utilities-2019-10-18-13-33-24-type-dependencies.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Remove @types packages from peerDependencies",
+  "packageName": "@uifabric/utilities",
+  "email": "tmichon@microsoft.com",
+  "commit": "6ce5d6155c6e8004d2bfbf443c1ff7c2878e697f",
+  "date": "2019-10-18T20:33:24.417Z",
+  "file": "D:\\Src\\Git\\OfficeDev\\office-ui-fabric-react-1\\change\\@uifabric-utilities-2019-10-18-13-33-24-type-dependencies.json"
+}

--- a/change/office-ui-fabric-react-2019-10-18-13-33-24-type-dependencies.json
+++ b/change/office-ui-fabric-react-2019-10-18-13-33-24-type-dependencies.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Remove @types packages from peerDependencies",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "commit": "6ce5d6155c6e8004d2bfbf443c1ff7c2878e697f",
+  "date": "2019-10-18T20:33:19.946Z",
+  "file": "D:\\Src\\Git\\OfficeDev\\office-ui-fabric-react-1\\change\\office-ui-fabric-react-2019-10-18-13-33-24-type-dependencies.json"
+}

--- a/packages/charting/package.json
+++ b/packages/charting/package.json
@@ -71,8 +71,6 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <17.0.0",
-    "@types/react-dom": ">=16.8.0 <17.0.0",
     "react": ">=16.8.0 <17.0.0",
     "react-dom": ">=16.8.0 <17.0.0"
   }

--- a/packages/date-time/package.json
+++ b/packages/date-time/package.json
@@ -55,8 +55,6 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <17.0.0",
-    "@types/react-dom": ">=16.8.0 <17.0.0",
     "react": ">=16.8.0 <17.0.0",
     "react-dom": ">=16.8.0 <17.0.0"
   }

--- a/packages/example-app-base/package.json
+++ b/packages/example-app-base/package.json
@@ -37,8 +37,6 @@
     "@uifabric/build": "^7.0.0"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <17.0.0",
-    "@types/react-dom": ">=16.8.0 <17.0.0",
     "react": ">=16.8.0 <17.0.0",
     "react-dom": ">=16.8.0 <17.0.0"
   },

--- a/packages/experiments/package.json
+++ b/packages/experiments/package.json
@@ -72,8 +72,6 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <17.0.0",
-    "@types/react-dom": ">=16.8.0 <17.0.0",
     "react": ">=16.8.0 <17.0.0",
     "react-dom": ">=16.8.0 <17.0.0"
   }

--- a/packages/file-type-icons/package.json
+++ b/packages/file-type-icons/package.json
@@ -36,8 +36,6 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <17.0.0",
-    "@types/react-dom": ">=16.8.0 <17.0.0",
     "react": ">=16.8.0 <17.0.0",
     "react-dom": ">=16.8.0 <17.0.0"
   }

--- a/packages/foundation-scenarios/package.json
+++ b/packages/foundation-scenarios/package.json
@@ -51,8 +51,6 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <17.0.0",
-    "@types/react-dom": ">=16.8.0 <17.0.0",
     "react": ">=16.8.0 <17.0.0",
     "react-dom": ">=16.8.0 <17.0.0"
   }

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -52,8 +52,6 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <17.0.0",
-    "@types/react-dom": ">=16.8.0 <17.0.0",
     "react": ">=16.8.0 <17.0.0",
     "react-dom": ">=16.8.0 <17.0.0"
   }

--- a/packages/lists/package.json
+++ b/packages/lists/package.json
@@ -53,8 +53,6 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <17.0.0",
-    "@types/react-dom": ">=16.8.0 <17.0.0",
     "react": ">=16.8.0 <17.0.0",
     "react-dom": ">=16.8.0 <17.0.0"
   }

--- a/packages/office-ui-fabric-react/package.json
+++ b/packages/office-ui-fabric-react/package.json
@@ -80,8 +80,6 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <17.0.0",
-    "@types/react-dom": ">=16.8.0 <17.0.0",
     "react": ">=16.8.0 <17.0.0",
     "react-dom": ">=16.8.0 <17.0.0"
   }

--- a/packages/react-cards/package.json
+++ b/packages/react-cards/package.json
@@ -59,8 +59,6 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <17.0.0",
-    "@types/react-dom": ">=16.8.0 <17.0.0",
     "react": ">=16.8.0 <17.0.0",
     "react-dom": ">=16.8.0 <17.0.0"
   }

--- a/packages/react-hooks/package.json
+++ b/packages/react-hooks/package.json
@@ -42,8 +42,6 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <17.0.0",
-    "@types/react-dom": ">=16.8.0 <17.0.0",
     "react": ">=16.8.0 <17.0.0",
     "react-dom": ">=16.8.0 <17.0.0"
   }

--- a/packages/test-utilities/package.json
+++ b/packages/test-utilities/package.json
@@ -47,8 +47,6 @@
     "@uifabric/set-version": "^7.0.2"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <17.0.0",
-    "@types/react-dom": ">=16.8.0 <17.0.0",
     "react": ">=16.8.0 <17.0.0",
     "react-dom": ">=16.8.0 <17.0.0"
   }

--- a/packages/tsx-editor/package.json
+++ b/packages/tsx-editor/package.json
@@ -53,8 +53,6 @@
     "typescript": "3.5.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <17.0.0",
-    "@types/react-dom": ">=16.8.0 <17.0.0",
     "react": ">=16.8.0 <17.0.0",
     "react-dom": ">=16.8.0 <17.0.0"
   }

--- a/packages/utilities/package.json
+++ b/packages/utilities/package.json
@@ -52,8 +52,6 @@
     "tslib": "^1.7.1"
   },
   "peerDependencies": {
-    "@types/react": ">=16.8.0 <17.0.0",
-    "@types/react-dom": ">=16.8.0 <17.0.0",
     "react": ">=16.8.0 <17.0.0",
     "react-dom": ">=16.8.0 <17.0.0"
   }

--- a/scripts/templates/create-package/EmptyPackageJson.mustache
+++ b/scripts/templates/create-package/EmptyPackageJson.mustache
@@ -52,8 +52,6 @@
     "tslib": "{{{tslib}}}"
   },
   "peerDependencies": {
-    "@types/react": "{{{typesReactPeerDep}}}",
-    "@types/react-dom": "{{{typesReactDomPeerDep}}}",
     "react": "{{{reactPeerDep}}}",
     "react-dom": "{{{reactDomPeerDep}}}"
   }


### PR DESCRIPTION
The presence of `@types/*` packages in `peerDependencies` causes issues with package manager such as `pnpm` which perform 'strict' resolution of peers, because each specific `@types/*` package brought in by a host package causes multiple installations of the Fabric packages to be created, one to satisfy each peer. Since `@types/*` packages are *not* consumed at runtime and thus can't cause breaks, it does not make sense to declare them as formal dependencies. The host should be free to consume whichever version of `@types/*` it wants, at own risk.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10914)