### PR TITLE
CommandBarButton: split button height fix

### DIFF
--- a/change/office-ui-fabric-react-2019-10-28-13-24-51-v-mare-CommandBar_splitbutton_height_fix.json
+++ b/change/office-ui-fabric-react-2019-10-28-13-24-51-v-mare-CommandBar_splitbutton_height_fix.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "CommandBarButton: Fix height issue when commandbar buttons iconOnly props set to true",
+  "packageName": "office-ui-fabric-react",
+  "email": "v-mare@microsoft.com",
+  "commit": "5718afe4c879cf9e241a4e30e79b89b738f99ec8",
+  "date": "2019-10-28T20:24:51.735Z",
+  "file": "/Users/maxrediker/Fabric_UI/office-ui-fabric-react/change/office-ui-fabric-react-2019-10-28-13-24-51-v-mare-CommandBar_splitbutton_height_fix.json"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/CommandBarButton/CommandBarButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/CommandBarButton/CommandBarButton.styles.ts
@@ -121,6 +121,7 @@ export const getStyles = memoizeFunction(
 
       // Split button styles
       splitButtonContainer: {
+        height: '100%',
         selectors: {
           [HighContrastSelector]: {
             border: 'none'

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
@@ -77,6 +77,7 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
 
                     {
                       display: inline-flex;
+                      height: 100%;
                       outline: transparent;
                       position: relative;
                     }
@@ -471,6 +472,7 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                     {
                       border: none;
                       display: inline-flex;
+                      height: 100%;
                       outline: none;
                       position: relative;
                     }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #10961
- [x] Include a change request file using `$ yarn change`

#### Description of changes

When using iconOnly props of the CommandBar the height of the containing element takes the height of the contents instead of the parent containing element (CommandBar.styles.ts > root > height - 44px). by adding height 100% to the CommandBarButton.styles.ts > splitButtonContainer you make it grab the 44px parent element height.

#### BEFORE
![Screen Shot 2019-10-28 at 1 33 30 PM](https://user-images.githubusercontent.com/13246181/67715736-a5425600-f987-11e9-88f5-4c65bf320be5.png)

#### AFTER
![Screen Shot 2019-10-28 at 1 33 01 PM](https://user-images.githubusercontent.com/13246181/67715715-9b205780-f987-11e9-935c-26327c70a511.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10976)