### PR TITLE
10936 toggle wrapping

### DIFF
--- a/change/office-ui-fabric-react-2019-10-30-15-31-27-10936-toggle-wrapping.json
+++ b/change/office-ui-fabric-react-2019-10-30-15-31-27-10936-toggle-wrapping.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Toggle: Force wrapping when width-constrained.",
+  "packageName": "office-ui-fabric-react",
+  "email": "jdh@microsoft.com",
+  "commit": "d1cfc7adf4482961e703470b2283495b0d046b77",
+  "date": "2019-10-30T22:31:27.285Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.styles.ts
@@ -60,7 +60,8 @@ export const getStyles = (props: IToggleStyleProps): IToggleStyles => {
         inlineLabel && {
           order: 1,
           marginLeft: 16
-        }
+        },
+      inlineLabel && { overflow: 'hidden' }
     ],
 
     container: [

--- a/packages/office-ui-fabric-react/src/components/Toggle/Toggle.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Toggle/Toggle.styles.ts
@@ -61,7 +61,7 @@ export const getStyles = (props: IToggleStyleProps): IToggleStyles => {
           order: 1,
           marginLeft: 16
         },
-      inlineLabel && { overflow: 'hidden' }
+      inlineLabel && { wordBreak: 'break-all' }
     ],
 
     container: [

--- a/packages/office-ui-fabric-react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -269,6 +269,7 @@ exports[`Toggle renders toggle correctly with inline label (JSX Element) 1`] = `
           padding-left: 0;
           padding-right: 0;
           padding-top: 5px;
+          word-break: break-all;
           word-wrap: break-word;
         }
     htmlFor="Toggle3"
@@ -403,6 +404,7 @@ exports[`Toggle renders toggle correctly with inline label (string) 1`] = `
           padding-left: 0;
           padding-right: 0;
           padding-top: 5px;
+          word-break: break-all;
           word-wrap: break-word;
         }
     htmlFor="Toggle2"
@@ -534,6 +536,7 @@ exports[`Toggle renders toggle correctly with inline label and on/off text provi
           padding-left: 0;
           padding-right: 0;
           padding-top: 5px;
+          word-break: break-all;
           word-wrap: break-word;
         }
     htmlFor="Toggle4"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -173,6 +173,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
               padding-left: 0;
               padding-right: 0;
               padding-top: 5px;
+              word-break: break-all;
               word-wrap: break-word;
             }
         htmlFor="Toggle3"
@@ -306,6 +307,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
               padding-left: 0;
               padding-right: 0;
               padding-top: 5px;
+              word-break: break-all;
               word-wrap: break-word;
             }
         htmlFor="Toggle4"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Basic.Example.tsx.shot
@@ -41,6 +41,7 @@ exports[`Component Examples renders Layer.Basic.Example.tsx correctly 1`] = `
             padding-left: 0;
             padding-right: 0;
             padding-top: 5px;
+            word-break: break-all;
             word-wrap: break-word;
           }
       htmlFor="Toggle0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Customized.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Customized.Example.tsx.shot
@@ -56,6 +56,7 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
             padding-left: 0;
             padding-right: 0;
             padding-top: 5px;
+            word-break: break-all;
             word-wrap: break-word;
           }
       htmlFor="Toggle1"
@@ -186,6 +187,7 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
             padding-left: 0;
             padding-right: 0;
             padding-top: 5px;
+            word-break: break-all;
             word-wrap: break-word;
           }
       htmlFor="Toggle2"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Hosted.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Hosted.Example.tsx.shot
@@ -48,6 +48,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
             padding-left: 0;
             padding-right: 0;
             padding-top: 5px;
+            word-break: break-all;
             word-wrap: break-word;
           }
       htmlFor="Toggle1"
@@ -193,6 +194,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
             padding-left: 0;
             padding-right: 0;
             padding-top: 5px;
+            word-break: break-all;
             word-wrap: break-word;
           }
       htmlFor="Toggle2"
@@ -344,6 +346,7 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
             padding-left: 0;
             padding-right: 0;
             padding-top: 5px;
+            word-break: break-all;
             word-wrap: break-word;
           }
       htmlFor="Toggle3"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.ErrorMessage.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.ErrorMessage.Example.tsx.shot
@@ -62,6 +62,7 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
             padding-left: 0;
             padding-right: 0;
             padding-top: 5px;
+            word-break: break-all;
             word-wrap: break-word;
           }
       htmlFor="Toggle0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.Basic.Example.tsx.shot
@@ -737,6 +737,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             padding-left: 0;
             padding-right: 0;
             padding-top: 5px;
+            word-break: break-all;
             word-wrap: break-word;
           }
       htmlFor="Toggle4"
@@ -907,6 +908,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             padding-left: 0;
             padding-right: 0;
             padding-top: 5px;
+            word-break: break-all;
             word-wrap: break-word;
           }
           @media screen and (-ms-high-contrast: active){& {
@@ -1076,6 +1078,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             padding-left: 0;
             padding-right: 0;
             padding-top: 5px;
+            word-break: break-all;
             word-wrap: break-word;
           }
       htmlFor="Toggle6"
@@ -1205,6 +1208,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             padding-left: 0;
             padding-right: 0;
             padding-top: 5px;
+            word-break: break-all;
             word-wrap: break-word;
           }
           @media screen and (-ms-high-contrast: active){& {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.CustomLabel.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.CustomLabel.Example.tsx.shot
@@ -261,6 +261,7 @@ exports[`Component Examples renders Toggle.CustomLabel.Example.tsx correctly 1`]
             padding-left: 0;
             padding-right: 0;
             padding-top: 5px;
+            word-break: break-all;
             word-wrap: break-word;
           }
       htmlFor="Toggle2"


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #10936
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Wraps long labels using `overflow: hidden;` (causing the existing word-wrap to take effect, no text is actually hidden.)

Before:
![Screen Shot 2019-10-30 at 3 29 39 PM](https://user-images.githubusercontent.com/147/67904247-022a4180-fb2b-11e9-904a-94ca73b1227e.png)

After:
![Screen Shot 2019-10-30 at 3 29 29 PM](https://user-images.githubusercontent.com/147/67904253-07878c00-fb2b-11e9-8500-e8629e54724a.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/10994)