### PR TITLE
[Date-time] date time accessibility pass

### DIFF
--- a/change/@uifabric-date-time-2019-11-19-16-58-04-lorejoh12-dateTimeAccessibility.json
+++ b/change/@uifabric-date-time-2019-11-19-16-58-04-lorejoh12-dateTimeAccessibility.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Accessibility fixes for date-time Calendar, adding new strings for new aria labels and fixing aria-live regions",
+  "packageName": "@uifabric/date-time",
+  "email": "jolore@microsoft.com",
+  "commit": "2e06318622eba26ed36ded82a07969a71e966e6e",
+  "date": "2019-11-20T00:57:34.064Z"
+}

--- a/change/office-ui-fabric-react-2019-11-19-16-58-04-lorejoh12-dateTimeAccessibility.json
+++ b/change/office-ui-fabric-react-2019-11-19-16-58-04-lorejoh12-dateTimeAccessibility.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fixing double selection in Calendar month picker",
+  "packageName": "office-ui-fabric-react",
+  "email": "jolore@microsoft.com",
+  "commit": "2e06318622eba26ed36ded82a07969a71e966e6e",
+  "date": "2019-11-20T00:58:04.101Z"
+}

--- a/packages/date-time/etc/date-time.api.md
+++ b/packages/date-time/etc/date-time.api.md
@@ -10,6 +10,7 @@ import { DayOfWeek } from 'office-ui-fabric-react/lib/utilities/dateValues/DateV
 import { FirstWeekOfYear } from 'office-ui-fabric-react/lib/utilities/dateValues/DateValues';
 import { IBaseProps } from '@uifabric/utilities';
 import { IBaseProps as IBaseProps_2 } from 'office-ui-fabric-react/lib/Utilities';
+import { ICalendarStrings as ICalendarStrings_2 } from '@uifabric/date-time';
 import { ICalloutProps } from 'office-ui-fabric-react/lib/Callout';
 import { IComponentAs } from '@uifabric/utilities';
 import { IRefObject } from '@uifabric/utilities';
@@ -54,6 +55,9 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
 export { DateRangeType }
 
 export { DayOfWeek }
+
+// @public (undocumented)
+export const defaultDayPickerStrings: ICalendarStrings_2;
 
 export { FirstWeekOfYear }
 
