### PR TITLE
Change gapSpace to 10 to resolve line chart flickering issue

### DIFF
--- a/change/@uifabric-charting-2019-10-23-18-01-45-user-v-ragor-Bug_3717122.json
+++ b/change/@uifabric-charting-2019-10-23-18-01-45-user-v-ragor-Bug_3717122.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Change gapSpace to 10 to resolve line chart flickering issue",
+  "packageName": "@uifabric/charting",
+  "email": "v-ragor@microsoft.com",
+  "commit": "39f7975985f9789b2baf9460c5d86c79186a93fc",
+  "date": "2019-10-23T12:31:45.867Z",
+  "file": "C:\\PAPCODE\\office-ui-fabric-react\\change\\@uifabric-charting-2019-10-23-18-01-45-user-v-ragor-Bug_3717122.json"
+}

--- a/packages/charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/charting/src/components/LineChart/LineChart.base.tsx
@@ -134,7 +134,7 @@ export class LineChartBase extends React.Component<
         </svg>
         <div className={this._classNames.legendContainer}>{legendBars}</div>
         {this.state.isCalloutVisible ? (
-          <Callout target={this.state.refSelected} isBeakVisible={false} gapSpace={5} directionalHint={DirectionalHint.topAutoEdge}>
+          <Callout target={this.state.refSelected} isBeakVisible={false} gapSpace={10} directionalHint={DirectionalHint.topAutoEdge}>
             <div className={this._classNames.calloutContentRoot}>
               <span className={this._classNames.calloutContentX}>{this.state.hoverXValue}</span>
               <span className={this._classNames.calloutContentY}>{this.state.hoverYValue}</span>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Change gapSpace to 10 to resolve line chart flickering issue.it will provide gap between mouse pointer and callout.

#### Focus areas to test
line chart on hover 
(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10948)