### PR TITLE
Fixing jest commonjs references via bad import

### DIFF
--- a/change/office-ui-fabric-react-2019-11-09-05-17-26-fix-import.json
+++ b/change/office-ui-fabric-react-2019-11-09-05-17-26-fix-import.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "FloatingPicker: Addressing bad import, causing jest to fail when referenced.",
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@hotmail.com",
+  "commit": "77ac7dbb04cd78767e87e40cd4da15c8cf35f254",
+  "date": "2019-11-09T13:17:26.847Z"
+}

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/Suggestions/SuggestionsControl.tsx
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/Suggestions/SuggestionsControl.tsx
@@ -10,7 +10,7 @@ import {
 } from './Suggestions.types';
 import { SuggestionsCore } from './SuggestionsCore';
 import * as stylesImport from './SuggestionsControl.scss';
-import { hiddenContentStyle, mergeStyles } from 'office-ui-fabric-react/lib/Styling';
+import { hiddenContentStyle, mergeStyles } from '../../../Styling';
 
 // tslint:disable-next-line:no-any
 const styles: any = stylesImport;


### PR DESCRIPTION
Addressing jest issue with described here:

https://github.com/HarryGifford/FabricJestTestImports



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11137)