### PR TITLE
ContextualMenu: Add example using ContextualMenu directly

### DIFF
--- a/change/office-ui-fabric-react-2019-11-07-17-05-33-jg-11113-contextualmenu-example.json
+++ b/change/office-ui-fabric-react-2019-11-07-17-05-33-jg-11113-contextualmenu-example.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "ContextualMenu: Add example using ContextualMenu directly.",
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com",
+  "commit": "96c2c231cab6b175d5721dbbecbba766da2aab38",
+  "date": "2019-11-08T01:05:33.195Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.doc.tsx
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { IDocPageProps } from '../../common/DocPage.types';
 
 import { ContextualMenuBasicExample } from './examples/ContextualMenu.Basic.Example';
+import { ContextualMenuDefaultExample } from './examples/ContextualMenu.Default.Example';
 import { ContextualMenuIconExample } from './examples/ContextualMenu.Icon.Example';
 import { ContextualMenuIconSecondaryTextExample } from './examples/ContextualMenu.Icon.SecondaryText.Example';
 import { ContextualMenuSubmenuExample } from './examples/ContextualMenu.Submenu.Example';
@@ -18,6 +19,7 @@ import { ContextualMenuHeaderExample } from './examples/ContextualMenu.Header.Ex
 import { ContextualMenuPersistedExample } from './examples/ContextualMenu.Persisted.Example';
 
 const ContextualMenuBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx') as string;
+const ContextualMenuDefaultExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Default.Example.tsx') as string;
 const ContextualMenuPersistedExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Persisted.Example.tsx') as string;
 const ContextualMenuIconExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Icon.Example.tsx') as string;
 const ContextualMenuIconSecondaryTextExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Icon.SecondaryText.Example.tsx') as string;
