### PR TITLE
Dropdown: Moving announcement of selected options from aria-describedby to aria-labelledby.

### DIFF
--- a/change/office-ui-fabric-react-2019-10-24-12-23-48-dropdownAriaLabelledBy.json
+++ b/change/office-ui-fabric-react-2019-10-24-12-23-48-dropdownAriaLabelledBy.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Dropdown: Moving announcement of selected options from aria-describedby to aria-labelledby.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "c31b256c602c05d4e5d21cbdaa9536c208f00e42",
+  "date": "2019-10-24T19:23:48.783Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -267,9 +267,8 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
               aria-haspopup="listbox"
               aria-expanded={isOpen ? 'true' : 'false'}
               aria-label={ariaLabel}
-              aria-labelledby={label && !ariaLabel ? this._labelId : undefined}
+              aria-labelledby={label && !ariaLabel ? mergeAriaAttributeValues(this._labelId, this._optionId) : undefined}
               aria-describedby={mergeAriaAttributeValues(
-                this._optionId,
                 keytipAttributes['aria-describedby'],
                 hasErrorMessage ? this._id + '-errorMessage' : undefined
               )}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -7,7 +7,6 @@ exports[`Dropdown multi-select Renders multiselect Dropdown correctly 1`] = `
 
 >
   <div
-    aria-describedby="Dropdown0-option"
     aria-expanded="false"
     aria-haspopup="listbox"
     className=
@@ -182,7 +181,6 @@ exports[`Dropdown single-select Renders single-select Dropdown correctly 1`] = `
 
 >
   <div
-    aria-describedby="Dropdown0-option"
     aria-expanded="false"
     aria-haspopup="listbox"
     className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
@@ -42,10 +42,9 @@ exports[`Component Examples renders Callout.Cover.Example.tsx correctly 1`] = `
         Directional hint
       </label>
       <div
-        aria-describedby="Dropdown0-option"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-labelledby="Dropdown0-label"
+        aria-labelledby="Dropdown0-label Dropdown0-option"
         className=
             ms-Dropdown
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
@@ -727,10 +727,9 @@ exports[`Component Examples renders Callout.Directional.Example.tsx correctly 1`
         Directional hint
       </label>
       <div
-        aria-describedby="Dropdown3-option"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-labelledby="Dropdown3-label"
+        aria-labelledby="Dropdown3-label Dropdown3-option"
         className=
             ms-Dropdown
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -205,7 +205,6 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                   }
             >
               <div
-                aria-describedby="Dropdown2-option"
                 aria-disabled={true}
                 aria-expanded="false"
                 aria-haspopup="listbox"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
@@ -44,10 +44,9 @@ exports[`Component Examples renders Coachmark.Basic.Example.tsx correctly 1`] = 
         Coachmark position
       </label>
       <div
-        aria-describedby="Dropdown0-option"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-labelledby="Dropdown0-label"
+        aria-labelledby="Dropdown0-label Dropdown0-option"
         className=
             ms-Dropdown
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
@@ -188,10 +188,9 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
         Directional hint
       </label>
       <div
-        aria-describedby="Dropdown1-option"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-labelledby="Dropdown1-label"
+        aria-labelledby="Dropdown1-label Dropdown1-option"
         className=
             ms-Dropdown
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
@@ -247,10 +247,9 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
       Select the first day of the week
     </label>
     <div
-      aria-describedby="Dropdown5-option"
       aria-expanded="false"
       aria-haspopup="listbox"
-      aria-labelledby="Dropdown5-label"
+      aria-labelledby="Dropdown5-label Dropdown5-option"
       className=
           ms-Dropdown
           {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
@@ -247,10 +247,9 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
       Select the first day of the week
     </label>
     <div
-      aria-describedby="Dropdown5-option"
       aria-expanded="false"
       aria-haspopup="listbox"
-      aria-labelledby="Dropdown5-label"
+      aria-labelledby="Dropdown5-label Dropdown5-option"
       className=
           ms-Dropdown
           {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
@@ -57,10 +57,9 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       Basic uncontrolled example
     </label>
     <div
-      aria-describedby="Dropdown0-option"
       aria-expanded="false"
       aria-haspopup="listbox"
-      aria-labelledby="Dropdown0-label"
+      aria-labelledby="Dropdown0-label Dropdown0-option"
       className=
           ms-Dropdown
           {
@@ -268,11 +267,10 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       Disabled example with defaultSelectedKey
     </label>
     <div
-      aria-describedby="Dropdown1-option"
       aria-disabled={true}
       aria-expanded="false"
       aria-haspopup="listbox"
-      aria-labelledby="Dropdown1-label"
+      aria-labelledby="Dropdown1-label Dropdown1-option"
       className=
           ms-Dropdown
           is-disabled
@@ -460,10 +458,9 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       Multi-select uncontrolled example
     </label>
     <div
-      aria-describedby="Dropdown2-option"
       aria-expanded="false"
       aria-haspopup="listbox"
-      aria-labelledby="Dropdown2-label"
+      aria-labelledby="Dropdown2-label Dropdown2-option"
       className=
           ms-Dropdown
           {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Controlled.Example.tsx.shot
@@ -36,10 +36,9 @@ exports[`Component Examples renders Dropdown.Controlled.Example.tsx correctly 1`
     Controlled example
   </label>
   <div
-    aria-describedby="Dropdown0-option"
     aria-expanded="false"
     aria-haspopup="listbox"
-    aria-labelledby="Dropdown0-label"
+    aria-labelledby="Dropdown0-label Dropdown0-option"
     className=
         ms-Dropdown
         {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.ControlledMulti.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.ControlledMulti.Example.tsx.shot
@@ -36,10 +36,9 @@ exports[`Component Examples renders Dropdown.ControlledMulti.Example.tsx correct
     Multi-select controlled example
   </label>
   <div
