### PR TITLE
Pivots move to overflow set when limited space - Initial PR for design review

### DIFF
--- a/change/office-ui-fabric-react-2019-11-22-14-30-15-msnyder-PivotOverflow.json
+++ b/change/office-ui-fabric-react-2019-11-22-14-30-15-msnyder-PivotOverflow.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Enabling pivots to move to overflow set based on available space",
+  "packageName": "office-ui-fabric-react",
+  "email": "msnyder@microsoft.com",
+  "commit": "58165b3f75cf267fa1bfddd679f4471c6850ecd7",
+  "date": "2019-11-22T22:30:15.528Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6128,11 +6128,20 @@ export interface IPickerItemProps<T> extends React.AllHTMLAttributes<HTMLElement
 // @public (undocumented)
 export interface IPivot {
     focus(): void;
+    remeasure(): void;
+}
+
+// @public (undocumented)
+export interface IPivotData {
+    cacheKey: string;
+    items: IPivotItemProps[];
+    overflowItems: IOverflowSetItemProps[];
 }
 
 // @public (undocumented)
 export interface IPivotItemProps extends React.HTMLAttributes<HTMLDivElement> {
     ariaLabel?: string;
+    cacheKey?: string;
     componentRef?: IRefObject<{}>;
     headerButtonProps?: {
         [key: string]: string | number | boolean;
@@ -6145,12 +6154,14 @@ export interface IPivotItemProps extends React.HTMLAttributes<HTMLDivElement> {
     // @deprecated
     linkText?: string;
     onRenderItemLink?: IRenderFunction<IPivotItemProps>;
+    renderedInOverflow?: boolean;
 }
 
 // @public (undocumented)
 export interface IPivotProps extends React.ClassAttributes<PivotBase>, React.HTMLAttributes<HTMLDivElement> {
     className?: string;
     componentRef?: IRefObject<IPivot>;
+    dataDidRender?: (renderedData: any) => void;
     defaultSelectedIndex?: number;
     defaultSelectedKey?: string;
     getTabId?: (itemKey: string, index: number) => string;
@@ -6161,8 +6172,15 @@ export interface IPivotProps extends React.ClassAttributes<PivotBase>, React.HTM
     initialSelectedKey?: string;
     linkFormat?: PivotLinkFormat;
     linkSize?: PivotLinkSize;
+    onDataGrown?: (movedItem: IPivotItemProps) => void;
+    onDataReduced?: (movedItem: IPivotItemProps) => void;
+    onGrowData?: (data: IPivotData) => IPivotData | undefined;
     onLinkClick?: (item?: PivotItem, ev?: React.MouseEvent<HTMLElement>) => void;
+    onReduceData?: (data: IPivotData) => IPivotData | undefined;
+    overflowButtonAs?: IComponentAs<IButtonProps>;
+    overflowButtonProps?: IButtonProps;
     selectedKey?: string | null;
+    shiftOnReduce?: boolean;
     styles?: IStyleFunctionOrObject<IPivotStyleProps, IPivotStyles>;
     theme?: ITheme;
 }
@@ -8430,9 +8448,11 @@ export namespace personaSize {
 export const Pivot: React.StatelessComponent<IPivotProps>;
 
 // @public
-export class PivotBase extends BaseComponent<IPivotProps, IPivotState> {
+export class PivotBase extends BaseComponent<IPivotProps, IPivotState> implements IPivot {
     constructor(props: IPivotProps);
     focus(): void;
+    // (undocumented)
+    remeasure(): void;
     // (undocumented)
     render(): JSX.Element;
     }

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6135,7 +6135,7 @@ export interface IPivot {
 export interface IPivotData {
     cacheKey: string;
     items: IPivotItemProps[];
-    overflowItems: IOverflowSetItemProps[];
+    overflowItems: IContextualMenuItem[];
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -136,6 +136,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
   public dismiss = (ev?: any, dismissAll?: boolean) => {
     const { onDismiss } = this.props;
 
+    // console.log('Base props: ', !!onDismiss, this.props)
     if (onDismiss) {
       onDismiss(ev, dismissAll);
     }
@@ -1070,7 +1071,9 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
 
     let dismiss = false;
     if (item.onClick) {
+      console.log('****Menu base clicked');
       dismiss = !!item.onClick(ev, item);
+      console.log('Bsae result: ', dismiss);
     } else if (this.props.onItemClick) {
       dismiss = !!this.props.onItemClick(ev, item);
     }

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
@@ -217,8 +217,8 @@ export class PivotBase extends BaseComponent<IPivotProps, IPivotState> implement
         id={tabId}
         key={itemKey}
         className={isSelected ? this._classNames.linkIsSelected : this._classNames.link}
-        onClick={this._onLinkClick.bind(this, itemKey)}
-        onKeyPress={this._onKeyPress.bind(this, itemKey)}
+        onClick={this._onLinkClick.bind(this, itemKey, true)}
+        onKeyPress={this._onKeyPress.bind(this, itemKey, true)}
         ariaLabel={link.ariaLabel}
         role="tab"
         aria-selected={isSelected}
@@ -325,18 +325,24 @@ export class PivotBase extends BaseComponent<IPivotProps, IPivotState> implement
 
   /**
    * Handles the onClick event on PivotLinks
+   * @param preventDefault in the case of the overflow set we don't want to prevent the default as that is what closes the menu
    */
-  private _onLinkClick(itemKey: string, ev: React.MouseEvent<HTMLElement>): void {
-    ev.preventDefault();
+  private _onLinkClick(itemKey: string, preventDefault: boolean, ev: React.MouseEvent<HTMLElement>): void {
+    if (preventDefault) {
+      ev.preventDefault();
+    }
     this._updateSelectedItem(itemKey, ev);
   }
 
   /**
    * Handle the onKeyPress eventon the PivotLinks
+   * @param preventDefault in the case of the overflow set we don't want to prevent the default as that is what closes the menu
    */
-  private _onKeyPress(itemKey: string, ev: React.KeyboardEvent<HTMLElement>): void {
+  private _onKeyPress(itemKey: string, preventDefault: boolean, ev: React.KeyboardEvent<HTMLElement>): void {
     if (ev.which === KeyCodes.enter) {
-      ev.preventDefault();
+      if (preventDefault) {
+        ev.preventDefault();
+      }
       this._updateSelectedItem(itemKey);
     }
   }
@@ -425,19 +431,19 @@ export class PivotBase extends BaseComponent<IPivotProps, IPivotState> implement
         itemType: ContextualMenuItemType.Normal, // mismatched types
         onMouseDown: undefined, // mismatched types
         text: movedItem.linkText || movedItem.headerText,
-        // TODO: Is is fair to assume itemKey will always have a value??
-        onClick: (ev?: React.MouseEvent<HTMLElement>): boolean => {
-          // if (ev && ev.keyCode) {
-          // | React.KeyboardEvent<HTMLElement>
-          // }
+        onClick: (ev?: React.MouseEvent<HTMLElement> | React.KeyboardEvent<HTMLElement>): boolean => {
           console.log('Before');
-          this._onLinkClick(movedItem.itemKey || '', ev!);
+          // is keyboard event
+          if (ev && 'keyCode' in ev) {
+            this._onKeyPress(movedItem.itemKey || '', false, ev as React.KeyboardEvent<HTMLElement>);
+          } else {
+            this._onLinkClick(movedItem.itemKey || '', false, ev as React.MouseEvent<HTMLElement>);
+          }
           console.log('***Hit me');
           return true; // tell the menu to close
         }
       };
 
-      // TODO: Is is fair to assume itemKey will always have a value??
       overflowItems = [convertedItem, ...overflowItems];
       primaryItems = shiftOnReduce ? primaryItems.slice(1) : primaryItems.slice(0, -1);
       const newData: IPivotData = { ...data, items: primaryItems, overflowItems };

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
@@ -325,7 +325,7 @@ export class PivotBase extends BaseComponent<IPivotProps, IPivotState> implement
 
   /**
    * Handles the onClick event on PivotLinks
-   * @param preventDefault in the case of the overflow set we don't want to prevent the default as that is what closes the menu
+   * @param preventDefault - in the case of the overflow set we don't want to prevent the default as that is what closes the menu
    */
   private _onLinkClick(itemKey: string, preventDefault: boolean, ev: React.MouseEvent<HTMLElement>): void {
     if (preventDefault) {
@@ -336,7 +336,7 @@ export class PivotBase extends BaseComponent<IPivotProps, IPivotState> implement
 
   /**
    * Handle the onKeyPress eventon the PivotLinks
-   * @param preventDefault in the case of the overflow set we don't want to prevent the default as that is what closes the menu
+   * @param preventDefault - in the case of the overflow set we don't want to prevent the default as that is what closes the menu
    */
   private _onKeyPress(itemKey: string, preventDefault: boolean, ev: React.KeyboardEvent<HTMLElement>): void {
     if (ev.which === KeyCodes.enter) {

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
@@ -4,16 +4,16 @@ import { CommandButton, CommandBarButton, IButtonProps } from '../../Button';
 import { IPivotProps, IPivotStyleProps, IPivotStyles, IPivot } from './Pivot.types';
 import { IPivotItemProps } from './PivotItem.types';
 import { FocusZoneDirection } from '../../FocusZone';
-import { PivotItem } from './PivotItem';
 import { PivotLinkFormat } from './Pivot.types';
 import { PivotLinkSize } from './Pivot.types';
+import { PivotItem } from './PivotItem';
 import { Icon } from '../../Icon';
-import { IOverflowSet } from '../OverflowSet/OverflowSet.types';
-import { OverflowSet } from '../OverflowSet';
-import { IResizeGroup } from '../ResizeGroup/ResizeGroup.types';
-import { ResizeGroup } from '../ResizeGroup';
-import { ICommandBarItemProps } from '../CommandBar/CommandBar.types';
 import { IContextualMenuItem, ContextualMenuItemType } from '../ContextualMenu/ContextualMenu.types';
+import { ICommandBarItemProps } from '../CommandBar/CommandBar.types';
+import { IOverflowSet } from '../OverflowSet/OverflowSet.types';
+import { OverflowSet } from '../OverflowSet/OverflowSet';
+import { IResizeGroup } from '../ResizeGroup/ResizeGroup.types';
+import { ResizeGroup } from '../ResizeGroup/ResizeGroup';
 
 const getClassNames = classNamesFunction<IPivotStyleProps, IPivotStyles>();
 export interface IPivotData {

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.doc.tsx
@@ -1,90 +1,97 @@
 import * as React from 'react';
-import { PivotBasicExample } from './examples/Pivot.Basic.Example';
+// import { PivotBasicExample } from './examples/Pivot.Basic.Example';
 
 import { IDocPageProps } from '../../common/DocPage.types';
-import { PivotIconCountExample } from './examples/Pivot.IconCount.Example';
-import { PivotLargeExample } from './examples/Pivot.Large.Example';
-import { PivotTabsExample } from './examples/Pivot.Tabs.Example';
-import { PivotTabsLargeExample } from './examples/Pivot.TabsLarge.Example';
-import { PivotOnChangeExample } from './examples/Pivot.OnChange.Example';
-import { PivotRemoveExample } from './examples/Pivot.Remove.Example';
-import { PivotOverrideExample } from './examples/Pivot.Override.Example';
-import { PivotSeparateExample } from './examples/Pivot.Separate.Example';
-import { PivotSeparateNoSelectedKeyExample } from './examples/Pivot.SeparateNoSelectedKey.Example';
+// import { PivotIconCountExample } from './examples/Pivot.IconCount.Example';
+// import { PivotLargeExample } from './examples/Pivot.Large.Example';
+// import { PivotTabsExample } from './examples/Pivot.Tabs.Example';
+// import { PivotTabsLargeExample } from './examples/Pivot.TabsLarge.Example';
+// import { PivotOnChangeExample } from './examples/Pivot.OnChange.Example';
+// import { PivotRemoveExample } from './examples/Pivot.Remove.Example';
+// import { PivotOverrideExample } from './examples/Pivot.Override.Example';
+// import { PivotSeparateExample } from './examples/Pivot.Separate.Example';
+// import { PivotSeparateNoSelectedKeyExample } from './examples/Pivot.SeparateNoSelectedKey.Example';
+import { PivotOverflowExample } from './examples/Pivot.Overflow.Example';
 
-const PivotRemoveExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.Remove.Example.tsx') as string;
-const PivotBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.Basic.Example.tsx') as string;
-const PivotLargeExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.Large.Example.tsx') as string;
-const PivotTabsExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.Tabs.Example.tsx') as string;
-const PivotTabsLargeExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.TabsLarge.Example.tsx') as string;
-const PivotOnChangeExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.OnChange.Example.tsx') as string;
-const PivotIconCountExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.IconCount.Example.tsx') as string;
-const PivotOverrideExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.Override.Example.tsx') as string;
-const PivotSeparateExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.Separate.Example.tsx') as string;
-const PivotNoSelectedKeyExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.SeparateNoSelectedKey.Example.tsx') as string;
+// const PivotRemoveExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.Remove.Example.tsx') as string;
+// const PivotBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.Basic.Example.tsx') as string;
+// const PivotLargeExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.Large.Example.tsx') as string;
+// const PivotTabsExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.Tabs.Example.tsx') as string;
+// const PivotTabsLargeExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.TabsLarge.Example.tsx') as string;
+// const PivotOnChangeExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.OnChange.Example.tsx') as string;
+// const PivotIconCountExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.IconCount.Example.tsx') as string;
+// const PivotOverrideExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.Override.Example.tsx') as string;
+// const PivotSeparateExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.Separate.Example.tsx') as string;
+// const PivotNoSelectedKeyExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.SeparateNoSelectedKey.Example.tsx') as string;
+const PivotOverflowExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Pivot/examples/Pivot.Overflow.Example.tsx') as string;
 
 export const PivotPageProps: IDocPageProps = {
   title: 'Pivot',
   componentName: 'Pivot',
   componentUrl: 'https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/office-ui-fabric-react/src/components/Pivot',
   examples: [
+    // {
+    //   title: 'Default Pivot',
+    //   code: PivotBasicExampleCode,
+    //   view: <PivotBasicExample />
+    // },
+    // {
+    //   title: 'Count and Icon',
+    //   code: PivotIconCountExampleCode,
+    //   view: <PivotIconCountExample />
+    // },
+    // {
+    //   title: 'Large link size',
+    //   code: PivotLargeExampleCode,
+    //   view: <PivotLargeExample />
+    // },
+    // {
+    //   title: 'Links of tab style',
+    //   code: PivotTabsExampleCode,
+    //   view: <PivotTabsExample />
+    // },
+    // {
+    //   title: 'Links of large tab style',
+    //   code: PivotTabsLargeExampleCode,
+    //   view: <PivotTabsLargeExample />
+    // },
+    // {
+    //   title: 'Trigger onchange event',
+    //   code: PivotOnChangeExampleCode,
+    //   view: <PivotOnChangeExample />
+    // },
+    // {
+    //   title: 'Show/Hide pivot item',
+    //   code: PivotRemoveExampleCode,
+    //   view: <PivotRemoveExample />
+    // },
+    // {
+    //   title: 'Override selected item',
+    //   code: PivotOverrideExampleCode,
+    //   view: <PivotOverrideExample />
+    // },
+    // {
+    //   title: 'Render content separately',
+    //   code: PivotSeparateExampleCode,
+    //   view: <PivotSeparateExample />
+    // },
+    // {
+    //   title: 'No pivots selected',
+    //   code: PivotNoSelectedKeyExampleCode,
+    //   view: <PivotSeparateNoSelectedKeyExample />
+    // },
     {
-      title: 'Default Pivot',
-      code: PivotBasicExampleCode,
-      view: <PivotBasicExample />
-    },
-    {
-      title: 'Count and Icon',
-      code: PivotIconCountExampleCode,
-      view: <PivotIconCountExample />
-    },
-    {
-      title: 'Large link size',
-      code: PivotLargeExampleCode,
-      view: <PivotLargeExample />
-    },
-    {
-      title: 'Links of tab style',
-      code: PivotTabsExampleCode,
-      view: <PivotTabsExample />
-    },
-    {
-      title: 'Links of large tab style',
-      code: PivotTabsLargeExampleCode,
-      view: <PivotTabsLargeExample />
-    },
-    {
-      title: 'Trigger onchange event',
-      code: PivotOnChangeExampleCode,
-      view: <PivotOnChangeExample />
-    },
-    {
-      title: 'Show/Hide pivot item',
-      code: PivotRemoveExampleCode,
-      view: <PivotRemoveExample />
-    },
-    {
-      title: 'Override selected item',
-      code: PivotOverrideExampleCode,
-      view: <PivotOverrideExample />
-    },
-    {
-      title: 'Render content separately',
-      code: PivotSeparateExampleCode,
-      view: <PivotSeparateExample />
-    },
-    {
-      title: 'No pivots selected',
-      code: PivotNoSelectedKeyExampleCode,
-      view: <PivotSeparateNoSelectedKeyExample />
+      title: 'Overflowing pivots',
+      code: PivotOverflowExampleCode,
+      view: <PivotOverflowExample />
     }
   ],
-  overview: require<string>('!raw-loader!office-ui-fabric-react/src/components/Pivot/docs/PivotOverview.md'),
-  bestPractices: '',
-  dos: require<string>('!raw-loader!office-ui-fabric-react/src/components/Pivot/docs/PivotDos.md'),
-  donts: require<string>('!raw-loader!office-ui-fabric-react/src/components/Pivot/docs/PivotDonts.md'),
-  isHeaderVisible: true,
-  isFeedbackVisible: true,
-  allowNativePropsForComponentName: 'PivotItem',
-  allowNativeProps: true
+  // overview: require<string>('!raw-loader!office-ui-fabric-react/src/components/Pivot/docs/PivotOverview.md'),
+  // bestPractices: '',
+  // dos: require<string>('!raw-loader!office-ui-fabric-react/src/components/Pivot/docs/PivotDos.md'),
+  // donts: require<string>('!raw-loader!office-ui-fabric-react/src/components/Pivot/docs/PivotDonts.md'),
+  isHeaderVisible: true
+  // isFeedbackVisible: true,
+  // allowNativePropsForComponentName: 'PivotItem',
+  // allowNativeProps: true
 };

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
@@ -3,8 +3,8 @@ import { PivotBase, IPivotData } from './Pivot.base';
 import { IStyle, ITheme } from '../../Styling';
 import { IRefObject, IStyleFunctionOrObject, IComponentAs } from '../../Utilities';
 import { PivotItem } from './PivotItem';
-import { IButtonProps } from '../Button';
 import { IPivotItemProps } from './PivotItem.types';
+import { IButtonProps } from '../Button/Button.types';
 
 /**
  * {@docCategory Pivot}

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.types.ts
@@ -1,8 +1,10 @@
 import * as React from 'react';
-import { PivotBase } from './Pivot.base';
+import { PivotBase, IPivotData } from './Pivot.base';
 import { IStyle, ITheme } from '../../Styling';
-import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
+import { IRefObject, IStyleFunctionOrObject, IComponentAs } from '../../Utilities';
 import { PivotItem } from './PivotItem';
+import { IButtonProps } from '../Button';
+import { IPivotItemProps } from './PivotItem.types';
 
 /**
  * {@docCategory Pivot}
@@ -12,6 +14,11 @@ export interface IPivot {
    * Sets focus to the first pivot tab.
    */
   focus(): void;
+
+  /**
+   * Remeasures the available space.
+   */
+  remeasure(): void;
 }
 
 /**
@@ -106,6 +113,53 @@ export interface IPivotProps extends React.ClassAttributes<PivotBase>, React.HTM
    * Useful if you're rendering content outside and need to connect aria-labelledby.
    */
   getTabId?: (itemKey: string, index: number) => string;
+
+  /**
+   * Props to be passed to overflow button.
+   * If `menuProps` are passed through this prop, any items provided will be prepended to any
+   * computed overflow items.
+   */
+  overflowButtonProps?: IButtonProps;
+
+  /**
+   * Custom component for the overflow button.
+   */
+  overflowButtonAs?: IComponentAs<IButtonProps>;
+
+  /**
+   * When true, items will be 'shifted' off the front of the array when reduced, and unshifted during grow.
+   */
+  shiftOnReduce?: boolean;
+
+  /**
+   * Custom function to reduce data if items do not fit in given space.
+   * Return `undefined` if no more steps can be taken to avoid infinate loop.
+   */
+  onReduceData?: (data: IPivotData) => IPivotData | undefined;
+
+  /**
+   * Custom function to grow data if items are too small for the given space.
+   * Return `undefined` if no more steps can be taken to avoid infinate loop.
+   */
+  onGrowData?: (data: IPivotData) => IPivotData | undefined;
+
+  /**
+   * Callback invoked when data has been reduced.
+   */
+  onDataReduced?: (movedItem: IPivotItemProps) => void;
+
+  /**
+   * Callback invoked when data has been grown.
+   */
+  onDataGrown?: (movedItem: IPivotItemProps) => void;
+
+  /**
+   * Function to be called every time data is rendered. It provides the data that was actually rendered.
+   * A use case would be adding telemetry when a particular control is shown in an overflow or dropped
+   * as a result of `onReduceData`, or to count the number of renders that an implementation of
+   * `onReduceData` triggers.
+   */
+  dataDidRender?: (renderedData: any) => void;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Pivot/PivotItem.types.ts
@@ -62,4 +62,16 @@ export interface IPivotItemProps extends React.HTMLAttributes<HTMLDivElement> {
    * Optional keytip for this PivotItem
    */
   keytipProps?: IKeytipProps;
+
+  /**
+   * A custom cache key to be used for this item. If `cacheKey` is changed, the cache will invalidate.
+   * Defaults to `key` value.
+   */
+  cacheKey?: string;
+
+  /**
+   * Context under which the item is being rendered.
+   * This value is mutated by the Pivot and is useful for adjusting the `onRender` function.
+   */
+  renderedInOverflow?: boolean;
 }

--- a/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.deprecated.test.tsx.snap
@@ -2,369 +2,407 @@
 
 exports[`Pivot renders link Pivot correctly 1`] = `
 <div>
-  <div
-    className=
-        ms-FocusZone
-        &:focus {
-          outline: none;
-        }
-    data-focuszone-id="FocusZone1"
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onMouseDownCapture={[Function]}
-  >
+  <div>
     <div
-      className=
-          ms-Pivot
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #0078d4;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-            white-space: nowrap;
-          }
-      role="tablist"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
     >
-      <button
-        aria-selected={true}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            is-selected
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 600;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: #0078d4;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background-color: Highlight;
-            }
-            &:hover::before {
-              left: 0px;
-              right: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              color: Highlight;
-            }
-        data-content="Test Link 1"
-        data-is-focusable={true}
-        id="Pivot0-Tab0"
-        name="Test Link 1"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+      <div
+        data-automation-id="visibleContent"
+        style={
+          Object {
+            "position": "fixed",
+            "visibility": "hidden",
+          }
+        }
       >
-        <span
+        <div
+          aria-orientation="horizontal"
           className=
-              ms-Button-flexContainer
+              ms-FocusZone
+              ms-OverflowSet
+              ms-Pivot
+              &:focus {
+                outline: none;
+              }
               {
-                align-items: center;
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #0078d4;
                 display: flex;
                 flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+                white-space: nowrap;
               }
-          data-automationid="splitbuttonprimary"
+          data-focuszone-id="FocusZone1"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+          role="presentation"
         >
-          <span
+          <div
             className=
-                ms-Pivot-linkContent
+                ms-OverflowSet-item
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inherit;
+                  flex-shrink: 0;
                 }
           >
-            <span
+            <button
+              aria-selected={true}
               className=
-                  ms-Pivot-text
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  ms-Pivot-link
+                  is-selected
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: 0px;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
                     display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 600;
+                    height: 44px;
+                    line-height: 44px;
+                    margin-right: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 8px;
+                    padding-right: 8px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
                     vertical-align: top;
                   }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 0px;
+                    bottom: 2px;
+                    content: attr(data-content);
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: relative;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    color: #201f1e;
+                    cursor: pointer;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:hover .ms-Button-icon {
+                    color: #0078d4;
+                  }
+                  &:focus {
+                    outline: none;
+                  }
+                  &:active {
+                    background-color: #edebe9;
+                    color: #201f1e;
+                  }
+                  &:active .ms-Button-icon {
+                    color: #004578;
+                  }
+                  &:before {
+                    background-color: #0078d4;
+                    bottom: 0px;
+                    content: "";
+                    height: 2px;
+                    left: 8px;
+                    position: absolute;
+                    right: 8px;
+                    transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                        right 0.267s cubic-bezier(.1,.25,.75,.9);
+                  }
+                  &:after {
+                    color: transparent;
+                    content: attr(data-content);
+                    display: block;
+                    font-weight: 700;
+                    height: 1px;
+                    overflow: hidden;
+                    visibility: hidden;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #605e5c;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:before {
+                    background-color: Highlight;
+                  }
+                  &:hover::before {
+                    left: 0px;
+                    right: 0px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: Highlight;
+                  }
+              data-content="Test Link 1"
+              data-is-focusable={true}
+              id="Pivot0-Tab0"
+              name="Test Link 1"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              role="tab"
+              type="button"
             >
-               
-              Test Link 1
-            </span>
-          </span>
-        </span>
-      </button>
-      <button
-        aria-selected={false}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-        data-content=""
-        data-is-focusable={true}
-        id="Pivot0-Tab1"
-        name=""
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
-      >
-        <span
-          className=
-              ms-Button-flexContainer
-              {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
-              }
-          data-automationid="splitbuttonprimary"
-        >
-          <span
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <span
+                  className=
+                      ms-Pivot-linkContent
+                      {
+                        flex: 0 1 100%;
+                      }
+                      & > *  {
+                        margin-left: 4px;
+                      }
+                      & > *:first-child {
+                        margin-left: 0px;
+                      }
+                >
+                  <span
+                    className=
+                        ms-Pivot-text
+                        {
+                          display: inline-block;
+                          vertical-align: top;
+                        }
+                  >
+                     
+                    Test Link 1
+                  </span>
+                </span>
+              </span>
+            </button>
+          </div>
+          <div
             className=
-                ms-Pivot-linkContent
+                ms-OverflowSet-item
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inherit;
+                  flex-shrink: 0;
                 }
           >
-            <span
+            <button
+              aria-selected={false}
               className=
-                  ms-Pivot-text
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  ms-Pivot-link
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: 0px;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
                     display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 44px;
+                    line-height: 44px;
+                    margin-right: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 8px;
+                    padding-right: 8px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
                     vertical-align: top;
                   }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 0px;
+                    bottom: 2px;
+                    content: attr(data-content);
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: relative;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    color: #201f1e;
+                    cursor: pointer;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:hover .ms-Button-icon {
+                    color: #0078d4;
+                  }
+                  &:focus {
+                    outline: none;
+                  }
+                  &:active {
+                    background-color: #edebe9;
+                    color: #201f1e;
+                  }
+                  &:active .ms-Button-icon {
+                    color: #004578;
+                  }
+                  &:before {
+                    background-color: transparent;
+                    bottom: 0px;
+                    content: "";
+                    height: 2px;
+                    left: 8px;
+                    position: absolute;
+                    right: 8px;
+                    transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                        right 0.267s cubic-bezier(.1,.25,.75,.9);
+                  }
+                  &:after {
+                    color: transparent;
+                    content: attr(data-content);
+                    display: block;
+                    font-weight: 700;
+                    height: 1px;
+                    overflow: hidden;
+                    visibility: hidden;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #605e5c;
+                  }
+              data-content=""
+              data-is-focusable={true}
+              id="Pivot0-Tab1"
+              name=""
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              role="tab"
+              type="button"
             >
-               
-              
-            </span>
-          </span>
-        </span>
-      </button>
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <span
+                  className=
+                      ms-Pivot-linkContent
+                      {
+                        flex: 0 1 100%;
+                      }
+                      & > *  {
+                        margin-left: 4px;
+                      }
+                      & > *:first-child {
+                        margin-left: 0px;
+                      }
+                >
+                  <span
+                    className=
+                        ms-Pivot-text
+                        {
+                          display: inline-block;
+                          vertical-align: top;
+                        }
+                  >
+                     
+                    
+                  </span>
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <div

--- a/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
@@ -2,381 +2,419 @@
 
 exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
 <div>
-  <div
-    className=
-        ms-FocusZone
-        &:focus {
-          outline: none;
-        }
-    data-focuszone-id="FocusZone1"
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onMouseDownCapture={[Function]}
-  >
+  <div>
     <div
-      className=
-          ms-Pivot
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #0078d4;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-            white-space: nowrap;
-          }
-      role="tablist"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
     >
-      <button
-        aria-selected={true}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            is-selected
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 600;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: #0078d4;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background-color: Highlight;
-            }
-            &:hover::before {
-              left: 0px;
-              right: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              color: Highlight;
-            }
-        data-content="test"
-        data-is-focusable={true}
-        id="Pivot0-Tab0"
-        name="test"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+      <div
+        data-automation-id="visibleContent"
+        style={
+          Object {
+            "position": "fixed",
+            "visibility": "hidden",
+          }
+        }
       >
-        <span
+        <div
+          aria-orientation="horizontal"
           className=
-              ms-Button-flexContainer
+              ms-FocusZone
+              ms-OverflowSet
+              ms-Pivot
+              &:focus {
+                outline: none;
+              }
               {
-                align-items: center;
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #0078d4;
                 display: flex;
                 flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+                white-space: nowrap;
               }
-          data-automationid="splitbuttonprimary"
+          data-focuszone-id="FocusZone1"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+          role="presentation"
         >
-          <span
+          <div
             className=
-                ms-Pivot-linkContent
+                ms-OverflowSet-item
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inherit;
+                  flex-shrink: 0;
                 }
           >
-            <span
+            <button
+              aria-selected={true}
               className=
-                  ms-Pivot-text
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  ms-Pivot-link
+                  is-selected
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: 0px;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
                     display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 600;
+                    height: 44px;
+                    line-height: 44px;
+                    margin-right: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 8px;
+                    padding-right: 8px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
                     vertical-align: top;
                   }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 0px;
+                    bottom: 2px;
+                    content: attr(data-content);
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: relative;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    color: #201f1e;
+                    cursor: pointer;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:hover .ms-Button-icon {
+                    color: #0078d4;
+                  }
+                  &:focus {
+                    outline: none;
+                  }
+                  &:active {
+                    background-color: #edebe9;
+                    color: #201f1e;
+                  }
+                  &:active .ms-Button-icon {
+                    color: #004578;
+                  }
+                  &:before {
+                    background-color: #0078d4;
+                    bottom: 0px;
+                    content: "";
+                    height: 2px;
+                    left: 8px;
+                    position: absolute;
+                    right: 8px;
+                    transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                        right 0.267s cubic-bezier(.1,.25,.75,.9);
+                  }
+                  &:after {
+                    color: transparent;
+                    content: attr(data-content);
+                    display: block;
+                    font-weight: 700;
+                    height: 1px;
+                    overflow: hidden;
+                    visibility: hidden;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #605e5c;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:before {
+                    background-color: Highlight;
+                  }
+                  &:hover::before {
+                    left: 0px;
+                    right: 0px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: Highlight;
+                  }
+              data-content="test"
+              data-is-focusable={true}
+              id="Pivot0-Tab0"
+              name="test"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              role="tab"
+              type="button"
             >
-               
-              test
-            </span>
-          </span>
-        </span>
-      </button>
-      <button
-        aria-selected={false}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-        data-content="Test Link (20+)"
-        data-is-focusable={true}
-        id="Pivot0-Tab1"
-        name="Test Link"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
-      >
-        <span
-          className=
-              ms-Button-flexContainer
-              {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
-              }
-          data-automationid="splitbuttonprimary"
-        >
-          <span
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <span
+                  className=
+                      ms-Pivot-linkContent
+                      {
+                        flex: 0 1 100%;
+                      }
+                      & > *  {
+                        margin-left: 4px;
+                      }
+                      & > *:first-child {
+                        margin-left: 0px;
+                      }
+                >
+                  <span
+                    className=
+                        ms-Pivot-text
+                        {
+                          display: inline-block;
+                          vertical-align: top;
+                        }
+                  >
+                     
+                    test
+                  </span>
+                </span>
+              </span>
+            </button>
+          </div>
+          <div
             className=
-                ms-Pivot-linkContent
+                ms-OverflowSet-item
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inherit;
+                  flex-shrink: 0;
                 }
           >
-            <span
+            <button
+              aria-selected={false}
               className=
-                  ms-Pivot-text
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  ms-Pivot-link
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: 0px;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
                     display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 44px;
+                    line-height: 44px;
+                    margin-right: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 8px;
+                    padding-right: 8px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
                     vertical-align: top;
                   }
-            >
-               
-              Test Link
-            </span>
-            <span
-              className=
-                  ms-Pivot-count
-                  {
-                    display: inline-block;
-                    vertical-align: top;
+                  &::-moz-focus-inner {
+                    border: 0;
                   }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 0px;
+                    bottom: 2px;
+                    content: attr(data-content);
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: relative;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    color: #201f1e;
+                    cursor: pointer;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:hover .ms-Button-icon {
+                    color: #0078d4;
+                  }
+                  &:focus {
+                    outline: none;
+                  }
+                  &:active {
+                    background-color: #edebe9;
+                    color: #201f1e;
+                  }
+                  &:active .ms-Button-icon {
+                    color: #004578;
+                  }
+                  &:before {
+                    background-color: transparent;
+                    bottom: 0px;
+                    content: "";
+                    height: 2px;
+                    left: 8px;
+                    position: absolute;
+                    right: 8px;
+                    transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                        right 0.267s cubic-bezier(.1,.25,.75,.9);
+                  }
+                  &:after {
+                    color: transparent;
+                    content: attr(data-content);
+                    display: block;
+                    font-weight: 700;
+                    height: 1px;
+                    overflow: hidden;
+                    visibility: hidden;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #605e5c;
+                  }
+              data-content="Test Link (20+)"
+              data-is-focusable={true}
+              id="Pivot0-Tab1"
+              name="Test Link"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              role="tab"
+              type="button"
             >
-               (
-              20+
-              )
-            </span>
-          </span>
-        </span>
-      </button>
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <span
+                  className=
+                      ms-Pivot-linkContent
+                      {
+                        flex: 0 1 100%;
+                      }
+                      & > *  {
+                        margin-left: 4px;
+                      }
+                      & > *:first-child {
+                        margin-left: 0px;
+                      }
+                >
+                  <span
+                    className=
+                        ms-Pivot-text
+                        {
+                          display: inline-block;
+                          vertical-align: top;
+                        }
+                  >
+                     
+                    Test Link
+                  </span>
+                  <span
+                    className=
+                        ms-Pivot-count
+                        {
+                          display: inline-block;
+                          vertical-align: top;
+                        }
+                  >
+                     (
+                    20+
+                    )
+                  </span>
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <div
@@ -393,368 +431,408 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
   className="specialClassName"
 >
   <div
-    className=
-        ms-FocusZone
-        &:focus {
-          outline: none;
-        }
-    data-focuszone-id="FocusZone1"
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onMouseDownCapture={[Function]}
+    className="specialClassName"
   >
     <div
-      className=
-          ms-Pivot
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #0078d4;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-            white-space: nowrap;
-          }
-      role="tablist"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
     >
-      <button
-        aria-selected={true}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            is-selected
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 600;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: #0078d4;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background-color: Highlight;
-            }
-            &:hover::before {
-              left: 0px;
-              right: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              color: Highlight;
-            }
-        data-content="Test Link 1"
-        data-is-focusable={true}
-        id="Pivot0-Tab0"
-        name="Test Link 1"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+      <div
+        data-automation-id="visibleContent"
+        style={
+          Object {
+            "position": "fixed",
+            "visibility": "hidden",
+          }
+        }
       >
-        <span
+        <div
+          aria-orientation="horizontal"
           className=
-              ms-Button-flexContainer
+              ms-FocusZone
+              ms-OverflowSet
+              ms-Pivot
+              &:focus {
+                outline: none;
+              }
               {
-                align-items: center;
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #0078d4;
                 display: flex;
                 flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+                white-space: nowrap;
               }
-          data-automationid="splitbuttonprimary"
+          data-focuszone-id="FocusZone1"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+          role="presentation"
         >
-          <span
+          <div
             className=
-                ms-Pivot-linkContent
+                ms-OverflowSet-item
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inherit;
+                  flex-shrink: 0;
                 }
           >
-            <span
+            <button
+              aria-selected={true}
               className=
-                  ms-Pivot-text
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  ms-Pivot-link
+                  is-selected
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: 0px;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
                     display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 600;
+                    height: 44px;
+                    line-height: 44px;
+                    margin-right: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 8px;
+                    padding-right: 8px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
                     vertical-align: top;
                   }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 0px;
+                    bottom: 2px;
+                    content: attr(data-content);
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: relative;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    color: #201f1e;
+                    cursor: pointer;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:hover .ms-Button-icon {
+                    color: #0078d4;
+                  }
+                  &:focus {
+                    outline: none;
+                  }
+                  &:active {
+                    background-color: #edebe9;
+                    color: #201f1e;
+                  }
+                  &:active .ms-Button-icon {
+                    color: #004578;
+                  }
+                  &:before {
+                    background-color: #0078d4;
+                    bottom: 0px;
+                    content: "";
+                    height: 2px;
+                    left: 8px;
+                    position: absolute;
+                    right: 8px;
+                    transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                        right 0.267s cubic-bezier(.1,.25,.75,.9);
+                  }
+                  &:after {
+                    color: transparent;
+                    content: attr(data-content);
+                    display: block;
+                    font-weight: 700;
+                    height: 1px;
+                    overflow: hidden;
+                    visibility: hidden;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #605e5c;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:before {
+                    background-color: Highlight;
+                  }
+                  &:hover::before {
+                    left: 0px;
+                    right: 0px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: Highlight;
+                  }
+              data-content="Test Link 1"
+              data-is-focusable={true}
+              id="Pivot0-Tab0"
+              name="Test Link 1"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              role="tab"
+              type="button"
             >
-               
-              Test Link 1
-            </span>
-          </span>
-        </span>
-      </button>
-      <button
-        aria-selected={false}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-        data-content="Test Link 2"
-        data-is-focusable={true}
-        id="Pivot0-Tab1"
-        name="Test Link 2"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
-      >
-        <span
-          className=
-              ms-Button-flexContainer
-              {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
-              }
-          data-automationid="splitbuttonprimary"
-        >
-          <span
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <span
+                  className=
+                      ms-Pivot-linkContent
+                      {
+                        flex: 0 1 100%;
+                      }
+                      & > *  {
+                        margin-left: 4px;
+                      }
+                      & > *:first-child {
+                        margin-left: 0px;
+                      }
+                >
+                  <span
+                    className=
+                        ms-Pivot-text
+                        {
+                          display: inline-block;
+                          vertical-align: top;
+                        }
+                  >
+                     
+                    Test Link 1
+                  </span>
+                </span>
+              </span>
+            </button>
+          </div>
+          <div
             className=
-                ms-Pivot-linkContent
+                ms-OverflowSet-item
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inherit;
+                  flex-shrink: 0;
                 }
           >
-            <span
+            <button
+              aria-selected={false}
               className=
-                  ms-Pivot-text
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  ms-Pivot-link
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: 0px;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
                     display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 44px;
+                    line-height: 44px;
+                    margin-right: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 8px;
+                    padding-right: 8px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
                     vertical-align: top;
                   }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 0px;
+                    bottom: 2px;
+                    content: attr(data-content);
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: relative;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    color: #201f1e;
+                    cursor: pointer;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:hover .ms-Button-icon {
+                    color: #0078d4;
+                  }
+                  &:focus {
+                    outline: none;
+                  }
+                  &:active {
+                    background-color: #edebe9;
+                    color: #201f1e;
+                  }
+                  &:active .ms-Button-icon {
+                    color: #004578;
+                  }
+                  &:before {
+                    background-color: transparent;
+                    bottom: 0px;
+                    content: "";
+                    height: 2px;
+                    left: 8px;
+                    position: absolute;
+                    right: 8px;
+                    transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                        right 0.267s cubic-bezier(.1,.25,.75,.9);
+                  }
+                  &:after {
+                    color: transparent;
+                    content: attr(data-content);
+                    display: block;
+                    font-weight: 700;
+                    height: 1px;
+                    overflow: hidden;
+                    visibility: hidden;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #605e5c;
+                  }
+              data-content="Test Link 2"
+              data-is-focusable={true}
+              id="Pivot0-Tab1"
+              name="Test Link 2"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              role="tab"
+              type="button"
             >
-               
-              Test Link 2
-            </span>
-          </span>
-        </span>
-      </button>
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <span
+                  className=
+                      ms-Pivot-linkContent
+                      {
+                        flex: 0 1 100%;
+                      }
+                      & > *  {
+                        margin-left: 4px;
+                      }
+                      & > *:first-child {
+                        margin-left: 0px;
+                      }
+                >
+                  <span
+                    className=
+                        ms-Pivot-text
+                        {
+                          display: inline-block;
+                          vertical-align: top;
+                        }
+                  >
+                     
+                    Test Link 2
+                  </span>
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <div
@@ -770,562 +848,609 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
 
 exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
 <div>
-  <div
-    className=
-        ms-FocusZone
-        &:focus {
-          outline: none;
-        }
-    data-focuszone-id="FocusZone1"
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onMouseDownCapture={[Function]}
-  >
+  <div>
     <div
-      className=
-          ms-Pivot
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #0078d4;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-            white-space: nowrap;
-          }
-      role="tablist"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
     >
-      <button
-        aria-selected={true}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            is-selected
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 600;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: #0078d4;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background-color: Highlight;
-            }
-            &:hover::before {
-              left: 0px;
-              right: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              color: Highlight;
-            }
-        data-content=" (12)"
-        data-is-focusable={true}
-        id="Pivot0-Tab0"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+      <div
+        data-automation-id="visibleContent"
+        style={
+          Object {
+            "position": "fixed",
+            "visibility": "hidden",
+          }
+        }
       >
-        <span
+        <div
+          aria-orientation="horizontal"
           className=
-              ms-Button-flexContainer
+              ms-FocusZone
+              ms-OverflowSet
+              ms-Pivot
+              &:focus {
+                outline: none;
+              }
               {
-                align-items: center;
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #0078d4;
                 display: flex;
                 flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+                white-space: nowrap;
               }
-          data-automationid="splitbuttonprimary"
+          data-focuszone-id="FocusZone1"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+          role="presentation"
         >
-          <span
+          <div
             className=
-                ms-Pivot-linkContent
+                ms-OverflowSet-item
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inherit;
+                  flex-shrink: 0;
                 }
           >
-            <span
+            <button
+              aria-selected={true}
               className=
-                  ms-Pivot-count
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  ms-Pivot-link
+                  is-selected
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: 0px;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
                     display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 600;
+                    height: 44px;
+                    line-height: 44px;
+                    margin-right: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 8px;
+                    padding-right: 8px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
                     vertical-align: top;
                   }
-            >
-               (
-              12
-              )
-            </span>
-          </span>
-        </span>
-      </button>
-      <button
-        aria-selected={false}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-        data-content="Test Link (12)"
-        data-is-focusable={true}
-        id="Pivot0-Tab1"
-        name="Test Link"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
-      >
-        <span
-          className=
-              ms-Button-flexContainer
-              {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
-              }
-          data-automationid="splitbuttonprimary"
-        >
-          <span
-            className=
-                ms-Pivot-linkContent
-                {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
-                }
-          >
-            <span
-              className=
-                  ms-Pivot-text
-                  {
-                    display: inline-block;
-                    vertical-align: top;
+                  &::-moz-focus-inner {
+                    border: 0;
                   }
-            >
-               
-              Test Link
-            </span>
-            <span
-              className=
-                  ms-Pivot-count
-                  {
-                    display: inline-block;
-                    vertical-align: top;
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 0px;
+                    bottom: 2px;
+                    content: attr(data-content);
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: relative;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
                   }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    color: #201f1e;
+                    cursor: pointer;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:hover .ms-Button-icon {
+                    color: #0078d4;
+                  }
+                  &:focus {
+                    outline: none;
+                  }
+                  &:active {
+                    background-color: #edebe9;
+                    color: #201f1e;
+                  }
+                  &:active .ms-Button-icon {
+                    color: #004578;
+                  }
+                  &:before {
+                    background-color: #0078d4;
+                    bottom: 0px;
+                    content: "";
+                    height: 2px;
+                    left: 8px;
+                    position: absolute;
+                    right: 8px;
+                    transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                        right 0.267s cubic-bezier(.1,.25,.75,.9);
+                  }
+                  &:after {
+                    color: transparent;
+                    content: attr(data-content);
+                    display: block;
+                    font-weight: 700;
+                    height: 1px;
+                    overflow: hidden;
+                    visibility: hidden;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #605e5c;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:before {
+                    background-color: Highlight;
+                  }
+                  &:hover::before {
+                    left: 0px;
+                    right: 0px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: Highlight;
+                  }
+              data-content=" (12)"
+              data-is-focusable={true}
+              id="Pivot0-Tab0"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              role="tab"
+              type="button"
             >
-               (
-              12
-              )
-            </span>
-          </span>
-        </span>
-      </button>
-      <button
-        aria-selected={false}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-        data-content="Text with icon xx"
-        data-is-focusable={true}
-        id="Pivot0-Tab2"
-        name="Text with icon"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
-      >
-        <span
-          className=
-              ms-Button-flexContainer
-              {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
-              }
-          data-automationid="splitbuttonprimary"
-        >
-          <span
-            className=
-                ms-Pivot-linkContent
-                {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
-                }
-          >
-            <span
-              className=
-                  ms-Pivot-icon
-
-            >
-              <i
-                aria-hidden={true}
+              <span
                 className=
-
+                    ms-Button-flexContainer
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      display: inline-block;
-                      font-family: "FabricMDL2Icons-1";
-                      font-style: normal;
-                      font-weight: normal;
-                      speak: none;
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
                     }
-                data-icon-name="Recent"
+                data-automationid="splitbuttonprimary"
               >
-                
-              </i>
-            </span>
-            <span
+                <span
+                  className=
+                      ms-Pivot-linkContent
+                      {
+                        flex: 0 1 100%;
+                      }
+                      & > *  {
+                        margin-left: 4px;
+                      }
+                      & > *:first-child {
+                        margin-left: 0px;
+                      }
+                >
+                  <span
+                    className=
+                        ms-Pivot-count
+                        {
+                          display: inline-block;
+                          vertical-align: top;
+                        }
+                  >
+                     (
+                    12
+                    )
+                  </span>
+                </span>
+              </span>
+            </button>
+          </div>
+          <div
+            className=
+                ms-OverflowSet-item
+                {
+                  display: inherit;
+                  flex-shrink: 0;
+                }
+          >
+            <button
+              aria-selected={false}
               className=
-                  ms-Pivot-text
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  ms-Pivot-link
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: 0px;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
                     display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 44px;
+                    line-height: 44px;
+                    margin-right: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 8px;
+                    padding-right: 8px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
                     vertical-align: top;
                   }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 0px;
+                    bottom: 2px;
+                    content: attr(data-content);
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: relative;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    color: #201f1e;
+                    cursor: pointer;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:hover .ms-Button-icon {
+                    color: #0078d4;
+                  }
+                  &:focus {
+                    outline: none;
+                  }
+                  &:active {
+                    background-color: #edebe9;
+                    color: #201f1e;
+                  }
+                  &:active .ms-Button-icon {
+                    color: #004578;
+                  }
+                  &:before {
+                    background-color: transparent;
+                    bottom: 0px;
+                    content: "";
+                    height: 2px;
+                    left: 8px;
+                    position: absolute;
+                    right: 8px;
+                    transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                        right 0.267s cubic-bezier(.1,.25,.75,.9);
+                  }
+                  &:after {
+                    color: transparent;
+                    content: attr(data-content);
+                    display: block;
+                    font-weight: 700;
+                    height: 1px;
+                    overflow: hidden;
+                    visibility: hidden;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #605e5c;
+                  }
+              data-content="Test Link (12)"
+              data-is-focusable={true}
+              id="Pivot0-Tab1"
+              name="Test Link"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              role="tab"
+              type="button"
             >
-               
-              Text with icon
-            </span>
-          </span>
-        </span>
-      </button>
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <span
+                  className=
+                      ms-Pivot-linkContent
+                      {
+                        flex: 0 1 100%;
+                      }
+                      & > *  {
+                        margin-left: 4px;
+                      }
+                      & > *:first-child {
+                        margin-left: 0px;
+                      }
+                >
+                  <span
+                    className=
+                        ms-Pivot-text
+                        {
+                          display: inline-block;
+                          vertical-align: top;
+                        }
+                  >
+                     
+                    Test Link
+                  </span>
+                  <span
+                    className=
+                        ms-Pivot-count
+                        {
+                          display: inline-block;
+                          vertical-align: top;
+                        }
+                  >
+                     (
+                    12
+                    )
+                  </span>
+                </span>
+              </span>
+            </button>
+          </div>
+          <div
+            className=
+                ms-OverflowSet-item
+                {
+                  display: inherit;
+                  flex-shrink: 0;
+                }
+          >
+            <button
+              aria-selected={false}
+              className=
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  ms-Pivot-link
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: 0px;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
+                    display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 44px;
+                    line-height: 44px;
+                    margin-right: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 8px;
+                    padding-right: 8px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
+                    vertical-align: top;
+                  }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 0px;
+                    bottom: 2px;
+                    content: attr(data-content);
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: relative;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    color: #201f1e;
+                    cursor: pointer;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:hover .ms-Button-icon {
+                    color: #0078d4;
+                  }
+                  &:focus {
+                    outline: none;
+                  }
+                  &:active {
+                    background-color: #edebe9;
+                    color: #201f1e;
+                  }
+                  &:active .ms-Button-icon {
+                    color: #004578;
+                  }
+                  &:before {
+                    background-color: transparent;
+                    bottom: 0px;
+                    content: "";
+                    height: 2px;
+                    left: 8px;
+                    position: absolute;
+                    right: 8px;
+                    transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                        right 0.267s cubic-bezier(.1,.25,.75,.9);
+                  }
+                  &:after {
+                    color: transparent;
+                    content: attr(data-content);
+                    display: block;
+                    font-weight: 700;
+                    height: 1px;
+                    overflow: hidden;
+                    visibility: hidden;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #605e5c;
+                  }
+              data-content="Text with icon xx"
+              data-is-focusable={true}
+              id="Pivot0-Tab2"
+              name="Text with icon"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              role="tab"
+              type="button"
+            >
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <span
+                  className=
+                      ms-Pivot-linkContent
+                      {
+                        flex: 0 1 100%;
+                      }
+                      & > *  {
+                        margin-left: 4px;
+                      }
+                      & > *:first-child {
+                        margin-left: 0px;
+                      }
+                >
+                  <span
+                    className=
+                        ms-Pivot-icon
+
+                  >
+                    <i
+                      aria-hidden={true}
+                      className=
+
+                          {
+                            -moz-osx-font-smoothing: grayscale;
+                            -webkit-font-smoothing: antialiased;
+                            display: inline-block;
+                            font-family: "FabricMDL2Icons-1";
+                            font-style: normal;
+                            font-weight: normal;
+                            speak: none;
+                          }
+                      data-icon-name="Recent"
+                    >
+                      
+                    </i>
+                  </span>
+                  <span
+                    className=
+                        ms-Pivot-text
+                        {
+                          display: inline-block;
+                          vertical-align: top;
+                        }
+                  >
+                     
+                    Text with icon
+                  </span>
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <div
@@ -1339,370 +1464,408 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
 
 exports[`Pivot renders large link Pivot correctly 1`] = `
 <div>
-  <div
-    className=
-        ms-FocusZone
-        &:focus {
-          outline: none;
-        }
-    data-focuszone-id="FocusZone1"
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onMouseDownCapture={[Function]}
-  >
+  <div>
     <div
-      className=
-          ms-Pivot
-          ms-Pivot--large
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #0078d4;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-            white-space: nowrap;
-          }
-      role="tablist"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
     >
-      <button
-        aria-selected={true}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            is-selected
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 18px;
-              font-weight: 600;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: #0078d4;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background-color: Highlight;
-            }
-            &:hover::before {
-              left: 0px;
-              right: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              color: Highlight;
-            }
-        data-content="Test Link 1"
-        data-is-focusable={true}
-        id="Pivot0-Tab0"
-        name="Test Link 1"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+      <div
+        data-automation-id="visibleContent"
+        style={
+          Object {
+            "position": "fixed",
+            "visibility": "hidden",
+          }
+        }
       >
-        <span
+        <div
+          aria-orientation="horizontal"
           className=
-              ms-Button-flexContainer
+              ms-FocusZone
+              ms-OverflowSet
+              ms-Pivot
+              ms-Pivot--large
+              &:focus {
+                outline: none;
+              }
               {
-                align-items: center;
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #0078d4;
                 display: flex;
                 flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+                white-space: nowrap;
               }
-          data-automationid="splitbuttonprimary"
+          data-focuszone-id="FocusZone1"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+          role="presentation"
         >
-          <span
+          <div
             className=
-                ms-Pivot-linkContent
+                ms-OverflowSet-item
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inherit;
+                  flex-shrink: 0;
                 }
           >
-            <span
+            <button
+              aria-selected={true}
               className=
-                  ms-Pivot-text
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  ms-Pivot-link
+                  is-selected
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: 0px;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
                     display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 18px;
+                    font-weight: 600;
+                    height: 44px;
+                    line-height: 44px;
+                    margin-right: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 8px;
+                    padding-right: 8px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
                     vertical-align: top;
                   }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 0px;
+                    bottom: 2px;
+                    content: attr(data-content);
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: relative;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    color: #201f1e;
+                    cursor: pointer;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:hover .ms-Button-icon {
+                    color: #0078d4;
+                  }
+                  &:focus {
+                    outline: none;
+                  }
+                  &:active {
+                    background-color: #edebe9;
+                    color: #201f1e;
+                  }
+                  &:active .ms-Button-icon {
+                    color: #004578;
+                  }
+                  &:before {
+                    background-color: #0078d4;
+                    bottom: 0px;
+                    content: "";
+                    height: 2px;
+                    left: 8px;
+                    position: absolute;
+                    right: 8px;
+                    transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                        right 0.267s cubic-bezier(.1,.25,.75,.9);
+                  }
+                  &:after {
+                    color: transparent;
+                    content: attr(data-content);
+                    display: block;
+                    font-weight: 700;
+                    height: 1px;
+                    overflow: hidden;
+                    visibility: hidden;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #605e5c;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:before {
+                    background-color: Highlight;
+                  }
+                  &:hover::before {
+                    left: 0px;
+                    right: 0px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: Highlight;
+                  }
+              data-content="Test Link 1"
+              data-is-focusable={true}
+              id="Pivot0-Tab0"
+              name="Test Link 1"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              role="tab"
+              type="button"
             >
-               
-              Test Link 1
-            </span>
-          </span>
-        </span>
-      </button>
-      <button
-        aria-selected={false}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 18px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-        data-content=""
-        data-is-focusable={true}
-        id="Pivot0-Tab1"
-        name=""
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
-      >
-        <span
-          className=
-              ms-Button-flexContainer
-              {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
-              }
-          data-automationid="splitbuttonprimary"
-        >
-          <span
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <span
+                  className=
+                      ms-Pivot-linkContent
+                      {
+                        flex: 0 1 100%;
+                      }
+                      & > *  {
+                        margin-left: 4px;
+                      }
+                      & > *:first-child {
+                        margin-left: 0px;
+                      }
+                >
+                  <span
+                    className=
+                        ms-Pivot-text
+                        {
+                          display: inline-block;
+                          vertical-align: top;
+                        }
+                  >
+                     
+                    Test Link 1
+                  </span>
+                </span>
+              </span>
+            </button>
+          </div>
+          <div
             className=
-                ms-Pivot-linkContent
+                ms-OverflowSet-item
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inherit;
+                  flex-shrink: 0;
                 }
           >
-            <span
+            <button
+              aria-selected={false}
               className=
-                  ms-Pivot-text
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  ms-Pivot-link
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: 0px;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
                     display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 18px;
+                    font-weight: 400;
+                    height: 44px;
+                    line-height: 44px;
+                    margin-right: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 8px;
+                    padding-right: 8px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
                     vertical-align: top;
                   }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 0px;
+                    bottom: 2px;
+                    content: attr(data-content);
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: relative;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    color: #201f1e;
+                    cursor: pointer;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:hover .ms-Button-icon {
+                    color: #0078d4;
+                  }
+                  &:focus {
+                    outline: none;
+                  }
+                  &:active {
+                    background-color: #edebe9;
+                    color: #201f1e;
+                  }
+                  &:active .ms-Button-icon {
+                    color: #004578;
+                  }
+                  &:before {
+                    background-color: transparent;
+                    bottom: 0px;
+                    content: "";
+                    height: 2px;
+                    left: 8px;
+                    position: absolute;
+                    right: 8px;
+                    transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                        right 0.267s cubic-bezier(.1,.25,.75,.9);
+                  }
+                  &:after {
+                    color: transparent;
+                    content: attr(data-content);
+                    display: block;
+                    font-weight: 700;
+                    height: 1px;
+                    overflow: hidden;
+                    visibility: hidden;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #605e5c;
+                  }
+              data-content=""
+              data-is-focusable={true}
+              id="Pivot0-Tab1"
+              name=""
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              role="tab"
+              type="button"
             >
-               
-              
-            </span>
-          </span>
-        </span>
-      </button>
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <span
+                  className=
+                      ms-Pivot-linkContent
+                      {
+                        flex: 0 1 100%;
+                      }
+                      & > *  {
+                        margin-left: 4px;
+                      }
+                      & > *:first-child {
+                        margin-left: 0px;
+                      }
+                >
+                  <span
+                    className=
+                        ms-Pivot-text
+                        {
+                          display: inline-block;
+                          vertical-align: top;
+                        }
+                  >
+                     
+                    
+                  </span>
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <div
@@ -1716,387 +1879,425 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
 
 exports[`Pivot renders large tabbed Pivot correctly 1`] = `
 <div>
-  <div
-    className=
-        ms-FocusZone
-        &:focus {
-          outline: none;
-        }
-    data-focuszone-id="FocusZone1"
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onMouseDownCapture={[Function]}
-  >
+  <div>
     <div
-      className=
-          ms-Pivot
-          ms-Pivot--large
-          ms-Pivot--tabs
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #0078d4;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-            white-space: nowrap;
-          }
-      role="tablist"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
     >
-      <button
-        aria-selected={true}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            is-selected
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: #0078d4;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #ffffff;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 18px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 0px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 10px;
-              padding-right: 10px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #106ebe;
-              color: #ffffff;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline-offset: -1px;
-              outline: none;
-            }
-            &:active {
-              background-color: #005a9e;
-              color: #ffffff;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: auto;
-              left: 0px;
-              position: absolute;
-              right: 0px;
-              top: 0px;
-              transition: none;
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-            .ms-Fabric--isFocusVisible &:focus::before {
-              background: transparent;
-              height: auto;
-              transition: none;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background-color: Highlight;
-            }
-            &:hover::before {
-              left: 0px;
-              right: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              -ms-high-contrast-adjust: none;
-              background: Highlight;
-              color: HighlightText;
-              font-weight: 600;
-            }
-        data-content="Test Link 1"
-        data-is-focusable={true}
-        id="Pivot0-Tab0"
-        name="Test Link 1"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+      <div
+        data-automation-id="visibleContent"
+        style={
+          Object {
+            "position": "fixed",
+            "visibility": "hidden",
+          }
+        }
       >
-        <span
+        <div
+          aria-orientation="horizontal"
           className=
-              ms-Button-flexContainer
+              ms-FocusZone
+              ms-OverflowSet
+              ms-Pivot
+              ms-Pivot--large
+              ms-Pivot--tabs
+              &:focus {
+                outline: none;
+              }
               {
-                align-items: center;
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #0078d4;
                 display: flex;
                 flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+                white-space: nowrap;
               }
-          data-automationid="splitbuttonprimary"
+          data-focuszone-id="FocusZone1"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+          role="presentation"
         >
-          <span
+          <div
             className=
-                ms-Pivot-linkContent
+                ms-OverflowSet-item
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inherit;
+                  flex-shrink: 0;
                 }
           >
-            <span
+            <button
+              aria-selected={true}
               className=
-                  ms-Pivot-text
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  ms-Pivot-link
+                  is-selected
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: #0078d4;
+                    border-radius: 0px;
+                    border: 0px;
+                    box-sizing: border-box;
+                    color: #ffffff;
+                    cursor: pointer;
                     display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 18px;
+                    font-weight: 400;
+                    height: 44px;
+                    line-height: 44px;
+                    margin-right: 0px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 10px;
+                    padding-right: 10px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
                     vertical-align: top;
                   }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 0px;
+                    bottom: 2px;
+                    content: attr(data-content);
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: relative;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #106ebe;
+                    color: #ffffff;
+                    cursor: pointer;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:hover .ms-Button-icon {
+                    color: #0078d4;
+                  }
+                  &:focus {
+                    outline-offset: -1px;
+                    outline: none;
+                  }
+                  &:active {
+                    background-color: #005a9e;
+                    color: #ffffff;
+                  }
+                  &:active .ms-Button-icon {
+                    color: #004578;
+                  }
+                  &:before {
+                    background-color: transparent;
+                    bottom: 0px;
+                    content: "";
+                    height: auto;
+                    left: 0px;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    transition: none;
+                  }
+                  &:after {
+                    color: transparent;
+                    content: attr(data-content);
+                    display: block;
+                    font-weight: 700;
+                    height: 1px;
+                    overflow: hidden;
+                    visibility: hidden;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #605e5c;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus::before {
+                    background: transparent;
+                    height: auto;
+                    transition: none;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:before {
+                    background-color: Highlight;
+                  }
+                  &:hover::before {
+                    left: 0px;
+                    right: 0px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    background: Highlight;
+                    color: HighlightText;
+                    font-weight: 600;
+                  }
+              data-content="Test Link 1"
+              data-is-focusable={true}
+              id="Pivot0-Tab0"
+              name="Test Link 1"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              role="tab"
+              type="button"
             >
-               
-              Test Link 1
-            </span>
-          </span>
-        </span>
-      </button>
-      <button
-        aria-selected={false}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: #ffffff;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 18px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 0px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 10px;
-              padding-right: 10px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #0078d4;
-              color: #ffffff;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              color: #000000;
-              outline-offset: -1px;
-              outline: none;
-            }
-            &:active {
-              background-color: #0078d4;
-              color: #ffffff;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-            .ms-Fabric--isFocusVisible &:focus::before {
-              background: transparent;
-              height: auto;
-              transition: none;
-            }
-        data-content=""
-        data-is-focusable={true}
-        id="Pivot0-Tab1"
-        name=""
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
-      >
-        <span
-          className=
-              ms-Button-flexContainer
-              {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
-              }
-          data-automationid="splitbuttonprimary"
-        >
-          <span
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <span
+                  className=
+                      ms-Pivot-linkContent
+                      {
+                        flex: 0 1 100%;
+                      }
+                      & > *  {
+                        margin-left: 4px;
+                      }
+                      & > *:first-child {
+                        margin-left: 0px;
+                      }
+                >
+                  <span
+                    className=
+                        ms-Pivot-text
+                        {
+                          display: inline-block;
+                          vertical-align: top;
+                        }
+                  >
+                     
+                    Test Link 1
+                  </span>
+                </span>
+              </span>
+            </button>
+          </div>
+          <div
             className=
-                ms-Pivot-linkContent
+                ms-OverflowSet-item
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inherit;
+                  flex-shrink: 0;
                 }
           >
-            <span
+            <button
+              aria-selected={false}
               className=
-                  ms-Pivot-text
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  ms-Pivot-link
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: #ffffff;
+                    border-radius: 0px;
+                    border: 0px;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
                     display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 18px;
+                    font-weight: 400;
+                    height: 44px;
+                    line-height: 44px;
+                    margin-right: 0px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 10px;
+                    padding-right: 10px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
                     vertical-align: top;
                   }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 0px;
+                    bottom: 2px;
+                    content: attr(data-content);
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: relative;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #0078d4;
+                    color: #ffffff;
+                    cursor: pointer;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:hover .ms-Button-icon {
+                    color: #0078d4;
+                  }
+                  &:focus {
+                    color: #000000;
+                    outline-offset: -1px;
+                    outline: none;
+                  }
+                  &:active {
+                    background-color: #0078d4;
+                    color: #ffffff;
+                  }
+                  &:active .ms-Button-icon {
+                    color: #004578;
+                  }
+                  &:before {
+                    background-color: transparent;
+                    bottom: 0px;
+                    content: "";
+                    height: 2px;
+                    left: 8px;
+                    position: absolute;
+                    right: 8px;
+                    transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                        right 0.267s cubic-bezier(.1,.25,.75,.9);
+                  }
+                  &:after {
+                    color: transparent;
+                    content: attr(data-content);
+                    display: block;
+                    font-weight: 700;
+                    height: 1px;
+                    overflow: hidden;
+                    visibility: hidden;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #605e5c;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus::before {
+                    background: transparent;
+                    height: auto;
+                    transition: none;
+                  }
+              data-content=""
+              data-is-focusable={true}
+              id="Pivot0-Tab1"
+              name=""
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              role="tab"
+              type="button"
             >
-               
-              
-            </span>
-          </span>
-        </span>
-      </button>
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <span
+                  className=
+                      ms-Pivot-linkContent
+                      {
+                        flex: 0 1 100%;
+                      }
+                      & > *  {
+                        margin-left: 4px;
+                      }
+                      & > *:first-child {
+                        margin-left: 0px;
+                      }
+                >
+                  <span
+                    className=
+                        ms-Pivot-text
+                        {
+                          display: inline-block;
+                          vertical-align: top;
+                        }
+                  >
+                     
+                    
+                  </span>
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <div
@@ -2110,369 +2311,407 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
 
 exports[`Pivot renders link Pivot correctly 1`] = `
 <div>
-  <div
-    className=
-        ms-FocusZone
-        &:focus {
-          outline: none;
-        }
-    data-focuszone-id="FocusZone1"
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onMouseDownCapture={[Function]}
-  >
+  <div>
     <div
-      className=
-          ms-Pivot
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #0078d4;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-            white-space: nowrap;
-          }
-      role="tablist"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
     >
-      <button
-        aria-selected={true}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            is-selected
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 600;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: #0078d4;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background-color: Highlight;
-            }
-            &:hover::before {
-              left: 0px;
-              right: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              color: Highlight;
-            }
-        data-content="Test Link 1"
-        data-is-focusable={true}
-        id="Pivot0-Tab0"
-        name="Test Link 1"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+      <div
+        data-automation-id="visibleContent"
+        style={
+          Object {
+            "position": "fixed",
+            "visibility": "hidden",
+          }
+        }
       >
-        <span
+        <div
+          aria-orientation="horizontal"
           className=
-              ms-Button-flexContainer
+              ms-FocusZone
+              ms-OverflowSet
+              ms-Pivot
+              &:focus {
+                outline: none;
+              }
               {
-                align-items: center;
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #0078d4;
                 display: flex;
                 flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+                white-space: nowrap;
               }
-          data-automationid="splitbuttonprimary"
+          data-focuszone-id="FocusZone1"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+          role="presentation"
         >
-          <span
+          <div
             className=
-                ms-Pivot-linkContent
+                ms-OverflowSet-item
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inherit;
+                  flex-shrink: 0;
                 }
           >
-            <span
+            <button
+              aria-selected={true}
               className=
-                  ms-Pivot-text
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  ms-Pivot-link
+                  is-selected
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: 0px;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
                     display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 600;
+                    height: 44px;
+                    line-height: 44px;
+                    margin-right: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 8px;
+                    padding-right: 8px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
                     vertical-align: top;
                   }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 0px;
+                    bottom: 2px;
+                    content: attr(data-content);
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: relative;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    color: #201f1e;
+                    cursor: pointer;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:hover .ms-Button-icon {
+                    color: #0078d4;
+                  }
+                  &:focus {
+                    outline: none;
+                  }
+                  &:active {
+                    background-color: #edebe9;
+                    color: #201f1e;
+                  }
+                  &:active .ms-Button-icon {
+                    color: #004578;
+                  }
+                  &:before {
+                    background-color: #0078d4;
+                    bottom: 0px;
+                    content: "";
+                    height: 2px;
+                    left: 8px;
+                    position: absolute;
+                    right: 8px;
+                    transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                        right 0.267s cubic-bezier(.1,.25,.75,.9);
+                  }
+                  &:after {
+                    color: transparent;
+                    content: attr(data-content);
+                    display: block;
+                    font-weight: 700;
+                    height: 1px;
+                    overflow: hidden;
+                    visibility: hidden;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #605e5c;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:before {
+                    background-color: Highlight;
+                  }
+                  &:hover::before {
+                    left: 0px;
+                    right: 0px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: Highlight;
+                  }
+              data-content="Test Link 1"
+              data-is-focusable={true}
+              id="Pivot0-Tab0"
+              name="Test Link 1"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              role="tab"
+              type="button"
             >
-               
-              Test Link 1
-            </span>
-          </span>
-        </span>
-      </button>
-      <button
-        aria-selected={false}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-        data-content=""
-        data-is-focusable={true}
-        id="Pivot0-Tab1"
-        name=""
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
-      >
-        <span
-          className=
-              ms-Button-flexContainer
-              {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
-              }
-          data-automationid="splitbuttonprimary"
-        >
-          <span
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <span
+                  className=
+                      ms-Pivot-linkContent
+                      {
+                        flex: 0 1 100%;
+                      }
+                      & > *  {
+                        margin-left: 4px;
+                      }
+                      & > *:first-child {
+                        margin-left: 0px;
+                      }
+                >
+                  <span
+                    className=
+                        ms-Pivot-text
+                        {
+                          display: inline-block;
+                          vertical-align: top;
+                        }
+                  >
+                     
+                    Test Link 1
+                  </span>
+                </span>
+              </span>
+            </button>
+          </div>
+          <div
             className=
-                ms-Pivot-linkContent
+                ms-OverflowSet-item
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inherit;
+                  flex-shrink: 0;
                 }
           >
-            <span
+            <button
+              aria-selected={false}
               className=
-                  ms-Pivot-text
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  ms-Pivot-link
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: 0px;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
                     display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 44px;
+                    line-height: 44px;
+                    margin-right: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 8px;
+                    padding-right: 8px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
                     vertical-align: top;
                   }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 0px;
+                    bottom: 2px;
+                    content: attr(data-content);
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: relative;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    color: #201f1e;
+                    cursor: pointer;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:hover .ms-Button-icon {
+                    color: #0078d4;
+                  }
+                  &:focus {
+                    outline: none;
+                  }
+                  &:active {
+                    background-color: #edebe9;
+                    color: #201f1e;
+                  }
+                  &:active .ms-Button-icon {
+                    color: #004578;
+                  }
+                  &:before {
+                    background-color: transparent;
+                    bottom: 0px;
+                    content: "";
+                    height: 2px;
+                    left: 8px;
+                    position: absolute;
+                    right: 8px;
+                    transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                        right 0.267s cubic-bezier(.1,.25,.75,.9);
+                  }
+                  &:after {
+                    color: transparent;
+                    content: attr(data-content);
+                    display: block;
+                    font-weight: 700;
+                    height: 1px;
+                    overflow: hidden;
+                    visibility: hidden;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #605e5c;
+                  }
+              data-content=""
+              data-is-focusable={true}
+              id="Pivot0-Tab1"
+              name=""
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              role="tab"
+              type="button"
             >
-               
-              
-            </span>
-          </span>
-        </span>
-      </button>
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <span
+                  className=
+                      ms-Pivot-linkContent
+                      {
+                        flex: 0 1 100%;
+                      }
+                      & > *  {
+                        margin-left: 4px;
+                      }
+                      & > *:first-child {
+                        margin-left: 0px;
+                      }
+                >
+                  <span
+                    className=
+                        ms-Pivot-text
+                        {
+                          display: inline-block;
+                          vertical-align: top;
+                        }
+                  >
+                     
+                    
+                  </span>
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <div
@@ -2486,386 +2725,424 @@ exports[`Pivot renders link Pivot correctly 1`] = `
 
 exports[`Pivot renders tabbed Pivot correctly 1`] = `
 <div>
-  <div
-    className=
-        ms-FocusZone
-        &:focus {
-          outline: none;
-        }
-    data-focuszone-id="FocusZone1"
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onMouseDownCapture={[Function]}
-  >
+  <div>
     <div
-      className=
-          ms-Pivot
-          ms-Pivot--tabs
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #0078d4;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-            white-space: nowrap;
-          }
-      role="tablist"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
     >
