### PR TITLE
Callout: example styles update

### DIFF
--- a/change/office-ui-fabric-react-2019-11-21-09-19-06-v-mare-Callout-example-fix.json
+++ b/change/office-ui-fabric-react-2019-11-21-09-19-06-v-mare-Callout-example-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Callout: Fixed bottom padding and button alignment to flex-end",
+  "packageName": "office-ui-fabric-react",
+  "email": "v-mare@microsoft.com",
+  "commit": "7c65d0eb9fd4b9f2389a3f5d0be66f7f437f3406",
+  "date": "2019-11-21T17:19:06.157Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/examples/Callout.FocusTrap.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/examples/Callout.FocusTrap.Example.tsx
@@ -50,7 +50,9 @@ const styles = mergeStyleSets({
     whiteSpace: 'nowrap'
   },
   buttons: {
-    padding: '0 24px 12px'
+    display: 'flex',
+    justifyContent: 'flex-end',
+    padding: '0 24px 24px'
   },
   subtext: [
     theme.fonts.small,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses a request from Chris Wymer
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The padding below the buttons in the Callout focusTrap example was to little (12px) and need to be 24px. the button alignment was left justified and needed to be right justified.

#### Before
<img width="236" alt="Screen Shot 2019-11-21 at 9 27 17 AM" src="https://user-images.githubusercontent.com/13246181/69361436-55327880-0c41-11ea-83a4-058f11de8443.png">

#### After
![Screen Shot 2019-11-20 at 3 38 07 PM](https://user-images.githubusercontent.com/13246181/69361446-59f72c80-0c41-11ea-95d2-3ea4124bbd76.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11268)