### PR TITLE
Fabric component: Adding dir=rtl support for scoped rtl/ltr regions on the page.

### DIFF
--- a/change/office-ui-fabric-react-2019-11-24-19-16-31-fabric-rtl.json
+++ b/change/office-ui-fabric-react-2019-11-24-19-16-31-fabric-rtl.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Fabric component: adding `dir=rtl` support to affect both the `dir` attribute as well as affecting the styling generated within scope (by creating an rtl-versioned theme and exposing it via `Customizer`.)",
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@hotmail.com",
+  "commit": "0c93b631db2d354fa0cb529981aa26d25834353d",
+  "date": "2019-11-25T03:16:31.848Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -4485,7 +4485,11 @@ export interface IFabricProps extends React.HTMLAttributes<HTMLDivElement> {
     // (undocumented)
     applyThemeToBody?: boolean;
     // (undocumented)
+    as?: React.ReactType;
+    // (undocumented)
     componentRef?: IRefObject<{}>;
+    // (undocumented)
+    dir?: 'rtl' | 'ltr' | 'auto';
     // (undocumented)
     styles?: IStyleFunctionOrObject<IFabricStyleProps, IFabricStyles>;
     // (undocumented)

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -4480,19 +4480,13 @@ export interface IExtendedPersonaProps extends IPersonaProps {
 
 // @public (undocumented)
 export interface IFabricProps extends React.HTMLAttributes<HTMLDivElement> {
-    // (undocumented)
     applyTheme?: boolean;
-    // (undocumented)
     applyThemeToBody?: boolean;
-    // (undocumented)
     as?: React.ReactType;
     // (undocumented)
     componentRef?: IRefObject<{}>;
-    // (undocumented)
     dir?: 'rtl' | 'ltr' | 'auto';
-    // (undocumented)
     styles?: IStyleFunctionOrObject<IFabricStyleProps, IFabricStyles>;
-    // (undocumented)
     theme?: ITheme;
 }
 

--- a/packages/office-ui-fabric-react/src/components/Fabric/Fabric.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Fabric/Fabric.base.tsx
@@ -1,9 +1,24 @@
 import * as React from 'react';
-import { getNativeProps, on, divProperties, classNamesFunction, getWindow, getDocument, isDirectionalKeyCode } from '../../Utilities';
+import {
+  Customizer,
+  getNativeProps,
+  on,
+  divProperties,
+  classNamesFunction,
+  getWindow,
+  getDocument,
+  isDirectionalKeyCode,
+  memoizeFunction
+} from '../../Utilities';
 import { getStyles } from './Fabric.styles';
 import { IFabricProps, IFabricStyleProps, IFabricStyles } from './Fabric.types';
 import { IProcessedStyleSet } from '@uifabric/merge-styles';
+import { ITheme } from '../../Styling';
+
 const getClassNames = classNamesFunction<IFabricStyleProps, IFabricStyles>();
+
+const getRTLTheme = memoizeFunction((theme: ITheme) => ({ ...theme, rtl: true }));
+
 export class FabricBase extends React.Component<
   IFabricProps,
   {
@@ -20,9 +35,18 @@ export class FabricBase extends React.Component<
   }
 
   public render() {
+    const { as: Root = 'div', theme, dir } = this.props;
     const classNames = this._getClassNames();
     const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties);
-    return <div {...divProps} className={classNames.root} ref={this._rootElement} />;
+
+    let renderedContent = <Root {...divProps} className={classNames.root} ref={this._rootElement} />;
+
+    // Expose an rtl based theme if neccessary.
+    if (theme && !theme.rtl && dir === 'rtl') {
+      renderedContent = <Customizer settings={{ theme: getRTLTheme(theme) }}>{renderedContent}</Customizer>;
+    }
+
+    return renderedContent;
   }
 
   public componentDidMount(): void {

--- a/packages/office-ui-fabric-react/src/components/Fabric/Fabric.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Fabric/Fabric.base.tsx
@@ -16,8 +16,7 @@ import { IProcessedStyleSet } from '@uifabric/merge-styles';
 import { ITheme } from '../../Styling';
 
 const getClassNames = classNamesFunction<IFabricStyleProps, IFabricStyles>();
-
-const getRTLTheme = memoizeFunction((theme: ITheme) => ({ ...theme, rtl: true }));
+const getRTLTheme = memoizeFunction((theme: ITheme, isRTL: boolean) => ({ ...theme, rtl: isRTL }));
 
 export class FabricBase extends React.Component<
   IFabricProps,
@@ -38,12 +37,12 @@ export class FabricBase extends React.Component<
     const { as: Root = 'div', theme, dir } = this.props;
     const classNames = this._getClassNames();
     const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties);
