### PR TITLE
CommandBar: divider fix

### DIFF
--- a/change/office-ui-fabric-react-2019-11-21-17-25-22-v-mare-CommandBarButton-divider-fix.json
+++ b/change/office-ui-fabric-react-2019-11-21-17-25-22-v-mare-CommandBarButton-divider-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "CommandBarButton: Fixed hidden CommandBarButton splitbuttonDivider",
+  "packageName": "office-ui-fabric-react",
+  "email": "v-mare@microsoft.com",
+  "commit": "0cae80c33eab4fb0ecbde1da925e740e85ddefe0",
+  "date": "2019-11-22T01:25:22.612Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/ButtonThemes.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/ButtonThemes.ts
@@ -1,6 +1,16 @@
 import { IButtonStyles } from './Button.types';
-import { ITheme, HighContrastSelector } from '../../Styling';
+import { ITheme, HighContrastSelector, IRawStyle } from '../../Styling';
 import { IsFocusVisibleClassName } from '../../Utilities';
+
+const splitButtonDividerBaseStyles = (): IRawStyle => {
+  return {
+    position: 'absolute',
+    width: 1,
+    right: 31,
+    top: 8,
+    bottom: 8
+  };
+};
 
 export function standardStyles(theme: ITheme): IButtonStyles {
   const { semanticColors: s, palette: p } = theme;
@@ -95,12 +105,8 @@ export function standardStyles(theme: ITheme): IButtonStyles {
     },
 
     splitButtonDivider: {
+      ...splitButtonDividerBaseStyles(),
       backgroundColor: p.neutralTertiaryAlt,
-      position: 'absolute',
-      width: 1,
-      right: 31,
-      top: 8,
-      bottom: 8,
       selectors: {
         [HighContrastSelector]: {
           backgroundColor: 'WindowText'
@@ -223,12 +229,8 @@ export function primaryStyles(theme: ITheme): IButtonStyles {
     },
 
     splitButtonDivider: {
-      backgroundColor: p.neutralTertiaryAlt,
-      position: 'absolute',
-      width: 1,
-      right: 31,
-      top: 8,
-      bottom: 8,
+      ...splitButtonDividerBaseStyles(),
+      backgroundColor: p.white,
       selectors: {
         [HighContrastSelector]: {
           backgroundColor: 'Window'

--- a/packages/office-ui-fabric-react/src/components/Button/CommandBarButton/CommandBarButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/CommandBarButton/CommandBarButton.styles.ts
@@ -130,9 +130,7 @@ export const getStyles = memoizeFunction(
       },
 
       splitButtonDivider: {
-        backgroundColor: p.neutralTertiaryAlt,
-        marginTop: 4,
-        marginBottom: 4
+        backgroundColor: p.neutralTertiaryAlt
       },
 
       splitButtonMenuButton: {

--- a/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -14,12 +14,25 @@ export const getStyles = memoizeFunction(
       border: 'none'
     };
 
-    const splitButtonDividerDisabled: IStyle = {
+    const splitButtonDividerBaseStyles: IStyle = {
       position: 'absolute',
       width: 1,
       right: 31,
       top: 8,
-      bottom: 8,
+      bottom: 8
+    };
+
+    const splitButtonDivider: IStyle = {
+      ...splitButtonDividerBaseStyles,
+      selectors: {
+        [HighContrastSelector]: {
+          backgroundColor: 'WindowText'
+        }
+      }
+    };
+
+    const splitButtonDividerDisabled: IStyle = {
+      ...splitButtonDividerBaseStyles,
       selectors: {
         [HighContrastSelector]: {
           backgroundColor: 'GrayText'
@@ -129,6 +142,7 @@ export const getStyles = memoizeFunction(
         marginRight: 0,
         marginBottom: 0
       },
+      splitButtonDivider: splitButtonDivider,
       splitButtonDividerDisabled: splitButtonDividerDisabled,
       splitButtonMenuButtonDisabled: {
         pointerEvents: 'none',

--- a/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/SplitButton/SplitButton.styles.ts
@@ -22,24 +22,6 @@ export const getStyles = memoizeFunction(
       bottom: 8
     };
 
-    const splitButtonDivider: IStyle = {
-      ...splitButtonDividerBaseStyles,
-      selectors: {
-        [HighContrastSelector]: {
-          backgroundColor: 'WindowText'
-        }
-      }
-    };
-
-    const splitButtonDividerDisabled: IStyle = {
-      ...splitButtonDividerBaseStyles,
-      selectors: {
-        [HighContrastSelector]: {
-          backgroundColor: 'GrayText'
-        }
-      }
-    };
-
     const splitButtonStyles: IButtonStyles = {
       splitButtonContainer: [
         getFocusStyle(theme, { highContrastStyle: buttonHighContrastFocus, inset: 2 }),
@@ -142,8 +124,22 @@ export const getStyles = memoizeFunction(
         marginRight: 0,
         marginBottom: 0
       },
-      splitButtonDivider: splitButtonDivider,
-      splitButtonDividerDisabled: splitButtonDividerDisabled,
+      splitButtonDivider: {
+        ...splitButtonDividerBaseStyles,
+        selectors: {
+          [HighContrastSelector]: {
+            backgroundColor: 'WindowText'
+          }
+        }
+      },
+      splitButtonDividerDisabled: {
+        ...splitButtonDividerBaseStyles,
+        selectors: {
+          [HighContrastSelector]: {
+            backgroundColor: 'GrayText'
+          }
+        }
+      },
       splitButtonMenuButtonDisabled: {
         pointerEvents: 'none',
         border: 'none',

--- a/packages/office-ui-fabric-react/src/components/Button/examples/Button.CustomSplit.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/examples/Button.CustomSplit.Example.tsx
@@ -10,7 +10,7 @@ export interface IButtonExampleProps {
 const customSplitButtonStyles: IButtonStyles = {
   splitButtonMenuButton: { backgroundColor: 'white', width: 28, border: 'none' },
   splitButtonMenuIcon: { fontSize: '7px' },
-  splitButtonDivider: { borderLeft: '1px solid #c8c8c8', right: 26 },
+  splitButtonDivider: { backgroundColor: '#c8c8c8', width: 1, right: 26, position: 'absolute', top: 4, bottom: 4 },
   splitButtonContainer: {
     selectors: {
       [HighContrastSelector]: { border: 'none' }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CustomSplit.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CustomSplit.Example.tsx.shot
@@ -346,8 +346,15 @@ exports[`Component Examples renders Button.CustomSplit.Example.tsx correctly 1`]
         className=
 
             {
-              border-left: 1px solid #c8c8c8;
+              background-color: #c8c8c8;
+              bottom: 4px;
+              position: absolute;
               right: 26px;
+              top: 4px;
+              width: 1px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background-color: WindowText;
             }
       />
     </span>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Split.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Split.Example.tsx.shot
@@ -698,7 +698,7 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
           className=
 
               {
-                background-color: #c8c6c4;
+                background-color: #ffffff;
                 bottom: 8px;
                 position: absolute;
                 right: 31px;
@@ -706,7 +706,7 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                 width: 1px;
               }
               @media screen and (-ms-high-contrast: active){& {
-                background-color: Window;
+                background-color: WindowText;
               }
         />
       </span>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
@@ -447,8 +447,14 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
 
                         {
                           background-color: #c8c6c4;
-                          margin-bottom: 4px;
-                          margin-top: 4px;
+                          bottom: 8px;
+                          position: absolute;
+                          right: 31px;
+                          top: 8px;
+                          width: 1px;
+                        }
+                        @media screen and (-ms-high-contrast: active){& {
+                          background-color: WindowText;
                         }
                   />
                 </span>
@@ -839,8 +845,6 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                         {
                           background-color: #c8c6c4;
                           bottom: 8px;
-                          margin-bottom: 4px;
-                          margin-top: 4px;
                           position: absolute;
                           right: 31px;
                           top: 8px;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #10960
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Fixes missing divider in CommandBarButton
Fixes CustomSplit button example
Refactors ButtonThemes and SplitButton.styles divider styles

#### Before/After CommandBarButton divider
![Screen Shot 2019-11-21 at 7 27 28 PM](https://user-images.githubusercontent.com/13246181/69395767-fac30780-0c94-11ea-8d64-f1a24612ded3.png)
![Screen Shot 2019-11-21 at 5 10 07 PM](https://user-images.githubusercontent.com/13246181/69395738-e717a100-0c94-11ea-8a78-210c5c21a995.png)

#### Before/After CustomSplit button divider
![Screen Shot 2019-11-21 at 5 19 28 PM](https://user-images.githubusercontent.com/13246181/69395787-0f9f9b00-0c95-11ea-8c3f-67b55bf7c2e0.png)
![Screen Shot 2019-11-21 at 5 18 58 PM](https://user-images.githubusercontent.com/13246181/69395789-1201f500-0c95-11ea-909a-2ef4aee70713.png)






###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11271)