### PR TITLE
Button: splitbutton divider fix and SplitButton styles reorg

### DIFF
--- a/change/office-ui-fabric-react-2019-11-06-11-54-47-v-mare-CommandBarButton-splitbutton-divider-fix.json
+++ b/change/office-ui-fabric-react-2019-11-06-11-54-47-v-mare-CommandBarButton-splitbutton-divider-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "SplitButton: Fixed divider styles. Refactored styles incorporating splitbutton styles from ButtonThemes.ts ",
+  "packageName": "office-ui-fabric-react",
+  "email": "v-mare@microsoft.com",
+  "commit": "8dd841dcfd8ef911f3e32cb68dacab3d14772e77",
+  "date": "2019-11-06T19:54:47.448Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/ButtonThemes.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/ButtonThemes.ts
@@ -3,7 +3,7 @@ import { ITheme, HighContrastSelector } from '../../Styling';
 import { IsFocusVisibleClassName } from '../../Utilities';
 
 export function standardStyles(theme: ITheme): IButtonStyles {
-  const { semanticColors: s, palette: p } = theme;
+  const { semanticColors: s } = theme;
 
   const buttonBackground = s.buttonBackground;
   const buttonBackgroundPressed = s.buttonBackgroundPressed;
@@ -59,83 +59,6 @@ export function standardStyles(theme: ITheme): IButtonStyles {
           backgroundColor: 'Window'
         }
       }
-    },
-
-    // Split button styles
-    splitButtonContainer: {
-      selectors: {
-        [HighContrastSelector]: {
-          border: 'none'
-        }
-      }
-    },
-
-    splitButtonMenuButton: {
-      color: p.white,
-      backgroundColor: 'transparent',
-      selectors: {
-        ':hover': {
-          backgroundColor: p.neutralLight,
-          selectors: {
-            [HighContrastSelector]: {
-              color: 'Highlight'
-            }
-          }
-        }
-      }
-    },
-
-    splitButtonMenuButtonDisabled: {
-      backgroundColor: s.buttonBackgroundDisabled,
-      selectors: {
-        ':hover': {
-          backgroundColor: s.buttonBackgroundDisabled
-        }
-      }
-    },
-
-    splitButtonDivider: {
-      backgroundColor: p.neutralTertiaryAlt,
-      position: 'absolute',
-      width: 1,
-      right: 31,
-      top: 8,
-      bottom: 8,
-      selectors: {
-        [HighContrastSelector]: {
-          backgroundColor: 'WindowText'
-        }
-      }
-    },
-
-    splitButtonDividerDisabled: {
-      backgroundColor: theme.palette.neutralTertiaryAlt
-    },
-
-    splitButtonMenuButtonChecked: {
-      backgroundColor: p.neutralQuaternaryAlt,
-      selectors: {
-        ':hover': {
-          backgroundColor: p.neutralQuaternaryAlt
-        }
-      }
-    },
-
-    splitButtonMenuButtonExpanded: {
-      backgroundColor: p.neutralQuaternaryAlt,
-      selectors: {
-        ':hover': {
-          backgroundColor: p.neutralQuaternaryAlt
-        }
-      }
-    },
-
-    splitButtonMenuIcon: {
-      color: s.buttonText
-    },
-
-    splitButtonMenuIconDisabled: {
-      color: s.buttonTextDisabled
     }
   };
 }
@@ -209,88 +132,6 @@ export function primaryStyles(theme: ITheme): IButtonStyles {
           color: 'GrayText',
           borderColor: 'GrayText',
           backgroundColor: 'Window'
-        }
-      }
-    },
-
-    // Split button styles
-    splitButtonContainer: {
-      selectors: {
-        [HighContrastSelector]: {
-          border: 'none'
-        }
-      }
-    },
-
-    splitButtonDivider: {
-      backgroundColor: p.neutralTertiaryAlt,
-      position: 'absolute',
-      width: 1,
-      right: 31,
-      top: 8,
-      bottom: 8,
-      selectors: {
-        [HighContrastSelector]: {
-          backgroundColor: 'Window'
-        }
-      }
-    },
-
-    splitButtonMenuButton: {
-      backgroundColor: s.primaryButtonBackground,
-      color: s.primaryButtonText,
-      selectors: {
-        [HighContrastSelector]: {
-          backgroundColor: 'WindowText'
-        },
-        ':hover': {
-          backgroundColor: s.primaryButtonBackgroundHovered,
-          selectors: {
-            [HighContrastSelector]: {
-              color: 'Highlight'
-            }
-          }
-        }
-      }
-    },
-
-    splitButtonMenuButtonDisabled: {
-      backgroundColor: s.primaryButtonBackgroundDisabled,
-      selectors: {
-        ':hover': {
-          backgroundColor: s.primaryButtonBackgroundDisabled
-        }
-      }
-    },
-
-    splitButtonMenuButtonChecked: {
-      backgroundColor: s.primaryButtonBackgroundPressed,
-      selectors: {
-        ':hover': {
-          backgroundColor: s.primaryButtonBackgroundPressed
-        }
-      }
-    },
-
-    splitButtonMenuButtonExpanded: {
-      backgroundColor: s.primaryButtonBackgroundPressed,
-      selectors: {
-        ':hover': {
-          backgroundColor: s.primaryButtonBackgroundPressed
-        }
-      }
-    },
-
-    splitButtonMenuIcon: {
-      color: s.primaryButtonText
-    },
-
-    splitButtonMenuIconDisabled: {
-      color: p.neutralTertiary,
-
-      selectors: {
-        [HighContrastSelector]: {
-          color: 'GrayText'
         }
       }
     }

