### PR TITLE
Dropdown should not count the hidden items in the aria-setsize attrib

### DIFF
--- a/change/office-ui-fabric-react-2019-11-18-13-41-15-dropdown-count.json
+++ b/change/office-ui-fabric-react-2019-11-18-13-41-15-dropdown-count.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Dropdown: do not count hidden items",
+  "packageName": "office-ui-fabric-react",
+  "email": "kchau@microsoft.com",
+  "commit": "1da91c91746f450f876f7409bcb071d5a5dcdf43",
+  "date": "2019-11-18T21:41:15.381Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/utilities/DropdownSizePosCache.test.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/utilities/DropdownSizePosCache.test.ts
@@ -65,4 +65,12 @@ describe('DropdownSizePosCache', () => {
     expect(cache.optionSetSize).toBe(7);
     expect(cache.positionInSet(3)).toBe(4);
   });
+
+  it('will respect hidden flag', () => {
+    const optionsWithHidden: IDropdownOption[] = [...pureOptions, { key: 'K', text: 'Option k', hidden: true }];
+    const cache: DropdownSizePosCache = new DropdownSizePosCache();
+    cache.updateOptions(optionsWithHidden);
+
+    expect(cache.optionSetSize).toBe(optionsWithHidden.length - 1);
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/Dropdown/utilities/DropdownSizePosCache.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/utilities/DropdownSizePosCache.ts
@@ -21,7 +21,10 @@ export class DropdownSizePosCache {
     const displayOnlyOptionsCache = [];
     let size = 0;
     for (let i = 0; i < options.length; i++) {
-      if (options[i].itemType === DropdownMenuItemType.Divider || options[i].itemType === DropdownMenuItemType.Header) {
+      if (
+        (options[i].itemType === DropdownMenuItemType.Divider || options[i].itemType === DropdownMenuItemType.Header) &&
+        !options[i].hidden
+      ) {
         displayOnlyOptionsCache.push(i);
       } else {
         size++;

--- a/packages/office-ui-fabric-react/src/components/Dropdown/utilities/DropdownSizePosCache.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/utilities/DropdownSizePosCache.ts
@@ -21,12 +21,9 @@ export class DropdownSizePosCache {
     const displayOnlyOptionsCache = [];
     let size = 0;
     for (let i = 0; i < options.length; i++) {
-      if (
-        (options[i].itemType === DropdownMenuItemType.Divider || options[i].itemType === DropdownMenuItemType.Header) &&
-        !options[i].hidden
-      ) {
+      if (options[i].itemType === DropdownMenuItemType.Divider || options[i].itemType === DropdownMenuItemType.Header) {
         displayOnlyOptionsCache.push(i);
-      } else {
+      } else if (!options[i].hidden) {
         size++;
       }
     }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11179
- [x] Include a change request file using `$ yarn change`

#### Description of changes

So, we already do not count the hidden items in the list as we keyboard down (1 of 3). But the main dropdowns till counts the hidden items. This fixes that

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11238)