### PR TITLE
File type icons add size 24

### DIFF
--- a/change/@uifabric-file-type-icons-2019-11-07-10-30-24-v-mare-FileTypeIcons-add-24.json
+++ b/change/@uifabric-file-type-icons-2019-11-07-10-30-24-v-mare-FileTypeIcons-add-24.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Added size 24 to file type icons",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "v-mare@microsoft.com",
+  "commit": "3da1a1bad7fabc19d95d927ed8b2501f894eeb74",
+  "date": "2019-11-07T18:30:24.083Z"
+}

--- a/packages/file-type-icons/src/getFileTypeIconProps.ts
+++ b/packages/file-type-icons/src/getFileTypeIconProps.ts
@@ -11,7 +11,7 @@ const LIST_ITEM = 'splist';
 const MULTIPLE_ITEMS = 'multiple';
 const DEFAULT_ICON_SIZE: FileTypeIconSize = 16;
 
-export type FileTypeIconSize = 16 | 20 | 32 | 40 | 48 | 64 | 96;
+export type FileTypeIconSize = 16 | 20 | 24 | 32 | 40 | 48 | 64 | 96;
 export type ImageFileType = 'svg' | 'png';
 
 export interface IFileTypeIconOptions {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11108
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Simply added '24' to FileTypeIconSize type


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11119)