### PR TITLE
Calendar: onDayKeyDown fix

### DIFF
--- a/change/office-ui-fabric-react-2019-11-14-11-35-12-v-mare-Calendar-onDayKeyDown-fix.json
+++ b/change/office-ui-fabric-react-2019-11-14-11-35-12-v-mare-Calendar-onDayKeyDown-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "CalendarDay: Fixed issue with onDayKeyDown re-opening callout",
+  "packageName": "office-ui-fabric-react",
+  "email": "v-mare@microsoft.com",
+  "commit": "7097d866fab772602a6d5b8e09c8da9a2df6ae21",
+  "date": "2019-11-14T19:35:12.129Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -499,6 +499,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
     return (ev: React.KeyboardEvent<HTMLElement>): void => {
       if (ev.which === KeyCodes.enter) {
         this._onSelectDate(originalDate, ev);
+        ev.preventDefault();
       } else {
         this._navigateMonthEdge(ev, originalDate, weekIndex, dayIndex);
       }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #10864
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Since the onClick event listens to both left mouse click AND the enter key, when selecting a calendar day _onSelectDate() would fire, hiding the callout, followed by _onClick, which would reopen the Callout. I simply added ev.preventDefault() to the _onDayKeyDown() method in CalendarDay.tsx to prevent this behavior.

NOTE: I see that this isn't an issue in packages/date-time

### ~~~~~~~~~~~ Before
![Calendar_onDayKeyDown_broken](https://user-images.githubusercontent.com/13246181/68890437-b901f200-06d3-11ea-8038-bda745a217fd.gif)

### ~~~~~~~~~~~ After
![Calendar_onDayKeyDown_fix](https://user-images.githubusercontent.com/13246181/68890446-bef7d300-06d3-11ea-964a-dfc05cd14fd5.gif)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11212)