### PR TITLE
10955 combobox callbacks

### DIFF
--- a/change/office-ui-fabric-react-2019-11-01-09-54-13-10955-combobox-callbacks.json
+++ b/change/office-ui-fabric-react-2019-11-01-09-54-13-10955-combobox-callbacks.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "ComboBox: onPendingValueChanged callback before onChange",
+  "packageName": "office-ui-fabric-react",
+  "email": "jdh@microsoft.com",
+  "commit": "cb7a98c85dbbff98050d92c3edb6b03530a50782",
+  "date": "2019-11-01T16:54:13.919Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -885,6 +885,11 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
 
       // Only setstate if combobox is uncontrolled.
       if (this.props.selectedKey || this.props.selectedKey === null) {
+        // If ComboBox value is changed, revert preview first
+        if (this._hasPendingValue && onPendingValueChanged) {
+          onPendingValueChanged();
+          this._hasPendingValue = false;
+        }
         if (onChange) {
           onChange(submitPendingValueEvent, option, index, undefined);
         }


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #10955
- [X] Include a change request file using `$ yarn change`

#### Description of changes

Commit 2de63934d1164f99229c640d83491c209f73ce5c introduced a change in behavior to the `ComboBox` where `onPendingValueChanged` would be called _after_ `onChange` if and only if the value was controlled.

This change reverts the change in behavior, such that `onPendingValueChanged` can be expected to be called before `onChange` in both scenarios.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11052)