-      <button
-        aria-selected={true}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            is-selected
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: #0078d4;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #ffffff;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 0px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 10px;
-              padding-right: 10px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #106ebe;
-              color: #ffffff;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline-offset: -1px;
-              outline: none;
-            }
-            &:active {
-              background-color: #005a9e;
-              color: #ffffff;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: auto;
-              left: 0px;
-              position: absolute;
-              right: 0px;
-              top: 0px;
-              transition: none;
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-            .ms-Fabric--isFocusVisible &:focus::before {
-              background: transparent;
-              height: auto;
-              transition: none;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background-color: Highlight;
-            }
-            &:hover::before {
-              left: 0px;
-              right: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              -ms-high-contrast-adjust: none;
-              background: Highlight;
-              color: HighlightText;
-              font-weight: 600;
-            }
-        data-content="Test Link 1"
-        data-is-focusable={true}
-        id="Pivot0-Tab0"
-        name="Test Link 1"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+      <div
+        data-automation-id="visibleContent"
+        style={
+          Object {
+            "position": "fixed",
+            "visibility": "hidden",
+          }
+        }
       >
-        <span
+        <div
+          aria-orientation="horizontal"
           className=
-              ms-Button-flexContainer
+              ms-FocusZone
+              ms-OverflowSet
+              ms-Pivot
+              ms-Pivot--tabs
+              &:focus {
+                outline: none;
+              }
               {
-                align-items: center;
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #0078d4;
                 display: flex;
                 flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+                white-space: nowrap;
               }
-          data-automationid="splitbuttonprimary"
+          data-focuszone-id="FocusZone1"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+          role="presentation"
         >
-          <span
+          <div
             className=
-                ms-Pivot-linkContent
+                ms-OverflowSet-item
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inherit;
+                  flex-shrink: 0;
                 }
           >
