### PR TITLE
Combobox and Dropdown: Fixed high contrast hover styles

### DIFF
--- a/change/office-ui-fabric-react-2019-11-15-11-07-45-dropdown-comobobox-highcontrast-hover.json
+++ b/change/office-ui-fabric-react-2019-11-15-11-07-45-dropdown-comobobox-highcontrast-hover.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Combobox and Dropdown: Fixed high contrast hover styles",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "9e548a6a90a33da5c1260124b2f06d8a7aa5539c",
+  "date": "2019-11-15T19:07:45.322Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -110,7 +110,13 @@ export const getOptionStyles = memoizeFunction(
       ],
       rootHovered: {
         backgroundColor: option.backgroundHoveredColor,
-        color: option.textHoveredColor
+        color: option.textHoveredColor,
+        selectors: {
+          [HighContrastSelector]: {
+            backgroundColor: 'Highlight',
+            color: 'HighlightText'
+          }
+        }
       },
       rootFocused: {
         backgroundColor: option.backgroundHoveredColor
@@ -122,6 +128,14 @@ export const getOptionStyles = memoizeFunction(
           selectors: {
             ':hover': {
               backgroundColor: option.backgroundHoveredColor
+            },
+            [HighContrastSelector]: {
+              selectors: {
+                ':hover': {
+                  backgroundColor: 'Highlight',
+                  color: 'HighlightText'
+                }
+              }
             }
           }
         },

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -127,10 +127,22 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
       selectors: {
         '&:hover:focus': {
           color: palette.neutralDark,
-          backgroundColor: !isSelected ? palette.neutralLighter : palette.neutralLight
+          backgroundColor: !isSelected ? palette.neutralLighter : palette.neutralLight,
+          selectors: {
+            [HighContrastSelector]: {
+              backgroundColor: 'Highlight',
+              color: 'HighlightText'
+            }
+          }
         },
         '&:focus': {
-          backgroundColor: !isSelected ? 'transparent' : palette.neutralLight
+          backgroundColor: !isSelected ? 'transparent' : palette.neutralLight,
+          selectors: {
+            [HighContrastSelector]: {
+              backgroundColor: 'Highlight',
+              color: 'HighlightText'
+            }
+          }
         },
         '&:active': {
           color: palette.neutralDark,

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -1862,8 +1862,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                           color: #201f1e;
                         }
                         @media screen and (-ms-high-contrast: active){&:hover {
+                          background-color: Highlight;
                           border-color: Highlight;
-                          color: Highlight;
+                          color: HighlightText;
                         }
                         &:hover .ms-Button-icon {
                           color: #0078d4;
@@ -2022,6 +2023,10 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                         &:hover {
                           background-color: #f3f2f1;
                         }
+                        @media screen and (-ms-high-contrast: active){&:hover {
+                          background-color: Highlight;
+                          color: HighlightText;
+                        }
                         .ms-Fabric--isFocusVisible &:after {
                           border: 1px solid #ffffff;
                           bottom: 0px;
@@ -2176,8 +2181,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                           color: #201f1e;
                         }
                         @media screen and (-ms-high-contrast: active){&:hover {
+                          background-color: Highlight;
                           border-color: Highlight;
-                          color: Highlight;
+                          color: HighlightText;
                         }
                         &:hover .ms-Button-icon {
                           color: #0078d4;
@@ -2334,8 +2340,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                           color: #201f1e;
                         }
                         @media screen and (-ms-high-contrast: active){&:hover {
+                          background-color: Highlight;
                           border-color: Highlight;
-                          color: Highlight;
+                          color: HighlightText;
                         }
                         &:hover .ms-Button-icon {
                           color: #0078d4;
@@ -2541,8 +2548,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                           color: #201f1e;
                         }
                         @media screen and (-ms-high-contrast: active){&:hover {
+                          background-color: Highlight;
                           border-color: Highlight;
-                          color: Highlight;
+                          color: HighlightText;
                         }
                         &:hover .ms-Button-icon {
                           color: #0078d4;
@@ -2848,8 +2856,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                           color: #201f1e;
                         }
                         @media screen and (-ms-high-contrast: active){&:hover {
+                          background-color: Highlight;
                           border-color: Highlight;
-                          color: Highlight;
+                          color: HighlightText;
                         }
                         &:hover .ms-Button-icon {
                           color: #0078d4;
@@ -3006,8 +3015,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                           color: #201f1e;
                         }
                         @media screen and (-ms-high-contrast: active){&:hover {
+                          background-color: Highlight;
                           border-color: Highlight;
-                          color: Highlight;
+                          color: HighlightText;
                         }
                         &:hover .ms-Button-icon {
                           color: #0078d4;
@@ -3164,8 +3174,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                           color: #201f1e;
                         }
                         @media screen and (-ms-high-contrast: active){&:hover {
+                          background-color: Highlight;
                           border-color: Highlight;
-                          color: Highlight;
+                          color: HighlightText;
                         }
                         &:hover .ms-Button-icon {
                           color: #0078d4;
@@ -3322,8 +3333,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                           color: #201f1e;
                         }
                         @media screen and (-ms-high-contrast: active){&:hover {
+                          background-color: Highlight;
                           border-color: Highlight;
-                          color: Highlight;
+                          color: HighlightText;
                         }
                         &:hover .ms-Button-icon {
                           color: #0078d4;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11185 
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Adding hover styles consistent with UI of other dropdowns

#### Focus areas to test

## Dropdown

Before:

![image](https://user-images.githubusercontent.com/1434956/68968992-bf0dd680-0798-11ea-9be1-691496324e3d.png)

![image](https://user-images.githubusercontent.com/1434956/68969004-c7661180-0798-11ea-91e0-e8b4c7bf66b1.png)

After: (yes the black box is odd, not sure how to get rid of it)

![image](https://user-images.githubusercontent.com/1434956/68969020-d351d380-0798-11ea-920f-0f3c2c777b32.png)

![image](https://user-images.githubusercontent.com/1434956/68969027-d9e04b00-0798-11ea-8d44-dd753b71fe59.png)

## Combobox
Before:

![image](https://user-images.githubusercontent.com/1434956/68969075-faa8a080-0798-11ea-8390-b822a4b2ad80.png)

After:

![image](https://user-images.githubusercontent.com/1434956/68969128-1b70f600-0799-11ea-8f5f-327ee6d5fe43.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11228)