### PR TITLE
TeachingBubble: Updating focus outline on close button for color contrast accessibility

### DIFF
--- a/change/office-ui-fabric-react-2019-11-20-16-44-12-teachingbubble-focus-fix.json
+++ b/change/office-ui-fabric-react-2019-11-20-16-44-12-teachingbubble-focus-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "TeachingBubble: adding focus outline to close button for color contrast accessibility. Color contrast ratio should be more then 3:1.",
+  "packageName": "office-ui-fabric-react",
+  "email": "marygans@microsoft.com",
+  "commit": "e45699f1940ef2eea40dccc17f24b6fd3463589d",
+  "date": "2019-11-21T00:44:12.716Z"
+}

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
@@ -93,7 +93,7 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
     theme
   } = props;
   const hasLargeHeadline: boolean = !hasCondensedHeadline && !hasSmallHeadline;
-  const { palette, fonts } = theme;
+  const { palette, semanticColors, fonts } = theme;
   const classNames = getGlobalClassNames(globalClassNames, theme);
 
   return {
@@ -132,6 +132,9 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
           ':active': {
             background: palette.themeDark,
             color: palette.white
+          },
+          ':focus': {
+            border: `1px solid ${semanticColors.variantBorder}`
           }
         }
       }

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -776,6 +776,9 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
               border-color: Highlight;
               color: Highlight;
             }
+            &:focus {
+              border: 1px solid #edebe9;
+            }
             &:active {
               background-color: #edebe9;
               background: #005a9e;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
@@ -1016,6 +1016,9 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                                                   border-color: Highlight;
                                                   color: Highlight;
                                                 }
+                                                &:focus {
+                                                  border: 1px solid #edebe9;
+                                                }
                                                 &:active {
                                                   background-color: #edebe9;
                                                   background: #005a9e;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #11149
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

TeachingBubble: Update focus outline on the close button since color contrast ratio should be more then 3:1.

**Before:**
<img width="353" alt="Screen Shot 2019-11-20 at 4 59 12 PM" src="https://user-images.githubusercontent.com/38991459/69291262-78b0e100-0bb7-11ea-9dfd-ca5122153453.png">

**After:** 
<img width="447" alt="Screen Shot 2019-11-20 at 4 47 52 PM" src="https://user-images.githubusercontent.com/38991459/69291257-7484c380-0bb7-11ea-9fae-e77f46ff77cf.png">


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11261)