@@ -171,6 +175,7 @@ export interface ICalendarStrings {
     closeButtonAriaLabel?: string;
     days: string[];
     goToToday: string;
+    monthPickerHeaderAriaLabel?: string;
     months: string[];
     nextMonthAriaLabel?: string;
     nextYearAriaLabel?: string;
@@ -178,9 +183,12 @@ export interface ICalendarStrings {
     prevMonthAriaLabel?: string;
     prevYearAriaLabel?: string;
     prevYearRangeAriaLabel?: string;
+    selectedDateFormatString?: string;
     shortDays: string[];
     shortMonths: string[];
+    todayDateFormatString?: string;
     weekNumberFormatString?: string;
+    yearPickerHeaderAriaLabel?: string;
 }
 
 // @public (undocumented)
@@ -202,6 +210,8 @@ export interface ICalendarStyles {
     divider: IStyle;
     // (undocumented)
     goTodayButton: IStyle;
+    // (undocumented)
+    liveRegion: IStyle;
     // (undocumented)
     monthPickerWrapper: IStyle;
     root: IStyle;

--- a/packages/date-time/src/components/Calendar/Calendar.base.tsx
+++ b/packages/date-time/src/components/Calendar/Calendar.base.tsx
@@ -16,7 +16,7 @@ import { ICalendarMonth } from './CalendarMonth/CalendarMonth.types';
 import { css, BaseComponent, KeyCodes, classNamesFunction, focusAsync, format } from '@uifabric/utilities';
 import { IProcessedStyleSet } from '@uifabric/styling';
 import { DayPickerStrings } from './defaults';
-import { addDays, addMonths, addYears } from 'office-ui-fabric-react/lib/utilities/dateMath/DateMath';
+import { addMonths, addYears } from 'office-ui-fabric-react/lib/utilities/dateMath/DateMath';
 
 const getClassNames = classNamesFunction<ICalendarStyleProps, ICalendarStyles>();
 

--- a/packages/date-time/src/components/Calendar/Calendar.base.tsx
+++ b/packages/date-time/src/components/Calendar/Calendar.base.tsx
@@ -178,14 +178,17 @@ export class CalendarBase extends BaseComponent<ICalendarProps, ICalendarState> 
     if (dateTimeFormatter && strings!.selectedDateFormatString) {
       selectedDateString = format(strings!.selectedDateFormatString, dateTimeFormatter.formatMonthDayYear(selectedDate!, strings!));
     }
-    const rootAriaLabel = selectedDateString + ', ' + todayDateString;
+    const selectionAndTodayString = selectedDateString + ', ' + todayDateString;
 
     return (
       <div
-        aria-label={rootAriaLabel}
+        aria-label={selectionAndTodayString}
         className={css(rootClass, classes.root, className, 'ms-slideDownIn10')}
         onKeyDown={this._onDatePickerPopupKeyDown}
       >
+        <div className={classes.liveRegion} aria-live="polite" aria-atomic="true">
+          <span>{selectedDateString}</span>
+        </div>
         {isDayPickerVisible && (
           <CalendarDay
             selectedDate={selectedDate!}

--- a/packages/date-time/src/components/Calendar/Calendar.base.tsx
+++ b/packages/date-time/src/components/Calendar/Calendar.base.tsx
@@ -13,26 +13,11 @@ import { CalendarDay } from './CalendarDay/CalendarDay';
 import { CalendarMonth } from './CalendarMonth/CalendarMonth';
 import { ICalendarDay } from './CalendarDay/CalendarDay.types';
 import { ICalendarMonth } from './CalendarMonth/CalendarMonth.types';
-import { css, BaseComponent, KeyCodes, classNamesFunction, focusAsync } from '@uifabric/utilities';
+import { css, BaseComponent, KeyCodes, classNamesFunction, focusAsync, format } from '@uifabric/utilities';
 import { IProcessedStyleSet } from '@uifabric/styling';
+import { DayPickerStrings } from './defaults';
 
 const getClassNames = classNamesFunction<ICalendarStyleProps, ICalendarStyles>();
-
-const DEFAULT_STRINGS = {
-  months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
-  shortMonths: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-  days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-  shortDays: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
-  goToToday: 'Go to today',
-  prevMonthAriaLabel: 'Go to previous month',
-  nextMonthAriaLabel: 'Go to next month',
-  prevYearAriaLabel: 'Go to previous year',
-  nextYearAriaLabel: 'Go to next year',
-  prevYearRangeAriaLabel: 'Previous year range',
-  nextYearRangeAriaLabel: 'Next year range',
-  closeButtonAriaLabel: 'Close date picker',
-  weekNumberFormatString: 'Week number {0}'
-};
 
 const leftArrow = 'Up';
 const rightArrow = 'Down';
@@ -88,7 +73,7 @@ export class CalendarBase extends BaseComponent<ICalendarProps, ICalendarState> 
     firstDayOfWeek: DayOfWeek.Sunday,
     dateRangeType: DateRangeType.Day,
     showGoToToday: true,
-    strings: DEFAULT_STRINGS,
+    strings: DayPickerStrings,
     highlightCurrentMonth: false,
     highlightSelectedMonth: false,
     navigationIcons: defaultIconStrings,
@@ -163,7 +148,9 @@ export class CalendarBase extends BaseComponent<ICalendarProps, ICalendarState> 
       showWeekNumbers,
       theme,
       calendarDayProps,
-      calendarMonthProps
+      calendarMonthProps,
+      dateTimeFormatter,
+      today
     } = this.props;
     const { selectedDate, navigatedDayDate, navigatedMonthDate, isMonthPickerVisible, isDayPickerVisible } = this.state;
     const onHeaderSelect = showMonthPickerAsOverlay ? this._onHeaderSelect : undefined;
@@ -182,8 +169,22 @@ export class CalendarBase extends BaseComponent<ICalendarProps, ICalendarState> 
       showWeekNumbers: showWeekNumbers
     });
 
+    let todayDateString: string = '';
+    let selectedDateString: string = '';
+    if (dateTimeFormatter && strings!.todayDateFormatString) {
+      todayDateString = format(strings!.todayDateFormatString, dateTimeFormatter.formatMonthDayYear(today!, strings!));
+    }
+    if (dateTimeFormatter && strings!.selectedDateFormatString) {
+      selectedDateString = format(strings!.selectedDateFormatString, dateTimeFormatter.formatMonthDayYear(selectedDate!, strings!));
+    }
+    const rootAriaLabel = selectedDateString + ', ' + todayDateString;
+
     return (
-      <div className={css(rootClass, classes.root, className, 'ms-slideDownIn10')} onKeyDown={this._onDatePickerPopupKeyDown}>
+      <div
+        aria-label={rootAriaLabel}
+        className={css(rootClass, classes.root, className, 'ms-slideDownIn10')}
+        onKeyDown={this._onDatePickerPopupKeyDown}
+      >
         {isDayPickerVisible && (
           <CalendarDay
             selectedDate={selectedDate!}

--- a/packages/date-time/src/components/Calendar/Calendar.base.tsx
+++ b/packages/date-time/src/components/Calendar/Calendar.base.tsx
@@ -16,6 +16,7 @@ import { ICalendarMonth } from './CalendarMonth/CalendarMonth.types';
 import { css, BaseComponent, KeyCodes, classNamesFunction, focusAsync, format } from '@uifabric/utilities';
 import { IProcessedStyleSet } from '@uifabric/styling';
 import { DayPickerStrings } from './defaults';
+import { addDays, addMonths, addYears } from 'office-ui-fabric-react/lib/utilities/dateMath/DateMath';
 
 const getClassNames = classNamesFunction<ICalendarStyleProps, ICalendarStyles>();
 
@@ -365,6 +366,26 @@ export class CalendarBase extends BaseComponent<ICalendarProps, ICalendarState> 
         this._handleEscKey(ev);
         break;
 
+      case KeyCodes.pageUp:
+        if (ev.ctrlKey) {
+          // go to next year
+          this._navigateDayPickerDay(addYears(this.state.navigatedDayDate!, 1));
+        } else {
+          // go to next month
+          this._navigateDayPickerDay(addMonths(this.state.navigatedDayDate!, 1));
+        }
+        ev.preventDefault();
+        break;
+      case KeyCodes.pageDown:
+        if (ev.ctrlKey) {
+          // go to previous year
+          this._navigateDayPickerDay(addYears(this.state.navigatedDayDate!, -1));
+        } else {
+          // go to previous month
+          this._navigateDayPickerDay(addMonths(this.state.navigatedDayDate!, -1));
+        }
+        ev.preventDefault();
+        break;
       default:
         break;
     }

--- a/packages/date-time/src/components/Calendar/Calendar.base.tsx
+++ b/packages/date-time/src/components/Calendar/Calendar.base.tsx
@@ -299,9 +299,10 @@ export class CalendarBase extends BaseComponent<ICalendarProps, ICalendarState> 
   };
 
   private _onNavigateMonthDate = (date: Date, focusOnNavigatedDay: boolean): void => {
+    this._focusOnUpdate = focusOnNavigatedDay;
+
     if (!focusOnNavigatedDay) {
       this._navigateMonthPickerDay(date);
-      this._focusOnUpdate = focusOnNavigatedDay;
       return;
     }
 

--- a/packages/date-time/src/components/Calendar/Calendar.styles.ts
+++ b/packages/date-time/src/components/Calendar/Calendar.styles.ts
@@ -67,6 +67,15 @@ export const styles = (props: ICalendarStyleProps): ICalendarStyles => {
           }
         }
       }
-    ]
+    ],
+    liveRegion: {
+      border: 0,
+      height: '1px',
+      margin: '-1px',
+      overflow: 'hidden',
+      padding: 0,
+      width: '1px',
+      position: 'absolute'
+    }
   };
 };

