### PR TITLE
Propagate 'version' (force-update) through GroupedList to List

### DIFF
--- a/change/office-ui-fabric-react-2019-11-04-12-19-31-details-column.json
+++ b/change/office-ui-fabric-react-2019-11-04-12-19-31-details-column.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Propagate version through List and GroupedList",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "commit": "cb1c1915fb899d13017fe9d8cb477781092f768c",
+  "date": "2019-11-04T20:19:31.025Z"
+}

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -88,13 +88,15 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
   }
 
   public render(): JSX.Element {
-    const { className, usePageCache, onShouldVirtualize, theme, styles, compact } = this.props;
+    const { className, usePageCache, onShouldVirtualize, theme, styles, compact, listProps = {} } = this.props;
     const { groups } = this.state;
     this._classNames = getClassNames(styles, {
       theme: theme!,
       className,
       compact: compact
     });
+
+    const { version } = listProps;
 
     return (
       <div className={this._classNames.root} data-automationid="GroupedList" data-is-scrollable="false" role="presentation">
@@ -111,6 +113,7 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
             getPageSpecification={this._getPageSpecification}
             usePageCache={usePageCache}
             onShouldVirtualize={onShouldVirtualize}
+            version={version}
           />
         )}
       </div>

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
@@ -188,13 +188,16 @@ export class GroupedListSection extends React.Component<IGroupedListSectionProps
       onShouldVirtualize,
       groupedListClassNames,
       groups,
-      compact
+      compact,
+      listProps = {}
     } = this.props;
     const { isSelected } = this.state;
     const renderCount = group && getGroupItemLimit ? getGroupItemLimit(group) : Infinity;
     const isShowAllVisible =
       group && !group.children && !group.isCollapsed && !group.isShowingAll && (group.count > renderCount || group.hasMoreData);
     const hasNestedGroups = group && group.children && group.children.length > 0;
+
+    const { version } = listProps;
 
     const dividerProps: IGroupDividerProps = {
       group,
@@ -231,6 +234,7 @@ export class GroupedListSection extends React.Component<IGroupedListSectionProps
             onRenderCell={this._renderSubGroup}
             getItemCountForPage={this._returnOne}
             onShouldVirtualize={onShouldVirtualize}
+            version={version}
             id={this._id}
           />
         ) : (

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -325,7 +325,8 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     if (
       newProps.items !== this.props.items ||
       newProps.renderCount !== this.props.renderCount ||
-      newProps.startIndex !== this.props.startIndex
+      newProps.startIndex !== this.props.startIndex ||
+      newProps.version !== this.props.version
     ) {
       // We have received new items so we want to make sure that initially we only render a single window to
       // fill the currently visible rect, and then later render additional windows.


### PR DESCRIPTION
Fixed #11062 by ensuring that the new `version` prop on `List` is propagated through `GroupedList` and that `List` properly invalidates its render cache in response.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11064)