### PR TITLE
FocusZone: reset alignment when receiving focus.

### DIFF
--- a/change/office-ui-fabric-react-2019-11-12-10-03-25-focuszone-fix.json
+++ b/change/office-ui-fabric-react-2019-11-12-10-03-25-focuszone-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "FocusZone: reset alignment when receiving focus.",
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@hotmail.com",
+  "commit": "5de98a2f5a9dcb3ccd6834bd4fbf4257afab5173",
+  "date": "2019-11-12T18:03:25.895Z"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -364,7 +364,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     // update alignment an immediate descendant
     if (newActiveElement && newActiveElement !== this._activeElement) {
       if (isImmediateDescendant || initialElementFocused) {
-        this._setFocusAlignment(newActiveElement, initialElementFocused);
+        this._setFocusAlignment(newActiveElement, true, true);
       }
 
       this._activeElement = newActiveElement;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10985
- [x] Include a change request file using `$ yarn change`

#### Description of changes

When focus is received within FocusZone from an external location, we will reset alignment, ensuring we don't reuse the old active element's alignment.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11170)