### PR TITLE
Dropdown title and fix dropdown click event

### DIFF
--- a/change/office-ui-fabric-react-2019-11-01-16-14-16-multiSelectDropdown.json
+++ b/change/office-ui-fabric-react-2019-11-01-16-14-16-multiSelectDropdown.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix dropdown title and event",
+  "packageName": "office-ui-fabric-react",
+  "email": "achal.jain@microsoft.com",
+  "commit": "46b1fcd125c12dc2593d1bb2780f51c31dd0b190",
+  "date": "2019-11-01T23:14:16.868Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.base.tsx
@@ -194,10 +194,10 @@ export class CheckboxBase extends React.Component<ICheckboxProps, ICheckboxState
   };
 
   private _onRenderLabel = (props: ICheckboxProps): JSX.Element | null => {
-    const { label } = props;
+    const { label, title } = props;
 
     return label ? (
-      <span aria-hidden="true" className={this._classNames.text}>
+      <span aria-hidden="true" className={this._classNames.text} title={title}>
         {label}
       </span>
     ) : null;

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -1029,7 +1029,7 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
   private _onDropdownClick = (ev: React.MouseEvent<HTMLDivElement>): void => {
     if (this.props.onClick) {
       this.props.onClick(ev);
-      if (ev.preventDefault) {
+      if (ev.defaultPrevented) {
         return;
       }
     }

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -919,7 +919,7 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
 
     if (this.props.onKeyUp) {
       this.props.onKeyUp(ev);
-      if (ev.preventDefault) {
+      if (ev.defaultPrevented) {
         return;
       }
     }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

1) Fix drop-down _onDropdownClick event. "preventDefault" is a method and will always return true. Made a fix to check for "defaultPrevented" property instead. 

2) Title does not show up for multiselect dropdown options. Added "title" attribute to label.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11055)