### PR TITLE
Callout and HoverCard: Fix anchor positions (#10730)

### DIFF
--- a/change/office-ui-fabric-react-2019-10-07-13-54-11-fix-anchor-positions.json
+++ b/change/office-ui-fabric-react-2019-10-07-13-54-11-fix-anchor-positions.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Callout and Card: Fix anchors for both",
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com",
+  "commit": "cbc935cf6a0e1d4fb1b7e980b347074dce817745",
+  "date": "2019-10-07T20:54:11.146Z",
+  "file": "/Users/joschect-m1/Git/office-ui-fabric-react/change/office-ui-fabric-react-2019-10-07-13-54-11-fix-anchor-positions.json"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -22,7 +22,8 @@ import {
   IPositionProps,
   getMaxHeight,
   IPosition,
-  RectangleEdge
+  RectangleEdge,
+  positionCard
 } from '../../utilities/positioning';
 import { Popup } from '../../Popup';
 import { classNamesFunction } from '../../Utilities';
@@ -373,7 +374,11 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
       currentProps = assign(currentProps, this.props);
       currentProps!.bounds = this._getBounds();
       currentProps!.target = this._target!;
-      const newPositions: ICalloutPositionedInfo = positionCallout(currentProps!, hostElement, calloutElement, positions);
+      // If there is a finalHeight given then we assume that the user knows and will handle
+      // additional positioning adjustments so we should call positionCard
+      const newPositions: ICalloutPositionedInfo = this.props.finalHeight
+        ? positionCard(currentProps!, hostElement, calloutElement, positions)
+        : positionCallout(currentProps!, hostElement, calloutElement, positions);
 
       // Set the new position only when the positions are not exists or one of the new callout positions are different.
       // The position should not change if the position is within 2 decimal places.

--- a/packages/office-ui-fabric-react/src/utilities/positioning/positioning.ts
+++ b/packages/office-ui-fabric-react/src/utilities/positioning/positioning.ts
@@ -417,22 +417,13 @@ function _getFlankingEdges(edge: RectangleEdge): { positiveEdge: RectangleEdge; 
 /**
  * Retrieve the final value for the return edge of elementRectangle.
  * If the elementRectangle is closer to one side of the bounds versus the other, the return edge is flipped to grow inward.
- * The finalized return edge should not flip if the element has already been positiuoned successfully to prevent the callout from
- * appearing to jump
  *
  * @param elementRectangle
  * @param targetEdge
  * @param bounds
- * @param previousPositions
  */
-function _finalizeReturnEdge(
-  elementRectangle: Rectangle,
-  returnEdge: RectangleEdge,
-  bounds?: Rectangle,
-  previousPositions?: boolean
-): RectangleEdge {
+function _finalizeReturnEdge(elementRectangle: Rectangle, returnEdge: RectangleEdge, bounds?: Rectangle): RectangleEdge {
   if (
-    !previousPositions &&
     bounds &&
     Math.abs(_getRelativeEdgeDifference(elementRectangle, bounds, returnEdge)) >
       Math.abs(_getRelativeEdgeDifference(elementRectangle, bounds, returnEdge * -1))
@@ -456,7 +447,7 @@ function _finalizeReturnEdge(
  * @param {RectangleEdge} bounds
  * @param {RectangleEdge} [alignmentEdge]
  * @param {boolean} coverTarget
- * @param {previousPositions} previousPositions
+ * @param {boolean} doNotFinalizeReturnEdge
  * @returns {IPartialIRectangle}
  */
 function _finalizeElementPosition(
@@ -466,19 +457,17 @@ function _finalizeElementPosition(
   bounds?: Rectangle,
   alignmentEdge?: RectangleEdge,
   coverTarget?: boolean,
-  previousPositions?: boolean
+  doNotFinalizeReturnEdge?: boolean
 ): IPartialIRectangle {
   const returnValue: IPartialIRectangle = {};
 
   const hostRect: Rectangle = _getRectangleFromElement(hostElement);
   const elementEdge = coverTarget ? targetEdge : targetEdge * -1;
   const elementEdgeString = RectangleEdge[elementEdge];
-  const returnEdge = _finalizeReturnEdge(
-    elementRectangle,
-    alignmentEdge ? alignmentEdge : _getFlankingEdges(targetEdge).positiveEdge,
-    bounds,
-    previousPositions
-  );
+  let returnEdge = alignmentEdge ? alignmentEdge : _getFlankingEdges(targetEdge).positiveEdge;
+  if (!doNotFinalizeReturnEdge) {
+    returnEdge = _finalizeReturnEdge(elementRectangle, returnEdge, bounds);
+  }
 
   returnValue[elementEdgeString] = _getRelativeEdgeDifference(elementRectangle, hostRect, elementEdge);
   returnValue[RectangleEdge[returnEdge]] = _getRelativeEdgeDifference(elementRectangle, hostRect, returnEdge);
@@ -742,20 +731,12 @@ function _positionElementRelative(
   return { ...positionedElement, targetRectangle: targetRect };
 }
 
-/**
- *
- * @param positionedElement The elements estimated position, is not page relative yet
- * @param hostElement The element which is hosting the positioning element
- * @param bounds The space in which the positioning element can render
- * @param coverTarget Whether or not the element should cover the target
- * @param previousPositions If the element has already been positioned before.
- */
 function _finalizePositionData(
   positionedElement: IElementPosition,
   hostElement: HTMLElement,
   bounds?: Rectangle,
   coverTarget?: boolean,
-  previousPositions?: boolean
+  doNotFinalizeReturnEdge?: boolean
 ): IPositionedData {
   const finalizedElement: IPartialIRectangle = _finalizeElementPosition(
     positionedElement.elementRectangle,
@@ -764,7 +745,7 @@ function _finalizePositionData(
     bounds,
     positionedElement.alignmentEdge,
     coverTarget,
-    previousPositions
+    doNotFinalizeReturnEdge
   );
   return {
     elementPosition: finalizedElement,
@@ -783,14 +764,15 @@ function _positionElement(
     ? _getRectangleFromIRect(props.bounds)
     : new Rectangle(0, window.innerWidth - getScrollbarWidth(), 0, window.innerHeight);
   const positionedElement: IElementPosition = _positionElementRelative(props, elementToPosition, boundingRect, previousPositions);
-  return _finalizePositionData(positionedElement, hostElement, boundingRect, props.coverTarget, !!previousPositions);
+  return _finalizePositionData(positionedElement, hostElement, boundingRect, props.coverTarget);
 }
 
 function _positionCallout(
   props: ICalloutPositionProps,
   hostElement: HTMLElement,
   callout: HTMLElement,
-  previousPositions?: ICalloutPositionedInfo
+  previousPositions?: ICalloutPositionedInfo,
+  doNotFinalizeReturnEdge?: boolean
 ): ICalloutPositionedInfo {
   const beakWidth: number = props.isBeakVisible ? props.beakWidth || 0 : 0;
   const gap: number = _calculateActualBeakWidthInPixels(beakWidth) / 2 + (props.gapSpace ? props.gapSpace : 0);
@@ -803,9 +785,18 @@ function _positionCallout(
   const beakPositioned: Rectangle = _positionBeak(beakWidth, positionedElement);
   const finalizedBeakPosition: ICalloutBeakPositionedInfo = _finalizeBeakPosition(positionedElement, beakPositioned, boundingRect);
   return {
-    ..._finalizePositionData(positionedElement, hostElement, boundingRect, props.coverTarget, !!previousPositions),
+    ..._finalizePositionData(positionedElement, hostElement, boundingRect, props.coverTarget, doNotFinalizeReturnEdge),
     beakPosition: finalizedBeakPosition
   };
+}
+
+function _positionCard(
+  props: ICalloutPositionProps,
+  hostElement: HTMLElement,
+  callout: HTMLElement,
+  previousPositions?: ICalloutPositionedInfo
+): ICalloutPositionedInfo {
+  return _positionCallout(props, hostElement, callout, previousPositions, true);
 }
 // END PRIVATE FUNCTIONS
 
@@ -850,6 +841,15 @@ export function positionCallout(
   previousPositions?: ICalloutPositionedInfo
 ): ICalloutPositionedInfo {
   return _positionCallout(props, hostElement, elementToPosition, previousPositions);
+}
+
+export function positionCard(
+  props: IPositionProps,
+  hostElement: HTMLElement,
+  elementToPosition: HTMLElement,
+  previousPositions?: ICalloutPositionedInfo
+): ICalloutPositionedInfo {
+  return _positionCard(props, hostElement, elementToPosition, previousPositions);
 }
 
 /**


### PR DESCRIPTION
* Revert "Positioning: Fix issue where anchor edge would flip even if previous positions calculated"

This reverts commit 52bfddc7567b8f910189142d75c2762358c0e62b.

* Callout and Card: Fix anchors for both

* Change files

* minor fix

* update comment

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10916)