### PR TITLE
Tooltip race fix

### DIFF
--- a/change/office-ui-fabric-react-2019-11-06-12-32-56-tooltip-thing.json
+++ b/change/office-ui-fabric-react-2019-11-06-12-32-56-tooltip-thing.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "TooltipHost: Fix dismiss race condition.",
+  "packageName": "office-ui-fabric-react",
+  "email": "jdh@microsoft.com",
+  "commit": "269e54674d4c9a0574c03677e0c07485585ab817",
+  "date": "2019-11-06T20:32:56.406Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
@@ -229,6 +229,8 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
 
   // Hide Tooltip
   private _hideTooltip = (): void => {
+    this._clearOpenTimer();
+    this._clearDismissTimer();
     this._toggleTooltip(false);
   };
 


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #10969
- [X] Include a change request file using `$ yarn change`

#### Description of changes

When a layer appears on top of a tooltip host, timers fail to get cleared in several circumstances. This ensures they are cleared so delayed openings don't happen unexpectedly.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11097)