### PR TITLE
CommandBar: Pass through div props to the rendered root of CommandBar.

### DIFF
--- a/change/office-ui-fabric-react-2019-11-05-18-47-45-xinyan-cd.json
+++ b/change/office-ui-fabric-react-2019-11-05-18-47-45-xinyan-cd.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Pass through div props to the rendered root of CommandBar.",
+  "packageName": "office-ui-fabric-react",
+  "email": "xinychen@microsoft.com",
+  "commit": "9c93008c22fc9aa53aa08319560a0c856c631007",
+  "date": "2019-11-05T10:47:45.124Z"
+}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -48,7 +48,6 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
 
   public render(): JSX.Element {
     const {
-      className,
       items,
       overflowItems,
       farItems,
@@ -71,18 +70,17 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
 
     // ResizeGroup will render these attributes to the root <div>.
     // TODO We may need to elevate classNames from <FocusZone> into <ResizeGroup> ?
-    const nativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties, ['data', 'className', 'styles']);
+    const nativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties);
 
     return (
       <ResizeGroup
+        {...nativeProps}
         componentRef={this._resizeGroup}
-        className={className}
         data={commandBarData}
         onReduceData={onReduceData}
         onGrowData={onGrowData}
         onRenderData={this._onRenderData}
         dataDidRender={dataDidRender}
-        {...nativeProps}
       />
     );
   }

--- a/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/CommandBar.base.tsx
@@ -8,7 +8,7 @@ import { FocusZone, FocusZoneDirection } from '../../FocusZone';
 import { classNamesFunction } from '../../Utilities';
 import { CommandBarButton, IButtonProps } from '../../Button';
 import { TooltipHost } from '../../Tooltip';
-import { IComponentAs } from '@uifabric/utilities';
+import { IComponentAs, getNativeProps, divProperties } from '@uifabric/utilities';
 import { mergeStyles, IStyle } from '@uifabric/styling';
 
 const getClassNames = classNamesFunction<ICommandBarStyleProps, ICommandBarStyles>();
@@ -69,6 +69,10 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
 
     this._classNames = getClassNames(styles!, { theme: theme! });
 
+    // ResizeGroup will render these attributes to the root <div>.
+    // TODO We may need to elevate classNames from <FocusZone> into <ResizeGroup> ?
+    const nativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties, ['data', 'className', 'styles']);
+
     return (
       <ResizeGroup
         componentRef={this._resizeGroup}
@@ -78,6 +82,7 @@ export class CommandBarBase extends BaseComponent<ICommandBarProps, {}> implemen
         onGrowData={onGrowData}
         onRenderData={this._onRenderData}
         dataDidRender={dataDidRender}
+        {...nativeProps}
       />
     );
   }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10353
- [x] Include a change request file using `$ yarn change`

#### Description of changes
This change passes through all the <div> attributes, `data-` / `aria-` attributes to the inner <ResizeGroup>, so it will be able to subsequently pass them to the native <div> element.

The following attributes are explicitly excluded from passing through:
* data
* className
* styles

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11073)