### PR TITLE
Searchbox/Textfield: Fix high contrast borders when disabled

### DIFF
--- a/change/office-ui-fabric-react-2019-11-20-09-54-14-search-text-highcontrast.json
+++ b/change/office-ui-fabric-react-2019-11-20-09-54-14-search-text-highcontrast.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updated searchbox and textfield disabled borders in high contrast",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "1ce08491e0c1ab8191e75b35170d1a2e7d6c8ac5",
+  "date": "2019-11-20T17:54:14.708Z"
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
@@ -92,7 +92,12 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
           borderColor: inputBorderDisabled,
           backgroundColor: inputBackgroundDisabled,
           pointerEvents: 'none',
-          cursor: 'default'
+          cursor: 'default',
+          selectors: {
+            [HighContrastSelector]: {
+              borderColor: 'GrayText'
+            }
+          }
         }
       ],
       underlined && [

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -156,7 +156,12 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
           width: '100%'
         },
         disabled && {
-          borderBottomColor: semanticColors.disabledBackground
+          borderBottomColor: semanticColors.disabledBackground,
+          selectors: {
+            [HighContrastSelector]: {
+              borderColor: 'GrayText'
+            }
+          }
         },
         !disabled && {
           selectors: {
@@ -185,16 +190,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
         display: 'flex',
         flexDirection: 'row',
         alignItems: 'stretch',
-        position: 'relative',
-        selectors: {
-          ':hover': {
-            selectors: {
-              [HighContrastSelector]: {
-                borderColor: 'Highlight'
-              }
-            }
-          }
-        }
+        position: 'relative'
       },
       multiline && {
         minHeight: '60px',
@@ -206,7 +202,12 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
         !disabled && {
           selectors: {
             ':hover': {
-              borderColor: semanticColors.inputBorderHovered
+              borderColor: semanticColors.inputBorderHovered,
+              selectors: {
+                [HighContrastSelector]: {
+                  borderColor: 'Highlight'
+                }
+              }
             }
           }
         },
@@ -215,8 +216,8 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
       disabled && {
         borderColor: semanticColors.disabledBackground,
         selectors: {
-          ':hover': {
-            borderColor: semanticColors.disabledBackground
+          [HighContrastSelector]: {
+            borderColor: 'GrayText'
           }
         },
 

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Disabled.Example.tsx.shot
@@ -88,11 +88,8 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                   padding-top: 0px;
                   position: relative;
                 }
-                &:hover {
-                  border-color: #f3f2f1;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover {
-                  border-color: Highlight;
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: GrayText;
                 }
           >
             <input
@@ -332,11 +329,8 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                   padding-top: 0px;
                   position: relative;
                 }
-                &:hover {
-                  border-color: #f3f2f1;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover {
-                  border-color: Highlight;
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: GrayText;
                 }
           >
             <input

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
@@ -56,6 +56,7 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
           pointer-events: none;
         }
         @media screen and (-ms-high-contrast: active){& {
+          border-color: GrayText;
           border: 1px solid WindowText;
         }
         &:hover {
@@ -196,6 +197,7 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
           pointer-events: none;
         }
         @media screen and (-ms-high-contrast: active){& {
+          border-color: GrayText;
           border: 1px solid WindowText;
         }
         &:hover {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -296,11 +296,8 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 padding-top: 0px;
                 position: relative;
               }
-              &:hover {
-                border-color: #f3f2f1;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: GrayText;
               }
         >
           <input
@@ -1697,11 +1694,8 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 padding-top: 0px;
                 position: relative;
               }
-              &:hover {
-                border-color: #f3f2f1;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: GrayText;
               }
         >
           <input

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
@@ -260,6 +260,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
               display: flex;
               width: 100%;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: GrayText;
+            }
       >
         <label
           className=
@@ -323,11 +326,8 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 position: relative;
                 text-align: left;
               }
-              &:hover {
-                border-color: #f3f2f1;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: GrayText;
               }
         >
           <input

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
@@ -304,11 +304,8 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 padding-top: 0px;
                 position: relative;
               }
-              &:hover {
-                border-color: #f3f2f1;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: GrayText;
               }
         >
           <textarea

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.PrefixAndSuffix.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.PrefixAndSuffix.Example.tsx.shot
@@ -324,11 +324,8 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                 padding-top: 0px;
                 position: relative;
               }
-              &:hover {
-                border-color: #f3f2f1;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: GrayText;
               }
         >
           <div


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10624
- [ ] Include a change request file using `$ yarn change`

Before:

![65621535-cbd03400-df78-11e9-9a8b-5a19032b22e5](https://user-images.githubusercontent.com/1434956/67963525-fb97da80-fbbb-11e9-8b60-fc607d51a03f.png)
![image](https://user-images.githubusercontent.com/1434956/67963926-a3150d00-fbbc-11e9-8232-b2a7a70f762d.png)



After:

![image](https://user-images.githubusercontent.com/1434956/67963783-69dc9d00-fbbc-11e9-87ce-c13689f9921e.png)


![image](https://user-images.githubusercontent.com/1434956/67962828-eb333000-fbba-11e9-8019-ef65664b7914.png)

![image](https://user-images.githubusercontent.com/1434956/67962865-f5edc500-fbba-11e9-85a5-d625ca427d84.png)

![image](https://user-images.githubusercontent.com/1434956/67962899-000fc380-fbbb-11e9-820d-3801f7a4b802.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11035)