### PR TITLE
ComboBox: Allow Space KeyUp to propagate

### DIFF
--- a/change/office-ui-fabric-react-2019-10-21-21-13-56-fix-combobox.json
+++ b/change/office-ui-fabric-react-2019-10-21-21-13-56-fix-combobox.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "let keyup event to propagate",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "31043b5ba01a88858e161416914df0c2a3365d32",
+  "date": "2019-10-22T04:13:56.180Z",
+  "file": "/Users/xgao/Projects/office-ui-fabric-react/change/office-ui-fabric-react-2019-10-21-21-13-56-fix-combobox.json"
+}

--- a/change/office-ui-fabric-react-2019-10-21-21-13-56-fix-combobox.json
+++ b/change/office-ui-fabric-react-2019-10-21-21-13-56-fix-combobox.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "let keyup event to propagate",
+  "comment": "ComboBox: Allow Space KeyUp event to propagate",
   "packageName": "office-ui-fabric-react",
   "email": "xgao@microsoft.com",
   "commit": "31043b5ba01a88858e161416914df0c2a3365d32",

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1851,18 +1851,14 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         // and allow the event to propagate
         if (!allowFreeform && autoComplete === 'off') {
           this._setOpenStateAndFocusOnClose(!isOpen, !!isOpen);
-          return;
         }
-        break;
+        return;
       default:
         if (shouldHandleKey && isOpen) {
           this._setOpenStateAndFocusOnClose(!isOpen, true /* focusInputAfterClose */);
         }
         return;
     }
-
-    ev.stopPropagation();
-    ev.preventDefault();
   };
 
   private _onOptionMouseEnter(index: number): void {


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #10775
- [X] Include a change request file using `$ yarn change`

#### Description of changes
We should not stop propagating the key up event when nothing is done by ComboBox during event handling


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10929)