### PR TITLE
PeoplePicker: Fix selected + hover Persona text styling

### DIFF
--- a/change/office-ui-fabric-react-2019-11-25-13-16-31-peoplePickerSelectedOnHover.json
+++ b/change/office-ui-fabric-react-2019-11-25-13-16-31-peoplePickerSelectedOnHover.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "PeoplePicker: Fix selected + hover Persona text styling.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "bf1ad76a48adaa45481f304f416ae0a73fdca9db",
+  "date": "2019-11-25T21:16:31.475Z"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/PeoplePickerItem.styles.ts
@@ -25,6 +25,9 @@ export function getStyles(props: IPeoplePickerItemSelectedStyleProps): IPeoplePi
       !disabled && {
         color: palette.white,
         selectors: {
+          ':hover': {
+            color: palette.white
+          },
           [HighContrastSelector]: {
             color: 'HighlightText'
           }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11293
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR addresses a styling bug that existed when hovering a selected item in the `PeoplePicker` component where it was applying a non-contrasting color for the text.

__Before:__

![image](https://user-images.githubusercontent.com/7798177/69579279-0f4e1b00-0f87-11ea-874d-d04a8577d0e0.png)

__After:__

![image](https://user-images.githubusercontent.com/7798177/69579467-6358ff80-0f87-11ea-829d-919a1101460e.png)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11304)