-            <span
+            <button
+              aria-selected={true}
               className=
-                  ms-Pivot-text
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  ms-Pivot-link
+                  is-selected
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: #0078d4;
+                    border-radius: 0px;
+                    border: 0px;
+                    box-sizing: border-box;
+                    color: #ffffff;
+                    cursor: pointer;
                     display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 44px;
+                    line-height: 44px;
+                    margin-right: 0px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 10px;
+                    padding-right: 10px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
                     vertical-align: top;
                   }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 0px;
+                    bottom: 2px;
+                    content: attr(data-content);
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: relative;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #106ebe;
+                    color: #ffffff;
+                    cursor: pointer;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:hover .ms-Button-icon {
+                    color: #0078d4;
+                  }
+                  &:focus {
+                    outline-offset: -1px;
+                    outline: none;
+                  }
+                  &:active {
+                    background-color: #005a9e;
+                    color: #ffffff;
+                  }
+                  &:active .ms-Button-icon {
+                    color: #004578;
+                  }
+                  &:before {
+                    background-color: transparent;
+                    bottom: 0px;
+                    content: "";
+                    height: auto;
+                    left: 0px;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                    transition: none;
+                  }
+                  &:after {
+                    color: transparent;
+                    content: attr(data-content);
+                    display: block;
+                    font-weight: 700;
+                    height: 1px;
+                    overflow: hidden;
+                    visibility: hidden;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #605e5c;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus::before {
+                    background: transparent;
+                    height: auto;
+                    transition: none;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:before {
+                    background-color: Highlight;
+                  }
+                  &:hover::before {
+                    left: 0px;
+                    right: 0px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    background: Highlight;
+                    color: HighlightText;
+                    font-weight: 600;
+                  }
+              data-content="Test Link 1"
+              data-is-focusable={true}
+              id="Pivot0-Tab0"
+              name="Test Link 1"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              role="tab"
+              type="button"
             >
-               
-              Test Link 1
-            </span>
-          </span>
-        </span>
-      </button>
-      <button
-        aria-selected={false}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: #ffffff;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 0px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 10px;
-              padding-right: 10px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #0078d4;
-              color: #ffffff;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              color: #000000;
-              outline-offset: -1px;
-              outline: none;
-            }
-            &:active {
-              background-color: #0078d4;
-              color: #ffffff;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-            .ms-Fabric--isFocusVisible &:focus::before {
-              background: transparent;
-              height: auto;
-              transition: none;
-            }
-        data-content=""
-        data-is-focusable={true}
-        id="Pivot0-Tab1"
-        name=""
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
-      >
-        <span
-          className=
-              ms-Button-flexContainer
-              {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
-              }
-          data-automationid="splitbuttonprimary"
-        >
-          <span
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <span
+                  className=
+                      ms-Pivot-linkContent
+                      {
+                        flex: 0 1 100%;
+                      }
+                      & > *  {
+                        margin-left: 4px;
+                      }
+                      & > *:first-child {
+                        margin-left: 0px;
+                      }
+                >
+                  <span
+                    className=
+                        ms-Pivot-text
+                        {
+                          display: inline-block;
+                          vertical-align: top;
+                        }
+                  >
+                     
+                    Test Link 1
+                  </span>
+                </span>
+              </span>
+            </button>
+          </div>
+          <div
             className=
