### PR TITLE
 TagPicker: prevent long items from overflowing narrow container

### DIFF
--- a/apps/vr-tests/src/stories/TagPicker.stories.tsx
+++ b/apps/vr-tests/src/stories/TagPicker.stories.tsx
@@ -2,7 +2,7 @@
 import * as React from 'react';
 import Screener from 'screener-storybook/src/screener';
 import { storiesOf } from '@storybook/react';
-import { FabricDecorator } from '../utilities';
+import { FabricDecorator, FabricDecoratorFixedWidth } from '../utilities';
 import { TagPicker, Fabric, ITag } from 'office-ui-fabric-react';
 
 const testTags: ITag[] = [
@@ -75,6 +75,28 @@ storiesOf('TagPicker', module)
     ),
     { rtl: true }
   );
+
+storiesOf('TagPicker', module)
+  .addDecorator(FabricDecoratorFixedWidth)
+  .addDecorator(story => (
+    <Screener steps={new Screener.Steps().snapshot('default', { cropTo: '.testWrapper' }).end()}>
+      {story()}
+    </Screener>
+  ))
+  .addStory('With long tag', () => (
+    // This example MUST be inside a narrow container which forces the tag to overflow
+    <Fabric style={{ width: 180 }}>
+      <TagPicker
+        onResolveSuggestions={getList}
+        defaultSelectedItems={[
+          {
+            key: 'test',
+            name: 'Very very long tag (this part should be truncated)'
+          }
+        ]}
+      />
+    </Fabric>
+  ));
 
 storiesOf('TagItem', module)
   .addDecorator(FabricDecorator)

--- a/change/office-ui-fabric-react-2019-10-18-23-26-58-tagpicker.json
+++ b/change/office-ui-fabric-react-2019-10-18-23-26-58-tagpicker.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "TagPicker: prevent long items from overflowing narrow container",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "commit": "3d330f77a317b5cbbfed105c270b7b4b942fa667",
+  "date": "2019-10-19T06:26:58.893Z",
+  "file": "/Users/elizabeth/git/fabric-react/change/office-ui-fabric-react-2019-10-18-23-26-58-tagpicker.json"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.styles.ts
@@ -34,6 +34,7 @@ export function getStyles(props: ITagItemStyleProps): ITagItemStyles {
         display: 'flex',
         flexWrap: 'nowrap',
         maxWidth: 300,
+        minWidth: 0, // needed to prevent long tags from overflowing container
         borderRadius: effects.roundedCorner2,
         background: !selected || disabled ? palette.neutralLighter : palette.themePrimary,
         selectors: {

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagPicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagPicker.test.tsx
@@ -36,7 +36,9 @@ describe('TagPicker', () => {
   });
 
   it('renders correctly', () => {
-    const component = renderer.create(<TagPicker onResolveSuggestions={onResolveSuggestions} />);
+    const component = renderer.create(
+      <TagPicker onResolveSuggestions={onResolveSuggestions} defaultSelectedItems={onResolveSuggestions('black')} />
+    );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
@@ -106,6 +108,7 @@ describe('TagPicker', () => {
 
     ReactDOM.unmountComponentAtNode(root);
   });
+
   it('fires change events correctly for controlled components', done => {
     const root = document.createElement('div');
     document.body.appendChild(root);

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
@@ -52,9 +52,213 @@ exports[`TagPicker renders correctly 1`] = `
               border-color: #323130;
             }
       >
+        <span
+          className=
+              ms-BasePicker-itemsWrapper
+              {
+                display: flex;
+                flex-wrap: wrap;
+                max-width: 100%;
+              }
+          id="selected-items-id__0"
+          role="list"
+        >
+          <div
+            className=
+                ms-TagItem
+                {
+                  background: #f3f2f1;
+                  border-radius: 2px;
+                  box-sizing: content-box;
+                  cursor: default;
+                  display: flex;
+                  flex-shrink: 1;
+                  flex-wrap: nowrap;
+                  height: 26px;
+                  line-height: 26px;
+                  margin-bottom: 2px;
+                  margin-left: 2px;
+                  margin-right: 2px;
+                  margin-top: 2px;
+                  max-width: 300px;
+                  min-width: 0px;
+                  outline: transparent;
+                  position: relative;
+                  user-select: none;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid #ffffff;
+                  bottom: 1px;
+                  content: "";
+                  left: 1px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 1px;
+                  top: 1px;
+                  z-index: 1;
+                }
+                &:hover {
+                  background: #edebe9;
+                  color: #201f1e;
+                }
+                &:hover .ms-TagItem-close {
+                  color: #323130;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border: 1px solid WindowText;
+                }
+            data-is-focusable={true}
+            data-selection-index={0}
+            role="listitem"
+          >
+            <span
+              aria-label="black"
+              className=
+                  ms-TagItem-text
+                  {
+                    margin-bottom: 0;
+                    margin-left: 8px;
+                    margin-right: 8px;
+                    margin-top: 0;
+                    min-width: 30px;
+                    overflow: hidden;
+                    text-overflow: ellipsis;
+                    white-space: nowrap;
+                  }
+            >
+              black
+            </span>
+            <button
+              className=
+                  ms-Button
+                  ms-Button--icon
+                  ms-TagItem-close
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0 2px 2px 0;
+                    border: none;
+                    box-sizing: border-box;
+                    color: #605e5c;
+                    cursor: pointer;
+                    display: inline-block;
+                    flex: 0 0 auto;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 100%;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 4px;
+                    padding-right: 4px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                    width: 30px;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 1px solid transparent;
+                    bottom: 2px;
+                    content: "";
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: absolute;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    background: #e1dfdd;
+                    color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:active {
+                    background-color: #005a9e;
+                    color: #ffffff;
+                  }
+              data-is-focusable={true}
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              type="button"
+            >
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: center;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <i
+                  aria-hidden={true}
+                  className=
+                      ms-Button-icon
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        display: inline-block;
+                        flex-shrink: 0;
+                        font-family: "FabricMDL2Icons";
+                        font-size: 12px;
+                        font-style: normal;
+                        font-weight: normal;
+                        height: 16px;
+                        line-height: 16px;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                        speak: none;
+                        text-align: center;
+                        vertical-align: middle;
+                      }
+                  data-icon-name="Cancel"
+                >
+                  
+                </i>
+              </span>
+            </button>
+          </div>
+        </span>
         <input
           aria-autocomplete="both"
           aria-controls=" "
+          aria-describedby="selected-items-id__0"
           autoCapitalize="off"
           autoComplete="off"
           className=


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10744
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add `min-width: 0` to the root of TagItem to prevent very long tags from overflow narrow TagPicker containers. (thank you [stack overflow](https://stackoverflow.com/a/36247448/890624)...)

Before:
![image](https://user-images.githubusercontent.com/5864305/67138946-536b3480-f1ff-11e9-938a-6eb2898f8b8a.png)

After:
![image](https://user-images.githubusercontent.com/5864305/67138942-40586480-f1ff-11e9-8443-767defcae7e1.png)

I added a screener test for this scenario, and added a default selected tag in the TagPicker snapshot test since TagItem wasn't getting any snapshot coverage.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10917)