### PR TITLE
getting rid of a typechecker for dev mode here since build already does the check

### DIFF
--- a/scripts/webpack/webpack-resources.js
+++ b/scripts/webpack/webpack-resources.js
@@ -204,9 +204,6 @@ module.exports = {
         },
 
         plugins: [
-          // TODO: will investigate why this doesn't work on mac
-          // new WebpackNotifierPlugin(),
-          new ForkTsCheckerWebpackPlugin(),
           ...(process.env.TF_BUILD ? [] : [new webpack.ProgressPlugin()]),
           ...(!process.env.TF_BUILD && process.env.cached ? [new HardSourceWebpackPlugin()] : [])
         ]


### PR DESCRIPTION
#### Description of changes

This further removes memory requirement of typechecking during webpack serve so that when demo app is being built for production (pr-deploy-site uses it), it wouldn't need to do typechecking again. The "ts" task function already does the build here so that extra fork-ts-plugin is actually redundant.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11036)