### PR TITLE
DocumentCard: Adding explicit focus styles

### DIFF
--- a/change/office-ui-fabric-react-2019-11-25-15-59-41-doc-card-focus.json
+++ b/change/office-ui-fabric-react-2019-11-25-15-59-41-doc-card-focus.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "DocumentCard: Adding explicit focus styles",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "3546fe64d1450554b93a1833a395ef53b3684bb0",
+  "date": "2019-11-25T23:59:41.364Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.styles.ts
@@ -1,4 +1,5 @@
-import { getGlobalClassNames } from '../../Styling';
+import { getGlobalClassNames, HighContrastSelector, IStyle } from '../../Styling';
+import { IsFocusVisibleClassName } from '../../Utilities';
 import { IDocumentCardStyleProps, IDocumentCardStyles } from './DocumentCard.types';
 import { DocumentCardPreviewGlobalClassNames as previewClassNames } from './DocumentCardPreview.styles';
 import { DocumentCardActivityGlobalClassNames as activityClassNames } from './DocumentCardActivity.styles';
@@ -17,6 +18,27 @@ export const getStyles = (props: IDocumentCardStyleProps): IDocumentCardStyles =
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
+  const getFocusBorder: IStyle = {
+    selectors: {
+      ':after': {
+        pointerEvents: 'none',
+        content: "''",
+        position: 'absolute',
+        left: -1,
+        top: -1,
+        bottom: -1,
+        right: -1,
+        // same color as existing hover border
+        border: '2px solid ' + palette.neutralTertiaryAlt,
+        selectors: {
+          [HighContrastSelector]: {
+            borderColor: 'Highlight'
+          }
+        }
+      }
+    }
+  };
+
   return {
     root: [
       classNames.root,
@@ -24,12 +46,17 @@ export const getStyles = (props: IDocumentCardStyleProps): IDocumentCardStyles =
         WebkitFontSmoothing: 'antialiased',
         backgroundColor: palette.white,
         border: `1px solid ${palette.neutralLight}`,
-        boxSizing: 'border-box',
         maxWidth: '320px',
         minWidth: '206px',
         userSelect: 'none',
         position: 'relative',
         selectors: {
+          ':focus': {
+            outline: '0px solid'
+          },
+          [`.${IsFocusVisibleClassName} &:focus`]: {
+            ...getFocusBorder
+          },
           [`.${locationClassNames.root} + .${titleClassNames.root}`]: {
             paddingTop: '4px'
           }

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.styles.ts
@@ -28,8 +28,7 @@ export const getStyles = (props: IDocumentCardStyleProps): IDocumentCardStyles =
         top: -1,
         bottom: -1,
         right: -1,
-        // same color as existing hover border
-        border: '2px solid ' + palette.neutralTertiaryAlt,
+        border: '2px solid ' + palette.neutralSecondary,
         selectors: {
           [HighContrastSelector]: {
             borderColor: 'Highlight'

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
@@ -8,11 +8,26 @@ exports[`DocumentCard renders DocumentCard correctly 1`] = `
         -webkit-font-smoothing: antialiased;
         background-color: #ffffff;
         border: 1px solid #edebe9;
-        box-sizing: border-box;
         max-width: 320px;
         min-width: 206px;
         position: relative;
         user-select: none;
+      }
+      &:focus {
+        outline: 0px solid;
+      }
+      .ms-Fabric--isFocusVisible &:focus:after {
+        border: 2px solid #c8c6c4;
+        bottom: -1px;
+        content: '';
+        left: -1px;
+        pointer-events: none;
+        position: absolute;
+        right: -1px;
+        top: -1px;
+      }
+      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+        border-color: Highlight;
       }
       & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
         padding-top: 4px;

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
@@ -17,7 +17,7 @@ exports[`DocumentCard renders DocumentCard correctly 1`] = `
         outline: 0px solid;
       }
       .ms-Fabric--isFocusVisible &:focus:after {
-        border: 2px solid #c8c6c4;
+        border: 2px solid #605e5c;
         bottom: -1px;
         content: '';
         left: -1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Basic.Example.tsx.shot
@@ -19,7 +19,7 @@ exports[`Component Examples renders DocumentCard.Basic.Example.tsx correctly 1`]
         outline: 0px solid;
       }
       .ms-Fabric--isFocusVisible &:focus:after {
-        border: 2px solid #c8c6c4;
+        border: 2px solid #605e5c;
         bottom: -1px;
         content: '';
         left: -1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Basic.Example.tsx.shot
@@ -10,11 +10,26 @@ exports[`Component Examples renders DocumentCard.Basic.Example.tsx correctly 1`]
         -webkit-font-smoothing: antialiased;
         background-color: #ffffff;
         border: 1px solid #edebe9;
-        box-sizing: border-box;
         max-width: 320px;
         min-width: 206px;
         position: relative;
         user-select: none;
+      }
+      &:focus {
+        outline: 0px solid;
+      }
+      .ms-Fabric--isFocusVisible &:focus:after {
+        border: 2px solid #c8c6c4;
+        bottom: -1px;
+        content: '';
+        left: -1px;
+        pointer-events: none;
+        position: absolute;
+        right: -1px;
+        top: -1px;
+      }
+      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+        border-color: Highlight;
       }
       & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
         padding-top: 4px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
@@ -33,13 +33,28 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
           -webkit-font-smoothing: antialiased;
           background-color: #ffffff;
           border: 1px solid #edebe9;
-          box-sizing: border-box;
           display: flex;
           height: 108px;
           max-width: 480px;
           min-width: 206px;
           position: relative;
           user-select: none;
+        }
+        &:focus {
+          outline: 0px solid;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 2px solid #c8c6c4;
+          bottom: -1px;
+          content: '';
+          left: -1px;
+          pointer-events: none;
+          position: absolute;
+          right: -1px;
+          top: -1px;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border-color: Highlight;
         }
         & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
           padding-top: 4px;
@@ -371,13 +386,28 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
           -webkit-font-smoothing: antialiased;
           background-color: #ffffff;
           border: 1px solid #edebe9;
-          box-sizing: border-box;
           display: flex;
           height: 108px;
           max-width: 480px;
           min-width: 206px;
           position: relative;
           user-select: none;
+        }
+        &:focus {
+          outline: 0px solid;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 2px solid #c8c6c4;
+          bottom: -1px;
+          content: '';
+          left: -1px;
+          pointer-events: none;
+          position: absolute;
+          right: -1px;
+          top: -1px;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border-color: Highlight;
         }
         & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
           padding-top: 4px;
@@ -955,13 +985,28 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
           -webkit-font-smoothing: antialiased;
           background-color: #ffffff;
           border: 1px solid #edebe9;
-          box-sizing: border-box;
           display: flex;
           height: 108px;
           max-width: 480px;
           min-width: 206px;
           position: relative;
           user-select: none;
+        }
+        &:focus {
+          outline: 0px solid;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 2px solid #c8c6c4;
+          bottom: -1px;
+          content: '';
+          left: -1px;
+          pointer-events: none;
+          position: absolute;
+          right: -1px;
+          top: -1px;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border-color: Highlight;
         }
         & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
           padding-top: 4px;
