### PR TITLE
Dropdown: fix item hover/keyboard nav state in high contrast mode

### DIFF
--- a/change/office-ui-fabric-react-2019-11-14-18-17-58-xgao-a11y-bug-fix.json
+++ b/change/office-ui-fabric-react-2019-11-14-18-17-58-xgao-a11y-bug-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix dropdown option style on keyboard navigation in high contrast mode",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "d19c19147da4b53c39dee655273bfdf7978e53d0",
+  "date": "2019-11-15T02:17:58.926Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -45,12 +45,7 @@ const highContrastItemAndTitleStateMixin: IRawStyle = {
     [HighContrastSelector]: {
       backgroundColor: 'Highlight',
       borderColor: 'Highlight',
-      color: 'HighlightText',
-      selectors: {
-        ':hover': {
-          color: 'HighlightText' // overrides the hover styling for buttons that are also selected
-        }
-      }
+      color: 'HighlightText'
     },
     ...highContrastAdjustMixin
   }
@@ -125,17 +120,26 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
   const itemSelectors = (isSelected: boolean = false) => {
     return {
       selectors: {
-        '&:hover:focus': {
-          color: palette.neutralDark,
-          backgroundColor: !isSelected ? palette.neutralLighter : palette.neutralLight
-        },
-        '&:focus': {
-          backgroundColor: !isSelected ? 'transparent' : palette.neutralLight
-        },
-        '&:active': {
-          color: palette.neutralDark,
-          backgroundColor: !isSelected ? palette.neutralLighter : palette.neutralLight
-        },
+        '&:hover:focus': [
+          {
+            color: palette.neutralDark,
+            backgroundColor: !isSelected ? palette.neutralLighter : palette.neutralLight
+          },
+          highContrastItemAndTitleStateMixin
+        ],
+        '&:focus': [
+          {
+            backgroundColor: !isSelected ? 'transparent' : palette.neutralLight
+          },
+          highContrastItemAndTitleStateMixin
+        ],
+        '&:active': [
+          {
+            color: palette.neutralDark,
+            backgroundColor: !isSelected ? palette.neutralLighter : palette.neutralLight
+          },
+          highContrastItemAndTitleStateMixin
+        ],
         [HighContrastSelector]: {
           borderColor: 'Window'
         },

--- a/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -52,9 +52,6 @@ exports[`Dropdown multi-select Renders multiselect Dropdown correctly 1`] = `
           border-color: Highlight;
           color: HighlightText;
         }
-        @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-          color: HighlightText;
-        }
         @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
           -ms-high-contrast-adjust: none;
         }
@@ -227,9 +224,6 @@ exports[`Dropdown single-select Renders single-select Dropdown correctly 1`] = `
         @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title {
           background-color: Highlight;
           border-color: Highlight;
-          color: HighlightText;
-        }
-        @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
           color: HighlightText;
         }
         @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
@@ -91,9 +91,6 @@ Array [
               border-color: Highlight;
               color: HighlightText;
             }
-            @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-              color: HighlightText;
-            }
             @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
               -ms-high-contrast-adjust: none;
             }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
@@ -776,9 +776,6 @@ Array [
               border-color: Highlight;
               color: HighlightText;
             }
-            @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-              color: HighlightText;
-            }
             @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
               -ms-high-contrast-adjust: none;
             }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -251,9 +251,6 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                       border-color: Highlight;
                       color: HighlightText;
                     }
-                    @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-                      color: HighlightText;
-                    }
                     @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
                       -ms-high-contrast-adjust: none;
                     }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
@@ -90,9 +90,6 @@ exports[`Component Examples renders Coachmark.Basic.Example.tsx correctly 1`] = 
               border-color: Highlight;
               color: HighlightText;
             }
-            @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-              color: HighlightText;
-            }
             @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
               -ms-high-contrast-adjust: none;
             }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
@@ -234,9 +234,6 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
               border-color: Highlight;
               color: HighlightText;
             }
-            @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-              color: HighlightText;
-            }
             @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
               -ms-high-contrast-adjust: none;
             }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
@@ -300,9 +300,6 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
             border-color: Highlight;
             color: HighlightText;
           }
-          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-            color: HighlightText;
-          }
           @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
             -ms-high-contrast-adjust: none;
           }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
@@ -300,9 +300,6 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
             border-color: Highlight;
             color: HighlightText;
           }
-          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-            color: HighlightText;
-          }
           @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
             -ms-high-contrast-adjust: none;
           }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
@@ -104,9 +104,6 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             border-color: Highlight;
             color: HighlightText;
           }
-          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-            color: HighlightText;
-          }
           @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
             -ms-high-contrast-adjust: none;
           }
@@ -317,9 +314,6 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             border-color: Highlight;
             color: HighlightText;
           }
-          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-            color: HighlightText;
-          }
           @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
             -ms-high-contrast-adjust: none;
           }
@@ -509,9 +503,6 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title {
             background-color: Highlight;
             border-color: Highlight;
-            color: HighlightText;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
             color: HighlightText;
           }
           @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Controlled.Example.tsx.shot
@@ -83,9 +83,6 @@ exports[`Component Examples renders Dropdown.Controlled.Example.tsx correctly 1`
           border-color: Highlight;
           color: HighlightText;
         }
