### PR TITLE
Dropdown: fixed checks on preventDefault which should be defaultPrevented

### DIFF
--- a/change/office-ui-fabric-react-2019-11-07-11-24-55-dropdown-default-prevented.json
+++ b/change/office-ui-fabric-react-2019-11-07-11-24-55-dropdown-default-prevented.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Dropdown: fixed checks on preventDefault which should be defaultPrevented",
+  "packageName": "office-ui-fabric-react",
+  "email": "micahgodbolt@gmail.com",
+  "commit": "b170a4f753096850a28286f1ca3af8b91213c58f",
+  "date": "2019-11-07T19:24:55.062Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -919,7 +919,7 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
 
     if (this.props.onKeyUp) {
       this.props.onKeyUp(ev);
-      if (ev.preventDefault) {
+      if (ev.defaultPrevented) {
         return;
       }
     }
@@ -1029,7 +1029,7 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
   private _onDropdownClick = (ev: React.MouseEvent<HTMLDivElement>): void => {
     if (this.props.onClick) {
       this.props.onClick(ev);
-      if (ev.preventDefault) {
+      if (ev.defaultPrevented) {
         return;
       }
     }


### PR DESCRIPTION
#### Pull request checklist

using onClick on a dropdown would cause the click to no longer open the dropdown because if (ev.preventDefault) always returns true. 

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11120)