### PR TITLE
Optmizing ResizeGroup when it gets new props which do not change the layout

### DIFF
--- a/change/office-ui-fabric-react-2019-11-13-16-28-50-ResizeGroupPerf2.json
+++ b/change/office-ui-fabric-react-2019-11-13-16-28-50-ResizeGroupPerf2.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Optmizing ResizeGroup when it gets new props which do not change the layout",
+  "packageName": "office-ui-fabric-react",
+  "email": "kushaly@microsoft.com",
+  "commit": "c6f818946d75d799b3a93f7747202bb124237fd6",
+  "date": "2019-11-14T00:28:50.060Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1331,7 +1331,7 @@ export const getNextResizeGroupStateProvider: (measurementCache?: {
 }) => {
     getNextState: (props: IResizeGroupProps, currentState: IResizeGroupState, getElementToMeasureDimension: () => number, newContainerDimension?: number | undefined) => IResizeGroupState | undefined;
     shouldRenderDataForMeasurement: (dataToMeasure: any) => boolean;
-    getInitialResizeGroupState: (data: any) => IResizeGroupState;
+    getInitialResizeGroupState: (props: IResizeGroupProps) => IResizeGroupState;
 };
 
 // @public
@@ -6390,6 +6390,7 @@ export interface IResizeGroupProps extends React.HTMLAttributes<ResizeGroupBase 
     data: any;
     dataDidRender?: (renderedData: any) => void;
     direction?: ResizeGroupDirection;
+    onBatchScaleData?: (prevData: any, scalingStepsCount: number) => any;
     onGrowData?: (prevData: any) => any;
     onReduceData: (prevData: any) => any;
     onRenderData: (data: any) => JSX.Element;
@@ -6402,6 +6403,7 @@ export interface IResizeGroupProps extends React.HTMLAttributes<ResizeGroupBase 
 export interface IResizeGroupState {
     dataToMeasure?: any;
     measureContainer?: boolean;
+    prevProps?: IResizeGroupProps;
     renderedData?: any;
     resizeDirection?: 'grow' | 'shrink';
 }
@@ -8562,13 +8564,26 @@ export class ResizeGroupBase extends BaseComponent<IResizeGroupProps, IResizeGro
     // (undocumented)
     componentDidMount(): void;
     // (undocumented)
-    componentDidUpdate(prevProps: IResizeGroupProps): void;
+    componentDidUpdate(): void;
+    // (undocumented)
+    static getDerivedStateFromProps(props: IResizeGroupProps, state: IResizeGroupState): {
+        renderedData: any;
+        measureContainer: boolean;
+        prevProps: IResizeGroupProps;
+        dataToMeasure?: undefined;
+        resizeDirection?: undefined;
+    } | {
+        dataToMeasure: any;
+        prevProps: IResizeGroupProps;
+        resizeDirection: string;
+        measureContainer: boolean;
+        renderedData?: undefined;
+    } | null;
     // (undocumented)
     remeasure(): void;
     // (undocumented)
     render(): JSX.Element;
-    // (undocumented)
-    UNSAFE_componentWillReceiveProps(nextProps: IResizeGroupProps): void;
+    shouldComponentUpdate(nextProps: IResizeGroupProps, nextState: IResizeGroupState): boolean;
     }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.base.tsx
