### PR TITLE
Microfeedback: (a11y) Added arial labels to component rating buttons

### DIFF
--- a/change/@uifabric-experiments-2019-11-07-01-42-05-kelkhadiri-a11yNarrator.json
+++ b/change/@uifabric-experiments-2019-11-07-01-42-05-kelkhadiri-a11yNarrator.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Added ariaLabel to microfeedback component",
+  "packageName": "@uifabric/experiments",
+  "email": "kamal.elkhadiri@microsoft.com",
+  "commit": "d3f7679023767a4cf05db9d2c8b68a28ef97542d",
+  "date": "2019-11-07T09:42:05.696Z"
+}

--- a/packages/experiments/src/components/MicroFeedback/MicroFeedback.types.ts
+++ b/packages/experiments/src/components/MicroFeedback/MicroFeedback.types.ts
@@ -105,6 +105,16 @@ export interface IMicroFeedbackProps
   dislikeIconTitle?: string;
 
   /**
+   * Defines a localized string for the aria label of the Like icon for the benefit of screen readers.
+   */
+  likeIconAriaLabel?: string;
+
+  /**
+   * Defines a localized string for the aria label of the Dislike icon for the benefit of screen readers.
+   */
+  dislikeIconAriaLabel?: string;
+
+  /**
    * Defines an optional question that is asked if Like is selected.
    */
   likeQuestion?: IMicroFeedbackQuestion;

--- a/packages/experiments/src/components/MicroFeedback/MicroFeedback.view.tsx
+++ b/packages/experiments/src/components/MicroFeedback/MicroFeedback.view.tsx
@@ -12,6 +12,8 @@ export const MicroFeedbackView: IMicroFeedbackComponent['view'] = props => {
     sendFollowUpIndex,
     likeIconTitle,
     dislikeIconTitle,
+    likeIconAriaLabel,
+    dislikeIconAriaLabel,
     likeQuestion,
     dislikeQuestion,
     vote,
@@ -102,10 +104,15 @@ export const MicroFeedbackView: IMicroFeedbackComponent['view'] = props => {
       <Slots.iconContainer horizontal>
         {children}
         <div ref={likeRef}>
-          <IconButton menuIconProps={{ iconName: likeIcon }} title={likeIconTitle} onClick={likeVoteClick} />
+          <IconButton menuIconProps={{ iconName: likeIcon }} title={likeIconTitle} ariaLabel={likeIconAriaLabel} onClick={likeVoteClick} />
         </div>
         <div ref={dislikeRef}>
-          <IconButton menuIconProps={{ iconName: dislikeIcon }} title={dislikeIconTitle} onClick={dislikeVoteClick} />
+          <IconButton
+            menuIconProps={{ iconName: dislikeIcon }}
+            title={dislikeIconTitle}
+            ariaLabel={dislikeIconAriaLabel}
+            onClick={dislikeVoteClick}
+          />
         </div>
       </Slots.iconContainer>
       {likeQuestion && !hideLikeCallout && renderFollowup(likeQuestion, likeRef.current)}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(a11y) Added ariaLabel to the rating buttons in microfeedback component and exposed them as props so that screen readers can announce the appropriate meaning/behavior of the buttons.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11112)