### PR TITLE
[Date-time] fix work week calendar hover

### DIFF
--- a/change/@uifabric-date-time-2019-10-23-14-57-44-lorejoh12-fixWorkWeekCalendarHover.json
+++ b/change/@uifabric-date-time-2019-10-23-14-57-44-lorejoh12-fixWorkWeekCalendarHover.json
@@ -4,6 +4,5 @@
   "packageName": "@uifabric/date-time",
   "email": "jolore@microsoft.com",
   "commit": "81548bf2b1f2092d423578a5a7a8261317a46059",
-  "date": "2019-10-23T21:57:44.281Z",
-  "file": "C:\\Users\\jolore\\git\\office-ui-fabric-react\\change\\@uifabric-date-time-2019-10-23-14-57-44-lorejoh12-fixWorkWeekCalendarHover.json"
+  "date": "2019-10-23T21:57:44.281Z"
 }

--- a/change/@uifabric-date-time-2019-10-23-14-57-44-lorejoh12-fixWorkWeekCalendarHover.json
+++ b/change/@uifabric-date-time-2019-10-23-14-57-44-lorejoh12-fixWorkWeekCalendarHover.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "updating work week hover state to match the actual days that are going to be selected. The mouse over state still takes the whole week into account",
+  "packageName": "@uifabric/date-time",
+  "email": "jolore@microsoft.com",
+  "commit": "81548bf2b1f2092d423578a5a7a8261317a46059",
+  "date": "2019-10-23T21:57:44.281Z",
+  "file": "C:\\Users\\jolore\\git\\office-ui-fabric-react\\change\\@uifabric-date-time-2019-10-23-14-57-44-lorejoh12-fixWorkWeekCalendarHover.json"
+}

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -23,7 +23,7 @@ import {
 } from 'office-ui-fabric-react/lib/utilities/dateMath/DateMath';
 import { ICalendarDayGridProps, ICalendarDayGridStyleProps, ICalendarDayGridStyles } from './CalendarDayGrid.types';
 import { IProcessedStyleSet } from '@uifabric/styling';
-import { DateRangeType } from '../Calendar/Calendar.types';
+import { DateRangeType, DayOfWeek } from '../Calendar/Calendar.types';
 
 const DAYS_IN_WEEK = 7;
 
@@ -437,21 +437,7 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
     let isAllDaysOfWeekOutOfMonth = false;
 
     // in work week view if the days aren't contiguous we use week view instead
-    let selectedDateRangeType = dateRangeType;
-    if (workWeekDays && dateRangeType === DateRangeType.WorkWeek) {
-      const sortedWWDays = workWeekDays.sort();
-      let isContiguous = true;
-      for (let i = 1; i < sortedWWDays.length; i++) {
-        if (sortedWWDays[i] !== sortedWWDays[i - 1] + 1) {
-          isContiguous = false;
-          break;
-        }
-      }
-
-      if (!isContiguous) {
-        selectedDateRangeType = DateRangeType.Week;
-      }
-    }
+    const selectedDateRangeType = this.getDateRangeTypeToUse(dateRangeType, workWeekDays);
 
     let selectedDates = getDateRangeArray(selectedDate, selectedDateRangeType, firstDayOfWeek, workWeekDays, daysToSelectInDayView);
     selectedDates = this._getBoundedDateRange(selectedDates, minDate, maxDate);
@@ -672,7 +658,7 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
     const { dateRangeType, firstDayOfWeek, workWeekDays, daysToSelectInDayView } = this.props;
 
     // The hover state looks weird with non-contiguous days in work week view. In work week, show week hover state
-    const dateRangeHoverType = dateRangeType === DateRangeType.WorkWeek ? DateRangeType.Week : dateRangeType;
+    const dateRangeHoverType = this.getDateRangeTypeToUse(dateRangeType, workWeekDays);
 
     // gets all the dates for the given date range type that are in the same date range as the given day
     const dateRange = getDateRangeArray(day.originalDate, dateRangeHoverType, firstDayOfWeek, workWeekDays, daysToSelectInDayView).map(
@@ -777,5 +763,28 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
         }
       });
     };
+  };
+
+  /**
+   * When given work week, if the days are non-contiguous, the hover states look really weird. So for non-contiguous work weeks,
+   * we'll just show week view instead
+   */
+  private getDateRangeTypeToUse = (dateRangeType: DateRangeType, workWeekDays: DayOfWeek[] | undefined): DateRangeType => {
+    if (workWeekDays && dateRangeType === DateRangeType.WorkWeek) {
+      const sortedWWDays = workWeekDays.sort();
+      let isContiguous = true;
+      for (let i = 1; i < sortedWWDays.length; i++) {
+        if (sortedWWDays[i] !== sortedWWDays[i - 1] + 1) {
+          isContiguous = false;
+          break;
+        }
+      }
+
+      if (!isContiguous) {
+        return DateRangeType.Week;
+      }
+    }
+
+    return dateRangeType;
   };
 }

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -771,7 +771,7 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
    */
   private getDateRangeTypeToUse = (dateRangeType: DateRangeType, workWeekDays: DayOfWeek[] | undefined): DateRangeType => {
     if (workWeekDays && dateRangeType === DateRangeType.WorkWeek) {
-      const sortedWWDays = workWeekDays.sort();
+      const sortedWWDays = workWeekDays.slice().sort();
       let isContiguous = true;
       for (let i = 1; i < sortedWWDays.length; i++) {
         if (sortedWWDays[i] !== sortedWWDays[i - 1] + 1) {
@@ -780,7 +780,7 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
         }
       }
 
-      if (!isContiguous) {
+      if (!isContiguous || workWeekDays.length === 0) {
         return DateRangeType.Week;
       }
     }

--- a/packages/date-time/src/components/pages/CalendarPage.tsx
+++ b/packages/date-time/src/components/pages/CalendarPage.tsx
@@ -96,6 +96,19 @@ export class CalendarPage extends React.Component<{}, {}> {
               />
             </ExampleCard>
             <ExampleCard
+              title="Calendar with selectableDays = [Monday, Tuesday, Wednesday, Thursday, Friday] provided, first day of week = Sunday"
+              code={CalendarInlineExampleCode}
+            >
+              <CalendarInlineExample
+                dateRangeType={DateRangeType.WorkWeek}
+                firstDayOfWeek={DayOfWeek.Sunday}
+                highlightCurrentMonth={false}
+                highlightSelectedMonth={true}
+                showGoToToday={true}
+                workWeekDays={[DayOfWeek.Monday, DayOfWeek.Tuesday, DayOfWeek.Wednesday, DayOfWeek.Thursday, DayOfWeek.Friday]}
+              />
+            </ExampleCard>
+            <ExampleCard
               title="Calendar with selectableDays = [Tuesday, Wednesday, Friday, Saturday] provided, first day of week = Monday"
               code={CalendarInlineExampleCode}
             >


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Updating the work week view of the Calendar component to match the actual days that are going to be selected. The mouseOver still takes the whole week into account, which can look a little odd (if work week is mon-fri, hovering over sunday will highlight that mon-fri still).

This fixes the issue where work week was always using week days during the hover.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11250)