### PR TITLE
Button: Adding color styles to show non-visible label in Fluent theme strong variant

### DIFF
--- a/change/@uifabric-fluent-theme-2019-11-25-11-48-20-button-label-fix.json
+++ b/change/@uifabric-fluent-theme-2019-11-25-11-48-20-button-label-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Button: Adding missing button label to Fluent theme in strong scheme",
+  "packageName": "@uifabric/fluent-theme",
+  "email": "marygans@microsoft.com",
+  "commit": "924721cbd843abf02752617cf003c73435f9654f",
+  "date": "2019-11-25T19:48:20.139Z"
+}

--- a/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
+++ b/packages/fluent-theme/src/fluent/styles/DefaultButton.styles.ts
@@ -68,7 +68,8 @@ export const DefaultButtonStyles = (props: IButtonProps): Partial<IButtonStyles>
           }
         },
         '.ms-Button.is-disabled': {
-          backgroundColor: palette.neutralLighter
+          backgroundColor: palette.neutralLighter,
+          color: palette.neutralTertiary
         },
         '.ms-Button.is-disabled + .ms-Button.is-disabled': {
           backgroundColor: palette.neutralLighter,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10863
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Adding missing button label in Fluent theme strong variant

**Before:** 
![Screen Shot 2019-11-25 at 11 52 42 AM](https://user-images.githubusercontent.com/38991459/69573063-40741e80-0f7a-11ea-832e-47a62961a9a8.png)

**After:**
![Screen Shot 2019-11-25 at 11 54 51 AM](https://user-images.githubusercontent.com/38991459/69573577-3dc5f900-0f7b-11ea-955a-0272a89b0e07.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11302)