### PR TITLE
Sabin/toggle compat 6

### DIFF
--- a/change/office-ui-fabric-react-2019-10-28-14-10-28-sabin-toggle-compat-6.json
+++ b/change/office-ui-fabric-react-2019-10-28-14-10-28-sabin-toggle-compat-6.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Make Fabric 6 Toggle Aria 1.0 compatible (ported from 7.0)",
+  "packageName": "office-ui-fabric-react",
+  "email": "satimals@microsoft.com",
+  "commit": "76a74c17ca52804354b348edc584df6f3ebc7463",
+  "date": "2019-10-28T21:10:28.777Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -7683,6 +7683,7 @@ export interface IToggleProps extends React.HTMLAttributes<HTMLElement> {
     // @deprecated (undocumented)
     onChanged?: (checked: boolean) => void;
     onText?: string;
+    role?: 'checkbox' | 'switch';
     styles?: IStyleFunctionOrObject<IToggleStyleProps, IToggleStyles>;
     theme?: ITheme;
 }

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.base.tsx
@@ -94,6 +94,8 @@ export class ToggleBase extends BaseComponent<IToggleProps, IToggleState> implem
       }
     }
 
+    const ariaRole = this.props.role ? this.props.role : 'switch';
+
     return (
       <RootType className={classNames.root} hidden={(toggleNativeProps as any).hidden}>
         {label && (
@@ -112,7 +114,7 @@ export class ToggleBase extends BaseComponent<IToggleProps, IToggleState> implem
                 disabled={disabled}
                 id={this._id}
                 type="button"
-                role="switch" // ARIA 1.1 definition; "checkbox" in ARIA 1.0
+                role={ariaRole}
                 ref={this._toggleButton}
                 aria-disabled={disabled}
                 aria-checked={checked}

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.types.ts
@@ -104,6 +104,12 @@ export interface IToggleProps extends React.HTMLAttributes<HTMLElement> {
    * Optional keytip for this toggle
    */
   keytipProps?: IKeytipProps;
+
+  /**
+   * (Optional) Specify whether to use the "switch" role (ARIA 1.1) or the checkbox role (ARIA 1.0).
+   * If unspecified, defaults to "switch".
+   */
+  role?: 'checkbox' | 'switch';
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Toggle/examples/Toggle.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Toggle/examples/Toggle.Basic.Example.tsx
@@ -116,6 +116,16 @@ export class ToggleBasicExample extends React.Component {
           onFocus={() => console.log('onFocus called')}
           onBlur={() => console.log('onBlur called')}
         />
+        <Toggle
+          defaultChecked={true}
+          label="Enabled and checked (ARIA 1.0 compatible)"
+          onText="On"
+          offText="Off"
+          onFocus={() => console.log('onFocus called')}
+          onBlur={() => console.log('onBlur called')}
+          onChange={this._onChange}
+          role="checkbox"
+        />
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.Basic.Example.tsx.shot
@@ -1761,5 +1761,181 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
       </button>
     </div>
   </div>
+  <div
+    className=
+        ms-Toggle
+        is-checked
+        is-enabled
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          margin-bottom: 8px;
+        }
+  >
+    <label
+      className=
+          ms-Label
+          ms-Toggle-label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #333333;
+            display: block;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
+          }
+      htmlFor="Toggle12"
+      id="Toggle12-label"
+    >
+      Enabled and checked (ARIA 1.0 compatible)
+    </label>
+    <div
+      className=
+          ms-Toggle-innerContainer
+          {
+            display: inline-flex;
+            position: relative;
+          }
+    >
+      <button
+        aria-checked={true}
+        aria-labelledby="Toggle12-label"
+        className=
+            ms-Toggle-background
+            {
+              align-items: center;
+              background: #0078d4;
+              border-color: transparent;
+              border-radius: 1em;
+              border-style: solid;
+              border-width: 1px;
+              box-sizing: border-box;
+              cursor: pointer;
+              display: flex;
+              font-size: 20px;
+              height: 1em;
+              justify-content: flex-end;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: .2em;
+              padding-right: .2em;
+              padding-top: 0;
+              position: relative;
+              transition: all 0.1s ease;
+              width: 2.2em;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #ffffff;
+              bottom: -2px;
+              content: "";
+              left: -2px;
+              outline: 1px solid #666666;
+              position: absolute;
+              right: -2px;
+              top: -2px;
+              z-index: 1;
+            }
+            &:hover {
+              background-color: #106ebe;
+              border-color: transparent;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              background-color: Highlight;
+              border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background-color: WindowText;
+            }
+        data-is-focusable={true}
+        id="Toggle12"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onClick={[Function]}
+        onFocus={[Function]}
+        role="checkbox"
+        type="button"
+      >
+        <div
+          className=
+              ms-Toggle-thumb
+              {
+                background-color: #ffffff;
+                border-color: transparent;
+                border-radius: .5em;
+                border-style: solid;
+                border-width: .28em;
+                box-sizing: border-box;
+                height: .5em;
+                transition: all 0.1s ease;
+                width: .5em;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background-color: Window;
+                border-color: Window;
+              }
+        />
+      </button>
+      <label
+        className=
+            ms-Label
+            ms-Toggle-stateText
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              box-shadow: none;
+              box-sizing: border-box;
+              color: #333333;
+              display: block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              margin-bottom: 0px;
+              margin-left: 0px;
+              margin-right: 0px;
+              margin-top: 0px;
+              overflow-wrap: break-word;
+              padding-bottom: 5px;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 5px;
+              word-wrap: break-word;
+            }
+            && {
+              margin-bottom: 0;
+              margin-left: 8px;
+              margin-right: 8px;
+              margin-top: 0;
+              padding-bottom: 0;
+              padding-left: 0;
+              padding-right: 0;
+              padding-top: 0;
+              user-select: none;
+            }
+        htmlFor="Toggle12"
+        id="Toggle12-stateText"
+      >
+        On
+      </label>
+    </div>
+  </div>
 </div>
 `;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #10966 
- [X] Include a change request file using `$ yarn change`

#### Description of changes
This adds the option to use "checkbox" role for the toggle button so that it is accessible in older browsers that do not support the "switch" role.

See PR on master for reference: https://github.com/OfficeDev/office-ui-fabric-react/pull/10967

#### Focus areas to test

Accessibility (IE 11 + Narrator should announce toggle state)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10978)