-                ms-Pivot-linkContent
+                ms-OverflowSet-item
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inherit;
+                  flex-shrink: 0;
                 }
           >
-            <span
+            <button
+              aria-selected={false}
               className=
-                  ms-Pivot-text
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  ms-Pivot-link
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: #ffffff;
+                    border-radius: 0px;
+                    border: 0px;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
                     display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 44px;
+                    line-height: 44px;
+                    margin-right: 0px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 10px;
+                    padding-right: 10px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
                     vertical-align: top;
                   }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 0px;
+                    bottom: 2px;
+                    content: attr(data-content);
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: relative;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #0078d4;
+                    color: #ffffff;
+                    cursor: pointer;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:hover .ms-Button-icon {
+                    color: #0078d4;
+                  }
+                  &:focus {
+                    color: #000000;
+                    outline-offset: -1px;
+                    outline: none;
+                  }
+                  &:active {
+                    background-color: #0078d4;
+                    color: #ffffff;
+                  }
+                  &:active .ms-Button-icon {
+                    color: #004578;
+                  }
+                  &:before {
+                    background-color: transparent;
+                    bottom: 0px;
+                    content: "";
+                    height: 2px;
+                    left: 8px;
+                    position: absolute;
+                    right: 8px;
+                    transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                        right 0.267s cubic-bezier(.1,.25,.75,.9);
+                  }
+                  &:after {
+                    color: transparent;
+                    content: attr(data-content);
+                    display: block;
+                    font-weight: 700;
+                    height: 1px;
+                    overflow: hidden;
+                    visibility: hidden;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #605e5c;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus::before {
+                    background: transparent;
+                    height: auto;
+                    transition: none;
+                  }
+              data-content=""
+              data-is-focusable={true}
+              id="Pivot0-Tab1"
+              name=""
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              role="tab"
+              type="button"
             >
