### PR TITLE
Remove SCSS from ChoiceGroup Examples

### DIFF
--- a/common/changes/office-ui-fabric-react/Remove_SCSS_From_ChoiceGroup_2019-11-01-02-12.json
+++ b/common/changes/office-ui-fabric-react/Remove_SCSS_From_ChoiceGroup_2019-11-01-02-12.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Removed SCSS from ChoiceGroup Examples. Added Codepen support for ChoiceGroup. Added ChoiceGroup.Custom.Examples.Style for Custom Example",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "pandasa123@gmail.com"
+}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.doc.tsx
@@ -12,7 +12,9 @@ const ChoiceGroupBasicExampleCodepen = require('!@uifabric/codepen-loader!office
 const ChoiceGroupLabelExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Label.Example.tsx') as string;
 const ChoiceGroupLabelExampleCodepen = require('!@uifabric/codepen-loader!office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Label.Example.tsx') as string;
 const ChoiceGroupCustomExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Custom.Example.tsx') as string;
+const ChoiceGroupCustomExampleCodepen = require('!@uifabric/codepen-loader!office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Custom.Example.tsx') as string;
 const ChoiceGroupImageExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Image.Example.tsx') as string;
+const ChoiceGroupImageExampleCodepen = require('!@uifabric/codepen-loader!office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Image.Example.tsx') as string;
 const ChoiceGroupIconExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Icon.Example.tsx') as string;
 const ChoiceGroupIconExampleCodepen = require('!@uifabric/codepen-loader!office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Icon.Example.tsx') as string;
 
@@ -37,11 +39,13 @@ export const ChoiceGroupPageProps: IDocPageProps = {
     {
       title: 'ChoiceGroup with dropdown',
       code: ChoiceGroupCustomExampleCode,
+      codepenJS: ChoiceGroupCustomExampleCodepen,
       view: <ChoiceGroupCustomExample />
     },
     {
       title: 'ChoiceGroups with images',
       code: ChoiceGroupImageExampleCode,
+      codepenJS: ChoiceGroupImageExampleCodepen,
       view: <ChoiceGroupImageExample />
     },
     {

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Custom.Example.Styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Custom.Example.Styles.ts
@@ -1,0 +1,19 @@
+import { IStyle } from '@uifabric/styling';
+
+interface IChoiceGroupCustomExampleStyles {
+  root?: IStyle;
+  dropdown: IStyle;
+}
+
+const choiceGroupCustomExampleStyle: IChoiceGroupCustomExampleStyles = {
+  root: {
+    display: 'flex',
+    alignItems: 'baseline'
+  },
+  dropdown: {
+    marginBottom: '0px',
+    marginLeft: '5px'
+  }
+};
+
+export { choiceGroupCustomExampleStyle, IChoiceGroupCustomExampleStyles };

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Custom.Example.scss
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Custom.Example.scss
@@ -1,8 +1,0 @@
-.root {
-  display: flex;
-  align-items: baseline;
-  .dropdown {
-    margin-bottom: 0;
-    margin-left: 5px;
-  }
-}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Custom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Custom.Example.tsx
@@ -1,10 +1,12 @@
 import * as React from 'react';
 import { ChoiceGroup } from 'office-ui-fabric-react/lib/ChoiceGroup';
-import { css } from 'office-ui-fabric-react/lib/Utilities';
+import { css, classNamesFunction } from 'office-ui-fabric-react/lib/Utilities';
 import { Dropdown } from 'office-ui-fabric-react/lib/Dropdown';
 
-import * as stylesImport from './ChoiceGroup.Custom.Example.scss';
-const styles: any = stylesImport;
+import { choiceGroupCustomExampleStyle, IChoiceGroupCustomExampleStyles } from './ChoiceGroup.Custom.Example.Styles';
+
+const getClassNames = classNamesFunction<{}, IChoiceGroupCustomExampleStyles>();
+const styles = getClassNames(choiceGroupCustomExampleStyle, {});
 
 export class ChoiceGroupCustomExample extends React.Component {
   public render() {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -114,7 +114,12 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
               type="radio"
             />
             <div
-              className=""
+              className=
+
+                  {
+                    align-items: baseline;
+                    display: flex;
+                  }
             >
               <label
                 className=
@@ -202,7 +207,10 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
               <div
                 className=
                     ms-Dropdown-container
-
+                    {
+                      margin-bottom: 0px;
+                      margin-left: 5px;
+                    }
               >
                 <div
                   aria-describedby="Dropdown2-option"


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #6075 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Removing SCSS helps with the following:
- Integrating components into their own codebase
- Codepen Export

Steps taken:

- Removing SCSS file
- Added ChoiceGroup Example Styles for ChoiceGroup Custom Example using SCSS
- Added Codepen export option to doc file
- Updated snapshots
- Verified functionality

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11045)