### PR TITLE
Checkbox: add title attribute

### DIFF
--- a/change/office-ui-fabric-react-2019-10-29-14-09-18-v-mare-Checkbox-add-tooltip.json
+++ b/change/office-ui-fabric-react-2019-10-29-14-09-18-v-mare-Checkbox-add-tooltip.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Checkbox: Added tooltip to checkbox containing div",
+  "comment": "Checkbox: Added title attribute to checkbox containing div",
   "packageName": "office-ui-fabric-react",
   "email": "v-mare@microsoft.com",
   "commit": "bd4d40323db6ec631ad9f2f6ba60e60bb0d7a121",

--- a/change/office-ui-fabric-react-2019-10-29-14-09-18-v-mare-Checkbox-add-tooltip.json
+++ b/change/office-ui-fabric-react-2019-10-29-14-09-18-v-mare-Checkbox-add-tooltip.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Checkbox: Added tooltip to checkbox containing div",
+  "packageName": "office-ui-fabric-react",
+  "email": "v-mare@microsoft.com",
+  "commit": "bd4d40323db6ec631ad9f2f6ba60e60bb0d7a121",
+  "date": "2019-10-29T21:09:18.722Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.base.tsx
@@ -104,7 +104,7 @@ export class CheckboxBase extends React.Component<ICheckboxProps, ICheckboxState
     return (
       <KeytipData keytipProps={keytipProps} disabled={disabled}>
         {(keytipAttributes: any): JSX.Element => (
-          <div className={this._classNames.root}>
+          <div className={this._classNames.root} title={title}>
             <input
               type="checkbox"
               {...inputProps}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #10983
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Gives a tooltip (provided by the browser) to the Checkbox component. All it is is adding title={title} to the containing div around Checkbox's input element.

(Example shown from Checkboxes used in Dropdown)
<img width="140" alt="Screen Shot 2019-10-29 at 2 19 24 PM" src="https://user-images.githubusercontent.com/13246181/67810120-35030580-fa57-11e9-9cf4-d8da9502fadc.png">


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10984)