### PR TITLE
ComboBox: Fixing options' custom styling not applying to multiselect ComboBoxes

### DIFF
--- a/change/office-ui-fabric-react-2019-11-25-15-28-30-comboBoxOptionStyling.json
+++ b/change/office-ui-fabric-react-2019-11-25-15-28-30-comboBoxOptionStyling.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "ComboBox: Fixing options' custom styling not applying to multiselect ComboBoxes.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "926cc3e438ced516587c94885136ca07f23606e6",
+  "date": "2019-11-25T23:28:30.749Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -537,7 +537,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
 
     // If the user passed is a value prop, use that
     // unless we are open and have a valid current pending index
-    if (!(isOpen && currentPendingIndexValid) && (text && (currentPendingValue === null || currentPendingValue === undefined))) {
+    if (!(isOpen && currentPendingIndexValid) && text && (currentPendingValue === null || currentPendingValue === undefined)) {
       return text;
     }
 
@@ -1055,15 +1055,15 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         // the live value in the underlying input matches the pending option; update the state
         if (
           currentPendingValue.toLocaleLowerCase() === pendingOptionText ||
-          ((autoComplete &&
+          (autoComplete &&
             pendingOptionText.indexOf(currentPendingValue.toLocaleLowerCase()) === 0 &&
-            (this._autofill.current &&
-              this._autofill.current.isValueSelected &&
-              currentPendingValue.length + (this._autofill.current.selectionEnd! - this._autofill.current.selectionStart!) ===
-                pendingOptionText.length)) ||
-            (this._autofill.current &&
-              this._autofill.current.inputElement &&
-              this._autofill.current.inputElement.value.toLocaleLowerCase() === pendingOptionText))
+            this._autofill.current &&
+            this._autofill.current.isValueSelected &&
+            currentPendingValue.length + (this._autofill.current.selectionEnd! - this._autofill.current.selectionStart!) ===
+              pendingOptionText.length) ||
+          (this._autofill.current &&
+            this._autofill.current.inputElement &&
+            this._autofill.current.inputElement.value.toLocaleLowerCase() === pendingOptionText)
         ) {
           this._setSelectedIndex(currentPendingValueValidIndex, submitPendingValueEvent);
           this._clearPendingInfo();
@@ -1234,10 +1234,9 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     const isSelected: boolean = this._isOptionSelected(item.index);
     const optionStyles = this._getCurrentOptionStyles(item);
     const optionClassNames = getComboBoxOptionClassNames(this._getCurrentOptionStyles(item));
-    const checkboxStyles = () => {
-      return optionStyles;
-    };
     const title = this._getPreviewText(item);
+
+    const onRenderCheckboxLabel = () => onRenderOption(item, this._onRenderOptionContent);
 
     const getOptionComponent = () => {
       return !this.props.multiSelect ? (
@@ -1245,7 +1244,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           id={id + '-list' + item.index}
           key={item.key}
           data-index={item.index}
-          styles={this._getCurrentOptionStyles(item)}
+          styles={optionStyles}
           checked={isSelected}
           className={'ms-ComboBox-option'}
           onClick={this._onItemClick(item)}
@@ -1271,7 +1270,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           ariaLabel={this._getPreviewText(item)}
           key={item.key}
           data-index={item.index}
-          styles={checkboxStyles}
+          styles={optionStyles}
           className={'ms-ComboBox-option'}
           data-is-focusable={true}
           onChange={this._onItemClick(item)}
@@ -1281,9 +1280,8 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           checked={isSelected}
           title={title}
           disabled={item.disabled}
-        >
-          {onRenderOption(item, this._onRenderOptionContent)}
-        </Checkbox>
+          onRenderLabel={onRenderCheckboxLabel}
+        />
       );
     };
 
@@ -1343,7 +1341,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     return currentPendingValueValidIndexOnHover >= 0
       ? currentPendingValueValidIndexOnHover
       : currentPendingValueValidIndex >= 0 ||
-        (includeCurrentPendingValue && (currentPendingValue !== null && currentPendingValue !== undefined))
+        (includeCurrentPendingValue && currentPendingValue !== null && currentPendingValue !== undefined)
       ? currentPendingValueValidIndex
       : this.props.multiSelect
       ? 0


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11294
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Custom styling for individual options was not being applied to the options in multi-select `ComboBoxes`. This occurred because we were doing the styling on the `Checkbox` children instead of on the `label`, which is what is actually rendered on a `Checkbox`. This PR fixes this issue by applying the styling via the `onRenderLabel` method.

__Before:__

![image](https://user-images.githubusercontent.com/7798177/69586847-b38c8d80-0f98-11ea-99df-04eb0fbd449c.png)

__After:__

![image](https://user-images.githubusercontent.com/7798177/69586853-b5eee780-0f98-11ea-85da-95c0bea304c1.png)


#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11305)