### PR TITLE
adding memory limit to 4gb for webpack

### DIFF
--- a/scripts/tasks/webpack.js
+++ b/scripts/tasks/webpack.js
@@ -4,7 +4,9 @@ const { webpackTask, argv, logger } = require('just-scripts');
 const path = require('path');
 const fs = require('fs');
 
-exports.webpack = webpackTask();
+exports.webpack = webpackTask({
+  nodeArgs: ['--max-old-space-size=4096']
+});
 exports.webpackDevServer = async function() {
   const fp = require('find-free-port');
   const webpackConfigFilePath = argv().webpackConfig || 'webpack.serve.config.js';


### PR DESCRIPTION
#### Description of changes

Our OUFR release job is running out of memory when doing webpack:

![image](https://user-images.githubusercontent.com/34725/67886696-24aa6380-fb07-11e9-87c3-42d45aebe186.png)

This bumps the memory limit to 4gb to address this issue.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10991)