-        @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-          color: HighlightText;
-        }
         @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
           -ms-high-contrast-adjust: none;
         }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.ControlledMulti.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.ControlledMulti.Example.tsx.shot
@@ -83,9 +83,6 @@ exports[`Component Examples renders Dropdown.ControlledMulti.Example.tsx correct
           border-color: Highlight;
           color: HighlightText;
         }
-        @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-          color: HighlightText;
-        }
         @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
           -ms-high-contrast-adjust: none;
         }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
@@ -104,9 +104,6 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
             border-color: Highlight;
             color: HighlightText;
           }
-          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-            color: HighlightText;
-          }
           @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
             -ms-high-contrast-adjust: none;
           }
@@ -468,9 +465,6 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
           @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title {
             background-color: Highlight;
             border-color: Highlight;
-            color: HighlightText;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
             color: HighlightText;
           }
           @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
@@ -276,9 +276,6 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
             border-color: Highlight;
             color: HighlightText;
           }
-          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-            color: HighlightText;
-          }
           @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
             -ms-high-contrast-adjust: none;
           }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
@@ -134,9 +134,6 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
               border-color: Highlight;
               color: HighlightText;
             }
-            @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-              color: HighlightText;
-            }
             @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
               -ms-high-contrast-adjust: none;
             }
@@ -443,9 +440,6 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
           @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title {
             background-color: Highlight;
             border-color: Highlight;
-            color: HighlightText;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
             color: HighlightText;
           }
           @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -917,9 +917,6 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
               border-color: Highlight;
               color: HighlightText;
             }
-            @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-              color: HighlightText;
-            }
             @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
               -ms-high-contrast-adjust: none;
             }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
@@ -1028,9 +1028,6 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
               border-color: Highlight;
               color: HighlightText;
             }
-            @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-              color: HighlightText;
-            }
             @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
               -ms-high-contrast-adjust: none;
             }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
@@ -188,9 +188,6 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
               border-color: Highlight;
               color: HighlightText;
             }
-            @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-              color: HighlightText;
-            }
             @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
               -ms-high-contrast-adjust: none;
             }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -4029,9 +4029,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                 border-color: Highlight;
                 color: HighlightText;
               }
-              @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-                color: HighlightText;
-              }
               @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
                 -ms-high-contrast-adjust: none;
               }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
@@ -3077,9 +3077,6 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 border-color: Highlight;
                 color: HighlightText;
               }
-              @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-                color: HighlightText;
-              }
               @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
                 -ms-high-contrast-adjust: none;
               }
@@ -3300,9 +3297,6 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
               @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title {
                 background-color: Highlight;
                 border-color: Highlight;
-                color: HighlightText;
-              }
-              @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
                 color: HighlightText;
               }
               @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapAdvanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapAdvanced.Example.tsx.shot
@@ -713,9 +713,6 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
                 border-color: Highlight;
                 color: HighlightText;
               }
-              @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-                color: HighlightText;
-              }
               @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
                 -ms-high-contrast-adjust: none;
               }
@@ -939,9 +936,6 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
                 border-color: Highlight;
                 color: HighlightText;
               }
-              @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-                color: HighlightText;
-              }
               @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
                 -ms-high-contrast-adjust: none;
               }
@@ -1163,9 +1157,6 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
               @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title {
                 background-color: Highlight;
                 border-color: Highlight;
-                color: HighlightText;
-              }
-              @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
                 color: HighlightText;
               }
               @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
@@ -1788,9 +1788,6 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       border-color: Highlight;
                       color: HighlightText;
                     }
-                    @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-                      color: HighlightText;
-                    }
                     @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
                       -ms-high-contrast-adjust: none;
                     }
@@ -2012,9 +2009,6 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title {
                       background-color: Highlight;
                       border-color: Highlight;
-                      color: HighlightText;
-                    }
-                    @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
                       color: HighlightText;
                     }
                     @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapAdvanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapAdvanced.Example.tsx.shot
@@ -713,9 +713,6 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
                 border-color: Highlight;
                 color: HighlightText;
               }
-              @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-                color: HighlightText;
-              }
               @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
                 -ms-high-contrast-adjust: none;
               }
@@ -939,9 +936,6 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
                 border-color: Highlight;
                 color: HighlightText;
               }
-              @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
-                color: HighlightText;
-              }
               @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {
                 -ms-high-contrast-adjust: none;
               }
@@ -1163,9 +1157,6 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
               @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title {
                 background-color: Highlight;
                 border-color: Highlight;
-                color: HighlightText;
-              }
-              @media screen and (-ms-high-contrast: active){&:focus .ms-Dropdown-title:hover {
                 color: HighlightText;
               }
               @media screen and (-ms-high-contrast: active), screen and (-ms-high-contrast: black-on-white){&:focus .ms-Dropdown-title {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10953
- [x] Include a change request file using `$ yarn change`

#### Description of changes
This change only affect single-select dropdown (multi-select dropdown remains same).

![image](https://user-images.githubusercontent.com/1207059/68912581-66ddc280-070d-11ea-81f1-6c2d2860a0da.png)

On keyboard nav/hover with one item selected:
![image](https://user-images.githubusercontent.com/1207059/68911986-a2778d00-070b-11ea-8d06-ebfc679f36c3.png)

Also reverted fix from https://github.com/OfficeDev/office-ui-fabric-react/issues/5238 as it's no longer reproing without it.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11218)