--- a/packages/office-ui-fabric-react/src/components/Button/CommandBarButton/CommandBarButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/CommandBarButton/CommandBarButton.styles.ts
@@ -2,13 +2,14 @@ import { IButtonStyles } from '../Button.types';
 import { ITheme, concatStyleSets, getFocusStyle, HighContrastSelector } from '../../../Styling';
 import { memoizeFunction } from '../../../Utilities';
 import { getStyles as getBaseButtonStyles } from '../BaseButton.styles';
-import { getStyles as getSplitButtonStyles } from '../SplitButton/SplitButton.styles';
+import { getStandardSplitStyles } from '../SplitButton/SplitButton.styles';
+
 import { ButtonGlobalClassNames } from '../BaseButton.classNames';
 
 export const getStyles = memoizeFunction(
   (theme: ITheme, customStyles?: IButtonStyles, focusInset?: string, focusColor?: string): IButtonStyles => {
     const baseButtonStyles: IButtonStyles = getBaseButtonStyles(theme);
-    const baseSplitButtonStyles: IButtonStyles = getSplitButtonStyles(theme);
+    const baseSplitButtonStyles: IButtonStyles = getStandardSplitStyles(theme);
 
     const { palette: p, semanticColors } = theme;
 

--- a/packages/office-ui-fabric-react/src/components/Button/CommandBarButton/CommandBarButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/CommandBarButton/CommandBarButton.styles.ts
@@ -2,14 +2,14 @@ import { IButtonStyles } from '../Button.types';
 import { ITheme, concatStyleSets, getFocusStyle, HighContrastSelector } from '../../../Styling';
 import { memoizeFunction } from '../../../Utilities';
 import { getStyles as getBaseButtonStyles } from '../BaseButton.styles';
-import { getStandardSplitStyles } from '../SplitButton/SplitButton.styles';
+import { getStandardSplitButtonStyles } from '../SplitButton/SplitButton.styles';
 
 import { ButtonGlobalClassNames } from '../BaseButton.classNames';
 
 export const getStyles = memoizeFunction(
   (theme: ITheme, customStyles?: IButtonStyles, focusInset?: string, focusColor?: string): IButtonStyles => {
     const baseButtonStyles: IButtonStyles = getBaseButtonStyles(theme);
-    const baseSplitButtonStyles: IButtonStyles = getStandardSplitStyles(theme);
+    const baseSplitButtonStyles: IButtonStyles = getStandardSplitButtonStyles(theme);
 
     const { palette: p, semanticColors } = theme;
 

--- a/packages/office-ui-fabric-react/src/components/Button/CompoundButton/CompoundButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/CompoundButton/CompoundButton.styles.ts
@@ -2,7 +2,7 @@ import { IButtonStyles } from '../Button.types';
 import { ITheme, concatStyleSets, FontWeights, HighContrastSelector } from '../../../Styling';
 import { memoizeFunction } from '../../../Utilities';
 import { getStyles as getBaseButtonStyles } from '../BaseButton.styles';
-import { getPrimarySplitStyles, getStandardSplitStyles } from '../SplitButton/SplitButton.styles';
+import { getPrimarySplitButtonStyles, getStandardSplitButtonStyles } from '../SplitButton/SplitButton.styles';
 import { primaryStyles, standardStyles } from '../ButtonThemes';
 
 export const getStyles = memoizeFunction(
@@ -134,7 +134,7 @@ export const getStyles = memoizeFunction(
       compoundButtonStyles,
       primary ? primaryStyles(theme) : standardStyles(theme),
       primary ? primaryCompoundTheme : standardCompoundTheme,
-      primary ? getPrimarySplitStyles(theme) : getStandardSplitStyles(theme),
+      primary ? getPrimarySplitButtonStyles(theme) : getStandardSplitButtonStyles(theme),
       customStyles
     )!;
   }

--- a/packages/office-ui-fabric-react/src/components/Button/CompoundButton/CompoundButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/CompoundButton/CompoundButton.styles.ts
@@ -2,7 +2,7 @@ import { IButtonStyles } from '../Button.types';
 import { ITheme, concatStyleSets, FontWeights, HighContrastSelector } from '../../../Styling';
 import { memoizeFunction } from '../../../Utilities';
 import { getStyles as getBaseButtonStyles } from '../BaseButton.styles';
-import { getStyles as getSplitButtonStyles } from '../SplitButton/SplitButton.styles';
+import { getPrimarySplitStyles, getStandardSplitStyles } from '../SplitButton/SplitButton.styles';
 import { primaryStyles, standardStyles } from '../ButtonThemes';
 
 export const getStyles = memoizeFunction(
@@ -10,7 +10,6 @@ export const getStyles = memoizeFunction(
     const { fonts, palette } = theme;
 
     const baseButtonStyles: IButtonStyles = getBaseButtonStyles(theme);
-    const splitButtonStyles: IButtonStyles = getSplitButtonStyles(theme);
     const compoundButtonStyles: IButtonStyles = {
       root: {
         maxWidth: '280px',
@@ -135,7 +134,7 @@ export const getStyles = memoizeFunction(
       compoundButtonStyles,
       primary ? primaryStyles(theme) : standardStyles(theme),
       primary ? primaryCompoundTheme : standardCompoundTheme,
-      splitButtonStyles,
+      primary ? getPrimarySplitStyles(theme) : getStandardSplitStyles(theme),
       customStyles
     )!;
   }

--- a/packages/office-ui-fabric-react/src/components/Button/DefaultButton/DefaultButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/DefaultButton/DefaultButton.styles.ts
@@ -2,7 +2,7 @@ import { IButtonStyles } from '../Button.types';
 import { ITheme, concatStyleSets, FontWeights } from '../../../Styling';
 import { memoizeFunction } from '../../../Utilities';
 import { getStyles as getBaseButtonStyles } from '../BaseButton.styles';
-import { getStyles as getSplitButtonStyles } from '../SplitButton/SplitButton.styles';
+import { getPrimarySplitStyles, getStandardSplitStyles } from '../SplitButton/SplitButton.styles';
 
 import { primaryStyles, standardStyles } from '../ButtonThemes';
 
@@ -12,7 +12,6 @@ const DEFAULT_BUTTON_MIN_WIDTH = '80px';
 export const getStyles = memoizeFunction(
   (theme: ITheme, customStyles?: IButtonStyles, primary?: boolean): IButtonStyles => {
     const baseButtonStyles: IButtonStyles = getBaseButtonStyles(theme);
-    const splitButtonStyles: IButtonStyles = getSplitButtonStyles(theme);
     const defaultButtonStyles: IButtonStyles = {
       root: {
         minWidth: DEFAULT_BUTTON_MIN_WIDTH,
@@ -27,7 +26,7 @@ export const getStyles = memoizeFunction(
       baseButtonStyles,
       defaultButtonStyles,
       primary ? primaryStyles(theme) : standardStyles(theme),
-      splitButtonStyles,
+      primary ? getPrimarySplitStyles(theme) : getStandardSplitStyles(theme),
       customStyles
     )!;
   }

--- a/packages/office-ui-fabric-react/src/components/Button/DefaultButton/DefaultButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/DefaultButton/DefaultButton.styles.ts
@@ -2,7 +2,7 @@ import { IButtonStyles } from '../Button.types';
 import { ITheme, concatStyleSets, FontWeights } from '../../../Styling';
 import { memoizeFunction } from '../../../Utilities';
 import { getStyles as getBaseButtonStyles } from '../BaseButton.styles';
-import { getPrimarySplitStyles, getStandardSplitStyles } from '../SplitButton/SplitButton.styles';
+import { getPrimarySplitButtonStyles, getStandardSplitButtonStyles } from '../SplitButton/SplitButton.styles';
 
 import { primaryStyles, standardStyles } from '../ButtonThemes';
 
@@ -26,7 +26,7 @@ export const getStyles = memoizeFunction(
       baseButtonStyles,
       defaultButtonStyles,
       primary ? primaryStyles(theme) : standardStyles(theme),
-      primary ? getPrimarySplitStyles(theme) : getStandardSplitStyles(theme),
+      primary ? getPrimarySplitButtonStyles(theme) : getStandardSplitButtonStyles(theme),
       customStyles
     )!;
   }

--- a/packages/office-ui-fabric-react/src/components/Button/IconButton/IconButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/IconButton/IconButton.styles.ts
@@ -2,12 +2,12 @@ import { IButtonStyles } from '../Button.types';
 import { ITheme, concatStyleSets, HighContrastSelector } from '../../../Styling';
 import { memoizeFunction } from '../../../Utilities';
 import { getStyles as getBaseButtonStyles } from '../BaseButton.styles';
-import { getStyles as getSplitButtonStyles } from '../SplitButton/SplitButton.styles';
+import { getStandardSplitStyles } from '../SplitButton/SplitButton.styles';
 
 export const getStyles = memoizeFunction(
   (theme: ITheme, customStyles?: IButtonStyles): IButtonStyles => {
     const baseButtonStyles: IButtonStyles = getBaseButtonStyles(theme);
-    const splitButtonStyles: IButtonStyles = getSplitButtonStyles(theme);
+    const splitButtonStyles: IButtonStyles = getStandardSplitStyles(theme);
     const { palette, semanticColors } = theme;
     const iconButtonStyles: IButtonStyles = {
       root: {

--- a/packages/office-ui-fabric-react/src/components/Button/IconButton/IconButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/IconButton/IconButton.styles.ts
@@ -2,12 +2,12 @@ import { IButtonStyles } from '../Button.types';
 import { ITheme, concatStyleSets, HighContrastSelector } from '../../../Styling';
 import { memoizeFunction } from '../../../Utilities';
 import { getStyles as getBaseButtonStyles } from '../BaseButton.styles';
-import { getStandardSplitStyles } from '../SplitButton/SplitButton.styles';
+import { getStandardSplitButtonStyles } from '../SplitButton/SplitButton.styles';
 
 export const getStyles = memoizeFunction(
   (theme: ITheme, customStyles?: IButtonStyles): IButtonStyles => {
     const baseButtonStyles: IButtonStyles = getBaseButtonStyles(theme);
-    const splitButtonStyles: IButtonStyles = getStandardSplitStyles(theme);
+    const splitButtonStyles: IButtonStyles = getStandardSplitButtonStyles(theme);
     const { palette, semanticColors } = theme;
     const iconButtonStyles: IButtonStyles = {
       root: {

--- a/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -2,180 +2,348 @@ import { IButtonStyles } from '../Button.types';
 import { HighContrastSelector, ITheme, concatStyleSets, getFocusStyle, IStyle } from '../../../Styling';
 import { memoizeFunction } from '../../../Utilities';
 
-export const getStyles = memoizeFunction(
-  (theme: ITheme, customStyles?: IButtonStyles): IButtonStyles => {
-    const { effects, palette } = theme;
+const buttonHighContrastFocus: IStyle = {
+  left: -2,
+  top: -2,
+  bottom: -2,
+  right: -2,
+  border: 'none'
+};
 
-    const buttonHighContrastFocus = {
-      left: -2,
-      top: -2,
-      bottom: -2,
-      right: -2,
-      border: 'none'
-    };
+const splitButtonContainer: IStyle = {
+  display: 'inline-flex',
+  selectors: {
+    '.ms-Button--default': {
+      borderTopRightRadius: '0',
+      borderBottomRightRadius: '0',
+      borderRight: 'none'
+    },
+    '.ms-Button--primary': {
+      borderTopRightRadius: '0',
+      borderBottomRightRadius: '0',
+      border: 'none',
 
-    const splitButtonDividerDisabled: IStyle = {
-      position: 'absolute',
-      width: 1,
-      right: 31,
-      top: 8,
-      bottom: 8,
       selectors: {
         [HighContrastSelector]: {
-          backgroundColor: 'GrayText'
+          border: 'none',
+          color: 'Window',
+          backgroundColor: 'WindowText',
+          MsHighContrastAdjust: 'none'
         }
       }
-    };
+    },
+    '.ms-Button--primary + .ms-Button': {
+      border: 'none'
+    }
+  }
+};
 
-    const splitButtonStyles: IButtonStyles = {
-      splitButtonContainer: [
-        getFocusStyle(theme, { highContrastStyle: buttonHighContrastFocus, inset: 2 }),
-        {
-          display: 'inline-flex',
-          selectors: {
-            '.ms-Button--default': {
-              borderTopRightRadius: '0',
-              borderBottomRightRadius: '0',
-              borderRight: 'none'
-            },
-            '.ms-Button--primary': {
-              borderTopRightRadius: '0',
-              borderBottomRightRadius: '0',
-              border: 'none',
+const splitButtonDivider: IStyle = {
+  position: 'absolute',
+  width: 1,
+  right: 31,
+  top: 8,
+  bottom: 8
+};
 
-              selectors: {
-                [HighContrastSelector]: {
-                  color: 'Window',
-                  backgroundColor: 'WindowText',
-                  MsHighContrastAdjust: 'none'
-                }
-              }
-            },
-            '.ms-Button--primary + .ms-Button': {
-              border: 'none'
-            }
-          }
+const splitButtonContainerHovered: IStyle = {
+  selectors: {
+    '.ms-Button--primary': {
+      selectors: {
+        [HighContrastSelector]: {
+          color: 'Window',
+          backgroundColor: 'Highlight'
         }
-      ],
-      splitButtonContainerHovered: {
-        selectors: {
-          '.ms-Button--primary': {
-            selectors: {
-              [HighContrastSelector]: {
-                color: 'Window',
-                backgroundColor: 'Highlight'
-              }
-            }
-          },
-          '.ms-Button.is-disabled': {
-            selectors: {
-              [HighContrastSelector]: {
-                color: 'GrayText',
-                borderColor: 'GrayText',
-                backgroundColor: 'Window'
-              }
-            }
-          }
+      }
+    },
+    '.ms-Button.is-disabled': {
+      selectors: {
+        [HighContrastSelector]: {
+          color: 'GrayText',
+          borderColor: 'GrayText',
+          backgroundColor: 'Window'
         }
-      },
-      splitButtonContainerChecked: {
-        selectors: {
-          '.ms-Button--primary': {
-            selectors: {
-              [HighContrastSelector]: {
-                color: 'Window',
-                backgroundColor: 'WindowText',
-                MsHighContrastAdjust: 'none'
-              }
-            }
-          }
+      }
+    }
+  }
+};
+
+const splitButtonContainerChecked: IStyle = {
+  selectors: {
+    '.ms-Button--primary': {
+      selectors: {
+        [HighContrastSelector]: {
+          color: 'Window',
+          backgroundColor: 'WindowText',
+          MsHighContrastAdjust: 'none'
         }
-      },
-      splitButtonContainerCheckedHovered: {
-        selectors: {
-          '.ms-Button--primary': {
-            selectors: {
-              [HighContrastSelector]: {
-                color: 'Window',
-                backgroundColor: 'WindowText',
-                MsHighContrastAdjust: 'none'
-              }
-            }
-          }
+      }
+    }
+  }
+};
+
+const splitButtonContainerCheckedHovered: IStyle = {
+  selectors: {
+    '.ms-Button--primary': {
+      selectors: {
+        [HighContrastSelector]: {
+          color: 'Window',
+          backgroundColor: 'WindowText',
+          MsHighContrastAdjust: 'none'
         }
-      },
-      splitButtonContainerFocused: {
-        outline: 'none!important'
-      },
+      }
+    }
+  }
+};
+
+const splitButtonMenuButton: IStyle = {
+  padding: 6,
+  height: 'auto',
+  boxSizing: 'border-box',
+  borderRadius: 0,
+  borderLeft: 'none',
+  outline: 'transparent',
+  userSelect: 'none',
+  display: 'inline-block',
+  textDecoration: 'none',
+  textAlign: 'center',
+  cursor: 'pointer',
+  verticalAlign: 'top',
+  width: 32,
+  marginLeft: -1,
+  marginTop: 0,
+  marginRight: 0,
+  marginBottom: 0
+};
+
+const splitButtonContainerFocused: IStyle = {
+  outline: 'none!important'
+};
+
+const splitButtonMenuButtonDisabled: IStyle = {
+  pointerEvents: 'none',
+  border: 'none',
+  selectors: {
+    ':hover': {
+      cursor: 'default'
+    },
+
+    '.ms-Button--primary': {
+      selectors: {
+        [HighContrastSelector]: {
+          color: 'GrayText',
+          borderColor: 'GrayText',
+          backgroundColor: 'Window'
+        }
+      }
+    },
+    [HighContrastSelector]: {
+      border: `1px solid GrayText`,
+      color: 'GrayText',
+      backgroundColor: 'Window'
+    }
+  }
+};
+
+const splitButtonFlexContainer: IStyle = {
+  display: 'flex',
+  height: '100%',
+  flexWrap: 'nowrap',
+  justifyContent: 'center',
+  alignItems: 'center'
+};
+
+const splitButtonContainerDisabled: IStyle = {
+  outline: 'none',
+  border: 'none',
+  selectors: {
+    [HighContrastSelector]: {
+      color: 'GrayText',
+      borderColor: 'GrayText',
+      backgroundColor: 'Window'
+    }
+  }
+};
+
+export const getStandardSplitStyles = memoizeFunction(
+  (theme: ITheme, customStyles?: IButtonStyles): IButtonStyles => {
+    const { effects, palette: p, semanticColors: s } = theme;
+
+    const standardSplitStyles: IButtonStyles = {
+      splitButtonContainer: [getFocusStyle(theme, { highContrastStyle: buttonHighContrastFocus, inset: 2 }), { ...splitButtonContainer }],
+      splitButtonContainerHovered: splitButtonContainerHovered,
+      splitButtonContainerChecked: splitButtonContainerChecked,
+      splitButtonContainerCheckedHovered: splitButtonContainerCheckedHovered,
+      splitButtonContainerFocused: splitButtonContainerFocused,
+
       splitButtonMenuButton: {
-        padding: 6,
-        height: 'auto',
-        boxSizing: 'border-box',
-        borderRadius: 0,
+        ...splitButtonMenuButton,
+        color: p.white,
+        backgroundColor: 'transparent',
         borderTopRightRadius: effects.roundedCorner2,
         borderBottomRightRadius: effects.roundedCorner2,
-        border: `1px solid ${palette.neutralSecondaryAlt}`,
-        borderLeft: 'none',
-        outline: 'transparent',
-        userSelect: 'none',
-        display: 'inline-block',
-        textDecoration: 'none',
-        textAlign: 'center',
-        cursor: 'pointer',
-        verticalAlign: 'top',
-        width: 32,
-        marginLeft: -1,
-        marginTop: 0,
-        marginRight: 0,
-        marginBottom: 0
-      },
-      splitButtonDividerDisabled: splitButtonDividerDisabled,
-      splitButtonMenuButtonDisabled: {
-        pointerEvents: 'none',
-        border: 'none',
+        border: `1px solid ${p.neutralSecondaryAlt}`,
         selectors: {
           ':hover': {
-            cursor: 'default'
-          },
-
-          '.ms-Button--primary': {
+            backgroundColor: p.neutralLight,
             selectors: {
               [HighContrastSelector]: {
-                color: 'GrayText',
-                borderColor: 'GrayText',
-                backgroundColor: 'Window'
+                color: 'Highlight'
               }
             }
-          },
+          }
+        }
+      },
+      splitButtonDivider: {
+        ...splitButtonDivider,
+        backgroundColor: p.neutralTertiaryAlt,
+        selectors: {
           [HighContrastSelector]: {
-            border: `1px solid GrayText`,
-            color: 'GrayText',
+            backgroundColor: 'WindowText'
+          }
+        }
+      },
+      splitButtonDividerDisabled: {
+        ...splitButtonDivider,
+        selectors: {
+          [HighContrastSelector]: {
+            backgroundColor: 'GrayText'
+          }
+        }
+      },
+
+      splitButtonMenuButtonChecked: {
+        backgroundColor: p.neutralQuaternaryAlt,
+        selectors: {
+          ':hover': {
+            backgroundColor: p.neutralQuaternaryAlt
+          }
+        }
+      },
+
+      splitButtonMenuButtonExpanded: {
+        backgroundColor: p.neutralQuaternaryAlt,
+        selectors: {
+          ':hover': {
+            backgroundColor: p.neutralQuaternaryAlt
+          }
+        }
+      },
+
+      splitButtonMenuButtonDisabled: {
+        ...splitButtonMenuButtonDisabled,
+        backgroundColor: s.buttonBackgroundDisabled,
+        selectors: {
+          ':hover': {
+            backgroundColor: s.buttonBackgroundDisabled
+          }
+        }
+      },
+
+      splitButtonFlexContainer: splitButtonFlexContainer,
+
+      splitButtonContainerDisabled: splitButtonContainerDisabled,
+
+      splitButtonMenuIcon: {
+        color: s.buttonText
+      },
+
+      splitButtonMenuIconDisabled: {
+        color: s.buttonTextDisabled
+      }
+    };
+    return concatStyleSets(standardSplitStyles, customStyles)!;
+  }
+);
+
+export const getPrimarySplitStyles = memoizeFunction(
+  (theme: ITheme, customStyles?: IButtonStyles): IButtonStyles => {
+    const { effects, palette: p, semanticColors: s } = theme;
+
+    const primarySplitStyles: IButtonStyles = {
+      splitButtonContainer: [getFocusStyle(theme, { highContrastStyle: buttonHighContrastFocus, inset: 2 }), { ...splitButtonContainer }],
+      splitButtonContainerChecked: splitButtonContainerChecked,
+      splitButtonContainerHovered: splitButtonContainerHovered,
+      splitButtonContainerCheckedHovered: splitButtonContainerCheckedHovered,
+      splitButtonContainerFocused: splitButtonContainerFocused,
+
+      splitButtonDivider: {
+        ...splitButtonDivider,
+        backgroundColor: s.primaryButtonText,
+        selectors: {
+          [HighContrastSelector]: {
             backgroundColor: 'Window'
           }
         }
       },
 
-      splitButtonFlexContainer: {
-        display: 'flex',
-        height: '100%',
-        flexWrap: 'nowrap',
-        justifyContent: 'center',
-        alignItems: 'center'
-      },
-
-      splitButtonContainerDisabled: {
-        outline: 'none',
-        border: 'none',
+      splitButtonMenuButton: {
+        ...splitButtonMenuButton,
+        color: s.primaryButtonText,
+        backgroundColor: s.primaryButtonBackground,
+        borderTopRightRadius: effects.roundedCorner2,
+        borderBottomRightRadius: effects.roundedCorner2,
+        border: `1px solid ${p.neutralSecondaryAlt}`,
         selectors: {
           [HighContrastSelector]: {
-            color: 'GrayText',
-            borderColor: 'GrayText',
-            backgroundColor: 'Window'
+            backgroundColor: 'WindowText'
+          },
+          ':hover': {
+            backgroundColor: s.primaryButtonBackgroundHovered,
+            selectors: {
+              [HighContrastSelector]: {
+                color: 'Highlight'
+              }
+            }
+          }
+        }
+      },
+
+      splitButtonFlexContainer: splitButtonFlexContainer,
+
+      splitButtonContainerDisabled: splitButtonContainerDisabled,
+
+      splitButtonMenuButtonDisabled: {
+        ...splitButtonMenuButtonDisabled,
+        backgroundColor: s.primaryButtonBackgroundDisabled,
+        selectors: {
+          ':hover': {
+            backgroundColor: s.primaryButtonBackgroundDisabled
+          }
+        }
+      },
+
+      splitButtonMenuButtonChecked: {
+        backgroundColor: s.primaryButtonBackgroundPressed,
+        selectors: {
+          ':hover': {
+            backgroundColor: s.primaryButtonBackgroundPressed
+          }
+        }
+      },
+
+      splitButtonMenuButtonExpanded: {
+        backgroundColor: s.primaryButtonBackgroundPressed,
+        selectors: {
+          ':hover': {
+            backgroundColor: s.primaryButtonBackgroundPressed
+          }
+        }
+      },
+
+      splitButtonMenuIcon: {
+        color: s.primaryButtonText
+      },
+
+      splitButtonMenuIconDisabled: {
+        color: p.neutralTertiary,
+        selectors: {
+          [HighContrastSelector]: {
+            color: 'GrayText'
           }
         }
       }
     };
-
-    return concatStyleSets(splitButtonStyles, customStyles)!;
+    return concatStyleSets(primarySplitStyles, customStyles)!;
   }
 );

--- a/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -160,7 +160,7 @@ const splitButtonContainerDisabled: IStyle = {
   }
 };
 
-export const getStandardSplitStyles = memoizeFunction(
+export const getStandardSplitButtonStyles = memoizeFunction(
   (theme: ITheme, customStyles?: IButtonStyles): IButtonStyles => {
     const { effects, palette: p, semanticColors: s } = theme;
 
@@ -258,7 +258,7 @@ export const getStandardSplitStyles = memoizeFunction(
   }
 );
 
-export const getPrimarySplitStyles = memoizeFunction(
+export const getPrimarySplitButtonStyles = memoizeFunction(
   (theme: ITheme, customStyles?: IButtonStyles): IButtonStyles => {
     const { effects, palette: p, semanticColors: s } = theme;
 

--- a/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -101,7 +101,7 @@ const splitButtonMenuButton: IStyle = {
   height: 'auto',
   boxSizing: 'border-box',
   borderRadius: 0,
-  borderLeft: 'none',
+  // borderLeft: 'none', add this here make border come back
   outline: 'transparent',
   userSelect: 'none',
   display: 'inline-block',
@@ -136,11 +136,6 @@ const splitButtonMenuButtonDisabled: IStyle = {
           backgroundColor: 'Window'
         }
       }
-    },
-    [HighContrastSelector]: {
-      border: `1px solid GrayText`,
-      color: 'GrayText',
-      backgroundColor: 'Window'
     }
   }
 };
@@ -183,6 +178,7 @@ export const getStandardSplitStyles = memoizeFunction(
         borderTopRightRadius: effects.roundedCorner2,
         borderBottomRightRadius: effects.roundedCorner2,
         border: `1px solid ${p.neutralSecondaryAlt}`,
+        borderLeft: 'none',
         selectors: {
           ':hover': {
             backgroundColor: p.neutralLight,
@@ -236,6 +232,12 @@ export const getStandardSplitStyles = memoizeFunction(
         selectors: {
           ':hover': {
             backgroundColor: s.buttonBackgroundDisabled
+          },
+          [HighContrastSelector]: {
+            border: `1px solid GrayText`,
+            borderLeft: 'none',
+            color: 'GrayText',
+            backgroundColor: 'Window'
           }
         }
       },

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CustomSplit.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CustomSplit.Example.tsx.shot
@@ -75,6 +75,7 @@ exports[`Component Examples renders Button.CustomSplit.Example.tsx correctly 1`]
         @media screen and (-ms-high-contrast: active){& .ms-Button--primary {
           -ms-high-contrast-adjust: none;
           background-color: WindowText;
+          border: none;
           color: Window;
         }
         & .ms-Button--primary + .ms-Button {
@@ -252,6 +253,7 @@ exports[`Component Examples renders Button.CustomSplit.Example.tsx correctly 1`]
               border-top-right-radius: 2px;
               border: none;
               box-sizing: border-box;
+              color: #ffffff;
               cursor: pointer;
               display: inline-block;
               height: auto;
@@ -269,6 +271,12 @@ exports[`Component Examples renders Button.CustomSplit.Example.tsx correctly 1`]
               user-select: none;
               vertical-align: top;
               width: 28px;
+            }
+            &:hover {
+              background-color: #edebe9;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              color: Highlight;
             }
         data-is-focusable={false}
         onClick={[Function]}
@@ -311,6 +319,7 @@ exports[`Component Examples renders Button.CustomSplit.Example.tsx correctly 1`]
                   speak: none;
                 }
                 {
+                  color: #323130;
                   flex-shrink: 0;
                   font-size: 7px;
                   height: 16px;
@@ -346,8 +355,16 @@ exports[`Component Examples renders Button.CustomSplit.Example.tsx correctly 1`]
         className=
 
             {
+              background-color: #c8c6c4;
               border-left: 1px solid #c8c8c8;
+              bottom: 8px;
+              position: absolute;
               right: 26px;
+              top: 8px;
+              width: 1px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background-color: WindowText;
             }
       />
     </span>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Split.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Split.Example.tsx.shot
@@ -52,9 +52,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
             outline: transparent;
             position: relative;
           }
-          @media screen and (-ms-high-contrast: active){& {
-            border: none;
-          }
           &::-moz-focus-inner {
             border: 0;
           }
@@ -89,6 +86,7 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active){& .ms-Button--primary {
             -ms-high-contrast-adjust: none;
             background-color: WindowText;
+            border: none;
             color: Window;
           }
           & .ms-Button--primary + .ms-Button {
@@ -380,9 +378,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
             outline: transparent;
             position: relative;
           }
-          @media screen and (-ms-high-contrast: active){& {
-            border: none;
-          }
           &::-moz-focus-inner {
             border: 0;
           }
@@ -417,6 +412,7 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active){& .ms-Button--primary {
             -ms-high-contrast-adjust: none;
             background-color: WindowText;
+            border: none;
             color: Window;
           }
           & .ms-Button--primary + .ms-Button {
@@ -588,7 +584,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
               {
                 background-color: #0078d4;
                 border-bottom-right-radius: 2px;
-                border-left: none;
                 border-radius: 0px;
                 border-top-right-radius: 2px;
                 border: 1px solid #8a8886;
@@ -698,7 +693,7 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           className=
 
               {
-                background-color: #c8c6c4;
+                background-color: #ffffff;
                 bottom: 8px;
                 position: absolute;
                 right: 31px;
@@ -721,9 +716,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
             display: inline-flex;
             outline: transparent;
             position: relative;
-          }
-          @media screen and (-ms-high-contrast: active){& {
-            border: none;
           }
           &::-moz-focus-inner {
             border: 0;
@@ -759,6 +751,7 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active){& .ms-Button--primary {
             -ms-high-contrast-adjust: none;
             background-color: WindowText;
+            border: none;
             color: Window;
           }
           & .ms-Button--primary + .ms-Button {
@@ -1055,12 +1048,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
             outline: none;
             position: relative;
           }
-          @media screen and (-ms-high-contrast: active){& {
-            background-color: Window;
-            border-color: GrayText;
-            border: none;
-            color: GrayText;
-          }
           &::-moz-focus-inner {
             border: 0;
           }
@@ -1095,10 +1082,16 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active){& .ms-Button--primary {
             -ms-high-contrast-adjust: none;
             background-color: WindowText;
+            border: none;
             color: Window;
           }
           & .ms-Button--primary + .ms-Button {
             border: none;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background-color: Window;
+            border-color: GrayText;
+            color: GrayText;
           }
       data-is-focusable={true}
       onFocusCapture={[Function]}
@@ -1275,18 +1268,13 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
               }
               &:hover {
                 background-color: #f3f2f1;
-                cursor: default;
               }
               @media screen and (-ms-high-contrast: active){&:hover {
                 color: Highlight;
               }
-              @media screen and (-ms-high-contrast: active){& .ms-Button--primary {
-                background-color: Window;
-                border-color: GrayText;
-                color: GrayText;
-              }
               @media screen and (-ms-high-contrast: active){& {
                 background-color: Window;
+                border-left: none;
                 border: 1px solid GrayText;
                 color: GrayText;
               }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
@@ -115,6 +115,7 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                     @media screen and (-ms-high-contrast: active){& .ms-Button--primary {
                       -ms-high-contrast-adjust: none;
                       background-color: WindowText;
+                      border: none;
                       color: Window;
                     }
                     & .ms-Button--primary + .ms-Button {
@@ -447,8 +448,16 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
 
                         {
                           background-color: #c8c6c4;
+                          bottom: 8px;
                           margin-bottom: 4px;
                           margin-top: 4px;
+                          position: absolute;
+                          right: 31px;
+                          top: 8px;
+                          width: 1px;
+                        }
+                        @media screen and (-ms-high-contrast: active){& {
+                          background-color: WindowText;
                         }
                   />
                 </span>
@@ -509,6 +518,7 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                     @media screen and (-ms-high-contrast: active){& .ms-Button--primary {
                       -ms-high-contrast-adjust: none;
                       background-color: WindowText;
+                      border: none;
                       color: Window;
                     }
                     & .ms-Button--primary + .ms-Button {
@@ -734,7 +744,6 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                         &:hover {
                           background-color: #f3f2f1;
                           color: #201f1e;
-                          cursor: default;
                         }
                         @media screen and (-ms-high-contrast: active){&:hover {
                           color: Highlight;
@@ -748,13 +757,9 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                         &:active .ms-Button-icon {
                           color: #323130;
                         }
-                        @media screen and (-ms-high-contrast: active){& .ms-Button--primary {
-                          background-color: Window;
-                          border-color: GrayText;
-                          color: GrayText;
-                        }
                         @media screen and (-ms-high-contrast: active){& {
                           background-color: Window;
+                          border-left: none;
                           border: 1px solid GrayText;
                           color: GrayText;
                         }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
@@ -561,9 +561,6 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
               outline: transparent;
               position: relative;
             }
-            @media screen and (-ms-high-contrast: active){& {
-              border: none;
-            }
             &::-moz-focus-inner {
               border: 0;
             }
@@ -598,6 +595,7 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
             @media screen and (-ms-high-contrast: active){& .ms-Button--primary {
               -ms-high-contrast-adjust: none;
               background-color: WindowText;
+              border: none;
               color: Window;
             }
             & .ms-Button--primary + .ms-Button {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
@@ -468,9 +468,6 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
             outline: transparent;
             position: relative;
           }
-          @media screen and (-ms-high-contrast: active){& {
-            border: none;
-          }
           &::-moz-focus-inner {
             border: 0;
           }
@@ -505,6 +502,7 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active){& .ms-Button--primary {
             -ms-high-contrast-adjust: none;
             background-color: WindowText;
+            border: none;
             color: Window;
           }
           & .ms-Button--primary + .ms-Button {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #10960
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This is a fix of the aforementioned issue but is also a transfer of all SplitButton styles out of ButtonThemes.ts and into SplitButton.styles.ts. 

#### CommandBar enabled splitbutton missing divider BEFORE
![Screen Shot 2019-11-06 at 1 48 26 PM](https://user-images.githubusercontent.com/13246181/68340941-38703f80-009c-11ea-9518-73a8c9519fb4.png)

#### CommandBar enabled splitbutton missing divider AFTER
![Screen Shot 2019-11-06 at 1 49 18 PM](https://user-images.githubusercontent.com/13246181/68340954-3f974d80-009c-11ea-8422-aec7095b77d8.png)

#### High Contrast styles confirmed unaffected
<img width="559" alt="spolitbutton_HS_styles" src="https://user-images.githubusercontent.com/13246181/68340621-a2d4b000-009b-11ea-89f9-8199904921f8.PNG">

#### Custom splitbutton issue BEFORE
![Screen Shot 2019-10-29 at 11 27 13 AM](https://user-images.githubusercontent.com/13246181/68340528-74ef6b80-009b-11ea-8e04-ccb414a46b93.png)

#### Custom splitbutton issue AFTER
![Screen Shot 2019-10-29 at 11 27 36 AM](https://user-images.githubusercontent.com/13246181/68340455-5ab58d80-009b-11ea-8dde-a8052fc3cc34.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11099)