### PR TITLE
PickerSuggestions: Styles were missing from interface even though they were being passed through

### DIFF
--- a/change/office-ui-fabric-react-2019-11-15-09-46-34-picker-suggestion-typings.json
+++ b/change/office-ui-fabric-react-2019-11-15-09-46-34-picker-suggestion-typings.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "PickerSuggestions: Fixed typings to include typed styles function",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "a6e2ea7d73d0e9af2021bb90f983180c55495096",
+  "date": "2019-11-15T17:46:34.883Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -686,7 +686,7 @@ export const CompactPeoplePicker: React.FunctionComponent<IPeoplePickerProps>;
 export class CompactPeoplePickerBase extends BasePeoplePicker {
     static defaultProps: {
         onRenderItem: (props: IPeoplePickerItemSelectedProps) => JSX.Element;
-        onRenderSuggestionsItem: (personaProps: IPersonaProps, suggestionsProps?: IBasePickerSuggestionsProps<any> | undefined) => JSX.Element;
+        onRenderSuggestionsItem: (personaProps: IPersonaProps, suggestionsProps?: ISuggestionItemProps<IPersonaProps> | undefined) => JSX.Element;
         createGenericItem: typeof createGenericItem;
     };
 }
@@ -1745,7 +1745,7 @@ export interface IBasePickerStyles {
 }
 
 // @public
-export interface IBasePickerSuggestionsProps<T = any> extends Pick<ISuggestionsProps<T>, 'onRenderNoResultFound' | 'suggestionsHeaderText' | 'mostRecentlyUsedHeaderText' | 'noResultsFoundText' | 'className' | 'suggestionsClassName' | 'suggestionsItemClassName' | 'searchForMoreText' | 'forceResolveText' | 'loadingText' | 'searchingText' | 'resultsFooterFull' | 'resultsFooter' | 'resultsMaximumNumber' | 'showRemoveButtons' | 'suggestionsAvailableAlertText' | 'suggestionsContainerAriaLabel'> {
+export interface IBasePickerSuggestionsProps<T = any> extends Pick<ISuggestionsProps<T>, 'onRenderNoResultFound' | 'suggestionsHeaderText' | 'mostRecentlyUsedHeaderText' | 'noResultsFoundText' | 'className' | 'suggestionsClassName' | 'suggestionsItemClassName' | 'searchForMoreText' | 'forceResolveText' | 'loadingText' | 'searchingText' | 'resultsFooterFull' | 'resultsFooter' | 'resultsMaximumNumber' | 'showRemoveButtons' | 'suggestionsAvailableAlertText' | 'suggestionsContainerAriaLabel' | 'styles'> {
 }
 
 // @public (undocumented)
@@ -5932,7 +5932,7 @@ export interface IPeoplePickerItemSuggestionProps extends IPeoplePickerItemShare
     compact?: boolean;
     personaProps?: IPersonaProps;
     styles?: IStyleFunctionOrObject<IPeoplePickerItemSuggestionStyleProps, IPeoplePickerItemSuggestionStyles>;
-    suggestionsProps?: IBasePickerSuggestionsProps;
+    suggestionsProps?: ISuggestionItemProps<IPersonaProps>;
 }
 
 // @public
