### PR TITLE
Fixed the webpack task to forward the production flag

### DIFF
--- a/scripts/tasks/webpack.js
+++ b/scripts/tasks/webpack.js
@@ -4,9 +4,13 @@ const { webpackCliTask, argv, logger } = require('just-scripts');
 const path = require('path');
 const fs = require('fs');
 
-exports.webpack = webpackCliTask({
-  nodeArgs: ['--max-old-space-size=4096']
-});
+exports.webpack = function() {
+  const args = argv();
+  return webpackCliTask({
+    webpackCliArgs: args.production ? ['--production'] : [],
+    nodeArgs: ['--max-old-space-size=4096']
+  });
+};
 exports.webpackDevServer = async function() {
   const fp = require('find-free-port');
   const webpackConfigFilePath = argv().webpackConfig || 'webpack.serve.config.js';


### PR DESCRIPTION
#### Overview

When I swapped us to `webpackCliTask`, I realized that we're not passing along the proper webpackCliArgs of "production" and the webpack.config.js files did not get the signal to build production copies. This led to us not releasing .min.js files in our nightly publishes.

This addresses the issue and I'll kick off a job to address this.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11081)