### PR TITLE
Fixes: basebutton not rendering the aria label in the outer div

### DIFF
--- a/change/office-ui-fabric-react-2019-10-23-13-51-25-master.json
+++ b/change/office-ui-fabric-react-2019-10-23-13-51-25-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Adds aria label to basebutton on the outer div",
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com",
+  "commit": "4fffd6c0bd1828a8b4c153b19ef2e22a2b95fcf3",
+  "date": "2019-10-23T20:51:25.327Z"
+}

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "dom-test": "cd apps/dom-tests && just-scripts jest-dom-with-webpack"
   },
   "devDependencies": {
-    "beachball": "^1.14.1",
+    "beachball": "^1.14.2",
     "lerna": "^3.15.0",
     "lint-staged": "^7.0.5"
   },

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -541,7 +541,7 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
       keytipProps = this._getMemoizedMenuButtonKeytipProps(keytipProps);
     }
 
-    const containerProps = getNativeProps<React.HTMLAttributes<HTMLSpanElement>>(buttonProps, [], ['disabled', 'aria-label']);
+    const containerProps = getNativeProps<React.HTMLAttributes<HTMLSpanElement>>(buttonProps, [], ['disabled']);
 
     // Add additional props to apply on primary action button
     if (primaryActionButtonProps) {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CustomSplit.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CustomSplit.Example.tsx.shot
@@ -32,6 +32,7 @@ exports[`Component Examples renders Button.CustomSplit.Example.tsx correctly 1`]
   <div
     aria-expanded={false}
     aria-haspopup={true}
+    aria-label="New item"
     aria-roledescription="split button"
     className=
 

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
@@ -72,6 +72,7 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
               <div
                 aria-expanded={false}
                 aria-haspopup={true}
+                aria-label="New"
                 className=
 
                     {

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -21,7 +21,7 @@
     "@uifabric/prettier-rules": "^7.0.4",
     "async": "^2.6.1",
     "autoprefixer": "^7.1.5",
-    "beachball": "^1.14.1",
+    "beachball": "^1.14.2",
     "chalk": "^2.1.0",
     "css-loader": "^0.28.7",
     "find-free-port": "~2.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3752,10 +3752,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-beachball@^1.14.1:
-  version "1.14.1"
-  resolved "https://registry.npmjs.org/beachball/-/beachball-1.14.1.tgz#91683f5c98d87778548b66458480e99fcdff1226"
-  integrity sha512-MKPaTaBeycAyDXailj1On0Lxsi6AKnVnNdrcBIj++Lpfy2xRnjACuP1CX+Yvw4qf6+FRPmbgVbj/xyU+GZbXXA==
+beachball@^1.14.2:
+  version "1.14.2"
+  resolved "https://registry.npmjs.org/beachball/-/beachball-1.14.2.tgz#aab2a947a8f607962b91f8ec0ed3c9a9891a3cf7"
+  integrity sha512-/NfY72bBBcykAuZ7o14OzPEhygJgfDpZqIdZWxH3nISnO1xSwnZlGosrUixsQjgcuibQ1q9sLDmP5VO/06XtSA==
   dependencies:
     fs-extra "^8.0.1"
     git-url-parse "^11.1.2"


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

This addresses an issue with the basebutton not rendering the aria label in the outer div

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10954)