@@ -1277,13 +1322,28 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
           -webkit-font-smoothing: antialiased;
           background-color: #ffffff;
           border: 1px solid #edebe9;
-          box-sizing: border-box;
           display: flex;
           height: 108px;
           max-width: 480px;
           min-width: 206px;
           position: relative;
           user-select: none;
+        }
+        &:focus {
+          outline: 0px solid;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 2px solid #c8c6c4;
+          bottom: -1px;
+          content: '';
+          left: -1px;
+          pointer-events: none;
+          position: absolute;
+          right: -1px;
+          top: -1px;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border-color: Highlight;
         }
         & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
           padding-top: 4px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
@@ -44,7 +44,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
           outline: 0px solid;
         }
         .ms-Fabric--isFocusVisible &:focus:after {
-          border: 2px solid #c8c6c4;
+          border: 2px solid #605e5c;
           bottom: -1px;
           content: '';
           left: -1px;
@@ -397,7 +397,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
           outline: 0px solid;
         }
         .ms-Fabric--isFocusVisible &:focus:after {
-          border: 2px solid #c8c6c4;
+          border: 2px solid #605e5c;
           bottom: -1px;
           content: '';
           left: -1px;
@@ -996,7 +996,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
           outline: 0px solid;
         }
         .ms-Fabric--isFocusVisible &:focus:after {
-          border: 2px solid #c8c6c4;
+          border: 2px solid #605e5c;
           bottom: -1px;
           content: '';
           left: -1px;
@@ -1333,7 +1333,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
           outline: 0px solid;
         }
         .ms-Fabric--isFocusVisible &:focus:after {
-          border: 2px solid #c8c6c4;
+          border: 2px solid #605e5c;
           bottom: -1px;
           content: '';
           left: -1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
@@ -11,11 +11,26 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
         -webkit-font-smoothing: antialiased;
         background-color: #ffffff;
         border: 1px solid #edebe9;
-        box-sizing: border-box;
         max-width: 320px;
         min-width: 206px;
         position: relative;
         user-select: none;
+      }
+      &:focus {
+        outline: 0px solid;
+      }
+      .ms-Fabric--isFocusVisible &:focus:after {
+        border: 2px solid #c8c6c4;
+        bottom: -1px;
+        content: '';
+        left: -1px;
+        pointer-events: none;
+        position: absolute;
+        right: -1px;
+        top: -1px;
+      }
+      @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+        border-color: Highlight;
       }
       & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
         padding-top: 4px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