-               
-              
-            </span>
-          </span>
-        </span>
-      </button>
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <span
+                  className=
+                      ms-Pivot-linkContent
+                      {
+                        flex: 0 1 100%;
+                      }
+                      & > *  {
+                        margin-left: 4px;
+                      }
+                      & > *:first-child {
+                        margin-left: 0px;
+                      }
+                >
+                  <span
+                    className=
+                        ms-Pivot-text
+                        {
+                          display: inline-block;
+                          vertical-align: top;
+                        }
+                  >
+                     
+                    
+                  </span>
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <div
@@ -2879,369 +3156,407 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
 
 exports[`Pivot supports JSX expressions 1`] = `
 <div>
-  <div
-    className=
-        ms-FocusZone
-        &:focus {
-          outline: none;
-        }
-    data-focuszone-id="FocusZone1"
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onMouseDownCapture={[Function]}
-  >
+  <div>
     <div
-      className=
-          ms-Pivot
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #0078d4;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-            white-space: nowrap;
-          }
-      role="tablist"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
     >
-      <button
-        aria-selected={false}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-        data-content="Test Link 1"
-        data-is-focusable={true}
-        id="Pivot0-Tab0"
-        name="Test Link 1"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+      <div
+        data-automation-id="visibleContent"
+        style={
+          Object {
+            "position": "fixed",
+            "visibility": "hidden",
+          }
+        }
       >
-        <span
+        <div
+          aria-orientation="horizontal"
           className=
-              ms-Button-flexContainer
+              ms-FocusZone
+              ms-OverflowSet
+              ms-Pivot
+              &:focus {
+                outline: none;
+              }
               {
-                align-items: center;
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #0078d4;
                 display: flex;
                 flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+                white-space: nowrap;
               }
-          data-automationid="splitbuttonprimary"
+          data-focuszone-id="FocusZone1"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+          role="presentation"
         >
-          <span
+          <div
             className=
-                ms-Pivot-linkContent
+                ms-OverflowSet-item
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inherit;
+                  flex-shrink: 0;
                 }
           >
-            <span
+            <button
+              aria-selected={false}
               className=
-                  ms-Pivot-text
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  ms-Pivot-link
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: 0px;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
                     display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 44px;
+                    line-height: 44px;
+                    margin-right: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 8px;
+                    padding-right: 8px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
                     vertical-align: top;
                   }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 0px;
+                    bottom: 2px;
+                    content: attr(data-content);
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: relative;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    color: #201f1e;
+                    cursor: pointer;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:hover .ms-Button-icon {
+                    color: #0078d4;
+                  }
+                  &:focus {
+                    outline: none;
+                  }
+                  &:active {
+                    background-color: #edebe9;
+                    color: #201f1e;
+                  }
+                  &:active .ms-Button-icon {
+                    color: #004578;
+                  }
+                  &:before {
+                    background-color: transparent;
+                    bottom: 0px;
+                    content: "";
+                    height: 2px;
+                    left: 8px;
+                    position: absolute;
+                    right: 8px;
+                    transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                        right 0.267s cubic-bezier(.1,.25,.75,.9);
+                  }
+                  &:after {
+                    color: transparent;
+                    content: attr(data-content);
+                    display: block;
+                    font-weight: 700;
+                    height: 1px;
+                    overflow: hidden;
+                    visibility: hidden;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #605e5c;
+                  }
+              data-content="Test Link 1"
+              data-is-focusable={true}
+              id="Pivot0-Tab0"
+              name="Test Link 1"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              role="tab"
+              type="button"
             >
-               
-              Test Link 1
-            </span>
-          </span>
-        </span>
-      </button>
-      <button
-        aria-selected={true}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            is-selected
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 600;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: #0078d4;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background-color: Highlight;
-            }
-            &:hover::before {
-              left: 0px;
-              right: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              color: Highlight;
-            }
-        data-content="Test Link 3"
-        data-is-focusable={true}
-        id="Pivot0-Tab1"
-        name="Test Link 3"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
-      >
-        <span
-          className=
-              ms-Button-flexContainer
-              {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
-              }
-          data-automationid="splitbuttonprimary"
-        >
-          <span
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <span
+                  className=
+                      ms-Pivot-linkContent
+                      {
+                        flex: 0 1 100%;
+                      }
+                      & > *  {
+                        margin-left: 4px;
+                      }
+                      & > *:first-child {
+                        margin-left: 0px;
+                      }
+                >
+                  <span
+                    className=
+                        ms-Pivot-text
+                        {
+                          display: inline-block;
+                          vertical-align: top;
+                        }
+                  >
+                     
+                    Test Link 1
+                  </span>
+                </span>
+              </span>
+            </button>
+          </div>
+          <div
             className=
-                ms-Pivot-linkContent
+                ms-OverflowSet-item
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inherit;
+                  flex-shrink: 0;
                 }
           >
-            <span
+            <button
+              aria-selected={true}
               className=
-                  ms-Pivot-text
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  ms-Pivot-link
+                  is-selected
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: 0px;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
                     display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 600;
+                    height: 44px;
+                    line-height: 44px;
+                    margin-right: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 8px;
+                    padding-right: 8px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
                     vertical-align: top;
                   }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 0px;
+                    bottom: 2px;
+                    content: attr(data-content);
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: relative;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    color: #201f1e;
+                    cursor: pointer;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:hover .ms-Button-icon {
+                    color: #0078d4;
+                  }
+                  &:focus {
+                    outline: none;
+                  }
+                  &:active {
+                    background-color: #edebe9;
+                    color: #201f1e;
+                  }
+                  &:active .ms-Button-icon {
+                    color: #004578;
+                  }
+                  &:before {
+                    background-color: #0078d4;
+                    bottom: 0px;
+                    content: "";
+                    height: 2px;
+                    left: 8px;
+                    position: absolute;
+                    right: 8px;
+                    transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                        right 0.267s cubic-bezier(.1,.25,.75,.9);
+                  }
+                  &:after {
+                    color: transparent;
+                    content: attr(data-content);
+                    display: block;
+                    font-weight: 700;
+                    height: 1px;
+                    overflow: hidden;
+                    visibility: hidden;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #605e5c;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:before {
+                    background-color: Highlight;
+                  }
+                  &:hover::before {
+                    left: 0px;
+                    right: 0px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: Highlight;
+                  }
+              data-content="Test Link 3"
+              data-is-focusable={true}
+              id="Pivot0-Tab1"
+              name="Test Link 3"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              role="tab"
+              type="button"
             >
-               
-              Test Link 3
-            </span>
-          </span>
-        </span>
-      </button>
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <span
+                  className=
+                      ms-Pivot-linkContent
+                      {
+                        flex: 0 1 100%;
+                      }
+                      & > *  {
+                        margin-left: 4px;
+                      }
+                      & > *:first-child {
+                        margin-left: 0px;
+                      }
+                >
+                  <span
+                    className=
+                        ms-Pivot-text
+                        {
+                          display: inline-block;
+                          vertical-align: top;
+                        }
+                  >
+                     
+                    Test Link 3
+                  </span>
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <div

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Overflow.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Overflow.Example.tsx
@@ -9,8 +9,15 @@ const labelStyles: Partial<IStyleSet<ILabelStyles>> = {
 
 export const PivotOverflowExample: React.FunctionComponent = () => {
   return (
-    <div style={{ width: 300 }}>
-      <Pivot>
+    <div style={{ width: '30%' }}>
+      <Pivot
+        styles={{
+          root: {
+            // Show where the edge of the pivot is at to indicate where it should be cutting off elements
+            border: '1px solid black'
+          }
+        }}
+      >
         <PivotItem
           headerText="My Files"
           headerButtonProps={{

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Overflow.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Overflow.Example.tsx
@@ -1,0 +1,47 @@
+import * as React from 'react';
+import { Label, ILabelStyles } from 'office-ui-fabric-react/lib/Label';
+import { Pivot, PivotItem } from 'office-ui-fabric-react/lib/Pivot';
+import { IStyleSet } from 'office-ui-fabric-react/lib/Styling';
+
+const labelStyles: Partial<IStyleSet<ILabelStyles>> = {
+  root: { marginTop: 10 }
+};
+
+export const PivotOverflowExample: React.FunctionComponent = () => {
+  return (
+    <div style={{ width: 300 }}>
+      <Pivot>
+        <PivotItem
+          headerText="My Files"
+          headerButtonProps={{
+            'data-order': 1,
+            'data-title': 'My Files Title'
+          }}
+        >
+          <Label styles={labelStyles}>Pivot #1</Label>
+        </PivotItem>
+        <PivotItem headerText="Recent">
+          <Label styles={labelStyles}>Pivot #2</Label>
+        </PivotItem>
+        <PivotItem headerText="Shared with me">
+          <Label styles={labelStyles}>Pivot #3</Label>
+        </PivotItem>
+        <PivotItem headerText="Other 1">
+          <Label styles={labelStyles}>Pivot #4</Label>
+        </PivotItem>
+        <PivotItem headerText="Other 2">
+          <Label styles={labelStyles}>Pivot #5</Label>
+        </PivotItem>
+        <PivotItem headerText="Other 3">
+          <Label styles={labelStyles}>Pivot #6</Label>
+        </PivotItem>
+        <PivotItem headerText="Other 4">
+          <Label styles={labelStyles}>Pivot #7</Label>
+        </PivotItem>
+        <PivotItem headerText="Other 5">
+          <Label styles={labelStyles}>Pivot #8</Label>
+        </PivotItem>
+      </Pivot>
+    </div>
+  );
+};

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -6,536 +6,583 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
     For Pivots, keytips will first show for each of the pivots. After selecting a pivot, the Keytips for its content are shown.
   </p>
   <div>
-    <div
-      className=
-          ms-FocusZone
-          &:focus {
-            outline: none;
-          }
-      data-focuszone-id="FocusZone1"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onMouseDownCapture={[Function]}
-    >
+    <div>
       <div
-        className=
-            ms-Pivot
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              box-shadow: none;
-              box-sizing: border-box;
-              color: #0078d4;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
-              position: relative;
-              white-space: nowrap;
-            }
-        role="tablist"
+        style={
+          Object {
+            "position": "relative",
+          }
+        }
       >
-        <button
-          aria-describedby="ktp-layer-id ktp-a"
-          aria-selected={true}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              is-selected
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 600;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: #0078d4;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background-color: Highlight;
-              }
-              &:hover::before {
-                left: 0px;
-                right: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                color: Highlight;
-              }
-          data-content="Pivot 1"
-          data-is-focusable={true}
-          data-ktp-execute-target="ktp-a"
-          data-ktp-target="ktp-a"
-          id="Pivot0-Tab0"
-          name="Pivot 1"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+        <div
+          data-automation-id="visibleContent"
+          style={
+            Object {
+              "position": "fixed",
+              "visibility": "hidden",
+            }
+          }
         >
-          <span
+          <div
+            aria-orientation="horizontal"
             className=
-                ms-Button-flexContainer
+                ms-FocusZone
+                ms-OverflowSet
+                ms-Pivot
+                &:focus {
+                  outline: none;
+                }
                 {
-                  align-items: center;
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #0078d4;
                   display: flex;
                   flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  white-space: nowrap;
                 }
-            data-automationid="splitbuttonprimary"
+            data-focuszone-id="FocusZone1"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDownCapture={[Function]}
+            role="presentation"
           >
-            <span
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-describedby="ktp-layer-id ktp-a"
+                aria-selected={true}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
+                    is-selected
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 600;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 8px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #201f1e;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #201f1e;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: #0078d4;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:before {
+                      background-color: Highlight;
+                    }
+                    &:hover::before {
+                      left: 0px;
+                      right: 0px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      color: Highlight;
+                    }
+                data-content="Pivot 1"
+                data-is-focusable={true}
+                data-ktp-execute-target="ktp-a"
+                data-ktp-target="ktp-a"
+                id="Pivot0-Tab0"
+                name="Pivot 1"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Pivot 1
-              </span>
-            </span>
-          </span>
-        </button>
-        <button
-          aria-describedby="ktp-layer-id ktp-b"
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-          data-content="Pivot 2"
-          data-is-focusable={true}
-          data-ktp-execute-target="ktp-b"
-          data-ktp-target="ktp-b"
-          id="Pivot0-Tab1"
-          name="Pivot 2"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Pivot 1
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-describedby="ktp-layer-id ktp-b"
+                aria-selected={false}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 8px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #201f1e;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #201f1e;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                data-content="Pivot 2"
+                data-is-focusable={true}
+                data-ktp-execute-target="ktp-b"
+                data-ktp-target="ktp-b"
+                id="Pivot0-Tab1"
+                name="Pivot 2"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Pivot 2
-              </span>
-            </span>
-          </span>
-        </button>
-        <button
-          aria-describedby="ktp-layer-id ktp-c"
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-          data-content="Pivot 3"
-          data-is-focusable={true}
-          data-ktp-execute-target="ktp-c"
-          data-ktp-target="ktp-c"
-          id="Pivot0-Tab2"
-          name="Pivot 3"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Pivot 2
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-describedby="ktp-layer-id ktp-c"
+                aria-selected={false}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 8px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #201f1e;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #201f1e;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                data-content="Pivot 3"
+                data-is-focusable={true}
+                data-ktp-execute-target="ktp-c"
+                data-ktp-target="ktp-c"
+                id="Pivot0-Tab2"
+                name="Pivot 3"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Pivot 3
-              </span>
-            </span>
-          </span>
-        </button>
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Pivot 3
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <div

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Basic.Example.tsx.shot
@@ -2,529 +2,576 @@
 
 exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
 <div>
-  <div
-    className=
-        ms-FocusZone
-        &:focus {
-          outline: none;
-        }
-    data-focuszone-id="FocusZone1"
-    onFocus={[Function]}
-    onKeyDown={[Function]}
-    onMouseDownCapture={[Function]}
-  >
+  <div>
     <div
-      className=
-          ms-Pivot
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            box-shadow: none;
-            box-sizing: border-box;
-            color: #0078d4;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            margin-bottom: 0px;
-            margin-left: 0px;
-            margin-right: 0px;
-            margin-top: 0px;
-            padding-bottom: 0px;
-            padding-left: 0px;
-            padding-right: 0px;
-            padding-top: 0px;
-            position: relative;
-            white-space: nowrap;
-          }
-      role="tablist"
+      style={
+        Object {
+          "position": "relative",
+        }
+      }
     >
-      <button
-        aria-selected={true}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            is-selected
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 600;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: #0078d4;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-            @media screen and (-ms-high-contrast: active){&:before {
-              background-color: Highlight;
-            }
-            &:hover::before {
-              left: 0px;
-              right: 0px;
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              color: Highlight;
-            }
-        data-content="My Files"
-        data-is-focusable={true}
-        data-order={1}
-        data-title="My Files Title"
-        id="Pivot0-Tab0"
-        name="My Files"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
+      <div
+        data-automation-id="visibleContent"
+        style={
+          Object {
+            "position": "fixed",
+            "visibility": "hidden",
+          }
+        }
       >
-        <span
+        <div
+          aria-orientation="horizontal"
           className=
-              ms-Button-flexContainer
+              ms-FocusZone
+              ms-OverflowSet
+              ms-Pivot
+              &:focus {
+                outline: none;
+              }
               {
-                align-items: center;
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                color: #0078d4;
                 display: flex;
                 flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+                white-space: nowrap;
               }
-          data-automationid="splitbuttonprimary"
+          data-focuszone-id="FocusZone1"
+          onFocus={[Function]}
+          onKeyDown={[Function]}
+          onMouseDownCapture={[Function]}
+          role="presentation"
         >
-          <span
+          <div
             className=
-                ms-Pivot-linkContent
+                ms-OverflowSet-item
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inherit;
+                  flex-shrink: 0;
                 }
           >
-            <span
+            <button
+              aria-selected={true}
               className=
-                  ms-Pivot-text
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  ms-Pivot-link
+                  is-selected
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: 0px;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
                     display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 600;
+                    height: 44px;
+                    line-height: 44px;
+                    margin-right: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 8px;
+                    padding-right: 8px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
                     vertical-align: top;
                   }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 0px;
+                    bottom: 2px;
+                    content: attr(data-content);
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: relative;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    color: #201f1e;
+                    cursor: pointer;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:hover .ms-Button-icon {
+                    color: #0078d4;
+                  }
+                  &:focus {
+                    outline: none;
+                  }
+                  &:active {
+                    background-color: #edebe9;
+                    color: #201f1e;
+                  }
+                  &:active .ms-Button-icon {
+                    color: #004578;
+                  }
+                  &:before {
+                    background-color: #0078d4;
+                    bottom: 0px;
+                    content: "";
+                    height: 2px;
+                    left: 8px;
+                    position: absolute;
+                    right: 8px;
+                    transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                        right 0.267s cubic-bezier(.1,.25,.75,.9);
+                  }
+                  &:after {
+                    color: transparent;
+                    content: attr(data-content);
+                    display: block;
+                    font-weight: 700;
+                    height: 1px;
+                    overflow: hidden;
+                    visibility: hidden;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #605e5c;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:before {
+                    background-color: Highlight;
+                  }
+                  &:hover::before {
+                    left: 0px;
+                    right: 0px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: Highlight;
+                  }
+              data-content="My Files"
+              data-is-focusable={true}
+              data-order={1}
+              data-title="My Files Title"
+              id="Pivot0-Tab0"
+              name="My Files"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              role="tab"
+              type="button"
             >
-               
-              My Files
-            </span>
-          </span>
-        </span>
-      </button>
-      <button
-        aria-selected={false}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-        data-content="Recent"
-        data-is-focusable={true}
-        id="Pivot0-Tab1"
-        name="Recent"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
-      >
-        <span
-          className=
-              ms-Button-flexContainer
-              {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
-              }
-          data-automationid="splitbuttonprimary"
-        >
-          <span
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <span
+                  className=
+                      ms-Pivot-linkContent
+                      {
+                        flex: 0 1 100%;
+                      }
+                      & > *  {
+                        margin-left: 4px;
+                      }
+                      & > *:first-child {
+                        margin-left: 0px;
+                      }
+                >
+                  <span
+                    className=
+                        ms-Pivot-text
+                        {
+                          display: inline-block;
+                          vertical-align: top;
+                        }
+                  >
+                     
+                    My Files
+                  </span>
+                </span>
+              </span>
+            </button>
+          </div>
+          <div
             className=
-                ms-Pivot-linkContent
+                ms-OverflowSet-item
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inherit;
+                  flex-shrink: 0;
                 }
           >
-            <span
+            <button
+              aria-selected={false}
               className=
-                  ms-Pivot-text
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  ms-Pivot-link
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: 0px;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
                     display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 44px;
+                    line-height: 44px;
+                    margin-right: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 8px;
+                    padding-right: 8px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
                     vertical-align: top;
                   }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 0px;
+                    bottom: 2px;
+                    content: attr(data-content);
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: relative;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    color: #201f1e;
+                    cursor: pointer;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:hover .ms-Button-icon {
+                    color: #0078d4;
+                  }
+                  &:focus {
+                    outline: none;
+                  }
+                  &:active {
+                    background-color: #edebe9;
+                    color: #201f1e;
+                  }
+                  &:active .ms-Button-icon {
+                    color: #004578;
+                  }
+                  &:before {
+                    background-color: transparent;
+                    bottom: 0px;
+                    content: "";
+                    height: 2px;
+                    left: 8px;
+                    position: absolute;
+                    right: 8px;
+                    transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                        right 0.267s cubic-bezier(.1,.25,.75,.9);
+                  }
+                  &:after {
+                    color: transparent;
+                    content: attr(data-content);
+                    display: block;
+                    font-weight: 700;
+                    height: 1px;
+                    overflow: hidden;
+                    visibility: hidden;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #605e5c;
+                  }
+              data-content="Recent"
+              data-is-focusable={true}
+              id="Pivot0-Tab1"
+              name="Recent"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              role="tab"
+              type="button"
             >
-               
-              Recent
-            </span>
-          </span>
-        </span>
-      </button>
-      <button
-        aria-selected={false}
-        className=
-            ms-Button
-            ms-Button--action
-            ms-Button--command
-            ms-Pivot-link
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              background-color: transparent;
-              border-radius: 0px;
-              border: 0px;
-              box-sizing: border-box;
-              color: #323130;
-              cursor: pointer;
-              display: inline-block;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              height: 44px;
-              line-height: 44px;
-              margin-right: 8px;
-              outline: transparent;
-              padding-bottom: 0;
-              padding-left: 8px;
-              padding-right: 8px;
-              padding-top: 0;
-              position: relative;
-              text-align: center;
-              text-decoration: none;
-              user-select: none;
-              vertical-align: top;
-            }
-            &::-moz-focus-inner {
-              border: 0;
-            }
-            .ms-Fabric--isFocusVisible &:focus:after {
-              border: 0px;
-              bottom: 2px;
-              content: attr(data-content);
-              left: 2px;
-              outline: 1px solid #605e5c;
-              position: relative;
-              right: 2px;
-              top: 2px;
-              z-index: 1;
-            }
-            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-              border: none;
-              bottom: -2px;
-              left: -2px;
-              outline-color: ButtonText;
-              right: -2px;
-              top: -2px;
-            }
-            &:active > * {
-              left: 0px;
-              position: relative;
-              top: 0px;
-            }
-            &:hover {
-              background-color: #f3f2f1;
-              color: #201f1e;
-              cursor: pointer;
-            }
-            @media screen and (-ms-high-contrast: active){&:hover {
-              border-color: Highlight;
-              color: Highlight;
-            }
-            &:hover .ms-Button-icon {
-              color: #0078d4;
-            }
-            &:focus {
-              outline: none;
-            }
-            &:active {
-              background-color: #edebe9;
-              color: #201f1e;
-            }
-            &:active .ms-Button-icon {
-              color: #004578;
-            }
-            &:before {
-              background-color: transparent;
-              bottom: 0px;
-              content: "";
-              height: 2px;
-              left: 8px;
-              position: absolute;
-              right: 8px;
-              transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                  right 0.267s cubic-bezier(.1,.25,.75,.9);
-            }
-            &:after {
-              color: transparent;
-              content: attr(data-content);
-              display: block;
-              font-weight: 700;
-              height: 1px;
-              overflow: hidden;
-              visibility: hidden;
-            }
-            .ms-Fabric--isFocusVisible &:focus {
-              outline: 1px solid #605e5c;
-            }
-        data-content="Shared with me"
-        data-is-focusable={true}
-        id="Pivot0-Tab2"
-        name="Shared with me"
-        onClick={[Function]}
-        onKeyDown={[Function]}
-        onKeyPress={[Function]}
-        onKeyUp={[Function]}
-        onMouseDown={[Function]}
-        onMouseUp={[Function]}
-        role="tab"
-        type="button"
-      >
-        <span
-          className=
-              ms-Button-flexContainer
-              {
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                height: 100%;
-                justify-content: flex-start;
-              }
-          data-automationid="splitbuttonprimary"
-        >
-          <span
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <span
+                  className=
+                      ms-Pivot-linkContent
+                      {
+                        flex: 0 1 100%;
+                      }
+                      & > *  {
+                        margin-left: 4px;
+                      }
+                      & > *:first-child {
+                        margin-left: 0px;
+                      }
+                >
+                  <span
+                    className=
+                        ms-Pivot-text
+                        {
+                          display: inline-block;
+                          vertical-align: top;
+                        }
+                  >
+                     
+                    Recent
+                  </span>
+                </span>
+              </span>
+            </button>
+          </div>
+          <div
             className=
-                ms-Pivot-linkContent
+                ms-OverflowSet-item
                 {
-                  flex: 0 1 100%;
-                }
-                & > *  {
-                  margin-left: 4px;
-                }
-                & > *:first-child {
-                  margin-left: 0px;
+                  display: inherit;
+                  flex-shrink: 0;
                 }
           >
-            <span
+            <button
+              aria-selected={false}
               className=
-                  ms-Pivot-text
+                  ms-Button
+                  ms-Button--action
+                  ms-Button--command
+                  ms-Pivot-link
                   {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    background-color: transparent;
+                    border-radius: 0px;
+                    border: 0px;
+                    box-sizing: border-box;
+                    color: #323130;
+                    cursor: pointer;
                     display: inline-block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 44px;
+                    line-height: 44px;
+                    margin-right: 8px;
+                    outline: transparent;
+                    padding-bottom: 0;
+                    padding-left: 8px;
+                    padding-right: 8px;
+                    padding-top: 0;
+                    position: relative;
+                    text-align: center;
+                    text-decoration: none;
+                    user-select: none;
                     vertical-align: top;
                   }
+                  &::-moz-focus-inner {
+                    border: 0;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus:after {
+                    border: 0px;
+                    bottom: 2px;
+                    content: attr(data-content);
+                    left: 2px;
+                    outline: 1px solid #605e5c;
+                    position: relative;
+                    right: 2px;
+                    top: 2px;
+                    z-index: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                    border: none;
+                    bottom: -2px;
+                    left: -2px;
+                    outline-color: ButtonText;
+                    right: -2px;
+                    top: -2px;
+                  }
+                  &:active > * {
+                    left: 0px;
+                    position: relative;
+                    top: 0px;
+                  }
+                  &:hover {
+                    background-color: #f3f2f1;
+                    color: #201f1e;
+                    cursor: pointer;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                    color: Highlight;
+                  }
+                  &:hover .ms-Button-icon {
+                    color: #0078d4;
+                  }
+                  &:focus {
+                    outline: none;
+                  }
+                  &:active {
+                    background-color: #edebe9;
+                    color: #201f1e;
+                  }
+                  &:active .ms-Button-icon {
+                    color: #004578;
+                  }
+                  &:before {
+                    background-color: transparent;
+                    bottom: 0px;
+                    content: "";
+                    height: 2px;
+                    left: 8px;
+                    position: absolute;
+                    right: 8px;
+                    transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                        right 0.267s cubic-bezier(.1,.25,.75,.9);
+                  }
+                  &:after {
+                    color: transparent;
+                    content: attr(data-content);
+                    display: block;
+                    font-weight: 700;
+                    height: 1px;
+                    overflow: hidden;
+                    visibility: hidden;
+                  }
+                  .ms-Fabric--isFocusVisible &:focus {
+                    outline: 1px solid #605e5c;
+                  }
+              data-content="Shared with me"
+              data-is-focusable={true}
+              id="Pivot0-Tab2"
+              name="Shared with me"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              onKeyPress={[Function]}
+              onKeyUp={[Function]}
+              onMouseDown={[Function]}
+              onMouseUp={[Function]}
+              role="tab"
+              type="button"
             >
-               
-              Shared with me
-            </span>
-          </span>
-        </span>
-      </button>
+              <span
+                className=
+                    ms-Button-flexContainer
+                    {
+                      align-items: center;
+                      display: flex;
+                      flex-wrap: nowrap;
+                      height: 100%;
+                      justify-content: flex-start;
+                    }
+                data-automationid="splitbuttonprimary"
+              >
+                <span
+                  className=
+                      ms-Pivot-linkContent
+                      {
+                        flex: 0 1 100%;
+                      }
+                      & > *  {
+                        margin-left: 4px;
+                      }
+                      & > *:first-child {
+                        margin-left: 0px;
+                      }
+                >
+                  <span
+                    className=
+                        ms-Pivot-text
+                        {
+                          display: inline-block;
+                          vertical-align: top;
+                        }
+                  >
+                     
+                    Shared with me
+                  </span>
+                </span>
+              </span>
+            </button>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <div

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Large.Example.tsx.shot
@@ -3,528 +3,575 @@
 exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
 <div>
   <div>
-    <div
-      className=
-          ms-FocusZone
-          &:focus {
-            outline: none;
-          }
-      data-focuszone-id="FocusZone1"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onMouseDownCapture={[Function]}
-    >
+    <div>
       <div
-        className=
-            ms-Pivot
-            ms-Pivot--large
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              box-shadow: none;
-              box-sizing: border-box;
-              color: #0078d4;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
-              position: relative;
-              white-space: nowrap;
-            }
-        role="tablist"
+        style={
+          Object {
+            "position": "relative",
+          }
+        }
       >
-        <button
-          aria-selected={true}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              is-selected
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 600;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: #0078d4;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background-color: Highlight;
-              }
-              &:hover::before {
-                left: 0px;
-                right: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                color: Highlight;
-              }
-          data-content="My Files"
-          data-is-focusable={true}
-          id="Pivot0-Tab0"
-          name="My Files"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+        <div
+          data-automation-id="visibleContent"
+          style={
+            Object {
+              "position": "fixed",
+              "visibility": "hidden",
+            }
+          }
         >
-          <span
+          <div
+            aria-orientation="horizontal"
             className=
-                ms-Button-flexContainer
+                ms-FocusZone
+                ms-OverflowSet
+                ms-Pivot
+                ms-Pivot--large
+                &:focus {
+                  outline: none;
+                }
                 {
-                  align-items: center;
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #0078d4;
                   display: flex;
                   flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  white-space: nowrap;
                 }
-            data-automationid="splitbuttonprimary"
+            data-focuszone-id="FocusZone1"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDownCapture={[Function]}
+            role="presentation"
           >
-            <span
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={true}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
+                    is-selected
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 18px;
+                      font-weight: 600;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 8px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #201f1e;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #201f1e;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: #0078d4;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:before {
+                      background-color: Highlight;
+                    }
+                    &:hover::before {
+                      left: 0px;
+                      right: 0px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      color: Highlight;
+                    }
+                data-content="My Files"
+                data-is-focusable={true}
+                id="Pivot0-Tab0"
+                name="My Files"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                My Files
-              </span>
-            </span>
-          </span>
-        </button>
-        <button
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-          data-content="Recent"
-          data-is-focusable={true}
-          id="Pivot0-Tab1"
-          name="Recent"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      My Files
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={false}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 18px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 8px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #201f1e;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #201f1e;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                data-content="Recent"
+                data-is-focusable={true}
+                id="Pivot0-Tab1"
+                name="Recent"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Recent
-              </span>
-            </span>
-          </span>
-        </button>
-        <button
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-          data-content="Shared with me"
-          data-is-focusable={true}
-          id="Pivot0-Tab2"
-          name="Shared with me"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Recent
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={false}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 18px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 8px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #201f1e;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #201f1e;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                data-content="Shared with me"
+                data-is-focusable={true}
+                id="Pivot0-Tab2"
+                name="Shared with me"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Shared with me
-              </span>
-            </span>
-          </span>
-        </button>
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Shared with me
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <div

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.OnChange.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.OnChange.Example.tsx.shot
@@ -3,717 +3,773 @@
 exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
 <div>
   <div>
-    <div
-      className=
-          ms-FocusZone
-          &:focus {
-            outline: none;
-          }
-      data-focuszone-id="FocusZone1"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onMouseDownCapture={[Function]}
-    >
+    <div>
       <div
-        className=
-            ms-Pivot
-            ms-Pivot--large
-            ms-Pivot--tabs
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              box-shadow: none;
-              box-sizing: border-box;
-              color: #0078d4;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
-              position: relative;
-              white-space: nowrap;
-            }
-        role="tablist"
+        style={
+          Object {
+            "position": "relative",
+          }
+        }
       >
-        <button
-          aria-selected={true}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              is-selected
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #0078d4;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #ffffff;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #106ebe;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #005a9e;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: auto;
-                left: 0px;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-                transition: none;
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background-color: Highlight;
-              }
-              &:hover::before {
-                left: 0px;
-                right: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                -ms-high-contrast-adjust: none;
-                background: Highlight;
-                color: HighlightText;
-                font-weight: 600;
-              }
-          data-content="Foo"
-          data-is-focusable={true}
-          id="Pivot0-Tab0"
-          name="Foo"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+        <div
+          data-automation-id="visibleContent"
+          style={
+            Object {
+              "position": "fixed",
+              "visibility": "hidden",
+            }
+          }
         >
-          <span
+          <div
+            aria-orientation="horizontal"
             className=
-                ms-Button-flexContainer
+                ms-FocusZone
+                ms-OverflowSet
+                ms-Pivot
+                ms-Pivot--large
+                ms-Pivot--tabs
+                &:focus {
+                  outline: none;
+                }
                 {
-                  align-items: center;
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #0078d4;
                   display: flex;
                   flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  white-space: nowrap;
                 }
-            data-automationid="splitbuttonprimary"
+            data-focuszone-id="FocusZone1"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDownCapture={[Function]}
+            role="presentation"
           >
-            <span
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={true}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
+                    is-selected
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #0078d4;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #ffffff;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 18px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 0px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 10px;
+                      padding-right: 10px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #106ebe;
+                      color: #ffffff;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      outline-offset: -1px;
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #005a9e;
+                      color: #ffffff;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: auto;
+                      left: 0px;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      transition: none;
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus::before {
+                      background: transparent;
+                      height: auto;
+                      transition: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:before {
+                      background-color: Highlight;
+                    }
+                    &:hover::before {
+                      left: 0px;
+                      right: 0px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      background: Highlight;
+                      color: HighlightText;
+                      font-weight: 600;
+                    }
+                data-content="Foo"
+                data-is-focusable={true}
+                id="Pivot0-Tab0"
+                name="Foo"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Foo
-              </span>
-            </span>
-          </span>
-        </button>
-        <button
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #0078d4;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                color: #000000;
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #0078d4;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-          data-content="Bar"
-          data-is-focusable={true}
-          id="Pivot0-Tab1"
-          name="Bar"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Foo
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={false}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #ffffff;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 18px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 0px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 10px;
+                      padding-right: 10px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #0078d4;
+                      color: #ffffff;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      color: #000000;
+                      outline-offset: -1px;
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #0078d4;
+                      color: #ffffff;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus::before {
+                      background: transparent;
+                      height: auto;
+                      transition: none;
+                    }
+                data-content="Bar"
+                data-is-focusable={true}
+                id="Pivot0-Tab1"
+                name="Bar"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Bar
-              </span>
-            </span>
-          </span>
-        </button>
-        <button
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #0078d4;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                color: #000000;
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #0078d4;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-          data-content="Bas"
-          data-is-focusable={true}
-          id="Pivot0-Tab2"
-          name="Bas"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Bar
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={false}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #ffffff;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 18px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 0px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 10px;
+                      padding-right: 10px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #0078d4;
+                      color: #ffffff;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      color: #000000;
+                      outline-offset: -1px;
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #0078d4;
+                      color: #ffffff;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus::before {
+                      background: transparent;
+                      height: auto;
+                      transition: none;
+                    }
+                data-content="Bas"
+                data-is-focusable={true}
+                id="Pivot0-Tab2"
+                name="Bas"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Bas
-              </span>
-            </span>
-          </span>
-        </button>
-        <button
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #0078d4;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                color: #000000;
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #0078d4;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-          data-content="Biz"
-          data-is-focusable={true}
-          id="Pivot0-Tab3"
-          name="Biz"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Bas
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={false}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #ffffff;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 18px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 0px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 10px;
+                      padding-right: 10px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #0078d4;
+                      color: #ffffff;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      color: #000000;
+                      outline-offset: -1px;
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #0078d4;
+                      color: #ffffff;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus::before {
+                      background: transparent;
+                      height: auto;
+                      transition: none;
+                    }
+                data-content="Biz"
+                data-is-focusable={true}
+                id="Pivot0-Tab3"
+                name="Biz"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Biz
-              </span>
-            </span>
-          </span>
-        </button>
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Biz
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <div

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Overflow.Example.tsx.shot
@@ -1,7 +1,13 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = `
-<div>
+exports[`Component Examples renders Pivot.Overflow.Example.tsx correctly 1`] = `
+<div
+  style={
+    Object {
+      "width": "30%",
+    }
+  }
+>
   <div>
     <div>
       <div
@@ -32,6 +38,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
+                  border: 1px solid black;
                   box-shadow: none;
                   box-sizing: border-box;
                   color: #0078d4;
@@ -182,8 +189,10 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                     @media screen and (-ms-high-contrast: active){& {
                       color: Highlight;
                     }
-                data-content="My Files (42) xx"
+                data-content="My Files"
                 data-is-focusable={true}
+                data-order={1}
+                data-title="My Files Title"
                 id="Pivot0-Tab0"
                 name="My Files"
                 onClick={[Function]}
@@ -222,29 +231,6 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                   >
                     <span
                       className=
-                          ms-Pivot-icon
-
-                    >
-                      <i
-                        aria-hidden={true}
-                        className=
-
-                            {
-                              -moz-osx-font-smoothing: grayscale;
-                              -webkit-font-smoothing: antialiased;
-                              display: inline-block;
-                              font-family: "FabricMDL2Icons-0";
-                              font-style: normal;
-                              font-weight: normal;
-                              speak: none;
-                            }
-                        data-icon-name="Emoji2"
-                      >
-                        
-                      </i>
-                    </span>
-                    <span
-                      className=
                           ms-Pivot-text
                           {
                             display: inline-block;
@@ -254,18 +240,6 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                        
                       My Files
                     </span>
-                    <span
-                      className=
-                          ms-Pivot-count
-                          {
-                            display: inline-block;
-                            vertical-align: top;
-                          }
-                    >
-                       (
-                      42
-                      )
-                    </span>
                   </span>
                 </span>
               </button>
@@ -384,9 +358,10 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                     .ms-Fabric--isFocusVisible &:focus {
                       outline: 1px solid #605e5c;
                     }
-                data-content=" (23) xx"
+                data-content="Recent"
                 data-is-focusable={true}
                 id="Pivot0-Tab1"
+                name="Recent"
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 onKeyPress={[Function]}
@@ -421,220 +396,6 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                           margin-left: 0px;
                         }
                   >
-                    <span
-                      className=
-                          ms-Pivot-icon
-
-                    >
-                      <i
-                        aria-hidden={true}
-                        className=
-
-                            {
-                              -moz-osx-font-smoothing: grayscale;
-                              -webkit-font-smoothing: antialiased;
-                              display: inline-block;
-                              font-family: "FabricMDL2Icons-1";
-                              font-style: normal;
-                              font-weight: normal;
-                              speak: none;
-                            }
-                        data-icon-name="Recent"
-                      >
-                        
-                      </i>
-                    </span>
-                    <span
-                      className=
-                          ms-Pivot-count
-                          {
-                            display: inline-block;
-                            vertical-align: top;
-                          }
-                    >
-                       (
-                      23
-                      )
-                    </span>
-                  </span>
-                </span>
-              </button>
-            </div>
-            <div
-              className=
-                  ms-OverflowSet-item
-                  {
-                    display: inherit;
-                    flex-shrink: 0;
-                  }
-            >
-              <button
-                aria-selected={false}
-                className=
-                    ms-Button
-                    ms-Button--action
-                    ms-Button--command
-                    ms-Pivot-link
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      background-color: transparent;
-                      border-radius: 0px;
-                      border: 0px;
-                      box-sizing: border-box;
-                      color: #323130;
-                      cursor: pointer;
-                      display: inline-block;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 44px;
-                      line-height: 44px;
-                      margin-right: 8px;
-                      outline: transparent;
-                      padding-bottom: 0;
-                      padding-left: 8px;
-                      padding-right: 8px;
-                      padding-top: 0;
-                      position: relative;
-                      text-align: center;
-                      text-decoration: none;
-                      user-select: none;
-                      vertical-align: top;
-                    }
-                    &::-moz-focus-inner {
-                      border: 0;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus:after {
-                      border: 0px;
-                      bottom: 2px;
-                      content: attr(data-content);
-                      left: 2px;
-                      outline: 1px solid #605e5c;
-                      position: relative;
-                      right: 2px;
-                      top: 2px;
-                      z-index: 1;
-                    }
-                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                      border: none;
-                      bottom: -2px;
-                      left: -2px;
-                      outline-color: ButtonText;
-                      right: -2px;
-                      top: -2px;
-                    }
-                    &:active > * {
-                      left: 0px;
-                      position: relative;
-                      top: 0px;
-                    }
-                    &:hover {
-                      background-color: #f3f2f1;
-                      color: #201f1e;
-                      cursor: pointer;
-                    }
-                    @media screen and (-ms-high-contrast: active){&:hover {
-                      border-color: Highlight;
-                      color: Highlight;
-                    }
-                    &:hover .ms-Button-icon {
-                      color: #0078d4;
-                    }
-                    &:focus {
-                      outline: none;
-                    }
-                    &:active {
-                      background-color: #edebe9;
-                      color: #201f1e;
-                    }
-                    &:active .ms-Button-icon {
-                      color: #004578;
-                    }
-                    &:before {
-                      background-color: transparent;
-                      bottom: 0px;
-                      content: "";
-                      height: 2px;
-                      left: 8px;
-                      position: absolute;
-                      right: 8px;
-                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
-                    }
-                    &:after {
-                      color: transparent;
-                      content: attr(data-content);
-                      display: block;
-                      font-weight: 700;
-                      height: 1px;
-                      overflow: hidden;
-                      visibility: hidden;
-                    }
-                    .ms-Fabric--isFocusVisible &:focus {
-                      outline: 1px solid #605e5c;
-                    }
-                data-content="Placeholder xx"
-                data-is-focusable={true}
-                id="Pivot0-Tab2"
-                name="Placeholder"
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                onKeyPress={[Function]}
-                onKeyUp={[Function]}
-                onMouseDown={[Function]}
-                onMouseUp={[Function]}
-                role="tab"
-                type="button"
-              >
-                <span
-                  className=
-                      ms-Button-flexContainer
-                      {
-                        align-items: center;
-                        display: flex;
-                        flex-wrap: nowrap;
-                        height: 100%;
-                        justify-content: flex-start;
-                      }
-                  data-automationid="splitbuttonprimary"
-                >
-                  <span
-                    className=
-                        ms-Pivot-linkContent
-                        {
-                          flex: 0 1 100%;
-                        }
-                        & > *  {
-                          margin-left: 4px;
-                        }
-                        & > *:first-child {
-                          margin-left: 0px;
-                        }
-                  >
-                    <span
-                      className=
-                          ms-Pivot-icon
-
-                    >
-                      <i
-                        aria-hidden={true}
-                        className=
-
-                            {
-                              -moz-osx-font-smoothing: grayscale;
-                              -webkit-font-smoothing: antialiased;
-                              display: inline-block;
-                              font-family: "FabricMDL2Icons-0";
-                              font-style: normal;
-                              font-weight: normal;
-                              speak: none;
-                            }
-                        data-icon-name="Globe"
-                      >
-                        
-                      </i>
-                    </span>
                     <span
                       className=
                           ms-Pivot-text
@@ -644,7 +405,7 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                           }
                     >
                        
-                      Placeholder
+                      Recent
                     </span>
                   </span>
                 </span>
@@ -764,9 +525,9 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                     .ms-Fabric--isFocusVisible &:focus {
                       outline: 1px solid #605e5c;
                     }
-                data-content="Shared with me (1) xx"
+                data-content="Shared with me"
                 data-is-focusable={true}
-                id="Pivot0-Tab3"
+                id="Pivot0-Tab2"
                 name="Shared with me"
                 onClick={[Function]}
                 onKeyDown={[Function]}
@@ -804,29 +565,6 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                   >
                     <span
                       className=
-                          ms-Pivot-icon
-
-                    >
-                      <i
-                        aria-hidden={true}
-                        className=
-
-                            {
-                              -moz-osx-font-smoothing: grayscale;
-                              -webkit-font-smoothing: antialiased;
-                              display: inline-block;
-                              font-family: "FabricMDL2Icons-4";
-                              font-style: normal;
-                              font-weight: normal;
-                              speak: none;
-                            }
-                        data-icon-name="Ringer"
-                      >
-                        
-                      </i>
-                    </span>
-                    <span
-                      className=
                           ms-Pivot-text
                           {
                             display: inline-block;
@@ -835,18 +573,6 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                     >
                        
                       Shared with me
-                    </span>
-                    <span
-                      className=
-                          ms-Pivot-count
-                          {
-                            display: inline-block;
-                            vertical-align: top;
-                          }
-                    >
-                       (
-                      1
-                      )
                     </span>
                   </span>
                 </span>
@@ -966,10 +692,10 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                     .ms-Fabric--isFocusVisible &:focus {
                       outline: 1px solid #605e5c;
                     }
-                data-content="Customized Rendering (10) xx"
+                data-content="Other 1"
                 data-is-focusable={true}
-                id="Pivot0-Tab4"
-                name="Customized Rendering"
+                id="Pivot0-Tab3"
+                name="Other 1"
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 onKeyPress={[Function]}
@@ -991,89 +717,698 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                       }
                   data-automationid="splitbuttonprimary"
                 >
-                  <span>
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
                     <span
                       className=
-                          ms-Pivot-linkContent
+                          ms-Pivot-text
                           {
-                            flex: 0 1 100%;
-                          }
-                          & > *  {
-                            margin-left: 4px;
-                          }
-                          & > *:first-child {
-                            margin-left: 0px;
-                          }
-                    >
-                      <span
-                        className=
-                            ms-Pivot-icon
-
-                      >
-                        <i
-                          aria-hidden={true}
-                          className=
-
-                              {
-                                -moz-osx-font-smoothing: grayscale;
-                                -webkit-font-smoothing: antialiased;
-                                display: inline-block;
-                                font-family: "FabricMDL2Icons-0";
-                                font-style: normal;
-                                font-weight: normal;
-                                speak: none;
-                              }
-                          data-icon-name="Globe"
-                        >
-                          
-                        </i>
-                      </span>
-                      <span
-                        className=
-                            ms-Pivot-text
-                            {
-                              display: inline-block;
-                              vertical-align: top;
-                            }
-                      >
-                         
-                        Customized Rendering
-                      </span>
-                      <span
-                        className=
-                            ms-Pivot-count
-                            {
-                              display: inline-block;
-                              vertical-align: top;
-                            }
-                      >
-                         (
-                        10
-                        )
-                      </span>
-                    </span>
-                    <i
-                      aria-hidden={true}
-                      className=
-
-                          {
-                            -moz-osx-font-smoothing: grayscale;
-                            -webkit-font-smoothing: antialiased;
                             display: inline-block;
-                            font-family: "FabricMDL2Icons-0";
-                            font-style: normal;
-                            font-weight: normal;
-                            speak: none;
+                            vertical-align: top;
                           }
-                      data-icon-name="Airplane"
-                      style={
-                        Object {
-                          "color": "red",
-                        }
-                      }
                     >
-                      
-                    </i>
+                       
+                      Other 1
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
+              className=
+                  ms-OverflowSet-item
+                  {
+                    display: inherit;
+                    flex-shrink: 0;
+                  }
+            >
+              <button
+                aria-selected={false}
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 8px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #201f1e;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #201f1e;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                data-content="Other 2"
+                data-is-focusable={true}
+                id="Pivot0-Tab4"
+                name="Other 2"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
+              >
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Other 2
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
+              className=
+                  ms-OverflowSet-item
+                  {
+                    display: inherit;
+                    flex-shrink: 0;
+                  }
+            >
+              <button
+                aria-selected={false}
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 8px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #201f1e;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #201f1e;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                data-content="Other 3"
+                data-is-focusable={true}
+                id="Pivot0-Tab5"
+                name="Other 3"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
+              >
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Other 3
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
+              className=
+                  ms-OverflowSet-item
+                  {
+                    display: inherit;
+                    flex-shrink: 0;
+                  }
+            >
+              <button
+                aria-selected={false}
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 8px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #201f1e;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #201f1e;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                data-content="Other 4"
+                data-is-focusable={true}
+                id="Pivot0-Tab6"
+                name="Other 4"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
+              >
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Other 4
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
+              className=
+                  ms-OverflowSet-item
+                  {
+                    display: inherit;
+                    flex-shrink: 0;
+                  }
+            >
+              <button
+                aria-selected={false}
+                className=
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
+                      display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 8px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
+                      vertical-align: top;
+                    }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #201f1e;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #201f1e;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                data-content="Other 5"
+                data-is-focusable={true}
+                id="Pivot0-Tab7"
+                name="Other 5"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
+              >
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Other 5
+                    </span>
                   </span>
                 </span>
               </button>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Override.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Override.Example.tsx.shot
@@ -3,527 +3,574 @@
 exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
 <div>
   <div>
-    <div
-      className=
-          ms-FocusZone
-          &:focus {
-            outline: none;
-          }
-      data-focuszone-id="FocusZone1"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onMouseDownCapture={[Function]}
-    >
+    <div>
       <div
-        className=
-            ms-Pivot
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              box-shadow: none;
-              box-sizing: border-box;
-              color: #0078d4;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
-              position: relative;
-              white-space: nowrap;
-            }
-        role="tablist"
+        style={
+          Object {
+            "position": "relative",
+          }
+        }
       >
-        <button
-          aria-selected={true}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              is-selected
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 600;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: #0078d4;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background-color: Highlight;
-              }
-              &:hover::before {
-                left: 0px;
-                right: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                color: Highlight;
-              }
-          data-content="My Files"
-          data-is-focusable={true}
-          id="Pivot0-Tab0"
-          name="My Files"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+        <div
+          data-automation-id="visibleContent"
+          style={
+            Object {
+              "position": "fixed",
+              "visibility": "hidden",
+            }
+          }
         >
-          <span
+          <div
+            aria-orientation="horizontal"
             className=
-                ms-Button-flexContainer
+                ms-FocusZone
+                ms-OverflowSet
+                ms-Pivot
+                &:focus {
+                  outline: none;
+                }
                 {
-                  align-items: center;
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #0078d4;
                   display: flex;
                   flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  white-space: nowrap;
                 }
-            data-automationid="splitbuttonprimary"
+            data-focuszone-id="FocusZone1"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDownCapture={[Function]}
+            role="presentation"
           >
-            <span
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={true}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
+                    is-selected
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 600;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 8px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #201f1e;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #201f1e;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: #0078d4;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:before {
+                      background-color: Highlight;
+                    }
+                    &:hover::before {
+                      left: 0px;
+                      right: 0px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      color: Highlight;
+                    }
+                data-content="My Files"
+                data-is-focusable={true}
+                id="Pivot0-Tab0"
+                name="My Files"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                My Files
-              </span>
-            </span>
-          </span>
-        </button>
-        <button
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-          data-content="Recent"
-          data-is-focusable={true}
-          id="Pivot0-Tab1"
-          name="Recent"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      My Files
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={false}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 8px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #201f1e;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #201f1e;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                data-content="Recent"
+                data-is-focusable={true}
+                id="Pivot0-Tab1"
+                name="Recent"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Recent
-              </span>
-            </span>
-          </span>
-        </button>
-        <button
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-          data-content="Shared with me"
-          data-is-focusable={true}
-          id="Pivot0-Tab2"
-          name="Shared with me"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Recent
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={false}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 8px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #201f1e;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #201f1e;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                data-content="Shared with me"
+                data-is-focusable={true}
+                id="Pivot0-Tab2"
+                name="Shared with me"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Shared with me
-              </span>
-            </span>
-          </span>
-        </button>
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Shared with me
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <div

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Remove.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Remove.Example.tsx.shot
@@ -3,717 +3,773 @@
 exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
 <div>
   <div>
-    <div
-      className=
-          ms-FocusZone
-          &:focus {
-            outline: none;
-          }
-      data-focuszone-id="FocusZone1"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onMouseDownCapture={[Function]}
-    >
+    <div>
       <div
-        className=
-            ms-Pivot
-            ms-Pivot--large
-            ms-Pivot--tabs
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              box-shadow: none;
-              box-sizing: border-box;
-              color: #0078d4;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
-              position: relative;
-              white-space: nowrap;
-            }
-        role="tablist"
+        style={
+          Object {
+            "position": "relative",
+          }
+        }
       >
-        <button
-          aria-selected={true}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              is-selected
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #0078d4;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #ffffff;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #106ebe;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #005a9e;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: auto;
-                left: 0px;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-                transition: none;
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background-color: Highlight;
-              }
-              &:hover::before {
-                left: 0px;
-                right: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                -ms-high-contrast-adjust: none;
-                background: Highlight;
-                color: HighlightText;
-                font-weight: 600;
-              }
-          data-content="Foo"
-          data-is-focusable={true}
-          id="Pivot0-Tab0"
-          name="Foo"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+        <div
+          data-automation-id="visibleContent"
+          style={
+            Object {
+              "position": "fixed",
+              "visibility": "hidden",
+            }
+          }
         >
-          <span
+          <div
+            aria-orientation="horizontal"
             className=
-                ms-Button-flexContainer
+                ms-FocusZone
+                ms-OverflowSet
+                ms-Pivot
+                ms-Pivot--large
+                ms-Pivot--tabs
+                &:focus {
+                  outline: none;
+                }
                 {
-                  align-items: center;
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #0078d4;
                   display: flex;
                   flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  white-space: nowrap;
                 }
-            data-automationid="splitbuttonprimary"
+            data-focuszone-id="FocusZone1"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDownCapture={[Function]}
+            role="presentation"
           >
-            <span
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={true}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
+                    is-selected
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #0078d4;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #ffffff;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 18px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 0px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 10px;
+                      padding-right: 10px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #106ebe;
+                      color: #ffffff;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      outline-offset: -1px;
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #005a9e;
+                      color: #ffffff;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: auto;
+                      left: 0px;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      transition: none;
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus::before {
+                      background: transparent;
+                      height: auto;
+                      transition: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:before {
+                      background-color: Highlight;
+                    }
+                    &:hover::before {
+                      left: 0px;
+                      right: 0px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      background: Highlight;
+                      color: HighlightText;
+                      font-weight: 600;
+                    }
+                data-content="Foo"
+                data-is-focusable={true}
+                id="Pivot0-Tab0"
+                name="Foo"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Foo
-              </span>
-            </span>
-          </span>
-        </button>
-        <button
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #0078d4;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                color: #000000;
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #0078d4;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-          data-content="Bar"
-          data-is-focusable={true}
-          id="Pivot0-Tab1"
-          name="Bar"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Foo
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={false}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #ffffff;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 18px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 0px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 10px;
+                      padding-right: 10px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #0078d4;
+                      color: #ffffff;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      color: #000000;
+                      outline-offset: -1px;
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #0078d4;
+                      color: #ffffff;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus::before {
+                      background: transparent;
+                      height: auto;
+                      transition: none;
+                    }
+                data-content="Bar"
+                data-is-focusable={true}
+                id="Pivot0-Tab1"
+                name="Bar"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Bar
-              </span>
-            </span>
-          </span>
-        </button>
-        <button
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #0078d4;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                color: #000000;
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #0078d4;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-          data-content="Bas"
-          data-is-focusable={true}
-          id="Pivot0-Tab2"
-          name="Bas"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Bar
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={false}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #ffffff;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 18px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 0px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 10px;
+                      padding-right: 10px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #0078d4;
+                      color: #ffffff;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      color: #000000;
+                      outline-offset: -1px;
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #0078d4;
+                      color: #ffffff;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus::before {
+                      background: transparent;
+                      height: auto;
+                      transition: none;
+                    }
+                data-content="Bas"
+                data-is-focusable={true}
+                id="Pivot0-Tab2"
+                name="Bas"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Bas
-              </span>
-            </span>
-          </span>
-        </button>
-        <button
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #0078d4;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                color: #000000;
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #0078d4;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-          data-content="Biz"
-          data-is-focusable={true}
-          id="Pivot0-Tab3"
-          name="Biz"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Bas
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={false}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #ffffff;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 18px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 0px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 10px;
+                      padding-right: 10px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #0078d4;
+                      color: #ffffff;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      color: #000000;
+                      outline-offset: -1px;
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #0078d4;
+                      color: #ffffff;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus::before {
+                      background: transparent;
+                      height: auto;
+                      transition: none;
+                    }
+                data-content="Biz"
+                data-is-focusable={true}
+                id="Pivot0-Tab3"
+                name="Biz"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Biz
-              </span>
-            </span>
-          </span>
-        </button>
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Biz
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <div

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Separate.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Separate.Example.tsx.shot
@@ -15,527 +15,574 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
     }
   />
   <div>
-    <div
-      className=
-          ms-FocusZone
-          &:focus {
-            outline: none;
-          }
-      data-focuszone-id="FocusZone1"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onMouseDownCapture={[Function]}
-    >
+    <div>
       <div
-        className=
-            ms-Pivot
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              box-shadow: none;
-              box-sizing: border-box;
-              color: #0078d4;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
-              position: relative;
-              white-space: nowrap;
-            }
-        role="tablist"
+        style={
+          Object {
+            "position": "relative",
+          }
+        }
       >
-        <button
-          aria-selected={true}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              is-selected
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 600;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: #0078d4;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background-color: Highlight;
-              }
-              &:hover::before {
-                left: 0px;
-                right: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                color: Highlight;
-              }
-          data-content="Rectangle red"
-          data-is-focusable={true}
-          id="ShapeColorPivot_rectangleRed"
-          name="Rectangle red"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+        <div
+          data-automation-id="visibleContent"
+          style={
+            Object {
+              "position": "fixed",
+              "visibility": "hidden",
+            }
+          }
         >
-          <span
+          <div
+            aria-orientation="horizontal"
             className=
-                ms-Button-flexContainer
+                ms-FocusZone
+                ms-OverflowSet
+                ms-Pivot
+                &:focus {
+                  outline: none;
+                }
                 {
-                  align-items: center;
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #0078d4;
                   display: flex;
                   flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  white-space: nowrap;
                 }
-            data-automationid="splitbuttonprimary"
+            data-focuszone-id="FocusZone1"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDownCapture={[Function]}
+            role="presentation"
           >
-            <span
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={true}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
+                    is-selected
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 600;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 8px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #201f1e;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #201f1e;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: #0078d4;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:before {
+                      background-color: Highlight;
+                    }
+                    &:hover::before {
+                      left: 0px;
+                      right: 0px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      color: Highlight;
+                    }
+                data-content="Rectangle red"
+                data-is-focusable={true}
+                id="ShapeColorPivot_rectangleRed"
+                name="Rectangle red"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Rectangle red
-              </span>
-            </span>
-          </span>
-        </button>
-        <button
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-          data-content="Square red"
-          data-is-focusable={true}
-          id="ShapeColorPivot_squareRed"
-          name="Square red"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Rectangle red
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={false}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 8px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #201f1e;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #201f1e;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                data-content="Square red"
+                data-is-focusable={true}
+                id="ShapeColorPivot_squareRed"
+                name="Square red"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Square red
-              </span>
-            </span>
-          </span>
-        </button>
-        <button
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: transparent;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 8px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 8px;
-                padding-right: 8px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline: none;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-          data-content="Rectangle green"
-          data-is-focusable={true}
-          id="ShapeColorPivot_rectangleGreen"
-          name="Rectangle green"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Square red
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={false}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 8px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #f3f2f1;
+                      color: #201f1e;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #edebe9;
+                      color: #201f1e;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                data-content="Rectangle green"
+                data-is-focusable={true}
+                id="ShapeColorPivot_rectangleGreen"
+                name="Rectangle green"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Rectangle green
-              </span>
-            </span>
-          </span>
-        </button>
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Rectangle green
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.SeparateNoSelectedKey.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.SeparateNoSelectedKey.Example.tsx.shot
@@ -27,515 +27,568 @@ exports[`Component Examples renders Pivot.SeparateNoSelectedKey.Example.tsx corr
       }
     >
       <div