-
+    const isRTL = dir === 'rtl';
     let renderedContent = <Root {...divProps} className={classNames.root} ref={this._rootElement} />;
 
-    // Expose an rtl based theme if neccessary.
-    if (theme && !theme.rtl && dir === 'rtl') {
-      renderedContent = <Customizer settings={{ theme: getRTLTheme(theme) }}>{renderedContent}</Customizer>;
+    // Expose an rtl based theme if dir is specified and it doesn't agree with the theme setting.
+    if (dir !== undefined && theme && (theme.rtl === undefined || theme.rtl !== isRTL)) {
+      renderedContent = <Customizer settings={{ theme: getRTLTheme(theme, isRTL) }}>{renderedContent}</Customizer>;
     }
 
     return renderedContent;

--- a/packages/office-ui-fabric-react/src/components/Fabric/Fabric.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Fabric/Fabric.test.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
 import { Fabric } from './Fabric';
+import { Checkbox } from '../../Checkbox';
+
 import { mount } from 'enzyme';
 
 describe('Fabric', () => {
@@ -12,6 +14,16 @@ describe('Fabric', () => {
 
   it('renders a Fabric component with applyTheme correctly', () => {
     const component = renderer.create(<Fabric applyTheme>test</Fabric>);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders a Fabric component in RTL', () => {
+    const component = renderer.create(
+      <Fabric dir="rtl">
+        <Checkbox label="I am in rtl" />
+      </Fabric>
+    );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/packages/office-ui-fabric-react/src/components/Fabric/Fabric.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Fabric/Fabric.test.tsx
@@ -20,10 +20,29 @@ describe('Fabric', () => {
 
   it('renders a Fabric component in RTL', () => {
     const component = renderer.create(
-      <Fabric dir="rtl">
-        <Checkbox label="I am in rtl" />
-      </Fabric>
+      <div>
+        <Checkbox label="I am a default Checkbox" />
+        <Fabric dir="ltr">
+          <Checkbox label="I am in ltr" />
+
+          <Fabric dir="rtl">
+            <Checkbox label="I am in rtl, inside of ltr" />
+
+            <Fabric dir="ltr">
+              <Checkbox label="I am in ltr, inside of rtl, inside of ltr" />
+            </Fabric>
+          </Fabric>
+        </Fabric>
+      </div>
     );
+
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders as a span using the "as" prop', () => {
+    const component = renderer.create(<Fabric as="span" />);
+
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });

--- a/packages/office-ui-fabric-react/src/components/Fabric/Fabric.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Fabric/Fabric.types.ts
@@ -4,12 +4,36 @@ import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
 
 export interface IFabricProps extends React.HTMLAttributes<HTMLDivElement> {
   componentRef?: IRefObject<{}>;
+
+  /**
+   * Overrides the root element type, defaults to `div`.
+   */
   as?: React.ReactType;
+
+  /**
+   * Injected by the `styled` HOC wrapper.
+   */
   theme?: ITheme;
+
+  /**
+   * Overrides the styles for the component.
+   */
   styles?: IStyleFunctionOrObject<IFabricStyleProps, IFabricStyles>;
+
+  /**
+   * Applies the current body background specified in the theme to the root element.
+   */
   applyTheme?: boolean;
+
+  /**
+   * Applies the current body background specified in the theme to the body element.
+   */
   applyThemeToBody?: boolean;
 
+  /**
+   * Specifies the direction of the content. Will inject a `dir` attribute, and also ensure that the `rtl` flag of the
+   * contextual theme object is set correctly so that css registered with merge-styles can be auto flipped correctly.
+   */
   dir?: 'rtl' | 'ltr' | 'auto';
 }
 

--- a/packages/office-ui-fabric-react/src/components/Fabric/Fabric.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Fabric/Fabric.types.ts
@@ -4,10 +4,13 @@ import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
 
 export interface IFabricProps extends React.HTMLAttributes<HTMLDivElement> {
   componentRef?: IRefObject<{}>;
+  as?: React.ReactType;
   theme?: ITheme;
   styles?: IStyleFunctionOrObject<IFabricStyleProps, IFabricStyles>;
   applyTheme?: boolean;
   applyThemeToBody?: boolean;
+
+  dir?: 'rtl' | 'ltr' | 'auto';
 }
 
 export interface IFabricStyleProps extends IFabricProps {

--- a/packages/office-ui-fabric-react/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
@@ -26,6 +26,174 @@ exports[`Fabric renders a Fabric component correctly 1`] = `
 </div>
 `;
 
+exports[`Fabric renders a Fabric component in RTL 1`] = `
+<div
+  className=
+      ms-Fabric
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        color: #323130;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+      }
+      & button {
+        font-family: inherit;
+      }
+      & input {
+        font-family: inherit;
+      }
+      & textarea {
+        font-family: inherit;
+      }
+  dir="rtl"
+>
+  <div
+    className=
+        ms-Checkbox
+        is-enabled
+        {
+          display: flex;
+          position: relative;
+        }
+        &:hover .ms-Checkbox-checkbox {
+          border-color: #323130;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+          border-color: Highlight;
+        }
+        &:focus .ms-Checkbox-checkbox {
+          border-color: #323130;
+        }
+        &:hover .ms-Checkbox-checkmark {
+          color: #605e5c;
+          opacity: 1;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+          color: Highlight;
+        }
+        &:hover .ms-Checkbox-text {
+          color: #201f1e;
+        }
+        &:focus .ms-Checkbox-text {
+          color: #201f1e;
+        }
+  >
+    <input
+      aria-checked="false"
+      aria-label="I am in rtl"
+      checked={false}
+      className=
+
+          {
+            background: none;
+            opacity: 0;
+            position: absolute;
+          }
+          .ms-Fabric--isFocusVisible &:focus + label::before {
+            outline-offset: 2px;
+            outline: 1px solid #605e5c;
+          }
+          @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+            outline: 1px solid ActiveBorder;
+          }
+      id="checkbox-0"
+      onBlur={[Function]}
+      onChange={[Function]}
+      onFocus={[Function]}
+      type="checkbox"
+    />
+    <label
+      className=
+          ms-Checkbox-label
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            align-items: flex-start;
+            cursor: pointer;
+            display: flex;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            position: relative;
+            text-align: right;
+            user-select: none;
+          }
+          &::before {
+            bottom: 0px;
+            content: "";
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+      htmlFor="checkbox-0"
+    >
+      <div
+        className=
+            ms-Checkbox-checkbox
+            {
+              align-items: center;
+              border-radius: 2px;
+              border: 1px solid #323130;
+              box-sizing: border-box;
+              display: flex;
+              flex-shrink: 0;
+              height: 20px;
+              justify-content: center;
+              margin-left: 4px;
+              overflow: hidden;
+              position: relative;
+              transition-duration: 200ms;
+              transition-property: background, border, border-color;
+              transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+              width: 20px;
+            }
+      >
+        <i
+          aria-hidden={true}
+          className=
+              ms-Checkbox-checkmark
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                color: #ffffff;
+                display: inline-block;
+                font-family: "FabricMDL2Icons";
+                font-style: normal;
+                font-weight: normal;
+                opacity: 0;
+                speak: none;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                -ms-high-contrast-adjust: none;
+                color: Window;
+              }
+          data-icon-name="CheckMark"
+        >
+          
+        </i>
+      </div>
+      <span
+        aria-hidden="true"
+        className=
+            ms-Checkbox-text
+            {
+              color: #323130;
+              font-size: 14px;
+              line-height: 20px;
+              margin-right: 4px;
+            }
+      >
+        I am in rtl
+      </span>
+    </label>
+  </div>
+</div>
+`;
+
 exports[`Fabric renders a Fabric component with applyTheme correctly 1`] = `
 <div
   className=

--- a/packages/office-ui-fabric-react/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
@@ -27,28 +27,7 @@ exports[`Fabric renders a Fabric component correctly 1`] = `
 `;
 
 exports[`Fabric renders a Fabric component in RTL 1`] = `
-<div
-  className=
-      ms-Fabric
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        color: #323130;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-      }
-      & button {
-        font-family: inherit;
-      }
-      & input {
-        font-family: inherit;
-      }
-      & textarea {
-        font-family: inherit;
-      }
-  dir="rtl"
->
+<div>
   <div
     className=
         ms-Checkbox
@@ -82,7 +61,7 @@ exports[`Fabric renders a Fabric component in RTL 1`] = `
   >
     <input
       aria-checked="false"
-      aria-label="I am in rtl"
+      aria-label="I am a default Checkbox"
       checked={false}
       className=
 
@@ -117,7 +96,7 @@ exports[`Fabric renders a Fabric component in RTL 1`] = `
             font-size: 14px;
             font-weight: 400;
             position: relative;
-            text-align: right;
+            text-align: left;
             user-select: none;
           }
           &::before {
@@ -143,7 +122,7 @@ exports[`Fabric renders a Fabric component in RTL 1`] = `
               flex-shrink: 0;
               height: 20px;
               justify-content: center;
-              margin-left: 4px;
+              margin-right: 4px;
               overflow: hidden;
               position: relative;
               transition-duration: 200ms;
@@ -184,12 +163,507 @@ exports[`Fabric renders a Fabric component in RTL 1`] = `
               color: #323130;
               font-size: 14px;
               line-height: 20px;
-              margin-right: 4px;
+              margin-left: 4px;
             }
       >
-        I am in rtl
+        I am a default Checkbox
       </span>
     </label>
+  </div>
+  <div
+    className=
+        ms-Fabric
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          color: #323130;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+        }
+        & button {
+          font-family: inherit;
+        }
+        & input {
+          font-family: inherit;
+        }
+        & textarea {
+          font-family: inherit;
+        }
+    dir="ltr"
+  >
+    <div
+      className=
+          ms-Checkbox
+          is-enabled
+          {
+            display: flex;
+            position: relative;
+          }
+          &:hover .ms-Checkbox-checkbox {
+            border-color: #323130;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+            border-color: Highlight;
+          }
+          &:focus .ms-Checkbox-checkbox {
+            border-color: #323130;
+          }
+          &:hover .ms-Checkbox-checkmark {
+            color: #605e5c;
+            opacity: 1;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+            color: Highlight;
+          }
+          &:hover .ms-Checkbox-text {
+            color: #201f1e;
+          }
+          &:focus .ms-Checkbox-text {
+            color: #201f1e;
+          }
+    >
+      <input
+        aria-checked="false"
+        aria-label="I am in ltr"
+        checked={false}
+        className=
+
+            {
+              background: none;
+              opacity: 0;
+              position: absolute;
+            }
+            .ms-Fabric--isFocusVisible &:focus + label::before {
+              outline-offset: 2px;
+              outline: 1px solid #605e5c;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+              outline: 1px solid ActiveBorder;
+            }
+        id="checkbox-1"
+        onBlur={[Function]}
+        onChange={[Function]}
+        onFocus={[Function]}
+        type="checkbox"
+      />
+      <label
+        className=
+            ms-Checkbox-label
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-items: flex-start;
+              cursor: pointer;
+              display: flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              position: relative;
+              text-align: left;
+              user-select: none;
+            }
+            &::before {
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              pointer-events: none;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+            }
+        htmlFor="checkbox-1"
+      >
+        <div
+          className=
+              ms-Checkbox-checkbox
+              {
+                align-items: center;
+                border-radius: 2px;
+                border: 1px solid #323130;
+                box-sizing: border-box;
+                display: flex;
+                flex-shrink: 0;
+                height: 20px;
+                justify-content: center;
+                margin-right: 4px;
+                overflow: hidden;
+                position: relative;
+                transition-duration: 200ms;
+                transition-property: background, border, border-color;
+                transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                width: 20px;
+              }
+        >
+          <i
+            aria-hidden={true}
+            className=
+                ms-Checkbox-checkmark
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #ffffff;
+                  display: inline-block;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  opacity: 0;
+                  speak: none;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  color: Window;
+                }
+            data-icon-name="CheckMark"
+          >
+            
+          </i>
+        </div>
+        <span
+          aria-hidden="true"
+          className=
+              ms-Checkbox-text
+              {
+                color: #323130;
+                font-size: 14px;
+                line-height: 20px;
+                margin-left: 4px;
+              }
+        >
+          I am in ltr
+        </span>
+      </label>
+    </div>
+    <div
+      className=
+          ms-Fabric
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #323130;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+          }
+          & button {
+            font-family: inherit;
+          }
+          & input {
+            font-family: inherit;
+          }
+          & textarea {
+            font-family: inherit;
+          }
+      dir="rtl"
+    >
+      <div
+        className=
+            ms-Checkbox
+            is-enabled
+            {
+              display: flex;
+              position: relative;
+            }
+            &:hover .ms-Checkbox-checkbox {
+              border-color: #323130;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+              border-color: Highlight;
+            }
+            &:focus .ms-Checkbox-checkbox {
+              border-color: #323130;
+            }
+            &:hover .ms-Checkbox-checkmark {
+              color: #605e5c;
+              opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+              color: Highlight;
+            }
+            &:hover .ms-Checkbox-text {
+              color: #201f1e;
+            }
+            &:focus .ms-Checkbox-text {
+              color: #201f1e;
+            }
+      >
+        <input
+          aria-checked="false"
+          aria-label="I am in rtl, inside of ltr"
+          checked={false}
+          className=
+
+              {
+                background: none;
+                opacity: 0;
+                position: absolute;
+              }
+              .ms-Fabric--isFocusVisible &:focus + label::before {
+                outline-offset: 2px;
+                outline: 1px solid #605e5c;
+              }
+              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+                outline: 1px solid ActiveBorder;
+              }
+          id="checkbox-2"
+          onBlur={[Function]}
+          onChange={[Function]}
+          onFocus={[Function]}
+          type="checkbox"
+        />
+        <label
+          className=
+              ms-Checkbox-label
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: flex-start;
+                cursor: pointer;
+                display: flex;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                position: relative;
+                text-align: right;
+                user-select: none;
+              }
+              &::before {
+                bottom: 0px;
+                content: "";
+                left: 0px;
+                pointer-events: none;
+                position: absolute;
+                right: 0px;
+                top: 0px;
+              }
+          htmlFor="checkbox-2"
+        >
+          <div
+            className=
+                ms-Checkbox-checkbox
+                {
+                  align-items: center;
+                  border-radius: 2px;
+                  border: 1px solid #323130;
+                  box-sizing: border-box;
+                  display: flex;
+                  flex-shrink: 0;
+                  height: 20px;
+                  justify-content: center;
+                  margin-left: 4px;
+                  overflow: hidden;
+                  position: relative;
+                  transition-duration: 200ms;
+                  transition-property: background, border, border-color;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 20px;
+                }
+          >
+            <i
+              aria-hidden={true}
+              className=
+                  ms-Checkbox-checkmark
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    color: #ffffff;
+                    display: inline-block;
+                    font-family: "FabricMDL2Icons";
+                    font-style: normal;
+                    font-weight: normal;
+                    opacity: 0;
+                    speak: none;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    -ms-high-contrast-adjust: none;
+                    color: Window;
+                  }
+              data-icon-name="CheckMark"
+            >
+              
+            </i>
+          </div>
+          <span
+            aria-hidden="true"
+            className=
+                ms-Checkbox-text
+                {
+                  color: #323130;
+                  font-size: 14px;
+                  line-height: 20px;
+                  margin-right: 4px;
+                }
+          >
+            I am in rtl, inside of ltr
+          </span>
+        </label>
+      </div>
+      <div
+        className=
+            ms-Fabric
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #323130;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+            }
+            & button {
+              font-family: inherit;
+            }
+            & input {
+              font-family: inherit;
+            }
+            & textarea {
+              font-family: inherit;
+            }
+        dir="ltr"
+      >
+        <div
+          className=
+              ms-Checkbox
+              is-enabled
+              {
+                display: flex;
+                position: relative;
+              }
+              &:hover .ms-Checkbox-checkbox {
+                border-color: #323130;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+                border-color: Highlight;
+              }
+              &:focus .ms-Checkbox-checkbox {
+                border-color: #323130;
+              }
+              &:hover .ms-Checkbox-checkmark {
+                color: #605e5c;
+                opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkmark {
+                color: Highlight;
+              }
+              &:hover .ms-Checkbox-text {
+                color: #201f1e;
+              }
+              &:focus .ms-Checkbox-text {
+                color: #201f1e;
+              }
+        >
+          <input
+            aria-checked="false"
+            aria-label="I am in ltr, inside of rtl, inside of ltr"
+            checked={false}
+            className=
+
+                {
+                  background: none;
+                  opacity: 0;
+                  position: absolute;
+                }
+                .ms-Fabric--isFocusVisible &:focus + label::before {
+                  outline-offset: 2px;
+                  outline: 1px solid #605e5c;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus + label::before {
+                  outline: 1px solid ActiveBorder;
+                }
+            id="checkbox-3"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="checkbox"
+          />
+          <label
+            className=
+                ms-Checkbox-label
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  align-items: flex-start;
+                  cursor: pointer;
+                  display: flex;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  position: relative;
+                  text-align: left;
+                  user-select: none;
+                }
+                &::before {
+                  bottom: 0px;
+                  content: "";
+                  left: 0px;
+                  pointer-events: none;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                }
+            htmlFor="checkbox-3"
+          >
+            <div
+              className=
+                  ms-Checkbox-checkbox
+                  {
+                    align-items: center;
+                    border-radius: 2px;
+                    border: 1px solid #323130;
+                    box-sizing: border-box;
+                    display: flex;
+                    flex-shrink: 0;
+                    height: 20px;
+                    justify-content: center;
+                    margin-right: 4px;
+                    overflow: hidden;
+                    position: relative;
+                    transition-duration: 200ms;
+                    transition-property: background, border, border-color;
+                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                    width: 20px;
+                  }
+            >
+              <i
+                aria-hidden={true}
+                className=
+                    ms-Checkbox-checkmark
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #ffffff;
+                      display: inline-block;
+                      font-family: "FabricMDL2Icons";
+                      font-style: normal;
+                      font-weight: normal;
+                      opacity: 0;
+                      speak: none;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      -ms-high-contrast-adjust: none;
+                      color: Window;
+                    }
+                data-icon-name="CheckMark"
+              >
+                
+              </i>
+            </div>
+            <span
+              aria-hidden="true"
+              className=
+                  ms-Checkbox-text
+                  {
+                    color: #323130;
+                    font-size: 14px;
+                    line-height: 20px;
+                    margin-left: 4px;
+                  }
+            >
+              I am in ltr, inside of rtl, inside of ltr
+            </span>
+          </label>
+        </div>
+      </div>
+    </div>
   </div>
 </div>
 `;
@@ -219,4 +693,28 @@ exports[`Fabric renders a Fabric component with applyTheme correctly 1`] = `
 >
   test
 </div>
+`;
+
+exports[`Fabric renders as a span using the "as" prop 1`] = `
+<span
+  className=
+      ms-Fabric
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        color: #323130;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+      }
+      & button {
+        font-family: inherit;
+      }
+      & input {
+        font-family: inherit;
+      }
+      & textarea {
+        font-family: inherit;
+      }
+/>
 `;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

The `Fabric` component currently takes `div` props and mixes them into the root element.

This PR does a couple things:

Adds `as` prop to allow the root element to be customized.

If `dir="rtl"` is set, the content will be wrapped in `Customizer` hosting an "rtl" theme. It takes care to use a memoized function to avoid re-creating theme objects redundantly.

Now you can apply scoped RTL sections in your UX:

```tsx
<Checkbox label='I am in LTR' />
<Fabric dir="rtl">
  <Checkbox label='I am in RTL' />
</Fabric>
```


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11295)