### PR TITLE
moved to webpack-cli instead of calling webpack directly via function

### DIFF
--- a/apps/server-rendered-app/webpack.config.js
+++ b/apps/server-rendered-app/webpack.config.js
@@ -6,7 +6,7 @@ const IS_PRODUCTION = process.argv.indexOf('--production') > -1;
 
 module.exports = resources.createConfig(
   BUNDLE_NAME,
-  IS_PRODUCTION,
+  true,
   {
     mode: 'production',
 

--- a/scripts/just.config.js
+++ b/scripts/just.config.js
@@ -1,6 +1,6 @@
 // @ts-check
 
-const { task, series, parallel, condition, option, argv, addResolvePath } = require('just-scripts');
+const { task, series, parallel, condition, option, argv, addResolvePath, resolveCwd } = require('just-scripts');
 
 const path = require('path');
 const fs = require('fs');
@@ -86,7 +86,13 @@ module.exports = function preset() {
       'sass',
       parallel(
         condition('validate', () => !argv().min),
-        series('ts', parallel(condition('webpack', () => !argv().min), condition('lint-imports', () => !argv().min)))
+        series(
+          'ts',
+          parallel(
+            condition('webpack', () => !argv().min && !!resolveCwd('webpack.config.js')),
+            condition('lint-imports', () => !argv().min)
+          )
+        )
       )
     )
   ).cached();

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -34,7 +34,7 @@
     "jest-environment-jsdom": "24.0.0",
     "jju": "^1.4.0",
     "json-loader": "^0.5.7",
-    "just-scripts": "~0.29.0",
+    "just-scripts": "~0.34.0",
     "mustache": "^2.3.0",
     "ngrok": "^3.0.1",
     "node-sass": "^4.5.3",

--- a/scripts/tasks/webpack.js
+++ b/scripts/tasks/webpack.js
@@ -1,10 +1,10 @@
 // @ts-check
 
-const { webpackTask, argv, logger } = require('just-scripts');
+const { webpackCliTask, argv, logger } = require('just-scripts');
 const path = require('path');
 const fs = require('fs');
 
-exports.webpack = webpackTask({
+exports.webpack = webpackCliTask({
   nodeArgs: ['--max-old-space-size=4096']
 });
 exports.webpackDevServer = async function() {

--- a/scripts/webpack/webpack-resources.js
+++ b/scripts/webpack/webpack-resources.js
@@ -206,7 +206,7 @@ module.exports = {
         plugins: [
           // TODO: will investigate why this doesn't work on mac
           // new WebpackNotifierPlugin(),
-          ...(!process.env.TF_BUILD && new ForkTsCheckerWebpackPlugin()),
+          ...(!process.env.TF_BUILD ? [new ForkTsCheckerWebpackPlugin()] : []),
           ...(process.env.TF_BUILD ? [] : [new webpack.ProgressPlugin()]),
           ...(!process.env.TF_BUILD && process.env.cached ? [new HardSourceWebpackPlugin()] : [])
         ]

--- a/scripts/webpack/webpack-resources.js
+++ b/scripts/webpack/webpack-resources.js
@@ -204,6 +204,9 @@ module.exports = {
         },
 
         plugins: [
+          // TODO: will investigate why this doesn't work on mac
+          // new WebpackNotifierPlugin(),
+          ...(!process.env.TF_BUILD && new ForkTsCheckerWebpackPlugin()),
           ...(process.env.TF_BUILD ? [] : [new webpack.ProgressPlugin()]),
           ...(!process.env.TF_BUILD && process.env.cached ? [new HardSourceWebpackPlugin()] : [])
         ]

--- a/yarn.lock
+++ b/yarn.lock
@@ -9156,10 +9156,10 @@ just-scripts-utils@^0.8.3:
     tar "^4.4.8"
     yargs "^12.0.5"
 
-just-scripts@~0.29.0:
-  version "0.29.0"
-  resolved "https://registry.npmjs.org/just-scripts/-/just-scripts-0.29.0.tgz#b20def1253a4599093a8aca23483609558761fac"
-  integrity sha512-+0XROILYWkbIdSYUQgzD4ogYNT1ksXdUW1WvJZRqoaeztXyZp8i7OIJ32F876HGz0qibjIbvYZ5wKx9uXHJKug==
+just-scripts@~0.34.0:
+  version "0.34.0"
+  resolved "https://registry.npmjs.org/just-scripts/-/just-scripts-0.34.0.tgz#50701b0e28970a48020e217cb88951d9582d5bb1"
+  integrity sha512-75m0+lvw0GyAQ3TQyut4s00OH1w0ImHHMRiSeBIJhDrU3LoVsIX83xJ+lMzDi42Nvk1qJuUaRDvirMkDAaCD7w==
   dependencies:
     "@types/node" "^10.12.18"
     chalk "^2.4.1"
@@ -9167,7 +9167,7 @@ just-scripts@~0.29.0:
     fs-extra "^7.0.1"
     glob "^7.1.3"
     just-scripts-utils ">=0.8.4 <1.0.0"
-    just-task ">=0.13.3 <1.0.0"
+    just-task ">=0.14.2 <1.0.0"
     npm-registry-fetch "^3.9.0"
     prompts "^2.0.1"
     run-parallel-limit "^1.0.5"
@@ -9181,10 +9181,10 @@ just-scripts@~0.29.0:
     chalk "^2.4.1"
     yargs "^12.0.5"
 
-"just-task@>=0.13.3 <1.0.0":
-  version "0.13.3"
-  resolved "https://registry.npmjs.org/just-task/-/just-task-0.13.3.tgz#144c1d6b37a4db56cf8171a1507ae2a2a8fdf0d3"
-  integrity sha512-NeBPgnUposkDfrghlHv/KHoouTlc0rVQWaJtqPj76vbOxP9RPZoapoDc22nQf1c8D/IQP60n9GpO5F2JfqvRXw==
+"just-task@>=0.14.2 <1.0.0":
+  version "0.14.2"
+  resolved "https://registry.npmjs.org/just-task/-/just-task-0.14.2.tgz#db29394ec12dcbdd3be67bc61d774e45a2452ff8"
+  integrity sha512-oHsJEZCysZIXxhbF1HmAqJUOhZep45UcprhRJ5vA+l+ev4NgMj+VfbobAuaXXLgmXrPG3bTzUJIJZVKRsaI4Zg==
   dependencies:
     "@microsoft/package-deps-hash" "^2.2.153"
     chalk "^2.4.1"


### PR DESCRIPTION
#### Description of changes

This PR will get us onto using webpack-cli instead (using a new just-scripts webpackCliTask). It adds back the deleted ts checker during development. I have made it so we don't do typechecking again in TF_BUILD situation (for minor speed gains)

From chatting with some folks, it seems that people DO use the typechecker for during inner loop development, so I'm adding that back for now.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11040)