@@ -20,7 +20,7 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
         outline: 0px solid;
       }
       .ms-Fabric--isFocusVisible &:focus:after {
-        border: 2px solid #c8c6c4;
+        border: 2px solid #605e5c;
         bottom: -1px;
         content: '';
         left: -1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Conversation.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Conversation.Example.tsx.shot
@@ -24,7 +24,7 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
           outline: 0px solid;
         }
         .ms-Fabric--isFocusVisible &:focus:after {
-          border: 2px solid #c8c6c4;
+          border: 2px solid #605e5c;
           bottom: -1px;
           content: '';
           left: -1px;
@@ -471,7 +471,7 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
           outline: 0px solid;
         }
         .ms-Fabric--isFocusVisible &:focus:after {
-          border: 2px solid #c8c6c4;
+          border: 2px solid #605e5c;
           bottom: -1px;
           content: '';
           left: -1px;
@@ -908,7 +908,7 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
           outline: 0px solid;
         }
         .ms-Fabric--isFocusVisible &:focus:after {
-          border: 2px solid #c8c6c4;
+          border: 2px solid #605e5c;
           bottom: -1px;
           content: '';
           left: -1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Conversation.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Conversation.Example.tsx.shot
@@ -12,7 +12,6 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
           -webkit-font-smoothing: antialiased;
           background-color: #ffffff;
           border: 1px solid #edebe9;
-          box-sizing: border-box;
           display: inline-block;
           margin-right: 20px;
           max-width: 320px;
@@ -20,6 +19,22 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
           position: relative;
           user-select: none;
           width: 320px;
+        }
+        &:focus {
+          outline: 0px solid;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 2px solid #c8c6c4;
+          bottom: -1px;
+          content: '';
+          left: -1px;
+          pointer-events: none;
+          position: absolute;
+          right: -1px;
+          top: -1px;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border-color: Highlight;
         }
         & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
           padding-top: 4px;
@@ -444,7 +459,6 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
           -webkit-font-smoothing: antialiased;
           background-color: #ffffff;
           border: 1px solid #edebe9;
-          box-sizing: border-box;
           display: inline-block;
           margin-right: 20px;
           max-width: 320px;
@@ -452,6 +466,22 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
           position: relative;
           user-select: none;
           width: 320px;
+        }
+        &:focus {
+          outline: 0px solid;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 2px solid #c8c6c4;
+          bottom: -1px;
+          content: '';
+          left: -1px;
+          pointer-events: none;
+          position: absolute;
+          right: -1px;
+          top: -1px;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border-color: Highlight;
         }
         & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
           padding-top: 4px;
