### PR TITLE
DetailsRow: Make data-is-focusable configurable

### DIFF
--- a/change/office-ui-fabric-react-2019-10-23-11-58-08-keco-detailsrow-focusable-config.json
+++ b/change/office-ui-fabric-react-2019-10-23-11-58-08-keco-detailsrow-focusable-config.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Make DetailsRow data-is-focusable configurable",
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com",
+  "commit": "6d0e302acf49b223fc1af8f9233098eefec7fc12",
+  "date": "2019-10-23T18:58:07.996Z",
+  "file": "C:\\Users\\keco\\Work\\office-ui-fabric-react\\change\\office-ui-fabric-react-2019-10-23-11-58-08-keco-detailsrow-focusable-config.json"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRow.base.tsx
@@ -246,6 +246,7 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
 
     return (
       <FocusZone
+        data-is-focusable={true}
         {...getNativeProps(this.props, divProperties)}
         {...(typeof isDraggable === 'boolean'
           ? {
@@ -260,7 +261,6 @@ export class DetailsRowBase extends React.Component<IDetailsRowBaseProps, IDetai
         aria-label={ariaLabel}
         aria-describedby={ariaDescribedBy}
         className={this._classNames.root}
-        data-is-focusable={true}
         data-selection-index={itemIndex}
         data-item-index={itemIndex}
         aria-rowindex={itemIndex + 1}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Alternative approach to https://github.com/OfficeDev/office-ui-fabric-react/pull/10619 which minimizes API changes.

The issue is a partner team ask to make `data-is-focusable` attribute configurable for `DetailsRow`. Currently it is set to `true` always.

**Usage**

To override `data-is-focusable` with this change-set, one must supply a custom row render method like the following:

```diff
diff --git a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
index 0c1928800..50109a117 100644
--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
@@ -4,6 +4,7 @@ import { DetailsList, DetailsListLayoutMode, Selection, IColumn } from 'office-u
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
 import { Fabric } from 'office-ui-fabric-react/lib/Fabric';
 import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
+import { DetailsRow, IDetailsRowProps } from '../DetailsRow';
 
 const exampleChildClass = mergeStyles({
   display: 'block',
@@ -78,12 +79,17 @@ export class DetailsListBasicExample extends React.Component<{}, IDetailsListBas
             ariaLabelForSelectAllCheckbox="Toggle selection for all items"
             checkButtonAriaLabel="Row checkbox"
             onItemInvoked={this._onItemInvoked}
+            onRenderRow={this._onRenderRow}
           />
         </MarqueeSelection>
       </Fabric>
     );
   }
 
+  private _onRenderRow = (props: IDetailsRowProps) => {
+    return <DetailsRow {...props} data-is-focusable={false} />;
+  };
+
   private _getSelectionDetails(): string {
     const selectionCount = this._selection.getSelectedCount();
```

cc: @RajeshGoriga @Raghurk 

#### Focus areas to test

- CI should pass


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10951)