### PR TITLE
ComboBox: adds a onRenderUpperContent (to match the lower one for symmetry)

### DIFF
--- a/change/office-ui-fabric-react-2019-11-13-09-07-53-combobox-uppercontent.json
+++ b/change/office-ui-fabric-react-2019-11-13-09-07-53-combobox-uppercontent.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "ComboBox: adding an onRenderUpperContent() flexpoint for combobox",
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com",
+  "commit": "773f576e485db4ae30476f37ae6bd21dd64ddbf2",
+  "date": "2019-11-13T17:07:53.742Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -2775,6 +2775,7 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox,
     onMenuOpen?: () => void;
     onPendingValueChanged?: (option?: IComboBoxOption, index?: number, value?: string) => void;
     onRenderLowerContent?: IRenderFunction<IComboBoxProps>;
+    onRenderUpperContent?: IRenderFunction<IComboBoxProps>;
     onResolveOptions?: (options: IComboBoxOption[]) => IComboBoxOption[] | PromiseLike<IComboBoxOption[]>;
     onScrollToItem?: (itemIndex: number) => void;
     options: IComboBoxOption[];

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1118,6 +1118,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       calloutProps,
       dropdownWidth,
       dropdownMaxWidth,
+      onRenderUpperContent = this._onRenderUpperContent,
       onRenderLowerContent = this._onRenderLowerContent,
       useComboBoxAsMenuWidth,
       persistMenu,
@@ -1148,6 +1149,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         hidden={persistMenu ? !isOpen : undefined}
         shouldRestoreFocus={shouldRestoreFocus}
       >
+        {onRenderUpperContent(this.props, this._onRenderUpperContent)}
         <div className={this._classNames.optionsContainerWrapper} ref={this._comboBoxMenu}>
           {(onRenderList as any)({ ...props }, this._onRenderList)}
         </div>
@@ -1198,6 +1200,11 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
 
   // Default _onRenderLowerContent function returns nothing
   private _onRenderLowerContent = (): null => {
+    return null;
+  };
+
+  // Default _onRenderUpperContent function returns nothing
+  private _onRenderUpperContent = (): null => {
     return null;
   };
 

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.types.ts
@@ -183,6 +183,11 @@ export interface IComboBoxProps extends ISelectableDroppableTextProps<IComboBox,
   scrollSelectedToTop?: boolean;
 
   /**
+   * Add additional content above the callout list.
+   */
+  onRenderUpperContent?: IRenderFunction<IComboBoxProps>;
+
+  /**
    * Add additional content below the callout list.
    */
   onRenderLowerContent?: IRenderFunction<IComboBoxProps>;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11168
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This adds a new render function to render a customizable content above the list (previously a onRenderLowerContent was already present)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11172)