### PR TITLE
removed the sticky={true} for the hover card.

### DIFF
--- a/change/@uifabric-charting-2019-11-21-12-59-29-user-v-sivsar-flickeringLegendChartIssue.json
+++ b/change/@uifabric-charting-2019-11-21-12-59-29-user-v-sivsar-flickeringLegendChartIssue.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "removing the sticky={true} property from the hover card as the card should hide when the mouse goes away from the target element, and also added the gap space 12 to avoid the flickering issue of the hover card",
+  "packageName": "@uifabric/charting",
+  "email": "v-sivsar@microsoft.com",
+  "commit": "b37e7aeba72e73d45e239558a08f8636980e1630",
+  "date": "2019-11-21T07:29:29.154Z",
+  "file": "C:\\git\\office-ui-fabric\\change\\@uifabric-charting-2019-11-21-12-59-29-user-v-sivsar-flickeringLegendChartIssue.json"
+}

--- a/packages/charting/src/components/Legends/Legends.base.tsx
+++ b/packages/charting/src/components/Legends/Legends.base.tsx
@@ -97,6 +97,9 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
           },
           item: {
             marginBottom: '16px'
+          },
+          overflowButton: {
+            marginBottom: '16px'
           }
         }}
       />
@@ -158,7 +161,8 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
     });
     const plainCardProps = {
       onRenderPlainCard: this._onRenderCompactCard,
-      renderData: renderOverflowData
+      renderData: renderOverflowData,
+      gapSpace: 12
     };
 
     // execute similar to "_onClick" and "_onLeave" logic at HoverCard onCardHide event
@@ -180,13 +184,7 @@ export class LegendsBase extends React.Component<ILegendsProps, ILegendState> {
       }
     };
     return (
-      <HoverCard
-        type={HoverCardType.plain}
-        plainCardProps={plainCardProps}
-        sticky={true}
-        instantOpenOnClick={true}
-        onCardHide={onHoverCardHideHandler}
-      >
+      <HoverCard type={HoverCardType.plain} plainCardProps={plainCardProps} instantOpenOnClick={true} onCardHide={onHoverCardHideHandler}>
         <div className={classNames.overflowIndicationTextStyle}>{items.length} more</div>
       </HoverCard>
     );


### PR DESCRIPTION
 ## Description of changes

i have removed the `stiky={true}` from the hover card, because when the mouse is away from the target element the hover card shouldn't appear. so removing the above specified property achieves this behavior.

and also added gapSpace to avoid flickering issues of the hover card. see below video


![hover card flickering issue](https://user-images.githubusercontent.com/33802398/69317301-ad2ca780-0c60-11ea-8c04-f829c1d03096.gif)

**after fix**

https://drive.google.com/open?id=1rGu6YhkqAuiHgbapzDEdjtUTZ3g0QotO



#### Focus areas to test

legends.base.tsx


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11262)