-        className=
-            ms-FocusZone
-            &:focus {
-              outline: none;
-            }
-        data-focuszone-id="FocusZone1"
-        onFocus={[Function]}
-        onKeyDown={[Function]}
-        onMouseDownCapture={[Function]}
+        style={
+          Object {
+            "flexGrow": 1,
+          }
+        }
       >
         <div
-          className=
-              ms-Pivot
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                box-shadow: none;
-                box-sizing: border-box;
-                color: #0078d4;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                margin-bottom: 0px;
-                margin-left: 0px;
-                margin-right: 0px;
-                margin-top: 0px;
-                padding-bottom: 0px;
-                padding-left: 0px;
-                padding-right: 0px;
-                padding-top: 0px;
-                position: relative;
-                white-space: nowrap;
-              }
-          role="tablist"
+          style={
+            Object {
+              "position": "relative",
+            }
+          }
         >
-          <button
-            aria-selected={false}
-            className=
-                ms-Button
-                ms-Button--action
-                ms-Button--command
-                ms-Pivot-link
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  background-color: transparent;
-                  border-radius: 0px;
-                  border: 0px;
-                  box-sizing: border-box;
-                  color: #323130;
-                  cursor: pointer;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 44px;
-                  line-height: 44px;
-                  margin-right: 8px;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 8px;
-                  padding-right: 8px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: center;
-                  text-decoration: none;
-                  user-select: none;
-                  vertical-align: top;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 0px;
-                  bottom: 2px;
-                  content: attr(data-content);
-                  left: 2px;
-                  outline: 1px solid #605e5c;
-                  position: relative;
-                  right: 2px;
-                  top: 2px;
-                  z-index: 1;
-                }
-                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                  border: none;
-                  bottom: -2px;
-                  left: -2px;
-                  outline-color: ButtonText;
-                  right: -2px;
-                  top: -2px;
-                }
-                &:active > * {
-                  left: 0px;
-                  position: relative;
-                  top: 0px;
-                }
-                &:hover {
-                  background-color: #f3f2f1;
-                  color: #201f1e;
-                  cursor: pointer;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover {
-                  border-color: Highlight;
-                  color: Highlight;
-                }
-                &:hover .ms-Button-icon {
-                  color: #0078d4;
-                }
-                &:focus {
-                  outline: none;
-                }
-                &:active {
-                  background-color: #edebe9;
-                  color: #201f1e;
-                }
-                &:active .ms-Button-icon {
-                  color: #004578;
-                }
-                &:before {
-                  background-color: transparent;
-                  bottom: 0px;
-                  content: "";
-                  height: 2px;
-                  left: 8px;
-                  position: absolute;
-                  right: 8px;
-                  transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                      right 0.267s cubic-bezier(.1,.25,.75,.9);
-                }
-                &:after {
-                  color: transparent;
-                  content: attr(data-content);
-                  display: block;
-                  font-weight: 700;
-                  height: 1px;
-                  overflow: hidden;
-                  visibility: hidden;
-                }
-                .ms-Fabric--isFocusVisible &:focus {
-                  outline: 1px solid #605e5c;
-                }
-            data-content="Thing1"
-            data-is-focusable={true}
-            id="ShapeColorPivot_Thing1"
-            name="Thing1"
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            role="tab"
-            type="button"
+          <div
+            data-automation-id="visibleContent"
+            style={
+              Object {
+                "position": "fixed",
+                "visibility": "hidden",
+              }
+            }
           >
-            <span
+            <div
+              aria-orientation="horizontal"
               className=
-                  ms-Button-flexContainer
+                  ms-FocusZone
+                  ms-OverflowSet
+                  ms-Pivot
+                  &:focus {
+                    outline: none;
+                  }
                   {
-                    align-items: center;
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    color: #0078d4;
                     display: flex;
                     flex-wrap: nowrap;
-                    height: 100%;
-                    justify-content: flex-start;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                    white-space: nowrap;
                   }
-              data-automationid="splitbuttonprimary"
+              data-focuszone-id="FocusZone1"
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseDownCapture={[Function]}
+              role="presentation"
             >
-              <span
+              <div
                 className=
-                    ms-Pivot-linkContent
+                    ms-OverflowSet-item
                     {
-                      flex: 0 1 100%;
-                    }
-                    & > *  {
-                      margin-left: 4px;
-                    }
-                    & > *:first-child {
-                      margin-left: 0px;
+                      display: inherit;
+                      flex-shrink: 0;
                     }
               >
-                <span
+                <button
+                  aria-selected={false}
                   className=
-                      ms-Pivot-text
+                      ms-Button
+                      ms-Button--action
+                      ms-Button--command
+                      ms-Pivot-link
                       {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        border-radius: 0px;
+                        border: 0px;
+                        box-sizing: border-box;
+                        color: #323130;
+                        cursor: pointer;
                         display: inline-block;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 44px;
+                        line-height: 44px;
+                        margin-right: 8px;
+                        outline: transparent;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: center;
+                        text-decoration: none;
+                        user-select: none;
                         vertical-align: top;
                       }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 0px;
+                        bottom: 2px;
+                        content: attr(data-content);
+                        left: 2px;
+                        outline: 1px solid #605e5c;
+                        position: relative;
+                        right: 2px;
+                        top: 2px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                        border: none;
+                        bottom: -2px;
+                        left: -2px;
+                        outline-color: ButtonText;
+                        right: -2px;
+                        top: -2px;
+                      }
+                      &:active > * {
+                        left: 0px;
+                        position: relative;
+                        top: 0px;
+                      }
+                      &:hover {
+                        background-color: #f3f2f1;
+                        color: #201f1e;
+                        cursor: pointer;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        border-color: Highlight;
+                        color: Highlight;
+                      }
+                      &:hover .ms-Button-icon {
+                        color: #0078d4;
+                      }
+                      &:focus {
+                        outline: none;
+                      }
+                      &:active {
+                        background-color: #edebe9;
+                        color: #201f1e;
+                      }
+                      &:active .ms-Button-icon {
+                        color: #004578;
+                      }
+                      &:before {
+                        background-color: transparent;
+                        bottom: 0px;
+                        content: "";
+                        height: 2px;
+                        left: 8px;
+                        position: absolute;
+                        right: 8px;
+                        transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                            right 0.267s cubic-bezier(.1,.25,.75,.9);
+                      }
+                      &:after {
+                        color: transparent;
+                        content: attr(data-content);
+                        display: block;
+                        font-weight: 700;
+                        height: 1px;
+                        overflow: hidden;
+                        visibility: hidden;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid #605e5c;
+                      }
+                  data-content="Thing1"
+                  data-is-focusable={true}
+                  id="ShapeColorPivot_Thing1"
+                  name="Thing1"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  role="tab"
+                  type="button"
                 >
