### PR TITLE
Combobox disabled options

### DIFF
--- a/change/office-ui-fabric-react-2019-11-22-10-15-18-combobox-disabled-options.json
+++ b/change/office-ui-fabric-react-2019-11-22-10-15-18-combobox-disabled-options.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Combobox: Noop if selected item is disabled",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "183a84df49f8c1c0003f12fe1cc34b039c2d03e8",
+  "date": "2019-11-22T18:15:18.983Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -596,6 +596,10 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           // the matched option's index
           index = currentPendingValueValidIndex;
           displayValues.push(this._normalizeToString(currentPendingValue));
+        } else if (!this.state.isOpen && currentPendingValue) {
+          displayValues.push(
+            this._indexWithinBounds(currentOptions, index) ? currentPendingValue : this._normalizeToString(suggestedDisplayValue)
+          );
         } else {
           displayValues.push(
             this._indexWithinBounds(currentOptions, index) ? currentOptions[index].text : this._normalizeToString(suggestedDisplayValue)

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -537,7 +537,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
 
     // If the user passed is a value prop, use that
     // unless we are open and have a valid current pending index
-    if (!(isOpen && currentPendingIndexValid) && (text && (currentPendingValue === null || currentPendingValue === undefined))) {
+    if (!(isOpen && currentPendingIndexValid) && text && (currentPendingValue === null || currentPendingValue === undefined)) {
       return text;
     }
 
@@ -868,7 +868,8 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     // there is nothing to do
     if (this.props.multiSelect || selectedIndices.length < 1 || (selectedIndices.length === 1 && selectedIndices[0] !== index)) {
       const option: IComboBoxOption = { ...currentOptions[index] };
-      if (!option) {
+      // if option doesn't existing, or option is disabled, we noop
+      if (!option || option.disabled) {
         return;
       }
       if (this.props.multiSelect) {
@@ -1055,15 +1056,15 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         // the live value in the underlying input matches the pending option; update the state
         if (
           currentPendingValue.toLocaleLowerCase() === pendingOptionText ||
-          ((autoComplete &&
+          (autoComplete &&
             pendingOptionText.indexOf(currentPendingValue.toLocaleLowerCase()) === 0 &&
-            (this._autofill.current &&
-              this._autofill.current.isValueSelected &&
-              currentPendingValue.length + (this._autofill.current.selectionEnd! - this._autofill.current.selectionStart!) ===
-                pendingOptionText.length)) ||
-            (this._autofill.current &&
-              this._autofill.current.inputElement &&
-              this._autofill.current.inputElement.value.toLocaleLowerCase() === pendingOptionText))
+            this._autofill.current &&
+            this._autofill.current.isValueSelected &&
+            currentPendingValue.length + (this._autofill.current.selectionEnd! - this._autofill.current.selectionStart!) ===
+              pendingOptionText.length) ||
+          (this._autofill.current &&
+            this._autofill.current.inputElement &&
+            this._autofill.current.inputElement.value.toLocaleLowerCase() === pendingOptionText)
         ) {
           this._setSelectedIndex(currentPendingValueValidIndex, submitPendingValueEvent);
           this._clearPendingInfo();
@@ -1343,7 +1344,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     return currentPendingValueValidIndexOnHover >= 0
       ? currentPendingValueValidIndexOnHover
       : currentPendingValueValidIndex >= 0 ||
-        (includeCurrentPendingValue && (currentPendingValue !== null && currentPendingValue !== undefined))
+        (includeCurrentPendingValue && currentPendingValue !== null && currentPendingValue !== undefined)
       ? currentPendingValueValidIndex
       : this.props.multiSelect
       ? 0


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11193 Fixes #11203
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Keyboard navigation and freeform were able to select disabled options. Now we check if the option is disabled right before setting the new value. If the option is disabled we noop and return to the previously selected value.

Also, seems prettier config changed a bit, so just note line 872

I also added in a fix to show the correct value for non freeform/autocomplete scenarios, which was dependent on the disabled fix.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11280)