### PR TITLE
Option to use checkbox role in Toggle component

### DIFF
--- a/change/office-ui-fabric-react-2019-10-24-17-56-34-sabin-toggle-compat.json
+++ b/change/office-ui-fabric-react-2019-10-24-17-56-34-sabin-toggle-compat.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Option to use checkbox role in Toggle component",
+  "packageName": "office-ui-fabric-react",
+  "email": "satimals@microsoft.com",
+  "commit": "db4a33a8a686d180db5f64e7417b0ea279d9fdd7",
+  "date": "2019-10-25T00:56:34.058Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -7674,6 +7674,7 @@ export interface IToggle {
 // @public
 export interface IToggleProps extends React.HTMLAttributes<HTMLElement> {
     ariaLabel?: string;
+    ariaRoleCheckbox?: boolean;
     as?: IComponentAs<React.HTMLAttributes<HTMLElement>>;
     checked?: boolean;
     componentRef?: IRefObject<IToggle>;

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
@@ -99,6 +99,9 @@ export class ToggleBase extends BaseComponent<IToggleProps, IToggleState> implem
       }
     }
 
+    // ARIA 1.1 definition; "checkbox" in ARIA 1.0
+    const ariaRole = this.props.ariaRoleCheckbox ? 'checkbox' : 'switch';
+
     return (
       <RootType className={classNames.root} hidden={(toggleNativeProps as any).hidden}>
         {label && (
@@ -117,7 +120,7 @@ export class ToggleBase extends BaseComponent<IToggleProps, IToggleState> implem
                 disabled={disabled}
                 id={this._id}
                 type="button"
-                role="switch" // ARIA 1.1 definition; "checkbox" in ARIA 1.0
+                role={ariaRole}
                 ref={this._toggleButton}
                 aria-disabled={disabled}
                 aria-checked={checked}

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.types.ts
@@ -104,6 +104,12 @@ export interface IToggleProps extends React.HTMLAttributes<HTMLElement> {
    * Optional keytip for this toggle
    */
   keytipProps?: IKeytipProps;
+
+  /**
+   * (Optional) If specified, uses 'checkbox' ARIA role instead of the 'switch' ARIA role,
+   * for backwards compatibility.
+   */
+  ariaRoleCheckbox?: boolean;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Toggle/examples/Toggle.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/examples/Toggle.Basic.Example.tsx
@@ -22,6 +22,15 @@ export const ToggleBasicExample: React.FunctionComponent = () => {
       <Toggle label="With inline label and without onText and offText" inlineLabel onChange={_onChange} />
 
       <Toggle label="Disabled with inline label and without onText and offText" inlineLabel disabled />
+
+      <Toggle
+        label="Enabled and checked (ARIA 1.0 compatible)"
+        defaultChecked
+        onText="On"
+        offText="Off"
+        onChange={_onChange}
+        ariaRoleCheckbox={true}
+      />
     </Stack>
   );
 };


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #10966 
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Since the `switch` ARIA role is not supported by all user agents (e.g, IE 11), this PR provides an option to use the `checkbox` role for backwards compatibility.