-                   
-                  Thing1
-                </span>
-              </span>
-            </span>
-          </button>
-          <button
-            aria-selected={false}
-            className=
-                ms-Button
-                ms-Button--action
-                ms-Button--command
-                ms-Pivot-link
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  background-color: transparent;
-                  border-radius: 0px;
-                  border: 0px;
-                  box-sizing: border-box;
-                  color: #323130;
-                  cursor: pointer;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 44px;
-                  line-height: 44px;
-                  margin-right: 8px;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 8px;
-                  padding-right: 8px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: center;
-                  text-decoration: none;
-                  user-select: none;
-                  vertical-align: top;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 0px;
-                  bottom: 2px;
-                  content: attr(data-content);
-                  left: 2px;
-                  outline: 1px solid #605e5c;
-                  position: relative;
-                  right: 2px;
-                  top: 2px;
-                  z-index: 1;
-                }
-                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                  border: none;
-                  bottom: -2px;
-                  left: -2px;
-                  outline-color: ButtonText;
-                  right: -2px;
-                  top: -2px;
-                }
-                &:active > * {
-                  left: 0px;
-                  position: relative;
-                  top: 0px;
-                }
-                &:hover {
-                  background-color: #f3f2f1;
-                  color: #201f1e;
-                  cursor: pointer;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover {
-                  border-color: Highlight;
-                  color: Highlight;
-                }
-                &:hover .ms-Button-icon {
-                  color: #0078d4;
-                }
-                &:focus {
-                  outline: none;
-                }
-                &:active {
-                  background-color: #edebe9;
-                  color: #201f1e;
-                }
-                &:active .ms-Button-icon {
-                  color: #004578;
-                }
-                &:before {
-                  background-color: transparent;
-                  bottom: 0px;
-                  content: "";
-                  height: 2px;
-                  left: 8px;
-                  position: absolute;
-                  right: 8px;
-                  transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                      right 0.267s cubic-bezier(.1,.25,.75,.9);
-                }
-                &:after {
-                  color: transparent;
-                  content: attr(data-content);
-                  display: block;
-                  font-weight: 700;
-                  height: 1px;
-                  overflow: hidden;
-                  visibility: hidden;
-                }
-                .ms-Fabric--isFocusVisible &:focus {
-                  outline: 1px solid #605e5c;
-                }
-            data-content="Thing2"
-            data-is-focusable={true}
-            id="ShapeColorPivot_Thing2"
-            name="Thing2"
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            role="tab"
-            type="button"
-          >
-            <span
-              className=
-                  ms-Button-flexContainer
-                  {
-                    align-items: center;
-                    display: flex;
-                    flex-wrap: nowrap;
-                    height: 100%;
-                    justify-content: flex-start;
-                  }
-              data-automationid="splitbuttonprimary"
-            >
-              <span
+                  <span
+                    className=
+                        ms-Button-flexContainer
+                        {
+                          align-items: center;
+                          display: flex;
+                          flex-wrap: nowrap;
+                          height: 100%;
+                          justify-content: flex-start;
+                        }
+                    data-automationid="splitbuttonprimary"
+                  >
+                    <span
+                      className=
+                          ms-Pivot-linkContent
+                          {
+                            flex: 0 1 100%;
+                          }
+                          & > *  {
+                            margin-left: 4px;
+                          }
+                          & > *:first-child {
+                            margin-left: 0px;
+                          }
+                    >
+                      <span
+                        className=
+                            ms-Pivot-text
+                            {
+                              display: inline-block;
+                              vertical-align: top;
+                            }
+                      >
+                         
+                        Thing1
+                      </span>
+                    </span>
+                  </span>
+                </button>
+              </div>
+              <div
                 className=
-                    ms-Pivot-linkContent
+                    ms-OverflowSet-item
                     {
-                      flex: 0 1 100%;
-                    }
-                    & > *  {
-                      margin-left: 4px;
-                    }
-                    & > *:first-child {
-                      margin-left: 0px;
+                      display: inherit;
+                      flex-shrink: 0;
                     }
               >
-                <span
+                <button
+                  aria-selected={false}
                   className=
-                      ms-Pivot-text
+                      ms-Button
+                      ms-Button--action
+                      ms-Button--command
+                      ms-Pivot-link
                       {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        border-radius: 0px;
+                        border: 0px;
+                        box-sizing: border-box;
+                        color: #323130;
+                        cursor: pointer;
                         display: inline-block;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 44px;
+                        line-height: 44px;
+                        margin-right: 8px;
+                        outline: transparent;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: center;
+                        text-decoration: none;
+                        user-select: none;
                         vertical-align: top;
                       }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 0px;
+                        bottom: 2px;
+                        content: attr(data-content);
+                        left: 2px;
+                        outline: 1px solid #605e5c;
+                        position: relative;
+                        right: 2px;
+                        top: 2px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                        border: none;
+                        bottom: -2px;
+                        left: -2px;
+                        outline-color: ButtonText;
+                        right: -2px;
+                        top: -2px;
+                      }
+                      &:active > * {
+                        left: 0px;
+                        position: relative;
+                        top: 0px;
+                      }
+                      &:hover {
+                        background-color: #f3f2f1;
+                        color: #201f1e;
+                        cursor: pointer;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        border-color: Highlight;
+                        color: Highlight;
+                      }
+                      &:hover .ms-Button-icon {
+                        color: #0078d4;
+                      }
+                      &:focus {
+                        outline: none;
+                      }
+                      &:active {
+                        background-color: #edebe9;
+                        color: #201f1e;
+                      }
+                      &:active .ms-Button-icon {
+                        color: #004578;
+                      }
+                      &:before {
+                        background-color: transparent;
+                        bottom: 0px;
+                        content: "";
+                        height: 2px;
+                        left: 8px;
+                        position: absolute;
+                        right: 8px;
+                        transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                            right 0.267s cubic-bezier(.1,.25,.75,.9);
+                      }
+                      &:after {
+                        color: transparent;
+                        content: attr(data-content);
+                        display: block;
+                        font-weight: 700;
+                        height: 1px;
+                        overflow: hidden;
+                        visibility: hidden;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid #605e5c;
+                      }
+                  data-content="Thing2"
+                  data-is-focusable={true}
+                  id="ShapeColorPivot_Thing2"
+                  name="Thing2"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  role="tab"
+                  type="button"
                 >