@@ -41,16 +41,6 @@ export interface IResizeGroupState {
    * instead of remounting.
    */
   measureDivKey?: ResizeGroupDivKey;
-
-  /**
-   * Integer which represents all the scaling steps applied for the data to render.
-   * If 0, data in props was rendered as is.
-   * If positive, we grew the data in props before we rendered it.
-   * If negative, we shrunk the data in props before we rendered it.
-   */
-  renderedDataScalingSteps?: number;
-
-  dataToMeasureScalingSteps?: number;
 }
 
 /**
@@ -119,7 +109,6 @@ export const getNextResizeGroupStateProvider = (measurementCache = getMeasuremen
    */
   function _shrinkContentsUntilTheyFit(
     data: any,
-    appliedScalingStepsCount: number,
     onReduceData: (prevData: any) => any,
     getElementToMeasureDimension: () => number
   ): IResizeGroupState {
@@ -170,7 +159,6 @@ export const getNextResizeGroupStateProvider = (measurementCache = getMeasuremen
    */
   function _growDataUntilItDoesNotFit(
     data: any,
-    appliedScalingStepsCount: number,
     onGrowData: (prevData: any) => any,
     getElementToMeasureDimension: () => number,
     onReduceData: (prevData: any) => any
@@ -228,7 +216,7 @@ export const getNextResizeGroupStateProvider = (measurementCache = getMeasuremen
       if (onGrowData) {
         nextState = {
           resizeDirection: 'grow',
-          dataToMeasure: renderedData
+          dataToMeasure: onGrowData(renderedData)
         };
       } else {
         nextState = {
@@ -279,12 +267,7 @@ export const getNextResizeGroupStateProvider = (measurementCache = getMeasuremen
       if (currentState.resizeDirection === 'grow' && props.onGrowData) {
         nextState = {
           ...nextState,
-          ..._growDataUntilItDoesNotFit(
-            currentState.dataToMeasure,
-            currentStaprops.onGrowData,
-            getElementToMeasureDimension,
-            props.onReduceData
-          )
+          ..._growDataUntilItDoesNotFit(currentState.dataToMeasure, props.onGrowData, getElementToMeasureDimension, props.onReduceData)
         };
       } else {
         nextState = {
@@ -316,8 +299,6 @@ export const getNextResizeGroupStateProvider = (measurementCache = getMeasuremen
   function getInitialResizeGroupState(data: any): IResizeGroupState {
     return {
       dataToMeasure: { ...data },
-      renderedDataScalingSteps: 0,
-      dataToMeasureScalingSteps: 0,
       resizeDirection: 'grow',
       measureContainer: true,
       measureDivKey: 'KeyOne'

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.base.tsx
@@ -104,7 +104,7 @@ export const getNextResizeGroupStateProvider = (measurementCache = getMeasuremen
     data: any,
     onReduceData: (prevData: any) => any,
     getElementToMeasureDimension: () => number
-  ): Partial<IResizeGroupState> {
+  ): IResizeGroupState {
     let dataToMeasure = data;
     let measuredDimension: number | undefined = _getMeasuredDimension(data, getElementToMeasureDimension);
 
@@ -155,7 +155,7 @@ export const getNextResizeGroupStateProvider = (measurementCache = getMeasuremen
     onGrowData: (prevData: any) => any,
     getElementToMeasureDimension: () => number,
     onReduceData: (prevData: any) => any
-  ): Partial<IResizeGroupState> {
+  ): IResizeGroupState {
     let dataToMeasure = data;
     let measuredDimension: number | undefined = _getMeasuredDimension(data, getElementToMeasureDimension);
 
@@ -203,8 +203,8 @@ export const getNextResizeGroupStateProvider = (measurementCache = getMeasuremen
     fullDimensionData: any,
     renderedData: any,
     onGrowData?: (prevData: any) => any
-  ): Partial<IResizeGroupState> {
-    let nextState: Partial<IResizeGroupState>;
+  ): IResizeGroupState {
+    let nextState: IResizeGroupState;
     if (newDimension > _containerDimension!) {
       if (onGrowData) {
         nextState = {
@@ -329,8 +329,8 @@ export class ResizeGroupBase extends BaseComponent<IResizeGroupProps, IResizeGro
       // If cache key is defined and equal to cache key of previous props' data we can do an optimization
       if (prevData.cacheKey && data.cacheKey === prevData.cacheKey) {
         // If they have batch scaling ability, and data has scaling steps count.
-        if (onBatchScaleData && data.zz__ScalingStepsCount && renderedData && renderedData.zz__ScalingStepsCount) {
-          const newData = onBatchScaleData({ ...data }, renderedData.zz__ScalingStepsCount);
+        if (onBatchScaleData && data.__ScalingStepsCount && renderedData && renderedData.__ScalingStepsCount) {
+          const newData = onBatchScaleData({ ...data }, renderedData.__ScalingStepsCount);
           // If new scaled data has same cacheKey as previously rendered data, it can safely be re-rendered
           if (newData.cacheKey === renderedData.cacheKey) {
             return {

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.base.tsx
@@ -41,6 +41,16 @@ export interface IResizeGroupState {
    * instead of remounting.
    */
   measureDivKey?: ResizeGroupDivKey;
+
+  /**
+   * Integer which represents all the scaling steps applied for the data to render.
+   * If 0, data in props was rendered as is.
+   * If positive, we grew the data in props before we rendered it.
+   * If negative, we shrunk the data in props before we rendered it.
+   */
+  renderedDataScalingSteps?: number;
+
+  dataToMeasureScalingSteps?: number;
 }
 
 /**
@@ -109,6 +119,7 @@ export const getNextResizeGroupStateProvider = (measurementCache = getMeasuremen
    */
   function _shrinkContentsUntilTheyFit(
     data: any,
+    appliedScalingStepsCount: number,
     onReduceData: (prevData: any) => any,
     getElementToMeasureDimension: () => number
   ): IResizeGroupState {
@@ -159,6 +170,7 @@ export const getNextResizeGroupStateProvider = (measurementCache = getMeasuremen
    */
   function _growDataUntilItDoesNotFit(
     data: any,
+    appliedScalingStepsCount: number,
     onGrowData: (prevData: any) => any,
     getElementToMeasureDimension: () => number,
     onReduceData: (prevData: any) => any
@@ -216,7 +228,7 @@ export const getNextResizeGroupStateProvider = (measurementCache = getMeasuremen
       if (onGrowData) {
         nextState = {
           resizeDirection: 'grow',
-          dataToMeasure: onGrowData(renderedData)
+          dataToMeasure: renderedData
         };
       } else {
         nextState = {
@@ -267,7 +279,12 @@ export const getNextResizeGroupStateProvider = (measurementCache = getMeasuremen
       if (currentState.resizeDirection === 'grow' && props.onGrowData) {
         nextState = {
           ...nextState,
-          ..._growDataUntilItDoesNotFit(currentState.dataToMeasure, props.onGrowData, getElementToMeasureDimension, props.onReduceData)
+          ..._growDataUntilItDoesNotFit(
+            currentState.dataToMeasure,
+            currentStaprops.onGrowData,
+            getElementToMeasureDimension,
+            props.onReduceData
+          )
         };
       } else {
         nextState = {
@@ -299,6 +316,8 @@ export const getNextResizeGroupStateProvider = (measurementCache = getMeasuremen
   function getInitialResizeGroupState(data: any): IResizeGroupState {
     return {
       dataToMeasure: { ...data },
+      renderedDataScalingSteps: 0,
+      dataToMeasureScalingSteps: 0,
       resizeDirection: 'grow',
       measureContainer: true,
       measureDivKey: 'KeyOne'
@@ -319,26 +338,6 @@ export const MeasuredContext = React.createContext({ isMeasured: false });
 // Styles for the hidden div used for measurement
 const hiddenDivStyles: React.CSSProperties = { position: 'fixed', visibility: 'hidden' };
 const hiddenParentStyles: React.CSSProperties = { position: 'relative' };
-
-export class Identity1 extends React.PureComponent<{ cref?: any; style?: any }> {
-  public render(): JSX.Element {
-    return (
-      <div ref={this.props.cref} {...this.props}>
-        {this.props.children}
-      </div>
-    );
-  }
-}
-
-export class Identity2 extends React.PureComponent<{ cref?: any; style?: any }> {
-  public render(): JSX.Element {
-    return (
-      <div ref={this.props.cref} {...this.props}>
-        {this.props.children}
-      </div>
-    );
-  }
-}
 
 export class ResizeGroupBase extends BaseComponent<IResizeGroupProps, IResizeGroupState> {
   private _nextResizeGroupStateProvider = getNextResizeGroupStateProvider();

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.base.tsx
@@ -329,8 +329,8 @@ export class ResizeGroupBase extends BaseComponent<IResizeGroupProps, IResizeGro
       // If cache key is defined and equal to cache key of previous props' data we can do an optimization
       if (prevData.cacheKey && data.cacheKey === prevData.cacheKey) {
         // If they have batch scaling ability, and data has scaling steps count.
-        if (onBatchScaleData && data.__ScalingStepsCount && renderedData && renderedData.__ScalingStepsCount) {
-          const newData = onBatchScaleData({ ...data }, renderedData.__ScalingStepsCount);
+        if (onBatchScaleData && data.__scalingStepsCount !== undefined && renderedData && renderedData.__scalingStepsCount !== undefined) {
+          const newData = onBatchScaleData({ ...data }, renderedData.__scalingStepsCount);
           // If new scaled data has same cacheKey as previously rendered data, it can safely be re-rendered
           if (newData.cacheKey === renderedData.cacheKey) {
             return {

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.test.tsx
@@ -562,7 +562,7 @@ describe('ResizeGroup', () => {
 
     const stateProvider = getNextResizeGroupStateProvider();
 
-    const initialState = stateProvider.getInitialResizeGroupState(props.data);
+    const initialState = stateProvider.getInitialResizeGroupState(props);
 
     const getElementToMeasureWidth = () => 100;
     const containerWidth = 75;

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.types.ts
@@ -87,7 +87,7 @@ export interface IResizeGroupProps extends React.HTMLAttributes<ResizeGroupBase 
    * and want to batch all of them together instead of making multiple calls to onGrowData/onReduceData.
    *
    * To use this,
-   * 1. Your data must always contain a property called `zz__ScalingStepsCount` which we will
+   * 1. Your data must always contain a property called `__ScalingStepsCount` which we will
    *    use to determine how many scalingSteps to apply when we next batch scale data.
    * 2. Your data must also contain `cacheKey` for this prop to be used.
    *

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.types.ts
@@ -86,8 +86,15 @@ export interface IResizeGroupProps extends React.HTMLAttributes<ResizeGroupBase 
    * Function to be performed on the data when we know how many scalingSteps to apply in total
    * and want to batch all of them together instead of making multiple calls to onGrowData/onReduceData.
    *
-   * Note that, to use this your data must always contain a property called `zzScalingStepsCount` which we will
-   * use to determine how many scalingSteps to apply when we next batch scale data.
+   * To use this,
+   * 1. Your data must always contain a property called `zz__ScalingStepsCount` which we will
+   *    use to determine how many scalingSteps to apply when we next batch scale data.
+   * 2. The data you provide in props should always be in the most "grown" state. Otherwise, there will be bugs
+   *    with scaling.
+   * 3. Your data must also contain `cacheKey` for this prop to be used.
+   *
+   * Correct usage of this prop will allow us to have optimized rendering. Because this will eliminate multiple calls
+   * to onGrowData and onReduceData you can better memoize your data and also avoid redundant computations.
    */
   onBatchScaleData?: (prevData: any, scalingStepsCount: number) => any;
 

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.types.ts
@@ -91,8 +91,8 @@ export interface IResizeGroupProps extends React.HTMLAttributes<ResizeGroupBase 
    *    use to determine how many scalingSteps to apply when we next batch scale data.
    * 2. Your data must also contain `cacheKey` for this prop to be used.
    *
-   * Correct usage of this prop will allow us to have optimized rendering. Because this will eliminate multiple calls
-   * to onGrowData and onReduceData you can better memoize your data and also avoid redundant computations.
+   * Correct usage of this prop will allow us to have optimized rendering. Because this will reduce multiple calls
+   * to onGrowData and onReduceData in some cases you can better memoize your data and also avoid redundant computations.
    */
   onBatchScaleData?: (prevData: any, scalingStepsCount: number) => any;
 

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.types.ts
@@ -78,9 +78,18 @@ export interface IResizeGroupProps extends React.HTMLAttributes<ResizeGroupBase 
   /**
    * Function to be performed on the data in order to increase its width. It is called in scenarios where the
    * container has more room than the previous render and we may be able to fit more content. If there are no more
-   * scaling operations to perform on teh data, it should return undefined to prevent an infinite render loop.
+   * scaling operations to perform on the data, it should return undefined to prevent an infinite render loop.
    */
   onGrowData?: (prevData: any) => any;
+
+  /**
+   * Function to be performed on the data when we know how many scalingSteps to apply in total
+   * and want to batch all of them together instead of making multiple calls to onGrowData/onReduceData.
+   *
+   * Note that, to use this your data must always contain a property called `zzScalingStepsCount` which we will
+   * use to determine how many scalingSteps to apply when we next batch scale data.
+   */
+  onBatchScaleData?: (prevData: any, scalingStepsCount: number) => any;
 
   /**
    * Function to be called every time data is rendered. It provides the data that was actually rendered.

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.types.ts
@@ -87,7 +87,7 @@ export interface IResizeGroupProps extends React.HTMLAttributes<ResizeGroupBase 
    * and want to batch all of them together instead of making multiple calls to onGrowData/onReduceData.
    *
    * To use this,
-   * 1. Your data must always contain a property called `__ScalingStepsCount` which we will
+   * 1. Your data must always contain a property called `__scalingStepsCount` which we will
    *    use to determine how many scalingSteps to apply when we next batch scale data.
    * 2. Your data must also contain `cacheKey` for this prop to be used.
    *

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/ResizeGroup.types.ts
@@ -89,9 +89,7 @@ export interface IResizeGroupProps extends React.HTMLAttributes<ResizeGroupBase 
    * To use this,
    * 1. Your data must always contain a property called `zz__ScalingStepsCount` which we will
    *    use to determine how many scalingSteps to apply when we next batch scale data.
-   * 2. The data you provide in props should always be in the most "grown" state. Otherwise, there will be bugs
-   *    with scaling.
-   * 3. Your data must also contain `cacheKey` for this prop to be used.
+   * 2. Your data must also contain `cacheKey` for this prop to be used.
    *
    * Correct usage of this prop will allow us to have optimized rendering. Because this will eliminate multiple calls
    * to onGrowData and onReduceData you can better memoize your data and also avoid redundant computations.

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/examples/ResizeGroup.OverflowSet.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/examples/ResizeGroup.OverflowSet.Example.tsx
@@ -7,6 +7,7 @@ import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
 import { IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import { mergeStyleSets } from 'office-ui-fabric-react';
+import { IOverflowSetItemProps } from '../../OverflowSet';
 
 const styles = mergeStyleSets({
   root: {
@@ -93,23 +94,7 @@ export class ResizeGroupOverflowSetExample extends BaseComponent<{}, IResizeGrou
           onReduceData={this._onReduceData}
           onGrowData={onGrowDataEnabled ? this._onGrowData : undefined}
           // tslint:disable-next-line:jsx-no-lambda
-          onRenderData={data => {
-            return (
-              <OverflowSet
-                items={data.primary}
-                overflowItems={data.overflow.length ? data.overflow : null}
-                onRenderItem={item => {
-                  return (
-                    <CommandBarButton text={item.name} iconProps={{ iconName: item.icon }} onClick={item.onClick} checked={item.checked} />
-                  );
-                }}
-                onRenderOverflowButton={overflowItems => {
-                  return <CommandBarButton menuProps={{ items: overflowItems! }} />;
-                }}
-                styles={{ root: { height: 40 } }}
-              />
-            );
-          }}
+          onRenderData={this.onRenderData}
         />
         <div className={styles.settingsGroup}>
           <Checkbox label="Enable caching" onChange={this._onCachingEnabledChanged} checked={cachingEnabled} />
@@ -180,5 +165,25 @@ export class ResizeGroupOverflowSetExample extends BaseComponent<{}, IResizeGrou
 
   private _onNumberOfItemsChanged = (event: React.FormEvent<HTMLDivElement>, option: IDropdownOption): void => {
     this.setState({ numberOfItems: parseInt(option.text, 10) });
+  };
+
+  private onRenderData = (data: any) => {
+    return (
+      <OverflowSet
+        items={data.primary}
+        overflowItems={data.overflow.length ? data.overflow : null}
+        onRenderItem={this.onRenderItem}
+        onRenderOverflowButton={this.onRenderOverflowButton}
+        styles={{ root: { height: 40 } }}
+      />
+    );
+  };
+
+  private onRenderItem = (item: IOverflowSetItemProps) => {
+    return <CommandBarButton text={item.name} iconProps={{ iconName: item.icon }} onClick={item.onClick} checked={item.checked} />;
+  };
+
+  private onRenderOverflowButton = (overflowItems: any[]) => {
+    return <CommandBarButton menuProps={{ items: overflowItems! }} />;
   };
 }

--- a/packages/office-ui-fabric-react/src/components/ResizeGroup/examples/ResizeGroup.OverflowSet.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ResizeGroup/examples/ResizeGroup.OverflowSet.Example.tsx
@@ -2,12 +2,11 @@ import * as React from 'react';
 import { BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
 import { CommandBarButton } from 'office-ui-fabric-react/lib/Button';
 import { ResizeGroup } from 'office-ui-fabric-react/lib/ResizeGroup';
-import { OverflowSet } from 'office-ui-fabric-react/lib/OverflowSet';
+import { OverflowSet, IOverflowSetItemProps } from 'office-ui-fabric-react/lib/OverflowSet';
 import { Checkbox } from 'office-ui-fabric-react/lib/Checkbox';
 import { IContextualMenuItem } from 'office-ui-fabric-react/lib/ContextualMenu';
 import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import { mergeStyleSets } from 'office-ui-fabric-react';
-import { IOverflowSetItemProps } from '../../OverflowSet';
 
 const styles = mergeStyleSets({
   root: {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
I have made previous changes that target ResizeGroup unsuccessfully :). This is another try.
This PR tries to solve the following problems - 
1. `ResizeGroup` still uses `UNSAFE_componentWillReceiveProps`. Changed that to be `getDerivedStateFromProps`.

2. `ResizeGroup` puts a lot of strain of memoization of data provided to the `ResizeGroup`. Suppose we have to apply a lot of scaling steps before our data fits. Now, if that data changes slightly (without affecting layout), `ResizeGroup` will start from original unscaled data and ask us to recompute new data after every scaling step. A lot times, this exceeds our cache limit for memoized data generation and leads to unnecessary re-rendering in downstream components. 

I thought it would nice to implement and use batch scaling of data for `ResizeGroup`. In this PR, I use to scale down new props with the same cache key as the previous props. If the cache key matches even after scaling down, we can directly render this data. This saves us a render also !

Note that for batch scaling of data, `ResizeGroup` needs to communicate how many total scaling steps to apply. This information will be read from the data's `__scalingStepsCount` property. The weird name is for avoiding collisions.

PS: With batchScaling, we can potentially in future make improvements to how many measurements we make by binary searching the scalingStepCount space instead of doing a linear search. 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11178)