### PR TITLE
Combobox: blank space selection

### DIFF
--- a/change/office-ui-fabric-react-2019-11-01-16-46-46-v-mare-Combobox-blank-space-selection.json
+++ b/change/office-ui-fabric-react-2019-11-01-16-46-46-v-mare-Combobox-blank-space-selection.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Combobox: Augmented checkbox to handle clicks from blank space to the right of the label ",
+  "packageName": "office-ui-fabric-react",
+  "email": "v-mare@microsoft.com",
+  "commit": "9c7b6b365149355efc7cb2d37a20352578dcab86",
+  "date": "2019-11-01T23:46:46.399Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -101,6 +101,9 @@ export const getOptionStyles = memoizeFunction(
             },
             '&.ms-Button--command:hover:active': {
               backgroundColor: option.backgroundPressedColor
+            },
+            '.ms-Checkbox-label': {
+              width: '100%'
             }
           }
         }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -1839,6 +1839,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                         &.ms-Button--command:hover:active {
                           background-color: #edebe9;
                         }
+                        & .ms-Checkbox-label {
+                          width: 100%;
+                        }
                         &:hover {
                           background-color: #f3f2f1;
                           color: #201f1e;
@@ -1998,6 +2001,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                         &.ms-Button--command:hover:active {
                           background-color: #edebe9;
                         }
+                        & .ms-Checkbox-label {
+                          width: 100%;
+                        }
                         &:hover {
                           background-color: #f3f2f1;
                         }
@@ -2146,6 +2152,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                         }
                         &.ms-Button--command:hover:active {
                           background-color: #edebe9;
+                        }
+                        & .ms-Checkbox-label {
+                          width: 100%;
                         }
                         &:hover {
                           background-color: #f3f2f1;
@@ -2301,6 +2310,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                         }
                         &.ms-Button--command:hover:active {
                           background-color: #edebe9;
+                        }
+                        & .ms-Checkbox-label {
+                          width: 100%;
                         }
                         &:hover {
                           background-color: #f3f2f1;
@@ -2506,6 +2518,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                         &.ms-Button--command:hover:active {
                           background-color: #edebe9;
                         }
+                        & .ms-Checkbox-label {
+                          width: 100%;
+                        }
                         &:hover {
                           background-color: #f3f2f1;
                           color: #201f1e;
@@ -2665,6 +2680,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                         &.ms-Button--command:hover:active {
                           background-color: #edebe9;
                         }
+                        & .ms-Checkbox-label {
+                          width: 100%;
+                        }
                         &:hover {
                           outline: 0px;
                         }
@@ -2806,6 +2824,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                         }
                         &.ms-Button--command:hover:active {
                           background-color: #edebe9;
+                        }
+                        & .ms-Checkbox-label {
+                          width: 100%;
                         }
                         &:hover {
                           background-color: #f3f2f1;
@@ -2962,6 +2983,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                         &.ms-Button--command:hover:active {
                           background-color: #edebe9;
                         }
+                        & .ms-Checkbox-label {
+                          width: 100%;
+                        }
                         &:hover {
                           background-color: #f3f2f1;
                           color: #201f1e;
@@ -3117,6 +3141,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                         &.ms-Button--command:hover:active {
                           background-color: #edebe9;
                         }
+                        & .ms-Checkbox-label {
+                          width: 100%;
+                        }
                         &:hover {
                           background-color: #f3f2f1;
                           color: #201f1e;
@@ -3271,6 +3298,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                         }
                         &.ms-Button--command:hover:active {
                           background-color: #edebe9;
+                        }
+                        & .ms-Checkbox-label {
+                          width: 100%;
                         }
                         &:hover {
                           background-color: #f3f2f1;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #11041
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Added ability for user to select Checkbox in Combobox via clicking the blank space to the right of the Checkbox's label

![Untitled](https://user-images.githubusercontent.com/13246181/68062409-74378d80-fcc7-11e9-8662-f862b2c81d18.gif)




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11056)