### PR TITLE
CommandBar: hidden attribute fix

### DIFF
--- a/change/office-ui-fabric-react-2019-11-04-13-26-55-v-mare-CommandBar-hidden-attribute-fix.json
+++ b/change/office-ui-fabric-react-2019-11-04-13-26-55-v-mare-CommandBar-hidden-attribute-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "CommandBar: Added ability to pass \"hidden:true\" on items objects in order to hide items ",
+  "packageName": "office-ui-fabric-react",
+  "email": "v-mare@microsoft.com",
+  "commit": "85a9eba3cd78c93b7b4682e8bf6fe9ce31c8e0d5",
+  "date": "2019-11-04T21:26:55.089Z"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -136,7 +136,8 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
 
     const itemText = item.text || item.name;
     const rootStyles: IStyle = {
-      height: '100%'
+      height: '100%',
+      display: item.hidden ? 'none' : 'inline-block'
     };
     const labelStyles: IStyle = {
       whiteSpace: 'nowrap'

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -136,8 +136,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
 
     const itemText = item.text || item.name;
     const rootStyles: IStyle = {
-      height: '100%',
-      display: item.hidden ? 'none' : 'inline-block'
+      height: '100%'
     };
     const labelStyles: IStyle = {
       whiteSpace: 'nowrap'

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.base.tsx
@@ -144,16 +144,18 @@ export class OverflowSetBase extends BaseComponent<IOverflowSetProps, {}> implem
   }
 
   private _onRenderItems = (items: IOverflowSetItemProps[]): JSX.Element[] => {
-    return items.map((item, i) => {
-      const wrapperDivProps: React.HTMLProps<HTMLDivElement> = {
-        className: this._classNames.item
-      };
-      return (
-        <div key={item.key} {...wrapperDivProps}>
-          {this.props.onRenderItem(item)}
-        </div>
-      );
-    });
+    return items
+      .filter(item => item.hidden !== true)
+      .map((item, i) => {
+        const wrapperDivProps: React.HTMLProps<HTMLDivElement> = {
+          className: this._classNames.item
+        };
+        return (
+          <div key={item.key} {...wrapperDivProps}>
+            {this.props.onRenderItem(item)}
+          </div>
+        );
+      });
   };
 
   private _onRenderOverflowButtonWrapper = (items: any[]): JSX.Element => {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #11034
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Adding hidden:true to CommandBar item array items hides items. Also, I've confirmed this change works in Win10 IE11.

#### Before (New Item Button)
![Screen Shot 2019-11-04 at 1 29 30 PM](https://user-images.githubusercontent.com/13246181/68159890-81db5600-ff07-11e9-8ee0-a69d0586895e.png)

#### Add Code (New Item Button)
![Screen Shot 2019-11-04 at 1 30 54 PM](https://user-images.githubusercontent.com/13246181/68159861-74be6700-ff07-11e9-9199-8e44cd76b450.png)

#### After (New Item Button)
![Screen Shot 2019-11-04 at 1 29 08 PM](https://user-images.githubusercontent.com/13246181/68159903-8b64be00-ff07-11e9-8bb7-7687a41fc403.png)







###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11067)