-                   
-                  Thing2
-                </span>
-              </span>
-            </span>
-          </button>
-          <button
-            aria-selected={false}
-            className=
-                ms-Button
-                ms-Button--action
-                ms-Button--command
-                ms-Pivot-link
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  background-color: transparent;
-                  border-radius: 0px;
-                  border: 0px;
-                  box-sizing: border-box;
-                  color: #323130;
-                  cursor: pointer;
-                  display: inline-block;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 44px;
-                  line-height: 44px;
-                  margin-right: 8px;
-                  outline: transparent;
-                  padding-bottom: 0;
-                  padding-left: 8px;
-                  padding-right: 8px;
-                  padding-top: 0;
-                  position: relative;
-                  text-align: center;
-                  text-decoration: none;
-                  user-select: none;
-                  vertical-align: top;
-                }
-                &::-moz-focus-inner {
-                  border: 0;
-                }
-                .ms-Fabric--isFocusVisible &:focus:after {
-                  border: 0px;
-                  bottom: 2px;
-                  content: attr(data-content);
-                  left: 2px;
-                  outline: 1px solid #605e5c;
-                  position: relative;
-                  right: 2px;
-                  top: 2px;
-                  z-index: 1;
-                }
-                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                  border: none;
-                  bottom: -2px;
-                  left: -2px;
-                  outline-color: ButtonText;
-                  right: -2px;
-                  top: -2px;
-                }
-                &:active > * {
-                  left: 0px;
-                  position: relative;
-                  top: 0px;
-                }
-                &:hover {
-                  background-color: #f3f2f1;
-                  color: #201f1e;
-                  cursor: pointer;
-                }
-                @media screen and (-ms-high-contrast: active){&:hover {
-                  border-color: Highlight;
-                  color: Highlight;
-                }
-                &:hover .ms-Button-icon {
-                  color: #0078d4;
-                }
-                &:focus {
-                  outline: none;
-                }
-                &:active {
-                  background-color: #edebe9;
-                  color: #201f1e;
-                }
-                &:active .ms-Button-icon {
-                  color: #004578;
-                }
-                &:before {
-                  background-color: transparent;
-                  bottom: 0px;
-                  content: "";
-                  height: 2px;
-                  left: 8px;
-                  position: absolute;
-                  right: 8px;
-                  transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                      right 0.267s cubic-bezier(.1,.25,.75,.9);
-                }
-                &:after {
-                  color: transparent;
-                  content: attr(data-content);
-                  display: block;
-                  font-weight: 700;
-                  height: 1px;
-                  overflow: hidden;
-                  visibility: hidden;
-                }
-                .ms-Fabric--isFocusVisible &:focus {
-                  outline: 1px solid #605e5c;
-                }
-            data-content="Thing3"
-            data-is-focusable={true}
-            id="ShapeColorPivot_Thing3"
-            name="Thing3"
-            onClick={[Function]}
-            onKeyDown={[Function]}
-            onKeyPress={[Function]}
-            onKeyUp={[Function]}
-            onMouseDown={[Function]}
-            onMouseUp={[Function]}
-            role="tab"
-            type="button"
-          >
-            <span
-              className=
-                  ms-Button-flexContainer
-                  {
-                    align-items: center;
-                    display: flex;
-                    flex-wrap: nowrap;
-                    height: 100%;
-                    justify-content: flex-start;
-                  }
-              data-automationid="splitbuttonprimary"
-            >
-              <span
+                  <span
+                    className=
+                        ms-Button-flexContainer
+                        {
+                          align-items: center;
+                          display: flex;
+                          flex-wrap: nowrap;
+                          height: 100%;
+                          justify-content: flex-start;
+                        }
+                    data-automationid="splitbuttonprimary"
+                  >
+                    <span
+                      className=
+                          ms-Pivot-linkContent
+                          {
+                            flex: 0 1 100%;
+                          }
+                          & > *  {
+                            margin-left: 4px;
+                          }
+                          & > *:first-child {
+                            margin-left: 0px;
+                          }
+                    >
+                      <span
+                        className=
+                            ms-Pivot-text
+                            {
+                              display: inline-block;
+                              vertical-align: top;
+                            }
+                      >
+                         
+                        Thing2
+                      </span>
+                    </span>
+                  </span>
+                </button>
+              </div>
+              <div
                 className=
-                    ms-Pivot-linkContent
+                    ms-OverflowSet-item
                     {
-                      flex: 0 1 100%;
-                    }
-                    & > *  {
-                      margin-left: 4px;
-                    }
-                    & > *:first-child {
-                      margin-left: 0px;
+                      display: inherit;
+                      flex-shrink: 0;
                     }
               >
-                <span
+                <button
+                  aria-selected={false}
                   className=
-                      ms-Pivot-text
+                      ms-Button
+                      ms-Button--action
+                      ms-Button--command
+                      ms-Pivot-link
                       {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        background-color: transparent;
+                        border-radius: 0px;
+                        border: 0px;
+                        box-sizing: border-box;
+                        color: #323130;
+                        cursor: pointer;
                         display: inline-block;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        height: 44px;
+                        line-height: 44px;
+                        margin-right: 8px;
+                        outline: transparent;
+                        padding-bottom: 0;
+                        padding-left: 8px;
+                        padding-right: 8px;
+                        padding-top: 0;
+                        position: relative;
+                        text-align: center;
+                        text-decoration: none;
+                        user-select: none;
                         vertical-align: top;
                       }
+                      &::-moz-focus-inner {
+                        border: 0;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus:after {
+                        border: 0px;
+                        bottom: 2px;
+                        content: attr(data-content);
+                        left: 2px;
+                        outline: 1px solid #605e5c;
+                        position: relative;
+                        right: 2px;
+                        top: 2px;
+                        z-index: 1;
+                      }
+                      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                        border: none;
+                        bottom: -2px;
+                        left: -2px;
+                        outline-color: ButtonText;
+                        right: -2px;
+                        top: -2px;
+                      }
+                      &:active > * {
+                        left: 0px;
+                        position: relative;
+                        top: 0px;
+                      }
+                      &:hover {
+                        background-color: #f3f2f1;
+                        color: #201f1e;
+                        cursor: pointer;
+                      }
+                      @media screen and (-ms-high-contrast: active){&:hover {
+                        border-color: Highlight;
+                        color: Highlight;
+                      }
+                      &:hover .ms-Button-icon {
+                        color: #0078d4;
+                      }
+                      &:focus {
+                        outline: none;
+                      }
+                      &:active {
+                        background-color: #edebe9;
+                        color: #201f1e;
+                      }
+                      &:active .ms-Button-icon {
+                        color: #004578;
+                      }
+                      &:before {
+                        background-color: transparent;
+                        bottom: 0px;
+                        content: "";
+                        height: 2px;
+                        left: 8px;
+                        position: absolute;
+                        right: 8px;
+                        transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                            right 0.267s cubic-bezier(.1,.25,.75,.9);
+                      }
+                      &:after {
+                        color: transparent;
+                        content: attr(data-content);
+                        display: block;
+                        font-weight: 700;
+                        height: 1px;
+                        overflow: hidden;
+                        visibility: hidden;
+                      }
+                      .ms-Fabric--isFocusVisible &:focus {
+                        outline: 1px solid #605e5c;
+                      }
+                  data-content="Thing3"
+                  data-is-focusable={true}
+                  id="ShapeColorPivot_Thing3"
+                  name="Thing3"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onKeyPress={[Function]}
+                  onKeyUp={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseUp={[Function]}
+                  role="tab"
+                  type="button"
                 >
-                   
-                  Thing3
-                </span>
-              </span>
-            </span>
-          </button>
+                  <span
+                    className=
+                        ms-Button-flexContainer
+                        {
+                          align-items: center;
+                          display: flex;
+                          flex-wrap: nowrap;
+                          height: 100%;
+                          justify-content: flex-start;
+                        }
+                    data-automationid="splitbuttonprimary"
+                  >
+                    <span
+                      className=
+                          ms-Pivot-linkContent
+                          {
+                            flex: 0 1 100%;
+                          }
+                          & > *  {
+                            margin-left: 4px;
+                          }
+                          & > *:first-child {
+                            margin-left: 0px;
+                          }
+                    >
+                      <span
+                        className=
+                            ms-Pivot-text
+                            {
+                              display: inline-block;
+                              vertical-align: top;
+                            }
+                      >
+                         
+                        Thing3
+                      </span>
+                    </span>
+                  </span>
+                </button>
+              </div>
+            </div>
+          </div>
         </div>
       </div>
     </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Tabs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Tabs.Example.tsx.shot
@@ -3,716 +3,772 @@
 exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
 <div>
   <div>
-    <div
-      className=
-          ms-FocusZone
-          &:focus {
-            outline: none;
-          }
-      data-focuszone-id="FocusZone1"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onMouseDownCapture={[Function]}
-    >
+    <div>
       <div
-        className=
-            ms-Pivot
-            ms-Pivot--tabs
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              box-shadow: none;
-              box-sizing: border-box;
-              color: #0078d4;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
-              position: relative;
-              white-space: nowrap;
-            }
-        role="tablist"
+        style={
+          Object {
+            "position": "relative",
+          }
+        }
       >
-        <button
-          aria-selected={true}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              is-selected
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #0078d4;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #ffffff;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #106ebe;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #005a9e;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: auto;
-                left: 0px;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-                transition: none;
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background-color: Highlight;
-              }
-              &:hover::before {
-                left: 0px;
-                right: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                -ms-high-contrast-adjust: none;
-                background: Highlight;
-                color: HighlightText;
-                font-weight: 600;
-              }
-          data-content="Foo"
-          data-is-focusable={true}
-          id="Pivot0-Tab0"
-          name="Foo"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+        <div
+          data-automation-id="visibleContent"
+          style={
+            Object {
+              "position": "fixed",
+              "visibility": "hidden",
+            }
+          }
         >
-          <span
+          <div
+            aria-orientation="horizontal"
             className=
-                ms-Button-flexContainer
+                ms-FocusZone
+                ms-OverflowSet
+                ms-Pivot
+                ms-Pivot--tabs
+                &:focus {
+                  outline: none;
+                }
                 {
-                  align-items: center;
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #0078d4;
                   display: flex;
                   flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  white-space: nowrap;
                 }
-            data-automationid="splitbuttonprimary"
+            data-focuszone-id="FocusZone1"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDownCapture={[Function]}
+            role="presentation"
           >
-            <span
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={true}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
+                    is-selected
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #0078d4;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #ffffff;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 0px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 10px;
+                      padding-right: 10px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #106ebe;
+                      color: #ffffff;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      outline-offset: -1px;
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #005a9e;
+                      color: #ffffff;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: auto;
+                      left: 0px;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      transition: none;
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus::before {
+                      background: transparent;
+                      height: auto;
+                      transition: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:before {
+                      background-color: Highlight;
+                    }
+                    &:hover::before {
+                      left: 0px;
+                      right: 0px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      background: Highlight;
+                      color: HighlightText;
+                      font-weight: 600;
+                    }
+                data-content="Foo"
+                data-is-focusable={true}
+                id="Pivot0-Tab0"
+                name="Foo"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Foo
-              </span>
-            </span>
-          </span>
-        </button>
-        <button
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #0078d4;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                color: #000000;
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #0078d4;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-          data-content="Bar"
-          data-is-focusable={true}
-          id="Pivot0-Tab1"
-          name="Bar"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Foo
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={false}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #ffffff;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 0px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 10px;
+                      padding-right: 10px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #0078d4;
+                      color: #ffffff;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      color: #000000;
+                      outline-offset: -1px;
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #0078d4;
+                      color: #ffffff;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus::before {
+                      background: transparent;
+                      height: auto;
+                      transition: none;
+                    }
+                data-content="Bar"
+                data-is-focusable={true}
+                id="Pivot0-Tab1"
+                name="Bar"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Bar
-              </span>
-            </span>
-          </span>
-        </button>
-        <button
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #0078d4;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                color: #000000;
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #0078d4;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-          data-content="Bas"
-          data-is-focusable={true}
-          id="Pivot0-Tab2"
-          name="Bas"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Bar
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={false}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #ffffff;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 0px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 10px;
+                      padding-right: 10px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #0078d4;
+                      color: #ffffff;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      color: #000000;
+                      outline-offset: -1px;
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #0078d4;
+                      color: #ffffff;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus::before {
+                      background: transparent;
+                      height: auto;
+                      transition: none;
+                    }
+                data-content="Bas"
+                data-is-focusable={true}
+                id="Pivot0-Tab2"
+                name="Bas"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Bas
-              </span>
-            </span>
-          </span>
-        </button>
-        <button
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #0078d4;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                color: #000000;
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #0078d4;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-          data-content="Biz"
-          data-is-focusable={true}
-          id="Pivot0-Tab3"
-          name="Biz"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Bas
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={false}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #ffffff;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 0px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 10px;
+                      padding-right: 10px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #0078d4;
+                      color: #ffffff;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      color: #000000;
+                      outline-offset: -1px;
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #0078d4;
+                      color: #ffffff;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus::before {
+                      background: transparent;
+                      height: auto;
+                      transition: none;
+                    }
+                data-content="Biz"
+                data-is-focusable={true}
+                id="Pivot0-Tab3"
+                name="Biz"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Biz
-              </span>
-            </span>
-          </span>
-        </button>
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Biz
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <div

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.TabsLarge.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.TabsLarge.Example.tsx.shot
@@ -3,717 +3,773 @@
 exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = `
 <div>
   <div>
-    <div
-      className=
-          ms-FocusZone
-          &:focus {
-            outline: none;
-          }
-      data-focuszone-id="FocusZone1"
-      onFocus={[Function]}
-      onKeyDown={[Function]}
-      onMouseDownCapture={[Function]}
-    >
+    <div>
       <div
-        className=
-            ms-Pivot
-            ms-Pivot--large
-            ms-Pivot--tabs
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              box-shadow: none;
-              box-sizing: border-box;
-              color: #0078d4;
-              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 400;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              padding-bottom: 0px;
-              padding-left: 0px;
-              padding-right: 0px;
-              padding-top: 0px;
-              position: relative;
-              white-space: nowrap;
-            }
-        role="tablist"
+        style={
+          Object {
+            "position": "relative",
+          }
+        }
       >
-        <button
-          aria-selected={true}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              is-selected
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #0078d4;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #ffffff;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #106ebe;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #005a9e;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: auto;
-                left: 0px;
-                position: absolute;
-                right: 0px;
-                top: 0px;
-                transition: none;
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-              @media screen and (-ms-high-contrast: active){&:before {
-                background-color: Highlight;
-              }
-              &:hover::before {
-                left: 0px;
-                right: 0px;
-              }
-              @media screen and (-ms-high-contrast: active){& {
-                -ms-high-contrast-adjust: none;
-                background: Highlight;
-                color: HighlightText;
-                font-weight: 600;
-              }
-          data-content="Foo"
-          data-is-focusable={true}
-          id="Pivot0-Tab0"
-          name="Foo"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
+        <div
+          data-automation-id="visibleContent"
+          style={
+            Object {
+              "position": "fixed",
+              "visibility": "hidden",
+            }
+          }
         >
-          <span
+          <div
+            aria-orientation="horizontal"
             className=
-                ms-Button-flexContainer
+                ms-FocusZone
+                ms-OverflowSet
+                ms-Pivot
+                ms-Pivot--large
+                ms-Pivot--tabs
+                &:focus {
+                  outline: none;
+                }
                 {
-                  align-items: center;
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  box-shadow: none;
+                  box-sizing: border-box;
+                  color: #0078d4;
                   display: flex;
                   flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  padding-bottom: 0px;
+                  padding-left: 0px;
+                  padding-right: 0px;
+                  padding-top: 0px;
+                  position: relative;
+                  white-space: nowrap;
                 }
-            data-automationid="splitbuttonprimary"
+            data-focuszone-id="FocusZone1"
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseDownCapture={[Function]}
+            role="presentation"
           >
-            <span
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={true}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
+                    is-selected
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #0078d4;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #ffffff;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 18px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 0px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 10px;
+                      padding-right: 10px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #106ebe;
+                      color: #ffffff;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      outline-offset: -1px;
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #005a9e;
+                      color: #ffffff;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: auto;
+                      left: 0px;
+                      position: absolute;
+                      right: 0px;
+                      top: 0px;
+                      transition: none;
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus::before {
+                      background: transparent;
+                      height: auto;
+                      transition: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:before {
+                      background-color: Highlight;
+                    }
+                    &:hover::before {
+                      left: 0px;
+                      right: 0px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      background: Highlight;
+                      color: HighlightText;
+                      font-weight: 600;
+                    }
+                data-content="Foo"
+                data-is-focusable={true}
+                id="Pivot0-Tab0"
+                name="Foo"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Foo
-              </span>
-            </span>
-          </span>
-        </button>
-        <button
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #0078d4;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                color: #000000;
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #0078d4;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-          data-content="Bar"
-          data-is-focusable={true}
-          id="Pivot0-Tab1"
-          name="Bar"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Foo
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={false}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #ffffff;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 18px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 0px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 10px;
+                      padding-right: 10px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #0078d4;
+                      color: #ffffff;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      color: #000000;
+                      outline-offset: -1px;
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #0078d4;
+                      color: #ffffff;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus::before {
+                      background: transparent;
+                      height: auto;
+                      transition: none;
+                    }
+                data-content="Bar"
+                data-is-focusable={true}
+                id="Pivot0-Tab1"
+                name="Bar"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Bar
-              </span>
-            </span>
-          </span>
-        </button>
-        <button
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #0078d4;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                color: #000000;
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #0078d4;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-          data-content="Bas"
-          data-is-focusable={true}
-          id="Pivot0-Tab2"
-          name="Bas"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Bar
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={false}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #ffffff;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 18px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 0px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 10px;
+                      padding-right: 10px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #0078d4;
+                      color: #ffffff;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      color: #000000;
+                      outline-offset: -1px;
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #0078d4;
+                      color: #ffffff;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus::before {
+                      background: transparent;
+                      height: auto;
+                      transition: none;
+                    }
+                data-content="Bas"
+                data-is-focusable={true}
+                id="Pivot0-Tab2"
+                name="Bas"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Bas
-              </span>
-            </span>
-          </span>
-        </button>
-        <button
-          aria-selected={false}
-          className=
-              ms-Button
-              ms-Button--action
-              ms-Button--command
-              ms-Pivot-link
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 0px;
-                border: 0px;
-                box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 18px;
-                font-weight: 400;
-                height: 44px;
-                line-height: 44px;
-                margin-right: 0px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 10px;
-                padding-right: 10px;
-                padding-top: 0;
-                position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
-              }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 0px;
-                bottom: 2px;
-                content: attr(data-content);
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: relative;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #0078d4;
-                color: #ffffff;
-                cursor: pointer;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:hover .ms-Button-icon {
-                color: #0078d4;
-              }
-              &:focus {
-                color: #000000;
-                outline-offset: -1px;
-                outline: none;
-              }
-              &:active {
-                background-color: #0078d4;
-                color: #ffffff;
-              }
-              &:active .ms-Button-icon {
-                color: #004578;
-              }
-              &:before {
-                background-color: transparent;
-                bottom: 0px;
-                content: "";
-                height: 2px;
-                left: 8px;
-                position: absolute;
-                right: 8px;
-                transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
-                                    right 0.267s cubic-bezier(.1,.25,.75,.9);
-              }
-              &:after {
-                color: transparent;
-                content: attr(data-content);
-                display: block;
-                font-weight: 700;
-                height: 1px;
-                overflow: hidden;
-                visibility: hidden;
-              }
-              .ms-Fabric--isFocusVisible &:focus {
-                outline: 1px solid #605e5c;
-              }
-              .ms-Fabric--isFocusVisible &:focus::before {
-                background: transparent;
-                height: auto;
-                transition: none;
-              }
-          data-content="Biz"
-          data-is-focusable={true}
-          id="Pivot0-Tab3"
-          name="Biz"
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          role="tab"
-          type="button"
-        >
-          <span
-            className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: flex-start;
-                }
-            data-automationid="splitbuttonprimary"
-          >
-            <span
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Bas
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+            <div
               className=
-                  ms-Pivot-linkContent
+                  ms-OverflowSet-item
                   {
-                    flex: 0 1 100%;
-                  }
-                  & > *  {
-                    margin-left: 4px;
-                  }
-                  & > *:first-child {
-                    margin-left: 0px;
+                    display: inherit;
+                    flex-shrink: 0;
                   }
             >
-              <span
+              <button
+                aria-selected={false}
                 className=
-                    ms-Pivot-text
+                    ms-Button
+                    ms-Button--action
+                    ms-Button--command
+                    ms-Pivot-link
                     {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: #ffffff;
+                      border-radius: 0px;
+                      border: 0px;
+                      box-sizing: border-box;
+                      color: #323130;
+                      cursor: pointer;
                       display: inline-block;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 18px;
+                      font-weight: 400;
+                      height: 44px;
+                      line-height: 44px;
+                      margin-right: 0px;
+                      outline: transparent;
+                      padding-bottom: 0;
+                      padding-left: 10px;
+                      padding-right: 10px;
+                      padding-top: 0;
+                      position: relative;
+                      text-align: center;
+                      text-decoration: none;
+                      user-select: none;
                       vertical-align: top;
                     }
+                    &::-moz-focus-inner {
+                      border: 0;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus:after {
+                      border: 0px;
+                      bottom: 2px;
+                      content: attr(data-content);
+                      left: 2px;
+                      outline: 1px solid #605e5c;
+                      position: relative;
+                      right: 2px;
+                      top: 2px;
+                      z-index: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                      border: none;
+                      bottom: -2px;
+                      left: -2px;
+                      outline-color: ButtonText;
+                      right: -2px;
+                      top: -2px;
+                    }
+                    &:active > * {
+                      left: 0px;
+                      position: relative;
+                      top: 0px;
+                    }
+                    &:hover {
+                      background-color: #0078d4;
+                      color: #ffffff;
+                      cursor: pointer;
+                    }
+                    @media screen and (-ms-high-contrast: active){&:hover {
+                      border-color: Highlight;
+                      color: Highlight;
+                    }
+                    &:hover .ms-Button-icon {
+                      color: #0078d4;
+                    }
+                    &:focus {
+                      color: #000000;
+                      outline-offset: -1px;
+                      outline: none;
+                    }
+                    &:active {
+                      background-color: #0078d4;
+                      color: #ffffff;
+                    }
+                    &:active .ms-Button-icon {
+                      color: #004578;
+                    }
+                    &:before {
+                      background-color: transparent;
+                      bottom: 0px;
+                      content: "";
+                      height: 2px;
+                      left: 8px;
+                      position: absolute;
+                      right: 8px;
+                      transition: left 0.267s cubic-bezier(.1,.25,.75,.9),
+                                          right 0.267s cubic-bezier(.1,.25,.75,.9);
+                    }
+                    &:after {
+                      color: transparent;
+                      content: attr(data-content);
+                      display: block;
+                      font-weight: 700;
+                      height: 1px;
+                      overflow: hidden;
+                      visibility: hidden;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus {
+                      outline: 1px solid #605e5c;
+                    }
+                    .ms-Fabric--isFocusVisible &:focus::before {
+                      background: transparent;
+                      height: auto;
+                      transition: none;
+                    }
+                data-content="Biz"
+                data-is-focusable={true}
+                id="Pivot0-Tab3"
+                name="Biz"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                onKeyPress={[Function]}
+                onKeyUp={[Function]}
+                onMouseDown={[Function]}
+                onMouseUp={[Function]}
+                role="tab"
+                type="button"
               >
-                 
-                Biz
-              </span>
-            </span>
-          </span>
-        </button>
+                <span
+                  className=
+                      ms-Button-flexContainer
+                      {
+                        align-items: center;
+                        display: flex;
+                        flex-wrap: nowrap;
+                        height: 100%;
+                        justify-content: flex-start;
+                      }
+                  data-automationid="splitbuttonprimary"
+                >
+                  <span
+                    className=
+                        ms-Pivot-linkContent
+                        {
+                          flex: 0 1 100%;
+                        }
+                        & > *  {
+                          margin-left: 4px;
+                        }
+                        & > *:first-child {
+                          margin-left: 0px;
+                        }
+                  >
+                    <span
+                      className=
+                          ms-Pivot-text
+                          {
+                            display: inline-block;
+                            vertical-align: top;
+                          }
+                    >
+                       
+                      Biz
+                    </span>
+                  </span>
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <div


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #4066
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Today, pivots are not very responsive. When many tabs are shown and take up a lot of horizontal space, they don't adapt when the page/container size changes. 
This change set is intended to add a resize group around the pivot and pushes items into an overflow set when there isn't enough room to show all the tabs.

This is just an initial change set to get some input on designs and things to consider. I'd love to hear your thoughts.
I also haven't touched the tests, I know there's going to be a bunch of work to do there.

#### Focus areas to test
Pivots

![image](https://user-images.githubusercontent.com/57726991/69388723-bd537f80-0c7e-11ea-9ad3-b2bac754b780.png)
![image](https://user-images.githubusercontent.com/57726991/69388789-e7a53d00-0c7e-11ea-9332-9b1291d0684f.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11270)