@@ -7311,7 +7311,7 @@ export interface ISuggestionsProps<T> extends React.Props<any> {
     searchingText?: string;
     showForceResolve?: () => boolean;
     showRemoveButtons?: boolean;
-    styles?: IStyleFunctionOrObject<any, any>;
+    styles?: IStyleFunctionOrObject<ISuggestionsStyleProps, ISuggestionsStyles>;
     suggestions: ISuggestionModel<T>[];
     suggestionsAvailableAlertText?: string;
     suggestionsClassName?: string;
@@ -7996,7 +7996,7 @@ export const ListPeoplePicker: React.FunctionComponent<IPeoplePickerProps>;
 export class ListPeoplePickerBase extends MemberListPeoplePicker {
     static defaultProps: {
         onRenderItem: (props: IPeoplePickerItemSelectedProps) => JSX.Element;
-        onRenderSuggestionsItem: (personaProps: IPersonaProps, suggestionsProps?: IBasePickerSuggestionsProps<any> | undefined) => JSX.Element;
+        onRenderSuggestionsItem: (personaProps: IPersonaProps, suggestionsProps?: ISuggestionItemProps<IPersonaProps> | undefined) => JSX.Element;
         createGenericItem: typeof createGenericItem;
     };
 }
@@ -8147,7 +8147,7 @@ export const NormalPeoplePicker: React.FunctionComponent<IPeoplePickerProps>;
 export class NormalPeoplePickerBase extends BasePeoplePicker {
     static defaultProps: {
         onRenderItem: (props: IPeoplePickerItemSelectedProps) => JSX.Element;
-        onRenderSuggestionsItem: (personaProps: IPersonaProps, suggestionsProps?: IBasePickerSuggestionsProps<any> | undefined) => JSX.Element;
+        onRenderSuggestionsItem: (personaProps: IPersonaProps, suggestionsProps?: ISuggestionItemProps<IPersonaProps> | undefined) => JSX.Element;
         createGenericItem: typeof createGenericItem;
     };
 }

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/PeoplePicker/FloatingPeoplePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/PeoplePicker/FloatingPeoplePicker.tsx
@@ -4,7 +4,7 @@ import { IBaseFloatingPickerProps } from '../BaseFloatingPicker.types';
 import { SuggestionItemNormal } from './PeoplePickerItems/SuggestionItemDefault';
 import { IPersonaProps } from '../../../Persona';
 import './PeoplePicker.scss';
-import { IBasePickerSuggestionsProps, ISuggestionModel } from '../../../Pickers';
+import { ISuggestionModel, ISuggestionItemProps } from '../../../Pickers';
 
 /**
  * {@docCategory FloatingPeoplePicker}
@@ -19,8 +19,8 @@ export class BaseFloatingPeoplePicker extends BaseFloatingPicker<IPersonaProps, 
 export class FloatingPeoplePicker extends BaseFloatingPeoplePicker {
   // tslint:disable-next-line:no-any
   public static defaultProps: any = {
-    onRenderSuggestionsItem: (props: IPersonaProps, itemProps?: IBasePickerSuggestionsProps) =>
-      SuggestionItemNormal({ ...props }, { ...itemProps }),
+    onRenderSuggestionsItem: (props: IPersonaProps, itemProps?: ISuggestionItemProps<IPersonaProps>) =>
+      SuggestionItemNormal({ ...props }, itemProps),
     createGenericItem: createItem
   };
 }

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/PeoplePicker/PeoplePickerItems/SuggestionItemDefault.tsx
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/PeoplePicker/PeoplePickerItems/SuggestionItemDefault.tsx
@@ -3,13 +3,10 @@ import * as React from 'react';
 /* tslint:enable */
 import { css } from '../../../../Utilities';
 import { Persona, PersonaSize, IPersonaProps, PersonaPresence } from '../../../../Persona';
-import { IBasePickerSuggestionsProps, ISuggestionItemProps } from '../../../../Pickers';
+import { ISuggestionItemProps } from '../../../../Pickers';
 import * as stylesImport from '../PeoplePicker.scss';
 
-export const SuggestionItemNormal: (persona: IPersonaProps, suggestionProps?: IBasePickerSuggestionsProps) => JSX.Element = (
-  personaProps: IPersonaProps,
-  suggestionItemProps?: ISuggestionItemProps<IPersonaProps>
-) => {
+export const SuggestionItemNormal = (personaProps: IPersonaProps, suggestionItemProps?: ISuggestionItemProps<IPersonaProps>) => {
   return (
     <div className={css('ms-PeoplePicker-personaContent', stylesImport.peoplePickerPersonaContent)}>
       <Persona

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
@@ -230,6 +230,7 @@ export interface IBasePickerSuggestionsProps<T = any>
     | 'showRemoveButtons'
     | 'suggestionsAvailableAlertText'
     | 'suggestionsContainerAriaLabel'
+    | 'styles'
   > {}
 
 /**

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePicker.tsx
@@ -2,13 +2,8 @@ import * as React from 'react';
 
 import { getRTL, getInitials, styled } from '../../../Utilities';
 import { BasePicker, BasePickerListBelow } from '../BasePicker';
-import {
-  IBasePickerProps,
-  IBasePickerSuggestionsProps,
-  ValidationState,
-  IBasePickerStyleProps,
-  IBasePickerStyles
-} from '../BasePicker.types';
+import { IBasePickerProps, ValidationState, IBasePickerStyleProps, IBasePickerStyles } from '../BasePicker.types';
+import { ISuggestionItemProps } from '../Suggestions/SuggestionsItem.types';
 import { PeoplePickerItem } from './PeoplePickerItems/PeoplePickerItem';
 import { IPersonaProps } from '../../../Persona';
 import { PeoplePickerItemSuggestion } from './PeoplePickerItems/PeoplePickerItemSuggestion';
@@ -39,7 +34,7 @@ export class NormalPeoplePickerBase extends BasePeoplePicker {
   /** Default props for NormalPeoplePicker. */
   public static defaultProps = {
     onRenderItem: (props: IPeoplePickerItemSelectedProps) => <PeoplePickerItem {...props} />,
-    onRenderSuggestionsItem: (personaProps: IPersonaProps, suggestionsProps?: IBasePickerSuggestionsProps) => (
+    onRenderSuggestionsItem: (personaProps: IPersonaProps, suggestionsProps?: ISuggestionItemProps<IPersonaProps>) => (
       <PeoplePickerItemSuggestion personaProps={personaProps} suggestionsProps={suggestionsProps} />
     ),
     createGenericItem: createGenericItem
@@ -54,7 +49,7 @@ export class CompactPeoplePickerBase extends BasePeoplePicker {
   /** Default props for CompactPeoplePicker. */
   public static defaultProps = {
     onRenderItem: (props: IPeoplePickerItemSelectedProps) => <PeoplePickerItem {...props} />,
-    onRenderSuggestionsItem: (personaProps: IPersonaProps, suggestionsProps?: IBasePickerSuggestionsProps) => (
+    onRenderSuggestionsItem: (personaProps: IPersonaProps, suggestionsProps?: ISuggestionItemProps<IPersonaProps>) => (
       <PeoplePickerItemSuggestion personaProps={personaProps} suggestionsProps={suggestionsProps} compact={true} />
     ),
     createGenericItem: createGenericItem
@@ -69,7 +64,7 @@ export class ListPeoplePickerBase extends MemberListPeoplePicker {
   /** Default props for ListPeoplePicker. */
   public static defaultProps = {
     onRenderItem: (props: IPeoplePickerItemSelectedProps) => <PeoplePickerItem {...props} />,
-    onRenderSuggestionsItem: (personaProps: IPersonaProps, suggestionsProps?: IBasePickerSuggestionsProps) => (
+    onRenderSuggestionsItem: (personaProps: IPersonaProps, suggestionsProps?: ISuggestionItemProps<IPersonaProps>) => (
       <PeoplePickerItemSuggestion personaProps={personaProps} suggestionsProps={suggestionsProps} />
     ),
     createGenericItem: createGenericItem

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.types.ts
@@ -3,7 +3,8 @@ import { IStyleFunctionOrObject } from '../../../../Utilities';
 import { IPersonaProps, IPersonaStyleProps, IPersonaCoinStyleProps } from '../../../../Persona';
 import { IPickerItemProps } from '../../PickerItem.types';
 import { IContextualMenuItem } from '../../../../ContextualMenu';
-import { ValidationState, IBasePickerSuggestionsProps } from '../../BasePicker.types';
+import { ValidationState } from '../../BasePicker.types';
+import { ISuggestionItemProps } from '../../Suggestions/SuggestionsItem.types';
 
 /**
  * Common props in between IPeoplePickerItemSelectedProps, IPeoplePickerItemWithMenuProps and IPeoplePickerItemSuggestionProps.
@@ -80,7 +81,7 @@ export interface IPeoplePickerItemSuggestionProps extends IPeoplePickerItemShare
   styles?: IStyleFunctionOrObject<IPeoplePickerItemSuggestionStyleProps, IPeoplePickerItemSuggestionStyles>;
 
   /** General common props for all PeoplePicker items suggestions. */
-  suggestionsProps?: IBasePickerSuggestionsProps;
+  suggestionsProps?: ISuggestionItemProps<IPersonaProps>;
 
   /**
    * Flag that controls whether each suggested PeoplePicker item (Persona) is rendered with or without secondary text for compact look.

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItemSuggestion.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItemSuggestion.tsx
@@ -16,7 +16,7 @@ export const PeoplePickerItemSuggestionBase = (props: IPeoplePickerItemSuggestio
 
   const classNames = getClassNames(styles, {
     theme: theme!,
-    className: (suggestionsProps && suggestionsProps.suggestionsItemClassName) || className
+    className: (suggestionsProps && suggestionsProps.className) || className
   });
 
   const personaStyles =

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SuggestionItemDefault.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SuggestionItemDefault.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import { css } from '../../../../Utilities';
 import { Persona, PersonaSize, IPersonaProps, PersonaPresence } from '../../../../Persona';
-import { IBasePickerSuggestionsProps, ISuggestionItemProps } from '../../../../Pickers';
+import { ISuggestionItemProps } from '../../../../Pickers';
 
 import * as stylesImport from './SuggestionItemDefault.scss';
 const styles: any = stylesImport;
@@ -10,10 +10,7 @@ const styles: any = stylesImport;
 /**
  * @deprecated Use the exported from the package level 'PeoplePickerItemSuggestion'. Will be removed in Fabric 7.0
  */
-export const SuggestionItemNormal: (persona: IPersonaProps, suggestionProps?: IBasePickerSuggestionsProps) => JSX.Element = (
-  personaProps: IPersonaProps,
-  suggestionItemProps?: ISuggestionItemProps<any>
-) => {
+export const SuggestionItemNormal = (personaProps: IPersonaProps, suggestionItemProps?: ISuggestionItemProps<any>) => {
   return (
     <div className={css('ms-PeoplePicker-personaContent', styles.peoplePickerPersonaContent)}>
       <Persona
@@ -31,10 +28,7 @@ export const SuggestionItemNormal: (persona: IPersonaProps, suggestionProps?: IB
  *  Will be removed in Fabric 7.0
  * @deprecated Use the exported from the package level 'PeoplePickerItemSuggestion' with compact prop set to true.
  */
-export const SuggestionItemSmall: (persona: IPersonaProps, suggestionProps?: IBasePickerSuggestionsProps) => JSX.Element = (
-  personaProps: IPersonaProps,
-  suggestionItemProps?: ISuggestionItemProps<any>
-) => {
+export const SuggestionItemSmall = (personaProps: IPersonaProps, suggestionItemProps?: ISuggestionItemProps<any>) => {
   return (
     <div className={css('ms-PeoplePicker-personaContent', styles.peoplePickerPersonaContent)}>
       <Persona

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.types.ts
@@ -216,7 +216,7 @@ export interface ISuggestionsProps<T> extends React.Props<any> {
   suggestionsListId?: string;
 
   /** Call to provide customized styling that will layer on top of the variant rules. */
-  styles?: IStyleFunctionOrObject<any, any>;
+  styles?: IStyleFunctionOrObject<ISuggestionsStyleProps, ISuggestionsStyles>;
 
   /** Theme provided by High-Order Component. */
   theme?: ITheme;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #11222
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Styles were being passed through to picker suggestions via `pickerSuggestionsProps` but the interface didn't include them. The styles prop was also missing typings making it difficult to know what the styles props and targets are of the control. 

#### Focus areas to test

@joschect do you have any issues with tightening of the styles interface? This will certainly throw errors for anyone passing in invalid style targets. 


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11226)