### PR TITLE
Styling: Add default units to flexBasis

### DIFF
--- a/change/@uifabric-experiments-2019-11-04-15-24-03-jg-11057-flex-basis.json
+++ b/change/@uifabric-experiments-2019-11-04-15-24-03-jg-11057-flex-basis.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add px units to flexBasis styling by default. Remove existing styling usage where it had no effect before this PR.",
+  "packageName": "@uifabric/experiments",
+  "email": "jagore@microsoft.com",
+  "commit": "f907d55f63a68d685743277f1f35188fbe6af62d",
+  "date": "2019-11-04T23:23:56.713Z"
+}

--- a/change/@uifabric-merge-styles-2019-11-04-15-24-03-jg-11057-flex-basis.json
+++ b/change/@uifabric-merge-styles-2019-11-04-15-24-03-jg-11057-flex-basis.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add px units to flexBasis styling by default. Remove existing styling usage where it had no effect before this PR.",
+  "packageName": "@uifabric/merge-styles",
+  "email": "jagore@microsoft.com",
+  "commit": "f907d55f63a68d685743277f1f35188fbe6af62d",
+  "date": "2019-11-04T23:24:01.651Z"
+}

--- a/change/office-ui-fabric-react-2019-11-04-15-24-03-jg-11057-flex-basis.json
+++ b/change/office-ui-fabric-react-2019-11-04-15-24-03-jg-11057-flex-basis.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add px units to flexBasis styling by default. Remove existing styling usage where it had no effect before this PR.",
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com",
+  "commit": "f907d55f63a68d685743277f1f35188fbe6af62d",
+  "date": "2019-11-04T23:24:03.755Z"
+}

--- a/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/Items/SelectedPersona.styles.ts
+++ b/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/Items/SelectedPersona.styles.ts
@@ -82,7 +82,6 @@ export const getStyles = (props: ISelectedPersonaStyleProps): ISelectedPersonaSt
         flex: '0 0 auto',
         width: 33,
         height: 33,
-        flexBasis: 32,
         selectors: {
           ':hover': {
             backgroundColor: palette.themeLight

--- a/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
+++ b/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
@@ -388,7 +388,6 @@ Array [
               color: #ffffff;
               cursor: pointer;
               display: inline-block;
-              flex-basis: 32;
               flex: 0 0 auto;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
@@ -898,7 +897,6 @@ Array [
               color: #ffffff;
               cursor: pointer;
               display: inline-block;
-              flex-basis: 32;
               flex: 0 0 auto;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;

--- a/packages/merge-styles/src/transforms/provideUnits.ts
+++ b/packages/merge-styles/src/transforms/provideUnits.ts
@@ -1,7 +1,6 @@
 const NON_PIXEL_NUMBER_PROPS = [
   'column-count',
   'font-weight',
-  'flex-basis',
   'flex',
   'flex-grow',
   'flex-shrink',

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.styles.ts
@@ -124,7 +124,6 @@ export function getStyles(props: IPeoplePickerItemSelectedStyleProps): IPeoplePi
         flex: '0 0 auto',
         width: REMOVE_BUTTON_SIZE,
         height: REMOVE_BUTTON_SIZE,
-        flexBasis: REMOVE_BUTTON_SIZE,
         selectors: {
           ':hover': {
             background: palette.neutralTertiaryAlt,

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -502,7 +502,6 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                     color: #323130;
                     cursor: pointer;
                     display: inline-block;
-                    flex-basis: 24;
                     flex: 0 0 auto;
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11057 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add default units of `px` to `flexBasis`, making it consistent with other styling properties such as `height`.

Removed a couple of existing numeric usages of `flexBasis` as they had no effect before this PR. @Adjective-Object and @joschect as FYI.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11069)