### PR TITLE
Foundation: Deprecate redundant type

### DIFF
--- a/change/@uifabric-foundation-2019-11-06-08-57-35-jg-deprecate-foundation-type.json
+++ b/change/@uifabric-foundation-2019-11-06-08-57-35-jg-deprecate-foundation-type.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Deprecate IPropsWithChildren type that is redundant with React.PropsWithChildren.",
+  "packageName": "@uifabric/foundation",
+  "email": "jagore@microsoft.com",
+  "commit": "94cd8074a7f306c79157de6c1910e9ee31608594",
+  "date": "2019-11-06T16:57:35.579Z"
+}

--- a/packages/foundation/etc/foundation.api.md
+++ b/packages/foundation/etc/foundation.api.md
@@ -84,7 +84,7 @@ export interface IProcessedSlotProps {
     className?: string;
 }
 
-// @public
+// @public @deprecated
 export type IPropsWithChildren<TProps> = React.PropsWithChildren<TProps>;
 
 // @public

--- a/packages/foundation/etc/foundation.api.md
+++ b/packages/foundation/etc/foundation.api.md
@@ -85,14 +85,12 @@ export interface IProcessedSlotProps {
 }
 
 // @public
-export type IPropsWithChildren<TProps> = TProps & {
-    children?: React.ReactNode;
-};
+export type IPropsWithChildren<TProps> = React.PropsWithChildren<TProps>;
 
 // @public
 export interface ISlot<TProps> {
     // (undocumented)
-    (componentProps: IPropsWithChildren<TProps> | undefined | null): ReturnType<React.FunctionComponent>;
+    (componentProps: React.PropsWithChildren<TProps> | undefined | null): ReturnType<React.FunctionComponent>;
     // (undocumented)
     isSlot?: boolean;
 }
@@ -123,7 +121,7 @@ export interface ISlotOptions<TProps> {
 export type ISlotProp<TProps extends ValidProps, TShorthandProp extends ValidShorthand = never> = TShorthandProp | TProps;
 
 // @public
-export type ISlotRender<TProps> = (props: IPropsWithChildren<TProps>, defaultComponent: React.ComponentType<TProps>) => ReturnType<React.FunctionComponent<TProps>>;
+export type ISlotRender<TProps> = (props: React.PropsWithChildren<TProps>, defaultComponent: React.ComponentType<TProps>) => ReturnType<React.FunctionComponent<TProps>>;
 
 // @public
 export type ISlots<TSlots> = {
@@ -189,7 +187,7 @@ export type ITokenFunction<TViewProps, TTokens> = (props: TViewProps, theme: ITh
 export type ITokenFunctionOrObject<TViewProps, TTokens> = ITokenFunction<TViewProps, TTokens> | TTokens;
 
 // @public
-export type IViewComponent<TViewProps> = (props: IPropsWithChildren<TViewProps>) => ReturnType<React.FunctionComponent>;
+export type IViewComponent<TViewProps> = (props: React.PropsWithChildren<TViewProps>) => ReturnType<React.FunctionComponent>;
 
 export { legacyStyled }
 

--- a/packages/foundation/src/IComponent.ts
+++ b/packages/foundation/src/IComponent.ts
@@ -9,7 +9,7 @@ import { IStyle, IStyleSet, ITheme } from '@uifabric/styling';
 
 /**
  * Helper interface for accessing user props children.
- * @deprecate Use React.PropsWithChildren.
+ * @deprecated Use React.PropsWithChildren.
  */
 export type IPropsWithChildren<TProps> = React.PropsWithChildren<TProps>;
 

--- a/packages/foundation/src/IComponent.ts
+++ b/packages/foundation/src/IComponent.ts
@@ -9,8 +9,9 @@ import { IStyle, IStyleSet, ITheme } from '@uifabric/styling';
 
 /**
  * Helper interface for accessing user props children.
+ * @deprecate Use React.PropsWithChildren.
  */
-export type IPropsWithChildren<TProps> = TProps & { children?: React.ReactNode };
+export type IPropsWithChildren<TProps> = React.PropsWithChildren<TProps>;
 
 /**
  * Helper type defining style sections, one for each component slot.
@@ -84,7 +85,7 @@ export type IStateComponentType<TComponentProps, TViewProps> = (props: Readonly<
 /**
  * Defines the contract for view components.
  */
-export type IViewComponent<TViewProps> = (props: IPropsWithChildren<TViewProps>) => ReturnType<React.FunctionComponent>;
+export type IViewComponent<TViewProps> = (props: React.PropsWithChildren<TViewProps>) => ReturnType<React.FunctionComponent>;
 
 /**
  * Component options used by foundation to tie elements together.

--- a/packages/foundation/src/ISlots.ts
+++ b/packages/foundation/src/ISlots.ts
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IStyle } from '@uifabric/styling';
-import { IComponentStyles, IPropsWithChildren } from './IComponent';
+import { IComponentStyles } from './IComponent';
 
 /**
  * Signature of components that have component factories.
@@ -37,7 +37,7 @@ export type ISlotDefinition<TSlots> = { [slot in keyof TSlots]: React.ElementTyp
  * Created Slot structure used for rendering by components.
  */
 export interface ISlot<TProps> {
-  (componentProps: IPropsWithChildren<TProps> | undefined | null): ReturnType<React.FunctionComponent>;
+  (componentProps: React.PropsWithChildren<TProps> | undefined | null): ReturnType<React.FunctionComponent>;
   isSlot?: boolean;
 }
 
@@ -122,6 +122,6 @@ export interface ISlotOptions<TProps> {
  * Content rendering provided by component.
  */
 export type ISlotRender<TProps> = (
-  props: IPropsWithChildren<TProps>,
+  props: React.PropsWithChildren<TProps>,
   defaultComponent: React.ComponentType<TProps>
 ) => ReturnType<React.FunctionComponent<TProps>>;

--- a/packages/foundation/src/next/IComponent.ts
+++ b/packages/foundation/src/next/IComponent.ts
@@ -1,12 +1,13 @@
+import * as React from 'react';
 import { IStyleSet } from '@uifabric/styling';
-import { IComponentOptions as IOldComponentOptions, IPropsWithChildren } from '../IComponent';
+import { IComponentOptions as IOldComponentOptions } from '../IComponent';
 import { ISlots, ISlotDefinition, ISlottableProps } from '../ISlots';
 
 /**
  * Defines the contract for view components.
  */
 export type IViewComponent<TViewProps, TComponentSlots = {}> = (
-  props: IPropsWithChildren<TViewProps>,
+  props: React.PropsWithChildren<TViewProps>,
   slots: ISlots<Required<TComponentSlots>>
 ) => ReturnType<React.FunctionComponent>;
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Deprecate `IPropsWithChildren` type that is redundant with `React.PropsWithChildren`.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11094)