@@ -866,7 +896,6 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
           -webkit-font-smoothing: antialiased;
           background-color: #ffffff;
           border: 1px solid #edebe9;
-          box-sizing: border-box;
           display: inline-block;
           margin-right: 20px;
           max-width: 320px;
@@ -874,6 +903,22 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
           position: relative;
           user-select: none;
           width: 320px;
+        }
+        &:focus {
+          outline: 0px solid;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 2px solid #c8c6c4;
+          bottom: -1px;
+          content: '';
+          left: -1px;
+          pointer-events: none;
+          position: absolute;
+          right: -1px;
+          top: -1px;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border-color: Highlight;
         }
         & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
           padding-top: 4px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Image.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Image.Example.tsx.shot
@@ -11,7 +11,6 @@ exports[`Component Examples renders DocumentCard.Image.Example.tsx correctly 1`]
           -webkit-font-smoothing: antialiased;
           background-color: #ffffff;
           border: 1px solid #edebe9;
-          box-sizing: border-box;
           display: inline-block;
           margin-bottom: 20px;
           margin-right: 20px;
@@ -20,6 +19,22 @@ exports[`Component Examples renders DocumentCard.Image.Example.tsx correctly 1`]
           position: relative;
           user-select: none;
           width: 320px;
+        }
+        &:focus {
+          outline: 0px solid;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 2px solid #c8c6c4;
+          bottom: -1px;
+          content: '';
+          left: -1px;
+          pointer-events: none;
+          position: absolute;
+          right: -1px;
+          top: -1px;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border-color: Highlight;
         }
         & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
           padding-top: 4px;
@@ -428,7 +443,6 @@ exports[`Component Examples renders DocumentCard.Image.Example.tsx correctly 1`]
           -webkit-font-smoothing: antialiased;
           background-color: #ffffff;
           border: 1px solid #edebe9;
-          box-sizing: border-box;
           display: inline-block;
           margin-bottom: 20px;
           margin-right: 20px;
@@ -437,6 +451,22 @@ exports[`Component Examples renders DocumentCard.Image.Example.tsx correctly 1`]
           position: relative;
           user-select: none;
           width: 320px;
+        }
+        &:focus {
+          outline: 0px solid;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 2px solid #c8c6c4;
+          bottom: -1px;
+          content: '';
+          left: -1px;
+          pointer-events: none;
+          position: absolute;
+          right: -1px;
+          top: -1px;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border-color: Highlight;
         }
         & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
           padding-top: 4px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Image.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Image.Example.tsx.shot
@@ -24,7 +24,7 @@ exports[`Component Examples renders DocumentCard.Image.Example.tsx correctly 1`]
           outline: 0px solid;
         }
         .ms-Fabric--isFocusVisible &:focus:after {
-          border: 2px solid #c8c6c4;
+          border: 2px solid #605e5c;
           bottom: -1px;
           content: '';
           left: -1px;
@@ -456,7 +456,7 @@ exports[`Component Examples renders DocumentCard.Image.Example.tsx correctly 1`]
           outline: 0px solid;
         }
         .ms-Fabric--isFocusVisible &:focus:after {
-          border: 2px solid #c8c6c4;
+          border: 2px solid #605e5c;
           bottom: -1px;
           content: '';
           left: -1px;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10661
- [x] Include a change request file using `$ yarn change`

#### Description of changes

before chrome:

![image](https://user-images.githubusercontent.com/1434956/69588077-64485c00-0f9c-11ea-98da-87ca47d4de0e.png)

before edge:

![image](https://user-images.githubusercontent.com/1434956/69588096-74f8d200-0f9c-11ea-902c-6909e010d8c7.png)


after:

![image](https://user-images.githubusercontent.com/1434956/70001938-70d83180-1513-11ea-8937-c04e56309652.png)



high contrast works nicely too:

![image](https://user-images.githubusercontent.com/1434956/69986508-635e7f80-14f2-11ea-9187-b9005e5b3be4.png)



#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11306)