### PR TITLE
[Breaking change] Move @uifabric/example-app to devDependency and remove re-exports in office-ui-fabric-react

### DIFF
--- a/change/office-ui-fabric-react-2019-10-28-14-20-36-keco-remove-example-data-dep.json
+++ b/change/office-ui-fabric-react-2019-10-28-14-20-36-keco-remove-example-data-dep.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Remove re-export of @uifabric/example-data from office-ui-fabric-react",
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com",
+  "commit": "d275d58e69a4a1d6d4a2d2a8691c488fa3e97954",
+  "date": "2019-10-28T21:20:36.224Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6,8 +6,6 @@
 
 import { BaseComponent } from '@uifabric/utilities';
 import { EventGroup } from '@uifabric/utilities';
-import { groupOne } from '@uifabric/example-data';
-import { groupTwo } from '@uifabric/example-data';
 import { IBaseProps } from '@uifabric/utilities';
 import { IComponent } from '@uifabric/foundation';
 import { IComponentAs } from '@uifabric/utilities';
@@ -34,9 +32,7 @@ import { IStyleFunctionOrObject } from '@uifabric/utilities';
 import { IStyleSet } from '@uifabric/styling';
 import { ITheme } from '@uifabric/styling';
 import { KeyCodes } from '@uifabric/utilities';
-import { mru } from '@uifabric/example-data';
 import { Omit } from '@uifabric/utilities';
-import { people } from '@uifabric/example-data';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import { Selection } from '@uifabric/utilities';
@@ -1406,15 +1402,11 @@ export const GroupFooter: React.StatelessComponent<IGroupFooterProps>;
 // @public (undocumented)
 export const GroupHeader: React.StatelessComponent<IGroupHeaderProps>;
 
-export { groupOne }
-
 // @public (undocumented)
 export const GroupShowAll: React.StatelessComponent<IGroupShowAllProps>;
 
 // @public (undocumented)
 export const GroupSpacer: React.FunctionComponent<IGroupSpacerProps>;
-
-export { groupTwo }
 
 // @public
 export const HEX_REGEX: RegExp;
@@ -8111,8 +8103,6 @@ export class ModalBase extends BaseComponent<IModalProps, IDialogState> implemen
     UNSAFE_componentWillReceiveProps(newProps: IModalProps): void;
 }
 
-export { mru }
-
 // @public (undocumented)
 export const Nav: React.StatelessComponent<INavProps>;
 
@@ -8213,8 +8203,6 @@ export enum PanelType {
     smallFixedNear = 2,
     smallFluid = 0
 }
-
-export { people }
 
 // @public (undocumented)
 export const PeoplePickerItem: React.FunctionComponent<IPeoplePickerItemSelectedProps>;

--- a/packages/office-ui-fabric-react/package.json
+++ b/packages/office-ui-fabric-react/package.json
@@ -47,6 +47,7 @@
     "@uifabric/test-utilities": "^7.0.6",
     "@uifabric/tslint-rules": "^7.0.5",
     "@uifabric/webpack-utils": "^7.0.4",
+    "@uifabric/example-data": "7.0.1",
     "enzyme": "~3.9.0",
     "enzyme-adapter-react-16": "^1.2.0",
     "enzyme-to-json": "^3.3.4",
@@ -68,7 +69,6 @@
   },
   "dependencies": {
     "@microsoft/load-themed-styles": "^1.7.13",
-    "@uifabric/example-data": "^7.0.1",
     "@uifabric/foundation": "^7.4.4",
     "@uifabric/icons": "^7.3.0",
     "@uifabric/merge-styles": "^7.8.0",

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/index.ts
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/index.ts
@@ -1,4 +1,3 @@
 export * from './BaseExtendedPicker';
 export * from './BaseExtendedPicker.types';
 export * from './PeoplePicker/ExtendedPeoplePicker';
-export { people, mru, groupOne, groupTwo } from '@uifabric/example-data';


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The refactor of test related code into its own module `@uifabric/example-data` in https://github.com/OfficeDev/office-ui-fabric-react/pull/10280 has a downstream effect that devs specify `@uifabric/example-data` in their `package.json` when consuming Fabric 7. This can result in the module's code being bundled in production assets if not tree-shaken properly.

Although we avoid breaking changes in the same major release, I believe this case to be exceptional. If consumers require the exports from this dependency then they can rely on the package itself in their app. This will also benefit non-consumers of the module who may be pulling in the bits in their production assets.

#### Focus areas to test

- CI to pass.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10977)