### PR TITLE
Production App - make sure the fabric-website also builds production given the --production flag

### DIFF
--- a/apps/fabric-website/webpack.config.js
+++ b/apps/fabric-website/webpack.config.js
@@ -1,12 +1,14 @@
 // @ts-check
 
-module.exports = function(env) {
+module.exports = function(env, argv) {
   const path = require('path');
   const resources = require('@uifabric/build/webpack/webpack-resources');
   const { addMonacoWebpackConfig } = require('@uifabric/tsx-editor/scripts/addMonacoWebpackConfig');
   // @ts-ignore
   const version = require('./package.json').version;
-  const isProductionArg = env && env.production;
+  // production mode is either coming from env variable, CLI argument as mode or production
+  const isProductionArg =
+    (env && (env.production || env.NODE_ENV === 'production')) || argv.mode === 'production' || argv.production === true;
   const now = Date.now();
 
   // Production defaults

--- a/change/@uifabric-fabric-website-2019-11-05-14-25-26-master.json
+++ b/change/@uifabric-fabric-website-2019-11-05-14-25-26-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fixing the production flag to be respected in the webpackCliTask world",
+  "packageName": "@uifabric/fabric-website",
+  "email": "kchau@microsoft.com",
+  "commit": "e35c4367b6f6f87ebf2d9372136a15c6b9eb190b",
+  "date": "2019-11-05T22:25:26.706Z"
+}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Apparently, fabric-website has a vastly different webpack.config.js so that the one fix for all other packages wouldn't work for this when respecting the --production flag. This PR will add this to the fabric-website app as well.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11088)