--- a/packages/date-time/src/components/Calendar/Calendar.types.ts
+++ b/packages/date-time/src/components/Calendar/Calendar.types.ts
@@ -242,6 +242,17 @@ export interface ICalendarStrings {
   nextYearRangeAriaLabel?: string;
 
   /**
+   * Aria-label format string for the header button in the month picker. Should have 1 string param e.g. "`{0}`, select to change the year".
+   * This aria-label will only be applied if the year picker is enabled, otherwise the label will default to the header string e.g. "2019"
+   */
+  monthPickerHeaderAriaLabel?: string;
+
+  /**
+   * Aria-label format string for the header button in the year picker. Should have 1 string param e.g. "`{0}`, select to change the month"
+   */
+  yearPickerHeaderAriaLabel?: string;
+
+  /**
    * Aria-label for the "close" button.
    */
   closeButtonAriaLabel?: string;
@@ -250,6 +261,16 @@ export interface ICalendarStrings {
    * Aria-label format string for the week number header. Should have 1 string param e.g. "week number `{0}`"
    */
   weekNumberFormatString?: string;
+
+  /**
+   * Aria-label format string for the currently selected date. Should have 1 string param e.g. "Selected date `{0}`"
+   */
+  selectedDateFormatString?: string;
+
+  /**
+   * Aria-label format string for today's date. Should have 1 string param e.g. "Today's date `{0}`"
+   */
+  todayDateFormatString?: string;
 }
 
 export interface ICalendarIconStrings {

--- a/packages/date-time/src/components/Calendar/Calendar.types.ts
+++ b/packages/date-time/src/components/Calendar/Calendar.types.ts
@@ -374,6 +374,8 @@ export interface ICalendarStyles {
   goTodayButton: IStyle;
 
   monthPickerWrapper: IStyle;
+
+  liveRegion: IStyle;
 }
 
 export enum AnimationDirection {

--- a/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
@@ -93,9 +93,7 @@ export class CalendarDayBase extends BaseComponent<ICalendarDayProps, ICalendarD
       <div className={classNames.root} id={dayPickerId}>
         <div className={classNames.header}>
           <button
-            key={dateTimeFormatter.formatMonthYear(navigatedDate, strings)}
-            aria-live="polite"
-            aria-relevant="text"
+            aria-live="polite" // if this component rerenders when text changes, aria-live will not be announced, so make key consistent
             aria-atomic="true"
             id={monthAndYearId}
             className={classNames.monthAndYear}

--- a/packages/date-time/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
@@ -160,7 +160,6 @@ export class CalendarMonthBase extends BaseComponent<ICalendarMonthProps, ICalen
       <div className={classNames.root}>
         <div className={classNames.headerContainer}>
           <button
-            key={yearString}
             className={classNames.currentItemButton}
             onClick={this._onHeaderSelect}
             onKeyDown={this._onButtonKeyDown(this._onHeaderSelect)}
@@ -169,7 +168,7 @@ export class CalendarMonthBase extends BaseComponent<ICalendarMonthProps, ICalen
             tabIndex={!!onHeaderSelect ? 0 : -1} // prevent focus if there's no action for the button
             type="button"
             aria-atomic={true}
-            aria-live="polite"
+            aria-live="polite" // if this component rerenders when text changes, aria-live will not be announced, so make key consistent
           >
             {yearString}
           </button>

--- a/packages/date-time/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
@@ -1,5 +1,4 @@
 import * as React from 'react';
-import { BaseComponent, css, getRTL, classNamesFunction } from 'office-ui-fabric-react/lib/Utilities';
 import { FocusZone } from 'office-ui-fabric-react/lib/FocusZone';
 import {
   addYears,
@@ -14,7 +13,7 @@ import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { ICalendarMonthProps, ICalendarMonthStyles, ICalendarMonthStyleProps } from './CalendarMonth.types';
 import { getStyles } from './CalendarMonth.styles';
 import { defaultIconStrings, defaultDateTimeFormatterCallbacks } from '../Calendar.base';
-import { KeyCodes } from '@uifabric/utilities';
+import { BaseComponent, css, getRTL, classNamesFunction, KeyCodes, format } from '@uifabric/utilities';
 import { ICalendarYear, ICalendarYearRange } from '../CalendarYear/CalendarYear.types';
 import { CalendarYear } from '../CalendarYear/CalendarYear';
 
@@ -137,7 +136,8 @@ export class CalendarMonthBase extends BaseComponent<ICalendarMonthProps, ICalen
           strings={{
             rangeAriaLabel: this._yearRangeToString,
             prevRangeAriaLabel: this._yearRangeToPrevDecadeLabel,
-            nextRangeAriaLabel: this._yearRangeToNextDecadeLabel
+            nextRangeAriaLabel: this._yearRangeToNextDecadeLabel,
+            headerAriaLabelFormatString: this.props.strings.yearPickerHeaderAriaLabel
           }}
           componentRef={this._calendarYearRef}
           styles={styles}
@@ -153,22 +153,25 @@ export class CalendarMonthBase extends BaseComponent<ICalendarMonthProps, ICalen
       rowIndexes.push(i);
     }
 
+    const yearString = dateFormatter.formatYear(navigatedDate);
+    const headerAriaLabel = strings.monthPickerHeaderAriaLabel ? format(strings.monthPickerHeaderAriaLabel, yearString) : yearString;
+
     return (
       <div className={classNames.root}>
         <div className={classNames.headerContainer}>
           <button
-            key={dateFormatter.formatYear(navigatedDate)}
+            key={yearString}
             className={classNames.currentItemButton}
             onClick={this._onHeaderSelect}
             onKeyDown={this._onButtonKeyDown(this._onHeaderSelect)}
-            aria-label={dateFormatter.formatYear(navigatedDate)}
+            aria-label={headerAriaLabel}
             data-is-focusable={!!onHeaderSelect}
             tabIndex={!!onHeaderSelect ? 0 : -1} // prevent focus if there's no action for the button
             type="button"
             aria-atomic={true}
             aria-live="polite"
           >
-            {dateFormatter.formatYear(navigatedDate)}
+            {yearString}
           </button>
           <div className={classNames.navigationButtonsContainer}>
             <button

--- a/packages/date-time/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
@@ -355,7 +355,6 @@ class CalendarYearTitle extends React.Component<ICalendarYearHeaderProps, {}> {
 
       return (
         <button
-          key={fromYear}
           className={classNames.currentItemButton}
           onClick={this._onHeaderSelect}
           onKeyDown={this._onHeaderKeyDown}
@@ -363,7 +362,7 @@ class CalendarYearTitle extends React.Component<ICalendarYearHeaderProps, {}> {
           role="button"
           type="button"
           aria-atomic={true}
-          aria-live="polite"
+          aria-live="polite" // if this component rerenders when text changes, aria-live will not be announced, so make key consistent
         >
           {this._onRenderYear(fromYear)} - {this._onRenderYear(toYear)}
         </button>

--- a/packages/date-time/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
@@ -9,7 +9,7 @@ import {
   ICalendarYearStyleProps,
   ICalendarYearStyles
 } from './CalendarYear.types';
-import { BaseComponent, KeyCodes, getRTL, classNamesFunction, css } from 'office-ui-fabric-react/lib/Utilities';
+import { BaseComponent, KeyCodes, getRTL, classNamesFunction, css, format } from 'office-ui-fabric-react/lib/Utilities';
 import { FocusZone } from 'office-ui-fabric-react/lib/FocusZone';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { ICalendarIconStrings } from '../Calendar.types';
@@ -344,11 +344,14 @@ class CalendarYearTitle extends React.Component<ICalendarYearHeaderProps, {}> {
 
     if (onHeaderSelect) {
       const rangeAriaLabel = (strings || DefaultCalendarYearStrings).rangeAriaLabel;
-      const ariaLabel = rangeAriaLabel
+      const headerAriaLabelFormatString = strings!.headerAriaLabelFormatString;
+      const currentDateRange = rangeAriaLabel
         ? typeof rangeAriaLabel === 'string'
           ? (rangeAriaLabel as string)
           : (rangeAriaLabel as ICalendarYearRangeToString)(this.props)
         : undefined;
+
+      const ariaLabel = headerAriaLabelFormatString ? format(headerAriaLabelFormatString, currentDateRange) : currentDateRange;
 
       return (
         <button

--- a/packages/date-time/src/components/Calendar/CalendarYear/CalendarYear.types.ts
+++ b/packages/date-time/src/components/Calendar/CalendarYear/CalendarYear.types.ts
@@ -21,6 +21,7 @@ export interface ICalendarYearStrings {
   rangeAriaLabel?: string | ICalendarYearRangeToString;
   prevRangeAriaLabel?: string | ICalendarYearRangeToString;
   nextRangeAriaLabel?: string | ICalendarYearRangeToString;
+  headerAriaLabelFormatString?: string;
 }
 
 export interface ICalendarYearProps extends IBaseProps<ICalendarYear> {

--- a/packages/date-time/src/components/Calendar/defaults.ts
+++ b/packages/date-time/src/components/Calendar/defaults.ts
@@ -1,0 +1,21 @@
+import { ICalendarStrings } from '@uifabric/date-time';
+
+export const DayPickerStrings: ICalendarStrings = {
+  months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
+  shortMonths: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+  days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+  shortDays: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
+  goToToday: 'Go to today',
+  weekNumberFormatString: 'Week number {0}',
+  prevMonthAriaLabel: 'Previous month',
+  nextMonthAriaLabel: 'Next month',
+  prevYearAriaLabel: 'Previous year',
+  nextYearAriaLabel: 'Next year',
+  prevYearRangeAriaLabel: 'Previous year range',
+  nextYearRangeAriaLabel: 'Next year range',
+  closeButtonAriaLabel: 'Close',
+  selectedDateFormatString: 'Selected date {0}',
+  todayDateFormatString: "Today's date {0}",
+  monthPickerHeaderAriaLabel: '{0}, select to change the year',
+  yearPickerHeaderAriaLabel: '{0}, select to change the month'
+};

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Button.Example.tsx
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Button.Example.tsx
@@ -1,22 +1,7 @@
 import * as React from 'react';
 import { DefaultButton, FocusTrapZone, Callout, DirectionalHint } from 'office-ui-fabric-react';
 import { Calendar, DayOfWeek } from '@uifabric/date-time';
-
-const DayPickerStrings = {
-  months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
-  shortMonths: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-  days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-  shortDays: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
-  goToToday: 'Go to today',
-  weekNumberFormatString: 'Week number {0}',
-  prevMonthAriaLabel: 'Previous month',
-  nextMonthAriaLabel: 'Next month',
-  prevYearAriaLabel: 'Previous year',
-  nextYearAriaLabel: 'Next year',
-  prevYearRangeAriaLabel: 'Previous year range',
-  nextYearRangeAriaLabel: 'Next year range',
-  closeButtonAriaLabel: 'Close'
-};
+import { DayPickerStrings } from '../defaults';
 
 export interface ICalendarButtonExampleState {
   showCalendar: boolean;

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Button.Example.tsx
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Button.Example.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { DefaultButton, FocusTrapZone, Callout, DirectionalHint } from 'office-ui-fabric-react';
-import { Calendar, DayOfWeek } from '@uifabric/date-time';
-import { DayPickerStrings } from '../defaults';
+import { Calendar, DayOfWeek, defaultDayPickerStrings } from '@uifabric/date-time';
 
 export interface ICalendarButtonExampleState {
   showCalendar: boolean;
@@ -69,7 +68,7 @@ export class CalendarButtonExample extends React.Component<ICalendarButtonExampl
                 isMonthPickerVisible={this.props.isMonthPickerVisible}
                 value={this.state.selectedDate!}
                 firstDayOfWeek={DayOfWeek.Sunday}
-                strings={DayPickerStrings}
+                strings={defaultDayPickerStrings}
                 isDayPickerVisible={this.props.isDayPickerVisible}
                 highlightCurrentMonth={this.props.highlightCurrentMonth}
                 highlightSelectedMonth={this.props.highlightSelectedMonth}

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Inline.Example.tsx
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Inline.Example.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { DefaultButton, Dropdown, IDropdownOption } from 'office-ui-fabric-react';
 import { addDays, getDateRangeArray } from 'office-ui-fabric-react/lib/utilities/dateMath/DateMath';
-import { Calendar, ICalendarProps, DateRangeType, DayOfWeek } from '@uifabric/date-time';
-import { DayPickerStrings } from '../defaults';
+import { Calendar, ICalendarProps, DateRangeType, DayOfWeek, defaultDayPickerStrings } from '@uifabric/date-time';
 
 import * as styles from './Calendar.Example.scss';
 
@@ -82,7 +81,7 @@ export class CalendarInlineExample extends React.Component<ICalendarInlineExampl
           showGoToToday={this.props.showGoToToday}
           value={this.state.selectedDate!}
           firstDayOfWeek={this.props.firstDayOfWeek ? this.props.firstDayOfWeek : DayOfWeek.Sunday}
-          strings={DayPickerStrings}
+          strings={defaultDayPickerStrings}
           highlightCurrentMonth={this.props.highlightCurrentMonth}
           highlightSelectedMonth={this.props.highlightSelectedMonth}
           isDayPickerVisible={this.props.isDayPickerVisible}

--- a/packages/date-time/src/components/Calendar/examples/Calendar.Inline.Example.tsx
+++ b/packages/date-time/src/components/Calendar/examples/Calendar.Inline.Example.tsx
@@ -2,24 +2,9 @@ import * as React from 'react';
 import { DefaultButton, Dropdown, IDropdownOption } from 'office-ui-fabric-react';
 import { addDays, getDateRangeArray } from 'office-ui-fabric-react/lib/utilities/dateMath/DateMath';
 import { Calendar, ICalendarProps, DateRangeType, DayOfWeek } from '@uifabric/date-time';
+import { DayPickerStrings } from '../defaults';
 
 import * as styles from './Calendar.Example.scss';
-
-const DayPickerStrings = {
-  months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
-  shortMonths: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-  days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-  shortDays: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
-  goToToday: 'Go to today',
-  weekNumberFormatString: 'Week number {0}',
-  prevMonthAriaLabel: 'Previous month',
-  nextMonthAriaLabel: 'Next month',
-  prevYearAriaLabel: 'Previous year',
-  nextYearAriaLabel: 'Next year',
-  prevYearRangeAriaLabel: 'Previous year range',
-  nextYearRangeAriaLabel: 'Next year range',
-  closeButtonAriaLabel: 'Close'
-};
 
 export interface ICalendarInlineExampleState {
   selectedDate?: Date | null;

--- a/packages/date-time/src/components/Calendar/index.ts
+++ b/packages/date-time/src/components/Calendar/index.ts
@@ -1,2 +1,3 @@
 export * from './Calendar';
 export * from './Calendar.types';
+export { DayPickerStrings as defaultDayPickerStrings } from './defaults';

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -248,7 +248,6 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
         onMouseDown={!ariaHidden ? this.onMouseDownDay(day) : undefined}
         onMouseUp={!ariaHidden ? this.onMouseUpDay(day) : undefined}
         onMouseOut={!ariaHidden ? this.onMouseOutDay(day) : undefined}
-        role="gridcell"
       >
         <button
           key={day.key + 'button'}
@@ -263,7 +262,7 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
           disabled={!allFocusable && !day.isInBounds}
           aria-disabled={!ariaHidden && !day.isInBounds}
           type="button"
-          role="button" // create grid structure
+          role="gridcell" // create grid structure
           aria-readonly={true} // prevent grid from being "editable"
         >
           <span aria-hidden="true">{dateTimeFormatter.formatDay(day.originalDate)}</span>

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -248,6 +248,7 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
         onMouseDown={!ariaHidden ? this.onMouseDownDay(day) : undefined}
         onMouseUp={!ariaHidden ? this.onMouseUpDay(day) : undefined}
         onMouseOut={!ariaHidden ? this.onMouseOutDay(day) : undefined}
+        role="gridcell"
       >
         <button
           key={day.key + 'button'}
@@ -262,7 +263,7 @@ export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, IC
           disabled={!allFocusable && !day.isInBounds}
           aria-disabled={!ariaHidden && !day.isInBounds}
           type="button"
-          role="gridcell" // create grid structure
+          role="button" // create grid structure
           aria-readonly={true} // prevent grid from being "editable"
         >
           <span aria-hidden="true">{dateTimeFormatter.formatDay(day.originalDate)}</span>

--- a/packages/date-time/src/components/DatePicker/defaults.ts
+++ b/packages/date-time/src/components/DatePicker/defaults.ts
@@ -1,0 +1,8 @@
+import { IDatePickerStrings } from '@uifabric/date-time';
+import { defaultDayPickerStrings } from '@uifabric/date-time';
+
+export const DayPickerStrings: IDatePickerStrings = {
+  ...defaultDayPickerStrings,
+  isRequiredErrorMessage: 'Field is required.',
+  invalidInputErrorMessage: 'Invalid date format.'
+};

--- a/packages/date-time/src/components/DatePicker/examples/DatePicker.Basic.Example.tsx
+++ b/packages/date-time/src/components/DatePicker/examples/DatePicker.Basic.Example.tsx
@@ -1,23 +1,8 @@
 import * as React from 'react';
 import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
-import { DatePicker, DayOfWeek, IDatePickerStrings } from '@uifabric/date-time';
+import { DatePicker, DayOfWeek } from '@uifabric/date-time';
 import './DatePicker.Examples.scss';
-
-const DayPickerStrings: IDatePickerStrings = {
-  months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
-  shortMonths: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-  days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-  shortDays: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
-  goToToday: 'Go to today',
-  weekNumberFormatString: 'Week number {0}',
-  prevMonthAriaLabel: 'Previous month',
-  nextMonthAriaLabel: 'Next month',
-  prevYearAriaLabel: 'Previous year',
-  nextYearAriaLabel: 'Next year',
-  prevYearRangeAriaLabel: 'Previous year range',
-  nextYearRangeAriaLabel: 'Next year range',
-  closeButtonAriaLabel: 'Close'
-};
+import { DayPickerStrings } from '../defaults';
 
 export interface IDatePickerBasicExampleState {
   firstDayOfWeek?: DayOfWeek;

--- a/packages/date-time/src/components/DatePicker/examples/DatePicker.Basic.Example.tsx
+++ b/packages/date-time/src/components/DatePicker/examples/DatePicker.Basic.Example.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
-import { DatePicker, DayOfWeek } from '@uifabric/date-time';
+import { DatePicker, DayOfWeek, defaultDayPickerStrings } from '@uifabric/date-time';
 import './DatePicker.Examples.scss';
-import { DayPickerStrings } from '../defaults';
 
 export interface IDatePickerBasicExampleState {
   firstDayOfWeek?: DayOfWeek;
@@ -22,7 +21,12 @@ export class DatePickerBasicExample extends React.Component<{}, IDatePickerBasic
 
     return (
       <div className="docs-DatePickerExample">
-        <DatePicker firstDayOfWeek={firstDayOfWeek} strings={DayPickerStrings} placeholder="Select a date..." ariaLabel="Select a date" />
+        <DatePicker
+          firstDayOfWeek={firstDayOfWeek}
+          strings={defaultDayPickerStrings}
+          placeholder="Select a date..."
+          ariaLabel="Select a date"
+        />
         <Dropdown
           label="Select the first day of the week"
           options={[

--- a/packages/date-time/src/components/DatePicker/examples/DatePicker.Bounded.Example.tsx
+++ b/packages/date-time/src/components/DatePicker/examples/DatePicker.Bounded.Example.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { DatePicker, DayOfWeek, IDatePickerStrings } from '@uifabric/date-time';
 import { addMonths, addYears } from 'office-ui-fabric-react/lib/utilities/dateMath/DateMath';
 import './DatePicker.Examples.scss';
+import { DayPickerStrings as defaultDayPickerStrings } from '../defaults';
 
 const today: Date = new Date(Date.now());
 const minDate: Date = addMonths(today, -1);
@@ -11,22 +12,7 @@ out-of-bounds dates to be picked or entered. In this example, the allowed dates 
 ${minDate.toLocaleDateString()}-${maxDate.toLocaleDateString()}`;
 
 const DayPickerStrings: IDatePickerStrings = {
-  months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
-  shortMonths: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-  days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-  shortDays: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
-  goToToday: 'Go to today',
-  weekNumberFormatString: 'Week number {0}',
-  prevMonthAriaLabel: 'Previous month',
-  nextMonthAriaLabel: 'Next month',
-  prevYearAriaLabel: 'Previous year',
-  nextYearAriaLabel: 'Next year',
-  prevYearRangeAriaLabel: 'Previous year range',
-  nextYearRangeAriaLabel: 'Next year range',
-  closeButtonAriaLabel: 'Close',
-
-  isRequiredErrorMessage: 'Field is required.',
-  invalidInputErrorMessage: 'Invalid date format.',
+  ...defaultDayPickerStrings,
   isOutOfBoundsErrorMessage: `Date must be between ${minDate.toLocaleDateString()}-${maxDate.toLocaleDateString()}`
 };
 

--- a/packages/date-time/src/components/DatePicker/examples/DatePicker.Bounded.Example.tsx
+++ b/packages/date-time/src/components/DatePicker/examples/DatePicker.Bounded.Example.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { DatePicker, DayOfWeek, IDatePickerStrings } from '@uifabric/date-time';
+import { DatePicker, DayOfWeek, IDatePickerStrings, defaultDayPickerStrings } from '@uifabric/date-time';
 import { addMonths, addYears } from 'office-ui-fabric-react/lib/utilities/dateMath/DateMath';
 import './DatePicker.Examples.scss';
-import { DayPickerStrings as defaultDayPickerStrings } from '../defaults';
 
 const today: Date = new Date(Date.now());
 const minDate: Date = addMonths(today, -1);

--- a/packages/date-time/src/components/DatePicker/examples/DatePicker.Disabled.Example.tsx
+++ b/packages/date-time/src/components/DatePicker/examples/DatePicker.Disabled.Example.tsx
@@ -1,22 +1,7 @@
 import * as React from 'react';
-import { DatePicker, DayOfWeek, IDatePickerStrings } from '@uifabric/date-time';
+import { DatePicker, DayOfWeek } from '@uifabric/date-time';
 import './DatePicker.Examples.scss';
-
-const DayPickerStrings: IDatePickerStrings = {
-  months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
-  shortMonths: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-  days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-  shortDays: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
-  goToToday: 'Go to today',
-  weekNumberFormatString: 'Week number {0}',
-  prevMonthAriaLabel: 'Previous month',
-  nextMonthAriaLabel: 'Next month',
-  prevYearAriaLabel: 'Previous year',
-  nextYearAriaLabel: 'Next year',
-  prevYearRangeAriaLabel: 'Previous year range',
-  nextYearRangeAriaLabel: 'Next year range',
-  closeButtonAriaLabel: 'Close'
-};
+import { DayPickerStrings } from '../defaults';
 
 export interface IDatePickerDisabledExampleState {
   firstDayOfWeek?: DayOfWeek;

--- a/packages/date-time/src/components/DatePicker/examples/DatePicker.Disabled.Example.tsx
+++ b/packages/date-time/src/components/DatePicker/examples/DatePicker.Disabled.Example.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { DatePicker, DayOfWeek } from '@uifabric/date-time';
+import { DatePicker, DayOfWeek, defaultDayPickerStrings } from '@uifabric/date-time';
 import './DatePicker.Examples.scss';
-import { DayPickerStrings } from '../defaults';
 
 export interface IDatePickerDisabledExampleState {
   firstDayOfWeek?: DayOfWeek;
@@ -23,7 +22,7 @@ export class DatePickerDisabledExample extends React.Component<{}, IDatePickerDi
       <div className="docs-DatePickerExample">
         <DatePicker
           firstDayOfWeek={firstDayOfWeek}
-          strings={DayPickerStrings}
+          strings={defaultDayPickerStrings}
           placeholder="Select a date..."
           ariaLabel="Select a date"
           disabled={true}
@@ -32,7 +31,7 @@ export class DatePickerDisabledExample extends React.Component<{}, IDatePickerDi
         <DatePicker
           label="Disabled (with label)"
           firstDayOfWeek={firstDayOfWeek}
-          strings={DayPickerStrings}
+          strings={defaultDayPickerStrings}
           placeholder="Select a date..."
           ariaLabel="Select a date"
           disabled={true}

--- a/packages/date-time/src/components/DatePicker/examples/DatePicker.Format.Example.tsx
+++ b/packages/date-time/src/components/DatePicker/examples/DatePicker.Format.Example.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
-import { DatePicker, DayOfWeek } from '@uifabric/date-time';
+import { DatePicker, DayOfWeek, defaultDayPickerStrings } from '@uifabric/date-time';
 import './DatePicker.Examples.scss';
-import { DayPickerStrings } from '../defaults';
 
 export interface IDatePickerFormatExampleState {
   firstDayOfWeek?: DayOfWeek;
@@ -35,7 +34,7 @@ export class DatePickerFormatExample extends React.Component<{}, IDatePickerForm
           allowTextInput={true}
           ariaLabel={desc}
           firstDayOfWeek={firstDayOfWeek}
-          strings={DayPickerStrings}
+          strings={defaultDayPickerStrings}
           value={value!}
           onSelectDate={this._onSelectDate}
           formatDate={this._onFormatDate}

--- a/packages/date-time/src/components/DatePicker/examples/DatePicker.Format.Example.tsx
+++ b/packages/date-time/src/components/DatePicker/examples/DatePicker.Format.Example.tsx
@@ -1,26 +1,8 @@
 import * as React from 'react';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
-import { DatePicker, DayOfWeek, IDatePickerStrings } from '@uifabric/date-time';
+import { DatePicker, DayOfWeek } from '@uifabric/date-time';
 import './DatePicker.Examples.scss';
-
-const DayPickerStrings: IDatePickerStrings = {
-  months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
-  shortMonths: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-  days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-  shortDays: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
-  goToToday: 'Go to today',
-  weekNumberFormatString: 'Week number {0}',
-  prevMonthAriaLabel: 'Previous month',
-  nextMonthAriaLabel: 'Next month',
-  prevYearAriaLabel: 'Previous year',
-  nextYearAriaLabel: 'Next year',
-  prevYearRangeAriaLabel: 'Previous year range',
-  nextYearRangeAriaLabel: 'Next year range',
-  closeButtonAriaLabel: 'Close',
-
-  isRequiredErrorMessage: 'Start date is required.',
-  invalidInputErrorMessage: 'Invalid date format.'
-};
+import { DayPickerStrings } from '../defaults';
 
 export interface IDatePickerFormatExampleState {
   firstDayOfWeek?: DayOfWeek;

--- a/packages/date-time/src/components/DatePicker/examples/DatePicker.Input.Example.tsx
+++ b/packages/date-time/src/components/DatePicker/examples/DatePicker.Input.Example.tsx
@@ -1,26 +1,8 @@
 import * as React from 'react';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
-import { DatePicker, DayOfWeek, IDatePickerStrings } from '@uifabric/date-time';
+import { DatePicker, DayOfWeek } from '@uifabric/date-time';
 import './DatePicker.Examples.scss';
-
-const DayPickerStrings: IDatePickerStrings = {
-  months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
-  shortMonths: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-  days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-  shortDays: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
-  goToToday: 'Go to today',
-  weekNumberFormatString: 'Week number {0}',
-  prevMonthAriaLabel: 'Previous month',
-  nextMonthAriaLabel: 'Next month',
-  prevYearAriaLabel: 'Previous year',
-  nextYearAriaLabel: 'Next year',
-  prevYearRangeAriaLabel: 'Previous year range',
-  nextYearRangeAriaLabel: 'Next year range',
-  closeButtonAriaLabel: 'Close',
-
-  isRequiredErrorMessage: 'Start date is required.',
-  invalidInputErrorMessage: 'Invalid date format.'
-};
+import { DayPickerStrings } from '../defaults';
 
 export interface IDatePickerInputExampleState {
   firstDayOfWeek?: DayOfWeek;

--- a/packages/date-time/src/components/DatePicker/examples/DatePicker.Input.Example.tsx
+++ b/packages/date-time/src/components/DatePicker/examples/DatePicker.Input.Example.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
-import { DatePicker, DayOfWeek } from '@uifabric/date-time';
+import { DatePicker, DayOfWeek, defaultDayPickerStrings } from '@uifabric/date-time';
 import './DatePicker.Examples.scss';
-import { DayPickerStrings } from '../defaults';
 
 export interface IDatePickerInputExampleState {
   firstDayOfWeek?: DayOfWeek;
@@ -34,7 +33,7 @@ export class DatePickerInputExample extends React.Component<{}, IDatePickerInput
           allowTextInput={true}
           ariaLabel={desc}
           firstDayOfWeek={firstDayOfWeek}
-          strings={DayPickerStrings}
+          strings={defaultDayPickerStrings}
           value={value!}
           onSelectDate={this._onSelectDate}
         />

--- a/packages/date-time/src/components/DatePicker/examples/DatePicker.Required.Example.tsx
+++ b/packages/date-time/src/components/DatePicker/examples/DatePicker.Required.Example.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
-import { DatePicker, DayOfWeek } from '@uifabric/date-time';
+import { DatePicker, DayOfWeek, defaultDayPickerStrings } from '@uifabric/date-time';
 import './DatePicker.Examples.scss';
-import { DayPickerStrings } from '../defaults';
 
 export interface IDatePickerRequiredExampleState {
   firstDayOfWeek?: DayOfWeek;
@@ -26,14 +25,14 @@ export class DatePickerRequiredExample extends React.Component<{}, IDatePickerRe
           label="Date required (with label)"
           isRequired={true}
           firstDayOfWeek={firstDayOfWeek}
-          strings={DayPickerStrings}
+          strings={defaultDayPickerStrings}
           placeholder="Select a date..."
           ariaLabel="Select a date"
         />
         <DatePicker
           isRequired={true}
           firstDayOfWeek={firstDayOfWeek}
-          strings={DayPickerStrings}
+          strings={defaultDayPickerStrings}
           placeholder="Date required with no label..."
           ariaLabel="Select a date"
         />

--- a/packages/date-time/src/components/DatePicker/examples/DatePicker.Required.Example.tsx
+++ b/packages/date-time/src/components/DatePicker/examples/DatePicker.Required.Example.tsx
@@ -1,25 +1,7 @@
 import * as React from 'react';
-import { DatePicker, DayOfWeek, IDatePickerStrings } from '@uifabric/date-time';
+import { DatePicker, DayOfWeek } from '@uifabric/date-time';
 import './DatePicker.Examples.scss';
-
-const DayPickerStrings: IDatePickerStrings = {
-  months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
-  shortMonths: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-  days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-  shortDays: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
-  goToToday: 'Go to today',
-  weekNumberFormatString: 'Week number {0}',
-  prevMonthAriaLabel: 'Previous month',
-  nextMonthAriaLabel: 'Next month',
-  prevYearAriaLabel: 'Previous year',
-  nextYearAriaLabel: 'Next year',
-  prevYearRangeAriaLabel: 'Previous year range',
-  nextYearRangeAriaLabel: 'Next year range',
-  closeButtonAriaLabel: 'Close',
-
-  isRequiredErrorMessage: 'Field is required.',
-  invalidInputErrorMessage: 'Invalid date format.'
-};
+import { DayPickerStrings } from '../defaults';
 
 export interface IDatePickerRequiredExampleState {
   firstDayOfWeek?: DayOfWeek;

--- a/packages/date-time/src/components/DatePicker/examples/DatePicker.WeekNumbers.Example.tsx
+++ b/packages/date-time/src/components/DatePicker/examples/DatePicker.WeekNumbers.Example.tsx
@@ -1,23 +1,8 @@
 import * as React from 'react';
 import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
-import { DatePicker, DayOfWeek, IDatePickerStrings } from '@uifabric/date-time';
+import { DatePicker, DayOfWeek } from '@uifabric/date-time';
 import './DatePicker.Examples.scss';
-
-const DayPickerStrings: IDatePickerStrings = {
-  months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
-  shortMonths: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-  days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-  shortDays: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
-  goToToday: 'Go to today',
-  weekNumberFormatString: 'Week number {0}',
-  prevMonthAriaLabel: 'Previous month',
-  nextMonthAriaLabel: 'Next month',
-  prevYearAriaLabel: 'Previous year',
-  nextYearAriaLabel: 'Next year',
-  prevYearRangeAriaLabel: 'Previous year range',
-  nextYearRangeAriaLabel: 'Next year range',
-  closeButtonAriaLabel: 'Close'
-};
+import { DayPickerStrings } from '../defaults';
 
 export interface IDatePickerBasicExampleState {
   firstDayOfWeek?: DayOfWeek;

--- a/packages/date-time/src/components/DatePicker/examples/DatePicker.WeekNumbers.Example.tsx
+++ b/packages/date-time/src/components/DatePicker/examples/DatePicker.WeekNumbers.Example.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
 import { Dropdown, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
-import { DatePicker, DayOfWeek } from '@uifabric/date-time';
+import { DatePicker, DayOfWeek, defaultDayPickerStrings } from '@uifabric/date-time';
 import './DatePicker.Examples.scss';
-import { DayPickerStrings } from '../defaults';
 
 export interface IDatePickerBasicExampleState {
   firstDayOfWeek?: DayOfWeek;
@@ -24,7 +23,7 @@ export class DatePickerWeekNumbersExample extends React.Component<{}, IDatePicke
       <div className="docs-DatePickerExample">
         <DatePicker
           firstDayOfWeek={firstDayOfWeek}
-          strings={DayPickerStrings}
+          strings={defaultDayPickerStrings}
           showWeekNumbers={true}
           firstWeekOfYear={1}
           showMonthPickerAsOverlay={true}

--- a/packages/date-time/src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Example.tsx
+++ b/packages/date-time/src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Example.tsx
@@ -1,24 +1,8 @@
 import * as React from 'react';
-import { WeeklyDayPicker, IWeeklyDayPickerProps, DayOfWeek, addDays } from '@uifabric/date-time';
+import { WeeklyDayPicker, IWeeklyDayPickerProps, DayOfWeek, addDays, defaultDayPickerStrings } from '@uifabric/date-time';
 
 import * as styles from './WeeklyDayPicker.Example.scss';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
-
-const DayPickerStrings = {
-  months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
-  shortMonths: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-  days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-  shortDays: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
-  goToToday: 'Go to today',
-  weekNumberFormatString: 'Week number {0}',
-  prevMonthAriaLabel: 'Previous month',
-  nextMonthAriaLabel: 'Next month',
-  prevYearAriaLabel: 'Previous year',
-  nextYearAriaLabel: 'Next year',
-  prevYearRangeAriaLabel: 'Previous year range',
-  nextYearRangeAriaLabel: 'Next year range',
-  closeButtonAriaLabel: 'Close'
-};
 
 export interface IWeeklyDayPickerInlineExampleState {
   selectedDate?: Date;
@@ -71,7 +55,7 @@ export class WeeklyDayPickerInlineExample extends React.Component<IWeeklyDayPick
         <WeeklyDayPicker
           onSelectDate={this._onSelectDate}
           firstDayOfWeek={this.props.firstDayOfWeek ? this.props.firstDayOfWeek : DayOfWeek.Sunday}
-          strings={DayPickerStrings}
+          strings={defaultDayPickerStrings}
           minDate={this.props.minDate}
           maxDate={this.props.maxDate}
           restrictedDates={this.props.restrictedDates}

--- a/packages/date-time/src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Expandable.Example.tsx
+++ b/packages/date-time/src/components/WeeklyDayPicker/examples/WeeklyDayPicker.Inline.Expandable.Example.tsx
@@ -1,26 +1,8 @@
 import * as React from 'react';
-import { WeeklyDayPicker, DayOfWeek, addDays, IWeeklyDayPickerProps } from '@uifabric/date-time';
+import { WeeklyDayPicker, DayOfWeek, addDays, IWeeklyDayPickerProps, defaultDayPickerStrings } from '@uifabric/date-time';
 
 import * as styles from './WeeklyDayPicker.Example.scss';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
-
-const DayPickerStrings = {
-  months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
-  shortMonths: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
-  days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
-  shortDays: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
-  goToToday: 'Go to today',
-  weekNumberFormatString: 'Week number {0}',
-  prevMonthAriaLabel: 'Previous month',
-  nextMonthAriaLabel: 'Next month',
-  prevYearAriaLabel: 'Previous year',
-  nextYearAriaLabel: 'Next year',
-  prevYearRangeAriaLabel: 'Previous year range',
-  nextYearRangeAriaLabel: 'Next year range',
-  closeButtonAriaLabel: 'Close',
-  prevWeekAriaLabel: 'Previous week',
-  nextWeekAriaLabel: 'Next week'
-};
 
 export interface IWeeklyDayPickerInlineExpandableExampleState {
   selectedDate?: Date;
@@ -85,7 +67,7 @@ export class WeeklyDayPickerInlineExpandableExample extends React.Component<
           {...this.props}
           onSelectDate={this._onSelectDate}
           firstDayOfWeek={this.props.firstDayOfWeek ? this.props.firstDayOfWeek : DayOfWeek.Sunday}
-          strings={DayPickerStrings}
+          strings={defaultDayPickerStrings}
           initialDate={this.state.selectedDate}
           showFullMonth={this.state.expanded}
         />

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarMonth.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarMonth.tsx
@@ -221,7 +221,7 @@ export class CalendarMonth extends BaseComponent<ICalendarMonthProps, ICalendarM
                         onClick={isInBounds ? this._selectMonthCallbacks[monthIndex] : undefined}
                         onKeyDown={isInBounds ? this._onSelectMonthKeyDown(monthIndex) : undefined}
                         aria-label={dateTimeFormatter.formatMonthYear(indexedMonth, strings)}
-                        aria-selected={isCurrentMonth || isNavigatedMonth}
+                        aria-selected={isNavigatedMonth}
                         data-is-focusable={isInBounds ? true : undefined}
                         ref={isNavigatedMonth ? this._navigatedMonthRef : undefined}
                         type="button"


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11143, #11144, #11142, #11141, #10908, #10352, #8305
- [x] Include a change request file using `$ yarn change`

#### Description of changes

#11143 Upon selecting the date, calendar dialog box blinks and focus moves to the arrow
the part with the focus moving to the arrow was already fixed in date-time, but here we also fix the issue of the focus not automatically moving to the day picker after selecting a month in the month picker

#11144 Name is not defined for the dialog which appears on pressing enter on click for calendar button
#8305 Today/Selected date is not read by screen reader
fixed by adding an aria-label to the root of the control which contains information for today/selected date. Will be read when first focusing into the control.

#11142 Information about the change of week is not narrated by screen reader whenever user press Enter on previous/next button
Added an aria-live region to the root Calendar component with the selected date information, which announces whenever date selection is changed, even from external sources like the previous/next button

#11141 Two months in the month Picker calendar is having aria-selected property as true when only one is selected by the user
Removed the duplicate aria-selected which was being applied to the current month (rather than selected month, which I left). This was only in OUFR, date-time was already correct.

#10908 Date pickers are not accessible using shortcut keys (PageUp, PageDown, Ctrl+PageUp & Ctrl+PageDown)
Added key listeners for the above keys to navigate forwards/backwards by a month/year

#10352 Name is not defined for the selected year button
Added an aria-label for the month picker header and year picker header buttons, telling you that clicking on the button will switch you to the other picker

In addition, consolidates all of the various default strings throughout date-time Calendar into a single defaults.ts file (and another one for DatePicker, which reads from it for the common strings). Now new strings only need to be added in 1 place instead of many.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11254)