### PR TITLE
Use closeButtonAriaLabel as   dialog component close button tool tip

### DIFF
--- a/change/office-ui-fabric-react-2019-11-25-18-02-32-user-v-satgar-ExposePropForDialog.json
+++ b/change/office-ui-fabric-react-2019-11-25-18-02-32-user-v-satgar-ExposePropForDialog.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Expose prop for dialog component close button tooltip",
+  "packageName": "office-ui-fabric-react",
+  "email": "email not defined",
+  "commit": "dbcbaed1f306bbe5f18433ef54165b21b1600fad",
+  "date": "2019-11-25T12:32:32.409Z"
+}

--- a/change/office-ui-fabric-react-2019-11-25-18-02-32-user-v-satgar-ExposePropForDialog.json
+++ b/change/office-ui-fabric-react-2019-11-25-18-02-32-user-v-satgar-ExposePropForDialog.json
@@ -1,8 +1,8 @@
 {
-  "type": "minor",
-  "comment": "Expose prop for dialog component close button tooltip",
+  "type": "patch",
+  "comment": "Dialog: Use closeButtonAriaLabel for close button tooltip",
   "packageName": "office-ui-fabric-react",
-  "email": "email not defined",
+  "email": "v-ragor@microsoft.com",
   "commit": "dbcbaed1f306bbe5f18433ef54165b21b1600fad",
   "date": "2019-11-25T12:32:32.409Z"
 }

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.base.tsx
@@ -33,7 +33,6 @@ export class DialogContentBase extends BaseComponent<IDialogContentProps, {}> {
       subText,
       titleId,
       title,
-      closeButtonToolTip,
       type,
       styles,
       theme,
@@ -74,7 +73,7 @@ export class DialogContentBase extends BaseComponent<IDialogContentProps, {}> {
                 iconProps={{ iconName: 'Cancel' }}
                 ariaLabel={closeButtonAriaLabel}
                 onClick={onDismiss as any}
-                title={closeButtonToolTip}
+                title={closeButtonAriaLabel}
               />
             )}
           </div>

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.base.tsx
@@ -33,6 +33,7 @@ export class DialogContentBase extends BaseComponent<IDialogContentProps, {}> {
       subText,
       titleId,
       title,
+      closeButtonToolTip,
       type,
       styles,
       theme,
@@ -73,6 +74,7 @@ export class DialogContentBase extends BaseComponent<IDialogContentProps, {}> {
                 iconProps={{ iconName: 'Cancel' }}
                 ariaLabel={closeButtonAriaLabel}
                 onClick={onDismiss as any}
+                title={closeButtonToolTip}
               />
             )}
           </div>

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.types.ts
@@ -43,7 +43,7 @@ export interface IDialogContentProps extends React.ClassAttributes<DialogContent
   showCloseButton?: boolean;
 
   /**
-   * Show an 'x' close button in the upper-right corner of the L2 panel
+   * Add tooltip for 'x' close button in the upper-right corner
    */
   closeButtonToolTip?: string;
 

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.types.ts
@@ -43,6 +43,11 @@ export interface IDialogContentProps extends React.ClassAttributes<DialogContent
   showCloseButton?: boolean;
 
   /**
+   * Show an 'x' close button in the upper-right corner of the L2 panel
+   */
+  closeButtonToolTip?: string;
+
+  /**
    * Other top buttons that will show up next to the close button
    */
   topButtonsProps?: IButtonProps[];

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.types.ts
@@ -43,11 +43,6 @@ export interface IDialogContentProps extends React.ClassAttributes<DialogContent
   showCloseButton?: boolean;
 
   /**
-   * Add tooltip for 'x' close button in the upper-right corner
-   */
-  closeButtonToolTip?: string;
-
-  /**
    * Other top buttons that will show up next to the close button
    */
   topButtonsProps?: IButtonProps[];

--- a/packages/office-ui-fabric-react/src/components/Dialog/examples/Dialog.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/examples/Dialog.Basic.Example.tsx
@@ -47,6 +47,7 @@ export class DialogBasicExample extends React.Component<{}, IDialogBasicExampleS
           dialogContentProps={{
             type: DialogType.normal,
             title: 'Missing Subject',
+            closeButtonToolTip: 'Close',
             subText: 'Do you want to send this message without a subject?'
           }}
           modalProps={{

--- a/packages/office-ui-fabric-react/src/components/Dialog/examples/Dialog.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/examples/Dialog.Basic.Example.tsx
@@ -47,7 +47,7 @@ export class DialogBasicExample extends React.Component<{}, IDialogBasicExampleS
           dialogContentProps={{
             type: DialogType.normal,
             title: 'Missing Subject',
-            closeButtonToolTip: 'Close',
+            closeButtonAriaLabel: 'Close',
             subText: 'Do you want to send this message without a subject?'
           }}
           modalProps={{


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Expose prop for Dialog component for close button tool tip


#### Focus areas to test
Dialog close button 

#### Screenshot

![image](https://user-images.githubusercontent.com/13463251/69541232-ab3f4d00-0fae-11ea-91f6-c0b27f35d1a9.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11299)