### PR TITLE
FocusZone: remove keydown event only when needed.

### DIFF
--- a/change/office-ui-fabric-react-2019-10-22-22-16-09-focuszone-keydown.json
+++ b/change/office-ui-fabric-react-2019-10-22-22-16-09-focuszone-keydown.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "FocusZone: unhooking capture keydown handler at the right time to avoid a race condition.",
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@hotmail.com",
+  "commit": "01728e3082bf41ea216f9f25a745c202a7489372",
+  "date": "2019-10-23T05:16:09.514Z",
+  "file": "C:\\fabric\\branch3\\change\\office-ui-fabric-react-2019-10-22-22-16-09-focuszone-keydown.json"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -23,7 +23,8 @@ import {
   shouldWrapFocus,
   warnDeprecations,
   portalContainsElement,
-  IPoint
+  IPoint,
+  getWindow
 } from '../../Utilities';
 import { mergeStyles } from '@uifabric/merge-styles';
 
@@ -61,6 +62,9 @@ const _allInstances: {
   [key: string]: FocusZone;
 } = {};
 const _outerZones: Set<FocusZone> = new Set();
+
+// Track the 1 global keydown listener we hook to window.
+let _disposeGlobalKeyDownListener: () => void | undefined;
 
 const ALLOWED_INPUT_TYPES = ['text', 'number', 'password', 'email', 'tel', 'url', 'search'];
 
@@ -135,8 +139,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     _allInstances[this._id] = this;
 
     if (root) {
-      const windowElement = root.ownerDocument!.defaultView!;
-
+      const windowElement = getWindow(root);
       let parentElement = getParent(root, ALLOW_VIRTUAL_ELEMENTS);
 
       while (parentElement && parentElement !== this._getDocument().body && parentElement.nodeType === 1) {
@@ -152,7 +155,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
       }
 
       if (windowElement && _outerZones.size === 1) {
-        this._disposables.push(on(windowElement, 'keydown', this._onKeyDownCapture, true));
+        _disposeGlobalKeyDownListener = on(windowElement, 'keydown', this._onKeyDownCapture, true);
       }
       this._disposables.push(on(root, 'blur', this._onBlur, true));
 
@@ -195,6 +198,11 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
 
     // Dispose all events.
     this._disposables.forEach(d => d());
+
+    // If this is the last outer zone, remove the keydown listener.
+    if (_outerZones.size === 0 && _disposeGlobalKeyDownListener) {
+      _disposeGlobalKeyDownListener();
+    }
   }
 
   public render() {


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #10804
- [X] Include a change request file using `$ yarn change`

#### Description of changes

In cases where there are multiple outer zones, we only hook up a window keydown listener on the first one.

If the first one unmounts, but other zones are still rendered, there is no longer the window keydown listener adjusting tabindexes. 

This fix unhooks the global keydown listener only when the last outer zone is unmounted.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10941)