### PR TITLE
Coachmark: focus indicator a11y fix

### DIFF
--- a/change/office-ui-fabric-react-2019-11-14-10-47-37-coachmark-focus-a11y.json
+++ b/change/office-ui-fabric-react-2019-11-14-10-47-37-coachmark-focus-a11y.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Coachmark: A11y fixes - Added focus indicator to coachmark when activated",
+  "packageName": "office-ui-fabric-react",
+  "email": "marygans@microsoft.com",
+  "commit": "43f7f133a268b9f361532518692dd463b2b0fa58",
+  "date": "2019-11-14T18:47:37.892Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.styles.ts
@@ -1,6 +1,6 @@
 import { keyframes, PulsingBeaconAnimationStyles, HighContrastSelector } from '../../Styling';
 import { ICoachmarkStyleProps, ICoachmarkStyles } from './Coachmark.types';
-import { getRTL } from '../../Utilities';
+import { getRTL, IsFocusVisibleClassName } from '../../Utilities';
 
 export const COACHMARK_WIDTH = 32;
 export const COACHMARK_HEIGHT = 32;
@@ -245,6 +245,9 @@ export function getStyles(props: ICoachmarkStyleProps): ICoachmarkStyles {
           [HighContrastSelector]: {
             backgroundColor: 'Window',
             border: '2px solid WindowText'
+          },
+          [`.${IsFocusVisibleClassName} &:focus`]: {
+            outline: `1px solid ${theme.palette.themeTertiary}`
           }
         }
       },

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
@@ -781,6 +781,9 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                                     background-color: Window;
                                     border: 2px solid WindowText;
                                   }
+                                  .ms-Fabric--isFocusVisible &:focus {
+                                    outline: 1px solid #71afe5;
+                                  }
                               data-is-focusable={true}
                               role="dialog"
                               tabIndex={-1}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #11183
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

 Added a focus indicator to coachmark when activated so users can see (without screen reader) that that the focus has moved to the coachmark and can be activated

**Before:** 
![Screen Shot 2019-11-14 at 10 35 53 AM](https://user-images.githubusercontent.com/38991459/68886824-be0f7300-06cc-11ea-96d0-922afa33cf25.png)

**After:** 
![Screen Shot 2019-11-14 at 10 35 18 AM](https://user-images.githubusercontent.com/38991459/68886852-ca93cb80-06cc-11ea-9231-95b59586254d.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11191)