### PR TITLE
Contextual menu preventdefault

### DIFF
--- a/change/office-ui-fabric-react-2019-11-05-11-40-36-contextual-menu-preventdefault.json
+++ b/change/office-ui-fabric-react-2019-11-05-11-40-36-contextual-menu-preventdefault.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "remove unnecessary preventDefault in contextual menu which broke ability to preventDefault during onDismiss",
+  "packageName": "office-ui-fabric-react",
+  "email": "micahgodbolt@gmail.com",
+  "commit": "63cde726a39c9ce5bc10be55da0c97fb9633c1a3",
+  "date": "2019-11-05T19:40:36.743Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -838,7 +838,6 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
 
     if (shouldHandleKey(ev)) {
       this._isFocusingPreviousElement = true;
-      ev.preventDefault();
       ev.stopPropagation();
       this.dismiss(ev, dismissAllMenus);
       handled = true;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11077
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Contextual menu's keyHandler is firing 'preventDefault' on every click, which means that the menuButton now can't close with any key clicks.

I believe the preventDefault is unnecessary as the function is already stopping propagation. I understand this might cause unexpected outcome, so I'm pushing this out to see what tests/feedback have to say.

#### Focus areas to test

What keyboard keypress might have unintended consequence now that the default isn't prevented.

Here's the boolean causing preventDefault and stopProp to fire:

https://github.com/OfficeDev/office-ui-fabric-react/blob/63cde726a39c9ce5bc10be55da0c97fb9633c1a3/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx#L786-L788

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11083)