-    aria-describedby="Dropdown0-option"
     aria-expanded="false"
     aria-haspopup="listbox"
-    aria-labelledby="Dropdown0-label"
+    aria-labelledby="Dropdown0-label Dropdown0-option"
     className=
         ms-Dropdown
         {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
@@ -57,7 +57,6 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
       Custom example
     </label>
     <div
-      aria-describedby="Dropdown0-option"
       aria-expanded="false"
       aria-haspopup="listbox"
       aria-label="Custom dropdown example"
@@ -421,7 +420,6 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
       </button>
     </div>
     <div
-      aria-describedby="Dropdown1-option"
       aria-expanded="false"
       aria-haspopup="listbox"
       aria-label="Custom dropdown label example"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
@@ -229,10 +229,9 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
       Dropdown with error message
     </label>
     <div
-      aria-describedby="Dropdown1-option"
       aria-expanded="false"
       aria-haspopup="listbox"
-      aria-labelledby="Dropdown1-label"
+      aria-labelledby="Dropdown1-label Dropdown1-option"
       className=
           ms-Dropdown
           {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
@@ -85,10 +85,9 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
         Required dropdown example
       </label>
       <div
-        aria-describedby="Dropdown0-option"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-labelledby="Dropdown0-label"
+        aria-labelledby="Dropdown0-label Dropdown0-option"
         aria-required={true}
         className=
             ms-Dropdown
@@ -395,7 +394,6 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
 
   >
     <div
-      aria-describedby="Dropdown4-option"
       aria-expanded="false"
       aria-haspopup="listbox"
       aria-required={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -853,10 +853,9 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
         Persona Size:
       </label>
       <div
-        aria-describedby="Dropdown5-option"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-labelledby="Dropdown5-label"
+        aria-labelledby="Dropdown5-label Dropdown5-option"
         className=
             ms-Dropdown
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
@@ -964,10 +964,9 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
         Overflow Button Type:
       </label>
       <div
-        aria-describedby="Dropdown5-option"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-labelledby="Dropdown5-label"
+        aria-labelledby="Dropdown5-label Dropdown5-option"
         className=
             ms-Dropdown
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
@@ -142,10 +142,9 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
         Select People Picker Type
       </label>
       <div
-        aria-describedby="Dropdown2-option"
         aria-expanded="false"
         aria-haspopup="listbox"
-        aria-labelledby="Dropdown2-label"
+        aria-labelledby="Dropdown2-label Dropdown2-option"
         className=
             ms-Dropdown
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -3971,10 +3971,9 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
           Number of items to render
         </label>
         <div
-          aria-describedby="Dropdown64-option"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="Dropdown64-label"
+          aria-labelledby="Dropdown64-label Dropdown64-option"
           className=
               ms-Dropdown
               {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
@@ -3031,10 +3031,9 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
           Horizontal alignment:
         </label>
         <div
-          aria-describedby="Dropdown12-option"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="Dropdown12-label"
+          aria-labelledby="Dropdown12-label Dropdown12-option"
           className=
               ms-Dropdown
               {
@@ -3254,10 +3253,9 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
           Vertical alignment:
         </label>
         <div
-          aria-describedby="Dropdown13-option"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="Dropdown13-label"
+          aria-labelledby="Dropdown13-label Dropdown13-option"
           className=
               ms-Dropdown
               {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapAdvanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapAdvanced.Example.tsx.shot
@@ -667,10 +667,9 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
           Horizontal alignment:
         </label>
         <div
-          aria-describedby="Dropdown2-option"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="Dropdown2-label"
+          aria-labelledby="Dropdown2-label Dropdown2-option"
           className=
               ms-Dropdown
               {
@@ -891,10 +890,9 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
           Vertical alignment:
         </label>
         <div
-          aria-describedby="Dropdown3-option"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="Dropdown3-label"
+          aria-labelledby="Dropdown3-label Dropdown3-option"
           className=
               ms-Dropdown
               {
@@ -1115,10 +1113,9 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
           Overflow:
         </label>
         <div
-          aria-describedby="Dropdown4-option"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="Dropdown4-label"
+          aria-labelledby="Dropdown4-label Dropdown4-option"
           className=
               ms-Dropdown
               {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
@@ -1742,10 +1742,9 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 Vertical alignment:
               </label>
               <div
-                aria-describedby="Dropdown8-option"
                 aria-expanded="false"
                 aria-haspopup="listbox"
-                aria-labelledby="Dropdown8-label"
+                aria-labelledby="Dropdown8-label Dropdown8-option"
                 className=
                     ms-Dropdown
                     {
@@ -1966,10 +1965,9 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 Horizontal alignment:
               </label>
               <div
-                aria-describedby="Dropdown9-option"
                 aria-expanded="false"
                 aria-haspopup="listbox"
-                aria-labelledby="Dropdown9-label"
+                aria-labelledby="Dropdown9-label Dropdown9-option"
                 className=
                     ms-Dropdown
                     {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapAdvanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapAdvanced.Example.tsx.shot
@@ -667,10 +667,9 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
           Horizontal alignment:
         </label>
         <div
-          aria-describedby="Dropdown2-option"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="Dropdown2-label"
+          aria-labelledby="Dropdown2-label Dropdown2-option"
           className=
               ms-Dropdown
               {
@@ -891,10 +890,9 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
           Vertical alignment:
         </label>
         <div
-          aria-describedby="Dropdown3-option"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="Dropdown3-label"
+          aria-labelledby="Dropdown3-label Dropdown3-option"
           className=
               ms-Dropdown
               {
@@ -1115,10 +1113,9 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
           Overflow:
         </label>
         <div
-          aria-describedby="Dropdown4-option"
           aria-expanded="false"
           aria-haspopup="listbox"
-          aria-labelledby="Dropdown4-label"
+          aria-labelledby="Dropdown4-label Dropdown4-option"
           className=
               ms-Dropdown
               {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

A recent change on Narrator made it so that the reading of `aria-describedby` attributes would be opt-in only via the `Narrator + 0` key combination. Given that, we've moved information about selected options out of that attribute and into `aria-labelledby` so that this information is read by default everytime.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10962)