### PR TITLE
Combobox: hidden option fix

### DIFF
--- a/change/office-ui-fabric-react-2019-10-31-12-25-57-v-mare-Combobox-hidden-option-fix.json
+++ b/change/office-ui-fabric-react-2019-10-31-12-25-57-v-mare-Combobox-hidden-option-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Combobox: Fixed issue where hidden options are shown when arrowing through combobox option list",
+  "packageName": "office-ui-fabric-react",
+  "email": "v-mare@microsoft.com",
+  "commit": "f2f8fc5b251c053fb2d9d1f212ec81e7e427840b",
+  "date": "2019-10-31T19:25:57.970Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -817,10 +817,17 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     const option: IComboBoxOption = currentOptions[newIndex];
 
     // attempt to skip headers and dividers
+    // if (
+    //   (option.itemType === SelectableOptionMenuItemType.Header ||
+    //     option.itemType === SelectableOptionMenuItemType.Divider ||
+    //     option.hidden === true,
+    //   option.disabled === true)
+    // ) {
     if (
       option.itemType === SelectableOptionMenuItemType.Header ||
       option.itemType === SelectableOptionMenuItemType.Divider ||
-      option.hidden === true
+      option.hidden === true ||
+      option.disabled === true
     ) {
       // Should we continue looking for an index to select?
       if (

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -816,13 +816,6 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
 
     const option: IComboBoxOption = currentOptions[newIndex];
 
-    // attempt to skip headers and dividers
-    // if (
-    //   (option.itemType === SelectableOptionMenuItemType.Header ||
-    //     option.itemType === SelectableOptionMenuItemType.Divider ||
-    //     option.hidden === true,
-    //   option.disabled === true)
-    // ) {
     if (
       option.itemType === SelectableOptionMenuItemType.Header ||
       option.itemType === SelectableOptionMenuItemType.Divider ||

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -819,8 +819,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     if (
       option.itemType === SelectableOptionMenuItemType.Header ||
       option.itemType === SelectableOptionMenuItemType.Divider ||
-      option.hidden === true ||
-      option.disabled === true
+      option.hidden === true
     ) {
       // Should we continue looking for an index to select?
       if (

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -817,7 +817,11 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     const option: IComboBoxOption = currentOptions[newIndex];
 
     // attempt to skip headers and dividers
-    if (option.itemType === SelectableOptionMenuItemType.Header || option.itemType === SelectableOptionMenuItemType.Divider) {
+    if (
+      option.itemType === SelectableOptionMenuItemType.Header ||
+      option.itemType === SelectableOptionMenuItemType.Divider ||
+      option.hidden === true
+    ) {
       // Should we continue looking for an index to select?
       if (
         searchDirection !== SearchDirection.none &&

--- a/packages/office-ui-fabric-react/src/components/ComboBox/examples/ComboBox.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/examples/ComboBox.Basic.Example.tsx
@@ -13,7 +13,7 @@ import {
 const INITIAL_OPTIONS: IComboBoxOption[] = [
   { key: 'Header1', text: 'First heading', itemType: SelectableOptionMenuItemType.Header },
   { key: 'A', text: 'Option A' },
-  { key: 'B', text: 'Option B' },
+  { key: 'B', text: 'Option B', hidden: true },
   { key: 'C', text: 'Option C' },
   { key: 'D', text: 'Option D' },
   { key: 'divider', text: '-', itemType: SelectableOptionMenuItemType.Divider },

--- a/packages/office-ui-fabric-react/src/components/ComboBox/examples/ComboBox.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/examples/ComboBox.Basic.Example.tsx
@@ -13,7 +13,7 @@ import {
 const INITIAL_OPTIONS: IComboBoxOption[] = [
   { key: 'Header1', text: 'First heading', itemType: SelectableOptionMenuItemType.Header },
   { key: 'A', text: 'Option A' },
-  { key: 'B', text: 'Option B', hidden: true },
+  { key: 'B', text: 'Option B' },
   { key: 'C', text: 'Option C' },
   { key: 'D', text: 'Option D' },
   { key: 'divider', text: '-', itemType: SelectableOptionMenuItemType.Divider },


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #11032
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Adds extra OR conditional clause, `option.hidden === true`, when determining the next selectable index in order to skip option items holding the hidden:true key value

#### Focus areas to test

Click Combobox Autofill input (Having set some options hidden: true)
Arrow up and down options
Any items that have been marked "hidden: true" should not be shown/skipped


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11038)