### PR TITLE
Pass link as a prop to linkAs in Nav component

### DIFF
--- a/change/office-ui-fabric-react-2019-11-18-15-46-58-srperias-linkAs.json
+++ b/change/office-ui-fabric-react-2019-11-18-15-46-58-srperias-linkAs.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add link to Nav props",
+  "packageName": "office-ui-fabric-react",
+  "email": "srperias@microsoft.com",
+  "commit": "0e9397251577c4a0faacafbd7b3b08fdfa13f407",
+  "date": "2019-11-18T23:46:58.033Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -5553,6 +5553,11 @@ export interface INav {
 }
 
 // @public (undocumented)
+export interface INavButtonProps extends IButtonProps {
+    link?: INavLink;
+}
+
+// @public (undocumented)
 export interface INavLink {
     [propertyName: string]: any;
     ariaLabel?: string;
@@ -5591,7 +5596,7 @@ export interface INavProps {
     groups: INavLinkGroup[] | null;
     initialSelectedKey?: string;
     isOnTop?: boolean;
-    linkAs?: IComponentAs<IButtonProps>;
+    linkAs?: IComponentAs<INavButtonProps>;
     onLinkClick?: (ev?: React.MouseEvent<HTMLElement>, item?: INavLink) => void;
     onLinkExpandClick?: (ev?: React.MouseEvent<HTMLElement>, item?: INavLink) => void;
     onRenderGroupHeader?: IRenderFunction<INavLinkGroup>;

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -124,6 +124,8 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
             ? link.ariaLabel
             : undefined
         }
+        link={link}
+        defaultRender={ActionButton}
       >
         {onRenderLink(link, this._onRenderLink)}
       </LinkAs>

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
@@ -65,7 +65,7 @@ export interface INavProps {
    * Render a custom link in place of the normal one.
    * This replaces the entire button rather than simply button content
    */
-  linkAs?: IComponentAs<IButtonProps>;
+  linkAs?: IComponentAs<INavButtonProps>;
 
   /**
    * Used to customize how content inside the link tag is rendered
@@ -371,4 +371,14 @@ export interface INavStyles {
    * Style set for the group content div inside group.
    */
   groupContent: IStyle;
+}
+
+/**
+ * {@docCategory Nav}
+ */
+export interface INavButtonProps extends IButtonProps {
+  /**
+   * (Optional) Link to be rendered.
+   */
+  link?: INavLink;
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
This change passes the link as a prop to linkAs which will allow users to customize linkAs component.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11239)