@@ -39,9 +41,14 @@ export const ContextualMenuPageProps: IDocPageProps = {
     'https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/office-ui-fabric-react/src/components/ContextualMenu',
   examples: [
     {
-      title: 'Default ContextualMenu',
+      title: 'Basic ContextualMenu',
       code: ContextualMenuBasicExampleCode,
       view: <ContextualMenuBasicExample />
+    },
+    {
+      title: 'Default ContextualMenu',
+      code: ContextualMenuDefaultExampleCode,
+      view: <ContextualMenuDefaultExample />
     },
     {
       title: 'ContextualMenu which is persisted in the DOM',

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx
@@ -1,9 +1,39 @@
 import * as React from 'react';
 import { ContextualMenu, ContextualMenuItemType, IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { useConstCallback } from '@uifabric/react-hooks';
 
 export interface IContextualMenuBasicExampleState {
   showContextualMenu?: boolean;
 }
+
+export const ContextualMenuBasicExample: React.FunctionComponent = () => {
+  const linkRef = React.useRef(null);
+  const [showContextualMenu, setShowContextualMenu] = React.useState(false);
+  const onShowContextualMenu = useConstCallback(() => setShowContextualMenu(true));
+  const onHideContextualMenu = useConstCallback(() => setShowContextualMenu(false));
+
+  return (
+    <div>
+      This example directly uses ContextualMenu to show how it can be attached to arbitrary elements. The remaining examples use
+      ContextualMenu through Fabric Button components.
+      <p>
+        <b>
+          <a ref={linkRef} onClick={onShowContextualMenu}>
+            Click for ContextualMenu
+          </a>
+        </b>
+      </p>
+      <ContextualMenu
+        items={menuItems}
+        hidden={!showContextualMenu}
+        target={linkRef}
+        onItemClick={onHideContextualMenu}
+        onDismiss={onHideContextualMenu}
+      />
+    </div>
+  );
+};
+
 const menuItems: IContextualMenuItem[] = [
   {
     key: 'newItem',
@@ -57,47 +87,3 @@ const menuItems: IContextualMenuItem[] = [
     onClick: () => console.error('Disabled item should not be clickable.')
   }
 ];
-
-export class ContextualMenuBasicExample extends React.Component<{}, IContextualMenuBasicExampleState> {
-  private contextualMenuTarget = React.createRef<HTMLAnchorElement>();
-
-  constructor(props: {}) {
-    super(props);
-    this.state = {
-      showContextualMenu: false
-    };
-  }
-
-  public render(): JSX.Element {
-    const { showContextualMenu } = this.state;
-
-    return (
-      <div>
-        This example directly uses ContextualMenu to show how it can be attached to arbitrary elements. The remaining examples use
-        ContextualMenu through Fabric Button components.
-        <p>
-          <b>
-            <a ref={this.contextualMenuTarget} onClick={this._onClickLink}>
-              Click for ContextualMenu
-            </a>
-          </b>
-        </p>
-        <ContextualMenu
-          items={menuItems}
-          hidden={!showContextualMenu}
-          target={this.contextualMenuTarget}
-          onItemClick={this._onDismiss}
-          onDismiss={this._onDismiss}
-        />
-      </div>
-    );
-  }
-
-  private _onClickLink = () => {
-    this.setState({ showContextualMenu: true });
-  };
-
-  private _onDismiss = () => {
-    this.setState({ showContextualMenu: false });
-  };
-}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Basic.Example.tsx
@@ -1,79 +1,103 @@
 import * as React from 'react';
-import { ContextualMenuItemType } from 'office-ui-fabric-react/lib/ContextualMenu';
-import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
-import './ContextualMenuExample.scss';
+import { ContextualMenu, ContextualMenuItemType, IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
 
-export class ContextualMenuBasicExample extends React.Component {
+export interface IContextualMenuBasicExampleState {
+  showContextualMenu?: boolean;
+}
+const menuItems: IContextualMenuItem[] = [
+  {
+    key: 'newItem',
+    text: 'New',
+    onClick: () => console.log('New clicked')
+  },
+  {
+    key: 'divider_1',
+    itemType: ContextualMenuItemType.Divider
+  },
+  {
+    key: 'rename',
+    text: 'Rename',
+    onClick: () => console.log('Rename clicked')
+  },
+  {
+    key: 'edit',
+    text: 'Edit',
+    onClick: () => console.log('Edit clicked')
+  },
+  {
+    key: 'properties',
+    text: 'Properties',
+    onClick: () => console.log('Properties clicked')
+  },
+  {
+    key: 'linkNoTarget',
+    text: 'Link same window',
+    href: 'http://bing.com'
+  },
+  {
+    key: 'linkWithTarget',
+    text: 'Link new window',
+    href: 'http://bing.com',
+    target: '_blank'
+  },
+  {
+    key: 'linkWithOnClick',
+    name: 'Link click',
+    href: 'http://bing.com',
+    onClick: (ev: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => {
+      alert('Link clicked');
+      ev.preventDefault();
+    },
+    target: '_blank'
+  },
+  {
+    key: 'disabled',
+    text: 'Disabled item',
+    disabled: true,
+    onClick: () => console.error('Disabled item should not be clickable.')
+  }
+];
+
+export class ContextualMenuBasicExample extends React.Component<{}, IContextualMenuBasicExampleState> {
+  private contextualMenuTarget = React.createRef<HTMLAnchorElement>();
+
   constructor(props: {}) {
     super(props);
     this.state = {
-      showCallout: false
+      showContextualMenu: false
     };
   }
 
   public render(): JSX.Element {
+    const { showContextualMenu } = this.state;
+
     return (
       <div>
-        <DefaultButton
-          text="Click for ContextualMenu"
-          menuProps={{
-            shouldFocusOnMount: true,
-            items: [
-              {
-                key: 'newItem',
-                text: 'New',
-                onClick: () => console.log('New clicked')
-              },
-              {
-                key: 'divider_1',
-                itemType: ContextualMenuItemType.Divider
-              },
-              {
-                key: 'rename',
-                text: 'Rename',
-                onClick: () => console.log('Rename clicked')
-              },
-              {
-                key: 'edit',
-                text: 'Edit',
-                onClick: () => console.log('Edit clicked')
-              },
-              {
-                key: 'properties',
-                text: 'Properties',
-                onClick: () => console.log('Properties clicked')
-              },
-              {
-                key: 'linkNoTarget',
-                text: 'Link same window',
-                href: 'http://bing.com'
-              },
-              {
-                key: 'linkWithTarget',
-                text: 'Link new window',
-                href: 'http://bing.com',
-                target: '_blank'
-              },
-              {
-                key: 'linkWithOnClick',
-                name: 'Link click',
-                href: 'http://bing.com',
-                onClick: (ev: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => {
-                  alert('Link clicked');
-                  ev.preventDefault();
-                },
-                target: '_blank'
-              },
-              {
-                key: 'disabled',
-                text: 'Disabled item',
-                disabled: true,
-                onClick: () => console.error('Disabled item should not be clickable.')
-              }
-            ]
-          }}
+        This example directly uses ContextualMenu to show how it can be attached to arbitrary elements. The remaining examples use
+        ContextualMenu through Fabric Button components.
+        <p>
+          <b>
+            <a ref={this.contextualMenuTarget} onClick={this._onClickLink}>
+              Click for ContextualMenu
+            </a>
+          </b>
+        </p>
+        <ContextualMenu
+          items={menuItems}
+          hidden={!showContextualMenu}
+          target={this.contextualMenuTarget}
+          onItemClick={this._onDismiss}
+          onDismiss={this._onDismiss}
         />
       </div>
     );
   }
+
+  private _onClickLink = () => {
+    this.setState({ showContextualMenu: true });
+  };
+
+  private _onDismiss = () => {
+    this.setState({ showContextualMenu: false });
+  };
 }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Default.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Default.Example.tsx
@@ -1,0 +1,72 @@
+import * as React from 'react';
+import { ContextualMenuItemType } from 'office-ui-fabric-react/lib/ContextualMenu';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import './ContextualMenuExample.scss';
+
+export class ContextualMenuDefaultExample extends React.Component {
+  public render(): JSX.Element {
+    return (
+      <div>
+        <DefaultButton
+          text="Click for ContextualMenu"
+          menuProps={{
+            shouldFocusOnMount: true,
+            items: [
+              {
+                key: 'newItem',
+                text: 'New',
+                onClick: () => console.log('New clicked')
+              },
+              {
+                key: 'divider_1',
+                itemType: ContextualMenuItemType.Divider
+              },
+              {
+                key: 'rename',
+                text: 'Rename',
+                onClick: () => console.log('Rename clicked')
+              },
+              {
+                key: 'edit',
+                text: 'Edit',
+                onClick: () => console.log('Edit clicked')
+              },
+              {
+                key: 'properties',
+                text: 'Properties',
+                onClick: () => console.log('Properties clicked')
+              },
+              {
+                key: 'linkNoTarget',
+                text: 'Link same window',
+                href: 'http://bing.com'
+              },
+              {
+                key: 'linkWithTarget',
+                text: 'Link new window',
+                href: 'http://bing.com',
+                target: '_blank'
+              },
+              {
+                key: 'linkWithOnClick',
+                name: 'Link click',
+                href: 'http://bing.com',
+                onClick: (ev: React.MouseEvent<HTMLAnchorElement | HTMLButtonElement>) => {
+                  alert('Link clicked');
+                  ev.preventDefault();
+                },
+                target: '_blank'
+              },
+              {
+                key: 'disabled',
+                text: 'Disabled item',
+                disabled: true,
+                onClick: () => console.error('Disabled item should not be clickable.')
+              }
+            ]
+          }}
+        />
+      </div>
+    );
+  }
+}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Basic.Example.tsx.shot
@@ -2,159 +2,1296 @@
 
 exports[`Component Examples renders ContextualMenu.Basic.Example.tsx correctly 1`] = `
 <div>
-  <button
-    aria-expanded={false}
-    aria-haspopup={true}
-    aria-owns={null}
-    className=
-        ms-Button
-        ms-Button--default
-        ms-Button--hasMenu
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          background-color: #ffffff;
-          border-radius: 2px;
-          border: 1px solid #8a8886;
-          box-sizing: border-box;
-          color: #323130;
-          cursor: pointer;
-          display: inline-block;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 400;
-          height: 32px;
-          min-width: 80px;
-          outline: transparent;
-          padding-bottom: 0;
-          padding-left: 16px;
-          padding-right: 16px;
-          padding-top: 0;
-          position: relative;
-          text-align: center;
-          text-decoration: none;
-          user-select: none;
-          vertical-align: top;
-        }
-        &::-moz-focus-inner {
-          border: 0;
-        }
-        .ms-Fabric--isFocusVisible &:focus:after {
-          border: 1px solid transparent;
-          bottom: 2px;
-          content: "";
-          left: 2px;
-          outline: 1px solid #605e5c;
-          position: absolute;
-          right: 2px;
-          top: 2px;
-          z-index: 1;
-        }
-        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-          border: none;
-          bottom: -2px;
-          left: -2px;
-          outline-color: ButtonText;
-          right: -2px;
-          top: -2px;
-        }
-        &:active > * {
-          left: 0px;
-          position: relative;
-          top: 0px;
-        }
-        &:hover {
-          background-color: #f3f2f1;
-          color: #201f1e;
-        }
-        @media screen and (-ms-high-contrast: active){&:hover {
-          border-color: Highlight;
-          color: Highlight;
-        }
-        &:active {
-          background-color: #edebe9;
-          color: #201f1e;
-        }
-    data-is-focusable={true}
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    onKeyPress={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseUp={[Function]}
-    type="button"
+  This example directly uses ContextualMenu to show how it can be attached to arbitrary elements. The remaining examples use ContextualMenu through Fabric Button components.
+  <p>
+    <b>
+      <a
+        onClick={[Function]}
+      >
+        Click for ContextualMenu
+      </a>
+    </b>
+  </p>
+  <span
+    className="ms-layer"
   >
-    <span
+    <div
       className=
-          ms-Button-flexContainer
+          ms-Fabric
+          ms-Layer-content
           {
-            align-items: center;
-            display: flex;
-            flex-wrap: nowrap;
-            height: 100%;
-            justify-content: center;
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #323130;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            visibility: visible;
           }
-      data-automationid="splitbuttonprimary"
+          & button {
+            font-family: inherit;
+          }
+          & input {
+            font-family: inherit;
+          }
+          & textarea {
+            font-family: inherit;
+          }
+      onBlur={[Function]}
+      onChange={[Function]}
+      onClick={[Function]}
+      onContextMenu={[Function]}
+      onDoubleClick={[Function]}
+      onDrag={[Function]}
+      onDragEnd={[Function]}
+      onDragEnter={[Function]}
+      onDragExit={[Function]}
+      onDragLeave={[Function]}
+      onDragOver={[Function]}
+      onDragStart={[Function]}
+      onDrop={[Function]}
+      onFocus={[Function]}
+      onInput={[Function]}
+      onKeyDown={[Function]}
+      onKeyPress={[Function]}
+      onKeyUp={[Function]}
+      onMouseDown={[Function]}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onMouseMove={[Function]}
+      onMouseOut={[Function]}
+      onMouseOver={[Function]}
+      onMouseUp={[Function]}
+      onSubmit={[Function]}
     >
-      <span
+      <div
         className=
-            ms-Button-textContainer
+            ms-Callout-container
             {
-              display: block;
-              flex-grow: 1;
+              position: relative;
             }
+        style={
+          Object {
+            "visibility": "hidden",
+          }
+        }
       >
-        <span
+        <div
           className=
-              ms-Button-label
+              ms-Callout
+              ms-ContextualMenu-Callout
               {
-                display: block;
-                font-weight: 600;
-                line-height: 100%;
-                margin-bottom: 0;
-                margin-left: 4px;
-                margin-right: 4px;
-                margin-top: 0;
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                border-radius: 2px;
+                box-shadow: 0 3.2px 7.2px 0 rgba(0, 0, 0, 0.132), 0 0.6px 1.8px 0 rgba(0, 0, 0, 0.108);
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                outline: transparent;
+                position: absolute;
               }
-          id="id__0"
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+                border-style: solid;
+                border-width: 1px;
+              }
+              &::-moz-focus-inner {
+                border: 0px;
+              }
+          hidden={true}
+          onScroll={[Function]}
+          style={
+            Object {
+              "filter": "opacity(0)",
+              "opacity": 0,
+            }
+          }
+          tabIndex={-1}
         >
-          Click for ContextualMenu
-        </span>
-      </span>
-      <i
-        aria-hidden={true}
-        className=
-            ms-Icon
-            ms-Button-menuIcon
-            {
-              display: inline-block;
+          <div
+            className=
+                ms-Callout-main
+                {
+                  background-color: #ffffff;
+                  border-radius: 2px;
+                  overflow-x: hidden;
+                  overflow-y: auto;
+                  position: relative;
+                }
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            onScroll={[Function]}
+            style={
+              Object {
+                "maxHeight": 752,
+                "outline": "none",
+                "overflowY": undefined,
+              }
             }
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              font-family: "FabricMDL2Icons";
-              font-style: normal;
-              font-weight: normal;
-              speak: none;
-            }
-            {
-              flex-shrink: 0;
-              font-size: 12px;
-              height: 16px;
-              line-height: 16px;
-              margin-bottom: 0;
-              margin-left: 4px;
-              margin-right: 4px;
-              margin-top: 0;
-              text-align: center;
-              vertical-align: middle;
-            }
-        data-icon-name="ChevronDown"
-        role="presentation"
-      >
-        
-      </i>
-    </span>
-  </button>
+          >
+            <div
+              className=
+                  ms-ContextualMenu-container
+                  &:focus {
+                    outline: 0px;
+                  }
+              onFocusCapture={[Function]}
+              onKeyDown={[Function]}
+              onKeyUp={[Function]}
+              tabIndex={-1}
+            >
+              <div
+                className=
+                    ms-FocusZone
+                    ms-ContextualMenu
+                    is-open
+                    &:focus {
+                      outline: none;
+                    }
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #ffffff;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      min-width: 180px;
+                    }
+                data-focuszone-id="FocusZone1"
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseDownCapture={[Function]}
+              >
+                <ul
+                  className=
+                      ms-ContextualMenu-list
+                      is-open
+                      {
+                        list-style-type: none;
+                        margin-bottom: 0;
+                        margin-left: 0;
+                        margin-right: 0;
+                        margin-top: 0;
+                        padding-bottom: 0;
+                        padding-left: 0;
+                        padding-right: 0;
+                        padding-top: 0;
+                      }
+                  onKeyDown={[Function]}
+                  onKeyUp={[Function]}
+                  role="menu"
+                >
+                  <li
+                    className=
+                        ms-ContextualMenu-item
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          box-sizing: border-box;
+                          color: #323130;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          position: relative;
+                        }
+                    role="presentation"
+                  >
+                    <button
+                      aria-disabled={false}
+                      aria-posinset={1}
+                      aria-setsize={8}
+                      className=
+                          ms-ContextualMenu-link
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            background-color: transparent;
+                            border: none;
+                            color: #323130;
+                            cursor: pointer;
+                            display: block;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            height: 36px;
+                            line-height: 36px;
+                            outline: transparent;
+                            padding-bottom: 0;
+                            padding-left: 4px;
+                            padding-right: 8px;
+                            padding-top: 0px;
+                            position: relative;
+                            text-align: left;
+                            width: 100%;
+                          }
+                          &::-moz-focus-inner {
+                            border: 0;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus:after {
+                            border: 1px solid #ffffff;
+                            bottom: 1px;
+                            content: "";
+                            left: 1px;
+                            outline: 1px solid #605e5c;
+                            position: absolute;
+                            right: 1px;
+                            top: 1px;
+                            z-index: 1;
+                          }
+                          &:hover {
+                            background-color: #f3f2f1;
+                            color: #201f1e;
+                          }
+                          @media screen and (-ms-high-contrast: active){&:hover {
+                            -ms-high-contrast-adjust: none;
+                            background-color: Highlight;
+                            border-color: Highlight;
+                            color: HighlightText;
+                          }
+                          &:active {
+                            background-color: #edebe9;
+                          }
+                          @media screen and (-ms-high-contrast: active){&:active {
+                            -ms-high-contrast-adjust: none;
+                            background-color: Highlight;
+                            border-color: Highlight;
+                            color: HighlightText;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus {
+                            background-color: #ffffff;
+                          }
+                          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                            -ms-high-contrast-adjust: none;
+                            background-color: Highlight;
+                            border-color: Highlight;
+                            color: HighlightText;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus:hover {
+                            background-color: #ffffff;
+                          }
+                          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:hover {
+                            -ms-high-contrast-adjust: none;
+                            background-color: Highlight;
+                            border-color: Highlight;
+                            color: HighlightText;
+                          }
+                          .ms-Fabric--isFocusVisible &:hover {
+                            background: inherit;
+                          }
+                      onClick={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseMove={[Function]}
+                      role="menuitem"
+                    >
+                      <div
+                        className=
+                            ms-ContextualMenu-linkContent
+                            {
+                              align-items: center;
+                              display: flex;
+                              height: inherit;
+                              max-width: 100%;
+                              white-space: nowrap;
+                            }
+                      >
+                        <span
+                          className=
+                              ms-ContextualMenu-itemText
+                              {
+                                display: inline-block;
+                                flex-grow: 1;
+                                margin-bottom: 0;
+                                margin-left: 4px;
+                                margin-right: 4px;
+                                margin-top: 0;
+                                overflow: hidden;
+                                text-overflow: ellipsis;
+                                vertical-align: middle;
+                                white-space: nowrap;
+                              }
+                        >
+                          New
+                        </span>
+                      </div>
+                    </button>
+                  </li>
+                  <li
+                    aria-hidden="true"
+                    className=
+                        ms-ContextualMenu-divider
+                        {
+                          background-color: #edebe9;
+                          display: block;
+                          height: 1px;
+                          position: relative;
+                        }
+                    role="separator"
+                  />
+                  <li
+                    className=
+                        ms-ContextualMenu-item
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          box-sizing: border-box;
+                          color: #323130;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          position: relative;
+                        }
+                    role="presentation"
+                  >
+                    <button
+                      aria-disabled={false}
+                      aria-posinset={2}
+                      aria-setsize={8}
+                      className=
+                          ms-ContextualMenu-link
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            background-color: transparent;
+                            border: none;
+                            color: #323130;
+                            cursor: pointer;
+                            display: block;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            height: 36px;
+                            line-height: 36px;
+                            outline: transparent;
+                            padding-bottom: 0;
+                            padding-left: 4px;
+                            padding-right: 8px;
+                            padding-top: 0px;
+                            position: relative;
+                            text-align: left;
+                            width: 100%;
+                          }
+                          &::-moz-focus-inner {
+                            border: 0;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus:after {
+                            border: 1px solid #ffffff;
+                            bottom: 1px;
+                            content: "";
+                            left: 1px;
+                            outline: 1px solid #605e5c;
+                            position: absolute;
+                            right: 1px;
+                            top: 1px;
+                            z-index: 1;
+                          }
+                          &:hover {
+                            background-color: #f3f2f1;
+                            color: #201f1e;
+                          }
+                          @media screen and (-ms-high-contrast: active){&:hover {
+                            -ms-high-contrast-adjust: none;
+                            background-color: Highlight;
+                            border-color: Highlight;
+                            color: HighlightText;
+                          }
+                          &:active {
+                            background-color: #edebe9;
+                          }
+                          @media screen and (-ms-high-contrast: active){&:active {
+                            -ms-high-contrast-adjust: none;
+                            background-color: Highlight;
+                            border-color: Highlight;
+                            color: HighlightText;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus {
+                            background-color: #ffffff;
+                          }
+                          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                            -ms-high-contrast-adjust: none;
+                            background-color: Highlight;
+                            border-color: Highlight;
+                            color: HighlightText;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus:hover {
+                            background-color: #ffffff;
+                          }
+                          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:hover {
+                            -ms-high-contrast-adjust: none;
+                            background-color: Highlight;
+                            border-color: Highlight;
+                            color: HighlightText;
+                          }
+                          .ms-Fabric--isFocusVisible &:hover {
+                            background: inherit;
+                          }
+                      onClick={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseMove={[Function]}
+                      role="menuitem"
+                    >
+                      <div
+                        className=
+                            ms-ContextualMenu-linkContent
+                            {
+                              align-items: center;
+                              display: flex;
+                              height: inherit;
+                              max-width: 100%;
+                              white-space: nowrap;
+                            }
+                      >
+                        <span
+                          className=
+                              ms-ContextualMenu-itemText
+                              {
+                                display: inline-block;
+                                flex-grow: 1;
+                                margin-bottom: 0;
+                                margin-left: 4px;
+                                margin-right: 4px;
+                                margin-top: 0;
+                                overflow: hidden;
+                                text-overflow: ellipsis;
+                                vertical-align: middle;
+                                white-space: nowrap;
+                              }
+                        >
+                          Rename
+                        </span>
+                      </div>
+                    </button>
+                  </li>
+                  <li
+                    className=
+                        ms-ContextualMenu-item
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          box-sizing: border-box;
+                          color: #323130;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          position: relative;
+                        }
+                    role="presentation"
+                  >
+                    <button
+                      aria-disabled={false}
+                      aria-posinset={3}
+                      aria-setsize={8}
+                      className=
+                          ms-ContextualMenu-link
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            background-color: transparent;
+                            border: none;
+                            color: #323130;
+                            cursor: pointer;
+                            display: block;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            height: 36px;
+                            line-height: 36px;
+                            outline: transparent;
+                            padding-bottom: 0;
+                            padding-left: 4px;
+                            padding-right: 8px;
+                            padding-top: 0px;
+                            position: relative;
+                            text-align: left;
+                            width: 100%;
+                          }
+                          &::-moz-focus-inner {
+                            border: 0;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus:after {
+                            border: 1px solid #ffffff;
+                            bottom: 1px;
+                            content: "";
+                            left: 1px;
+                            outline: 1px solid #605e5c;
+                            position: absolute;
+                            right: 1px;
+                            top: 1px;
+                            z-index: 1;
+                          }
+                          &:hover {
+                            background-color: #f3f2f1;
+                            color: #201f1e;
+                          }
+                          @media screen and (-ms-high-contrast: active){&:hover {
+                            -ms-high-contrast-adjust: none;
+                            background-color: Highlight;
+                            border-color: Highlight;
+                            color: HighlightText;
+                          }
+                          &:active {
+                            background-color: #edebe9;
+                          }
+                          @media screen and (-ms-high-contrast: active){&:active {
+                            -ms-high-contrast-adjust: none;
+                            background-color: Highlight;
+                            border-color: Highlight;
+                            color: HighlightText;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus {
+                            background-color: #ffffff;
+                          }
+                          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                            -ms-high-contrast-adjust: none;
+                            background-color: Highlight;
+                            border-color: Highlight;
+                            color: HighlightText;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus:hover {
+                            background-color: #ffffff;
+                          }
+                          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:hover {
+                            -ms-high-contrast-adjust: none;
+                            background-color: Highlight;
+                            border-color: Highlight;
+                            color: HighlightText;
+                          }
+                          .ms-Fabric--isFocusVisible &:hover {
+                            background: inherit;
+                          }
+                      onClick={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseMove={[Function]}
+                      role="menuitem"
+                    >
+                      <div
+                        className=
+                            ms-ContextualMenu-linkContent
+                            {
+                              align-items: center;
+                              display: flex;
+                              height: inherit;
+                              max-width: 100%;
+                              white-space: nowrap;
+                            }
+                      >
+                        <span
+                          className=
+                              ms-ContextualMenu-itemText
+                              {
+                                display: inline-block;
+                                flex-grow: 1;
+                                margin-bottom: 0;
+                                margin-left: 4px;
+                                margin-right: 4px;
+                                margin-top: 0;
+                                overflow: hidden;
+                                text-overflow: ellipsis;
+                                vertical-align: middle;
+                                white-space: nowrap;
+                              }
+                        >
+                          Edit
+                        </span>
+                      </div>
+                    </button>
+                  </li>
+                  <li
+                    className=
+                        ms-ContextualMenu-item
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          box-sizing: border-box;
+                          color: #323130;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          position: relative;
+                        }
+                    role="presentation"
+                  >
+                    <button
+                      aria-disabled={false}
+                      aria-posinset={4}
+                      aria-setsize={8}
+                      className=
+                          ms-ContextualMenu-link
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            background-color: transparent;
+                            border: none;
+                            color: #323130;
+                            cursor: pointer;
+                            display: block;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            height: 36px;
+                            line-height: 36px;
+                            outline: transparent;
+                            padding-bottom: 0;
+                            padding-left: 4px;
+                            padding-right: 8px;
+                            padding-top: 0px;
+                            position: relative;
+                            text-align: left;
+                            width: 100%;
+                          }
+                          &::-moz-focus-inner {
+                            border: 0;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus:after {
+                            border: 1px solid #ffffff;
+                            bottom: 1px;
+                            content: "";
+                            left: 1px;
+                            outline: 1px solid #605e5c;
+                            position: absolute;
+                            right: 1px;
+                            top: 1px;
+                            z-index: 1;
+                          }
+                          &:hover {
+                            background-color: #f3f2f1;
+                            color: #201f1e;
+                          }
+                          @media screen and (-ms-high-contrast: active){&:hover {
+                            -ms-high-contrast-adjust: none;
+                            background-color: Highlight;
+                            border-color: Highlight;
+                            color: HighlightText;
+                          }
+                          &:active {
+                            background-color: #edebe9;
+                          }
+                          @media screen and (-ms-high-contrast: active){&:active {
+                            -ms-high-contrast-adjust: none;
+                            background-color: Highlight;
+                            border-color: Highlight;
+                            color: HighlightText;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus {
+                            background-color: #ffffff;
+                          }
+                          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                            -ms-high-contrast-adjust: none;
+                            background-color: Highlight;
+                            border-color: Highlight;
+                            color: HighlightText;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus:hover {
+                            background-color: #ffffff;
+                          }
+                          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:hover {
+                            -ms-high-contrast-adjust: none;
+                            background-color: Highlight;
+                            border-color: Highlight;
+                            color: HighlightText;
+                          }
+                          .ms-Fabric--isFocusVisible &:hover {
+                            background: inherit;
+                          }
+                      onClick={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseMove={[Function]}
+                      role="menuitem"
+                    >
+                      <div
+                        className=
+                            ms-ContextualMenu-linkContent
+                            {
+                              align-items: center;
+                              display: flex;
+                              height: inherit;
+                              max-width: 100%;
+                              white-space: nowrap;
+                            }
+                      >
+                        <span
+                          className=
+                              ms-ContextualMenu-itemText
+                              {
+                                display: inline-block;
+                                flex-grow: 1;
+                                margin-bottom: 0;
+                                margin-left: 4px;
+                                margin-right: 4px;
+                                margin-top: 0;
+                                overflow: hidden;
+                                text-overflow: ellipsis;
+                                vertical-align: middle;
+                                white-space: nowrap;
+                              }
+                        >
+                          Properties
+                        </span>
+                      </div>
+                    </button>
+                  </li>
+                  <li
+                    className=
+                        ms-ContextualMenu-item
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          box-sizing: border-box;
+                          color: #323130;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          position: relative;
+                        }
+                    role="presentation"
+                  >
+                    <div>
+                      <a
+                        aria-disabled={false}
+                        aria-posinset={5}
+                        aria-setsize={8}
+                        className=
+                            ms-ContextualMenu-link
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              background-color: transparent;
+                              border: none;
+                              box-sizing: border-box;
+                              color: inherit;
+                              cursor: pointer;
+                              display: block;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              height: 36px;
+                              letter-spacing: normal;
+                              line-height: 36px;
+                              outline: transparent;
+                              padding-bottom: 0;
+                              padding-left: 4px;
+                              padding-right: 8px;
+                              padding-top: 0px;
+                              position: relative;
+                              text-align: left;
+                              text-decoration: none;
+                              text-indent: 0px;
+                              text-rendering: auto;
+                              text-shadow: none;
+                              text-transform: none;
+                              width: 100%;
+                              word-spacing: normal;
+                            }
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #ffffff;
+                              bottom: 1px;
+                              content: "";
+                              left: 1px;
+                              outline: 1px solid #605e5c;
+                              position: absolute;
+                              right: 1px;
+                              top: 1px;
+                              z-index: 1;
+                            }
+                            &:hover {
+                              background-color: #f3f2f1;
+                              color: #201f1e;
+                            }
+                            @media screen and (-ms-high-contrast: active){&:hover {
+                              -ms-high-contrast-adjust: none;
+                              background-color: Highlight;
+                              border-color: Highlight;
+                              color: HighlightText;
+                            }
+                            &:active {
+                              background-color: #edebe9;
+                            }
+                            @media screen and (-ms-high-contrast: active){&:active {
+                              -ms-high-contrast-adjust: none;
+                              background-color: Highlight;
+                              border-color: Highlight;
+                              color: HighlightText;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus {
+                              background-color: #ffffff;
+                            }
+                            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                              -ms-high-contrast-adjust: none;
+                              background-color: Highlight;
+                              border-color: Highlight;
+                              color: HighlightText;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:hover {
+                              background-color: #ffffff;
+                            }
+                            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:hover {
+                              -ms-high-contrast-adjust: none;
+                              background-color: Highlight;
+                              border-color: Highlight;
+                              color: HighlightText;
+                            }
+                            .ms-Fabric--isFocusVisible &:hover {
+                              background: inherit;
+                            }
+                        href="http://bing.com"
+                        onClick={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseMove={[Function]}
+                        role="menuitem"
+                      >
+                        <div
+                          className=
+                              ms-ContextualMenu-linkContent
+                              {
+                                align-items: center;
+                                display: flex;
+                                height: inherit;
+                                max-width: 100%;
+                                white-space: nowrap;
+                              }
+                        >
+                          <span
+                            className=
+                                ms-ContextualMenu-itemText
+                                {
+                                  display: inline-block;
+                                  flex-grow: 1;
+                                  margin-bottom: 0;
+                                  margin-left: 4px;
+                                  margin-right: 4px;
+                                  margin-top: 0;
+                                  overflow: hidden;
+                                  text-overflow: ellipsis;
+                                  vertical-align: middle;
+                                  white-space: nowrap;
+                                }
+                          >
+                            Link same window
+                          </span>
+                        </div>
+                      </a>
+                    </div>
+                  </li>
+                  <li
+                    className=
+                        ms-ContextualMenu-item
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          box-sizing: border-box;
+                          color: #323130;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          position: relative;
+                        }
+                    role="presentation"
+                  >
+                    <div>
+                      <a
+                        aria-disabled={false}
+                        aria-posinset={6}
+                        aria-setsize={8}
+                        className=
+                            ms-ContextualMenu-link
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              background-color: transparent;
+                              border: none;
+                              box-sizing: border-box;
+                              color: inherit;
+                              cursor: pointer;
+                              display: block;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              height: 36px;
+                              letter-spacing: normal;
+                              line-height: 36px;
+                              outline: transparent;
+                              padding-bottom: 0;
+                              padding-left: 4px;
+                              padding-right: 8px;
+                              padding-top: 0px;
+                              position: relative;
+                              text-align: left;
+                              text-decoration: none;
+                              text-indent: 0px;
+                              text-rendering: auto;
+                              text-shadow: none;
+                              text-transform: none;
+                              width: 100%;
+                              word-spacing: normal;
+                            }
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #ffffff;
+                              bottom: 1px;
+                              content: "";
+                              left: 1px;
+                              outline: 1px solid #605e5c;
+                              position: absolute;
+                              right: 1px;
+                              top: 1px;
+                              z-index: 1;
+                            }
+                            &:hover {
+                              background-color: #f3f2f1;
+                              color: #201f1e;
+                            }
+                            @media screen and (-ms-high-contrast: active){&:hover {
+                              -ms-high-contrast-adjust: none;
+                              background-color: Highlight;
+                              border-color: Highlight;
+                              color: HighlightText;
+                            }
+                            &:active {
+                              background-color: #edebe9;
+                            }
+                            @media screen and (-ms-high-contrast: active){&:active {
+                              -ms-high-contrast-adjust: none;
+                              background-color: Highlight;
+                              border-color: Highlight;
+                              color: HighlightText;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus {
+                              background-color: #ffffff;
+                            }
+                            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                              -ms-high-contrast-adjust: none;
+                              background-color: Highlight;
+                              border-color: Highlight;
+                              color: HighlightText;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:hover {
+                              background-color: #ffffff;
+                            }
+                            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:hover {
+                              -ms-high-contrast-adjust: none;
+                              background-color: Highlight;
+                              border-color: Highlight;
+                              color: HighlightText;
+                            }
+                            .ms-Fabric--isFocusVisible &:hover {
+                              background: inherit;
+                            }
+                        href="http://bing.com"
+                        onClick={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseMove={[Function]}
+                        rel="nofollow noopener noreferrer"
+                        role="menuitem"
+                        target="_blank"
+                      >
+                        <div
+                          className=
+                              ms-ContextualMenu-linkContent
+                              {
+                                align-items: center;
+                                display: flex;
+                                height: inherit;
+                                max-width: 100%;
+                                white-space: nowrap;
+                              }
+                        >
+                          <span
+                            className=
+                                ms-ContextualMenu-itemText
+                                {
+                                  display: inline-block;
+                                  flex-grow: 1;
+                                  margin-bottom: 0;
+                                  margin-left: 4px;
+                                  margin-right: 4px;
+                                  margin-top: 0;
+                                  overflow: hidden;
+                                  text-overflow: ellipsis;
+                                  vertical-align: middle;
+                                  white-space: nowrap;
+                                }
+                          >
+                            Link new window
+                          </span>
+                        </div>
+                      </a>
+                    </div>
+                  </li>
+                  <li
+                    className=
+                        ms-ContextualMenu-item
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          box-sizing: border-box;
+                          color: #323130;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          position: relative;
+                        }
+                    role="presentation"
+                  >
+                    <div>
+                      <a
+                        aria-disabled={false}
+                        aria-posinset={7}
+                        aria-setsize={8}
+                        className=
+                            ms-ContextualMenu-link
+                            {
+                              -moz-osx-font-smoothing: grayscale;
+                              -webkit-font-smoothing: antialiased;
+                              background-color: transparent;
+                              border: none;
+                              box-sizing: border-box;
+                              color: inherit;
+                              cursor: pointer;
+                              display: block;
+                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                              font-size: 14px;
+                              font-weight: 400;
+                              height: 36px;
+                              letter-spacing: normal;
+                              line-height: 36px;
+                              outline: transparent;
+                              padding-bottom: 0;
+                              padding-left: 4px;
+                              padding-right: 8px;
+                              padding-top: 0px;
+                              position: relative;
+                              text-align: left;
+                              text-decoration: none;
+                              text-indent: 0px;
+                              text-rendering: auto;
+                              text-shadow: none;
+                              text-transform: none;
+                              width: 100%;
+                              word-spacing: normal;
+                            }
+                            &::-moz-focus-inner {
+                              border: 0;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:after {
+                              border: 1px solid #ffffff;
+                              bottom: 1px;
+                              content: "";
+                              left: 1px;
+                              outline: 1px solid #605e5c;
+                              position: absolute;
+                              right: 1px;
+                              top: 1px;
+                              z-index: 1;
+                            }
+                            &:hover {
+                              background-color: #f3f2f1;
+                              color: #201f1e;
+                            }
+                            @media screen and (-ms-high-contrast: active){&:hover {
+                              -ms-high-contrast-adjust: none;
+                              background-color: Highlight;
+                              border-color: Highlight;
+                              color: HighlightText;
+                            }
+                            &:active {
+                              background-color: #edebe9;
+                            }
+                            @media screen and (-ms-high-contrast: active){&:active {
+                              -ms-high-contrast-adjust: none;
+                              background-color: Highlight;
+                              border-color: Highlight;
+                              color: HighlightText;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus {
+                              background-color: #ffffff;
+                            }
+                            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                              -ms-high-contrast-adjust: none;
+                              background-color: Highlight;
+                              border-color: Highlight;
+                              color: HighlightText;
+                            }
+                            .ms-Fabric--isFocusVisible &:focus:hover {
+                              background-color: #ffffff;
+                            }
+                            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:hover {
+                              -ms-high-contrast-adjust: none;
+                              background-color: Highlight;
+                              border-color: Highlight;
+                              color: HighlightText;
+                            }
+                            .ms-Fabric--isFocusVisible &:hover {
+                              background: inherit;
+                            }
+                        href="http://bing.com"
+                        name="Link click"
+                        onClick={[Function]}
+                        onMouseEnter={[Function]}
+                        onMouseLeave={[Function]}
+                        onMouseMove={[Function]}
+                        rel="nofollow noopener noreferrer"
+                        role="menuitem"
+                        target="_blank"
+                      >
+                        <div
+                          className=
+                              ms-ContextualMenu-linkContent
+                              {
+                                align-items: center;
+                                display: flex;
+                                height: inherit;
+                                max-width: 100%;
+                                white-space: nowrap;
+                              }
+                        >
+                          <span
+                            className=
+                                ms-ContextualMenu-itemText
+                                {
+                                  display: inline-block;
+                                  flex-grow: 1;
+                                  margin-bottom: 0;
+                                  margin-left: 4px;
+                                  margin-right: 4px;
+                                  margin-top: 0;
+                                  overflow: hidden;
+                                  text-overflow: ellipsis;
+                                  vertical-align: middle;
+                                  white-space: nowrap;
+                                }
+                          >
+                            Link click
+                          </span>
+                        </div>
+                      </a>
+                    </div>
+                  </li>
+                  <li
+                    className=
+                        ms-ContextualMenu-item
+                        {
+                          -moz-osx-font-smoothing: grayscale;
+                          -webkit-font-smoothing: antialiased;
+                          box-sizing: border-box;
+                          color: #323130;
+                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                          font-size: 14px;
+                          font-weight: 400;
+                          position: relative;
+                        }
+                    role="presentation"
+                  >
+                    <button
+                      aria-disabled={true}
+                      aria-posinset={8}
+                      aria-setsize={8}
+                      className=
+                          ms-ContextualMenu-link
+                          is-disabled
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            background-color: transparent;
+                            border: none;
+                            color: #a19f9d;
+                            cursor: default;
+                            display: block;
+                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                            font-size: 14px;
+                            font-weight: 400;
+                            height: 36px;
+                            line-height: 36px;
+                            outline: transparent;
+                            padding-bottom: 0;
+                            padding-left: 4px;
+                            padding-right: 8px;
+                            padding-top: 0px;
+                            pointer-events: none;
+                            position: relative;
+                            text-align: left;
+                            width: 100%;
+                          }
+                          &::-moz-focus-inner {
+                            border: 0;
+                          }
+                          .ms-Fabric--isFocusVisible &:focus:after {
+                            border: 1px solid #ffffff;
+                            bottom: 1px;
+                            content: "";
+                            left: 1px;
+                            outline: 1px solid #605e5c;
+                            position: absolute;
+                            right: 1px;
+                            top: 1px;
+                            z-index: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active){& {
+                            color: GrayText;
+                            opacity: 1;
+                          }
+                      onClick={[Function]}
+                      onMouseDown={[Function]}
+                      onMouseEnter={[Function]}
+                      onMouseLeave={[Function]}
+                      onMouseMove={[Function]}
+                      role="menuitem"
+                    >
+                      <div
+                        className=
+                            ms-ContextualMenu-linkContent
+                            {
+                              align-items: center;
+                              display: flex;
+                              height: inherit;
+                              max-width: 100%;
+                              white-space: nowrap;
+                            }
+                      >
+                        <span
+                          className=
+                              ms-ContextualMenu-itemText
+                              {
+                                display: inline-block;
+                                flex-grow: 1;
+                                margin-bottom: 0;
+                                margin-left: 4px;
+                                margin-right: 4px;
+                                margin-top: 0;
+                                overflow: hidden;
+                                text-overflow: ellipsis;
+                                vertical-align: middle;
+                                white-space: nowrap;
+                              }
+                        >
+                          Disabled item
+                        </span>
+                      </div>
+                    </button>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </span>
 </div>
 `;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Default.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Default.Example.tsx.shot
@@ -1,0 +1,160 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Component Examples renders ContextualMenu.Default.Example.tsx correctly 1`] = `
+<div>
+  <button
+    aria-expanded={false}
+    aria-haspopup={true}
+    aria-owns={null}
+    className=
+        ms-Button
+        ms-Button--default
+        ms-Button--hasMenu
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: #ffffff;
+          border-radius: 2px;
+          border: 1px solid #8a8886;
+          box-sizing: border-box;
+          color: #323130;
+          cursor: pointer;
+          display: inline-block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 32px;
+          min-width: 80px;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid transparent;
+          bottom: 2px;
+          content: "";
+          left: 2px;
+          outline: 1px solid #605e5c;
+          position: absolute;
+          right: 2px;
+          top: 2px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:active > * {
+          left: 0px;
+          position: relative;
+          top: 0px;
+        }
+        &:hover {
+          background-color: #f3f2f1;
+          color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #edebe9;
+          color: #201f1e;
+        }
+    data-is-focusable={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    onKeyPress={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
+    type="button"
+  >
+    <span
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
+      data-automationid="splitbuttonprimary"
+    >
+      <span
+        className=
+            ms-Button-textContainer
+            {
+              display: block;
+              flex-grow: 1;
+            }
+      >
+        <span
+          className=
+              ms-Button-label
+              {
+                display: block;
+                font-weight: 600;
+                line-height: 100%;
+                margin-bottom: 0;
+                margin-left: 4px;
+                margin-right: 4px;
+                margin-top: 0;
+              }
+          id="id__0"
+        >
+          Click for ContextualMenu
+        </span>
+      </span>
+      <i
+        aria-hidden={true}
+        className=
+            ms-Icon
+            ms-Button-menuIcon
+            {
+              display: inline-block;
+            }
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              font-family: "FabricMDL2Icons";
+              font-style: normal;
+              font-weight: normal;
+              speak: none;
+            }
+            {
+              flex-shrink: 0;
+              font-size: 12px;
+              height: 16px;
+              line-height: 16px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              text-align: center;
+              vertical-align: middle;
+            }
+        data-icon-name="ChevronDown"
+        role="presentation"
+      >
+        
+      </i>
+    </span>
+  </button>
+</div>
+`;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11113
- [x] Include a change request file using `$ yarn change`

#### Description of changes

PR #2878 removed all uses of `ContextualMenu` from the examples, leading to some confusion in #11113 as to the availability of a generic `ContextualMenu` component. This PR just adds an example using `ContextualMenu` directly.

Also fix some inconsistency in basic vs. default naming in the existing example.

![image](https://user-images.githubusercontent.com/26070760/68440891-41870c80-0181-11ea-8407-db3ef8a62380.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11124)