### PR TITLE
DropdownOption title consistency for multiSelect case

### DIFF
--- a/change/office-ui-fabric-react-2019-11-14-12-40-37-dropdown-title.json
+++ b/change/office-ui-fabric-react-2019-11-14-12-40-37-dropdown-title.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "DropDown: make dropdown option title prop to be assigned consistently for the multiselect case",
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com",
+  "commit": "745782f7e6e0238a70a63feff60658dd62da79c5",
+  "date": "2019-11-14T20:40:37.817Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -626,7 +626,7 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
           onMouseMove: this._onItemMouseMove.bind(this, item)
         }}
         label={item.text}
-        title={item.title ? item.title : item.text}
+        title={title}
         onRenderLabel={this._onRenderItemLabel.bind(this, item)}
         className={itemClassName}
         role="option"


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11187
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Probably for historical reasons, the DropdownOption render hands down title prop differently between multiselect and non-multiselect cases. These behavior almost the same - the difference is in how the code treats null / undefined.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11213)