### PR TITLE
Removing circular import for IPoint in positioning.types.d.ts

### DIFF
--- a/change/office-ui-fabric-react-2019-10-26-02-45-08-patch-1.json
+++ b/change/office-ui-fabric-react-2019-10-26-02-45-08-patch-1.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "removing circular IPoint import",
+  "packageName": "office-ui-fabric-react",
+  "email": "mehanig@gmail.com",
+  "commit": "262fa433b51065deadc15aaf850e5cfb9670066c",
+  "date": "2019-10-26T00:45:08.922Z"
+}

--- a/packages/office-ui-fabric-react/src/utilities/positioning/positioning.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/positioning/positioning.types.ts
@@ -1,5 +1,4 @@
 import { DirectionalHint } from '../../common/DirectionalHint';
-import { IPoint } from './positioning.types';
 import { IRectangle } from '../../Utilities';
 
 export enum RectangleEdge {


### PR DESCRIPTION
Looks like this file is failing with TypeScript3.7-rc  because of 
ERROR in ..office-ui-fabric-react/lib/utilities/positioning/positioning.types.d.ts(2,10):
TS2440: Import declaration conflicts with local declaration of 'IPoint'.

#### Pull request checklist
- [x] Include a change request file using `$ yarn change`

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10972)