### PR TITLE
TeachingBubble: Text no longer hidden under close button.

### DIFF
--- a/apps/vr-tests/src/stories/TeachingBubble.stories.tsx
+++ b/apps/vr-tests/src/stories/TeachingBubble.stories.tsx
@@ -25,7 +25,7 @@ storiesOf('TeachingBubble', module)
           calloutProps={{ directionalHint: DirectionalHint.bottomCenter }}
           isWide={true}
           hasSmallHeadline={true}
-          hasCloseIcon={true}
+          hasCloseButton={true}
           primaryButtonProps={{ children: 'Got it' }}
           headline="Discover what’s trending around you"
         >
@@ -40,7 +40,7 @@ storiesOf('TeachingBubble', module)
     return (
       <TeachingBubble
         hasSmallHeadline={true}
-        hasCloseIcon={true}
+        hasCloseButton={true}
         primaryButtonProps={{
           children: 'Got it'
         }}

--- a/change/office-ui-fabric-react-2019-11-25-16-27-13-teachingbubble-fix.json
+++ b/change/office-ui-fabric-react-2019-11-25-16-27-13-teachingbubble-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "TeachingBubble: margin for header no longer is hidden under a close button.",
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com",
+  "commit": "b539f5ee1c3bbd793a83ad269f0458dbfec5659f",
+  "date": "2019-11-26T00:27:13.835Z"
+}

--- a/change/office-ui-fabric-react-2019-11-25-16-27-13-teachingbubble-fix.json
+++ b/change/office-ui-fabric-react-2019-11-25-16-27-13-teachingbubble-fix.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "TeachingBubble: margin for header no longer is hidden under a close button.",
+  "comment": "TeachingBubble: add hasCloseButton and deprecate hasCloseIcon; prevent header text from overlapping with close button.",
   "packageName": "office-ui-fabric-react",
   "email": "dzearing@microsoft.com",
   "commit": "b539f5ee1c3bbd793a83ad269f0458dbfec5659f",

--- a/change/office-ui-fabric-react-2019-11-25-16-27-13-teachingbubble-fix.json
+++ b/change/office-ui-fabric-react-2019-11-25-16-27-13-teachingbubble-fix.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "TeachingBubble: margin for header no longer is hidden under a close button.",
   "packageName": "office-ui-fabric-react",
   "email": "dzearing@microsoft.com",

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -7468,6 +7468,8 @@ export interface ITeachingBubbleProps extends React.ClassAttributes<TeachingBubb
     calloutProps?: ICalloutProps;
     componentRef?: IRefObject<ITeachingBubble>;
     footerContent?: string | JSX.Element;
+    hasCloseButton?: boolean;
+    // @deprecated (undocumented)
     hasCloseIcon?: boolean;
     hasCondensedHeadline?: boolean;
     hasSmallHeadline?: boolean;
@@ -7495,6 +7497,7 @@ export type ITeachingBubbleStyleProps = Required<Pick<ITeachingBubbleProps, 'the
     calloutClassName?: string;
     primaryButtonClassName?: string;
     secondaryButtonClassName?: string;
+    hasCloseButton?: boolean;
 };
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/Coachmark/examples/Coachmark.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/examples/Coachmark.Basic.Example.tsx
@@ -117,7 +117,7 @@ export class CoachmarkBasicExample extends BaseComponent<{}, ICoachmarkBasicExam
           >
             <TeachingBubbleContent
               headline="Example Title"
-              hasCloseIcon={true}
+              hasCloseButton={true}
               closeButtonAriaLabel="Close"
               primaryButtonProps={buttonProps}
               secondaryButtonProps={buttonProps2}

--- a/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.CommandBarButtonAs.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/examples/CommandBar.CommandBarButtonAs.Example.tsx
@@ -40,7 +40,7 @@ const CoachmarkCommandBarButton: React.FunctionComponent<ICoachmarkCommandBarBut
         >
           <TeachingBubbleContent
             headline="Example Title"
-            hasCloseIcon={true}
+            hasCloseButton={true}
             closeButtonAriaLabel="Close"
             onDismiss={onDismiss}
             ariaDescribedBy="example-description1"

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.base.tsx
@@ -57,12 +57,23 @@ export class TeachingBubbleBase extends BaseComponent<ITeachingBubbleProps, ITea
   }
 
   public render(): JSX.Element {
-    const { calloutProps: setCalloutProps, targetElement, onDismiss, isWide, styles, theme, target } = this.props;
+    const {
+      calloutProps: setCalloutProps,
+      targetElement,
+      onDismiss,
+      // Default to deprecated value if provided.
+      hasCloseButton = this.props.hasCloseIcon,
+      isWide,
+      styles,
+      theme,
+      target
+    } = this.props;
     const calloutProps = { ...this._defaultCalloutProps, ...setCalloutProps };
     const stylesProps: ITeachingBubbleStyleProps = {
       theme: theme!,
       isWide,
-      calloutClassName: calloutProps ? calloutProps.className : undefined
+      calloutClassName: calloutProps ? calloutProps.className : undefined,
+      hasCloseButton
     };
 
     const classNames = getClassNames(styles, stylesProps);

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.deprecated.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.deprecated.test.tsx
@@ -1,0 +1,20 @@
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+import { TeachingBubbleContent } from './TeachingBubbleContent';
+
+describe('TeachingBubble', () => {
+  it('renders renders with hasCloseIcon which is deprecated', () => {
+    const componentContent = renderer.create(
+      <TeachingBubbleContent
+        headline="Test Title"
+        hasCloseIcon={true}
+        primaryButtonProps={{ children: 'Test Primary Button', className: 'primary-className' }}
+        secondaryButtonProps={{ children: 'Test Secondary Button', className: 'secondary-className' }}
+      >
+        Content
+      </TeachingBubbleContent>
+    );
+    const treeContent = componentContent.toJSON();
+    expect(treeContent).toMatchSnapshot();
+  });
+});

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
@@ -164,10 +164,10 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
     header: [
       classNames.header,
       ...headerStyle(classNames, hasCondensedHeadline, hasSmallHeadline),
+      { marginRight: 24 },
       (hasCondensedHeadline || hasSmallHeadline) && [
         fonts.medium,
         {
-          marginRight: 24,
           fontWeight: FontWeights.semibold
         }
       ]

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
@@ -87,6 +87,7 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
     calloutClassName,
     hasCondensedHeadline,
     hasSmallHeadline,
+    hasCloseButton,
     isWide,
     primaryButtonClassName,
     secondaryButtonClassName,
@@ -164,7 +165,7 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
     header: [
       classNames.header,
       ...headerStyle(classNames, hasCondensedHeadline, hasSmallHeadline),
-      { marginRight: 24 },
+      hasCloseButton && { marginRight: 24 },
       (hasCondensedHeadline || hasSmallHeadline) && [
         fonts.medium,
         {

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.test.tsx
@@ -47,7 +47,7 @@ describe('TeachingBubble', () => {
     const componentContent = renderer.create(
       <TeachingBubbleContent
         headline="Test Title"
-        hasCloseIcon={true}
+        hasCloseButton={true}
         primaryButtonProps={{ children: 'Test Primary Button', className: 'primary-className' }}
         secondaryButtonProps={{ children: 'Test Secondary Button', className: 'secondary-className' }}
       >

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.types.ts
@@ -54,12 +54,17 @@ export interface ITeachingBubbleProps extends React.ClassAttributes<TeachingBubb
   hasCondensedHeadline?: boolean;
 
   /**
-   * Does the TeachingBubble have a close button in the top right corner?
+   * @deprecated Use `hasCloseButton`.
    */
   hasCloseIcon?: boolean;
 
   /**
-   * An Image for the Teaching Bubble.
+   * Whether the TeachingBubble renders close button in the top right corner.
+   */
+  hasCloseButton?: boolean;
+
+  /**
+   * An Image for the TeachingBubble.
    */
   illustrationImage?: IImageProps;
 
@@ -96,7 +101,7 @@ export interface ITeachingBubbleProps extends React.ClassAttributes<TeachingBubb
   onDismiss?: (ev?: any) => void;
 
   /**
-   * Whether or not the Teaching Bubble is wide, with image on the left side.
+   * Whether or not the TeachingBubble is wide, with image on the left side.
    */
   isWide?: boolean;
 
@@ -127,6 +132,8 @@ export type ITeachingBubbleStyleProps = Required<Pick<ITeachingBubbleProps, 'the
     primaryButtonClassName?: string;
     /** Class name for secondary button. */
     secondaryButtonClassName?: string;
+    /** If the close button is visible. */
+    hasCloseButton?: boolean;
   };
 
 /**
@@ -152,7 +159,7 @@ export interface ITeachingBubbleStyles {
  * {@docCategory TeachingBubble}
  */
 export interface ITeachingBubbleSubComponentStyles {
-  /** Refers to the callout that hosts the teaching bubble. */
+  /** Refers to the callout that hosts the TeachingBubble. */
   // TODO: this should be the interface once we're on TS 2.9.2 but otherwise causes errors in 2.8.4
   // callout: IStyleFunctionOrObject<ICalloutContentStyleProps, ICalloutContentStyles>;
   callout: IStyleFunctionOrObject<any, any>;

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
@@ -54,7 +54,7 @@ export class TeachingBubbleContentBase extends BaseComponent<ITeachingBubbleProp
       secondaryButtonProps,
       headline,
       hasCondensedHeadline,
-      hasCloseIcon,
+      hasCloseButton = this.props.hasCloseIcon,
       onDismiss,
       closeButtonAriaLabel,
       hasSmallHeadline,
@@ -76,6 +76,7 @@ export class TeachingBubbleContentBase extends BaseComponent<ITeachingBubbleProp
       theme: theme!,
       hasCondensedHeadline,
       hasSmallHeadline,
+      hasCloseButton,
       isWide,
       primaryButtonClassName: primaryButtonProps ? primaryButtonProps.className : undefined,
       secondaryButtonClassName: secondaryButtonProps ? secondaryButtonProps.className : undefined
@@ -125,7 +126,7 @@ export class TeachingBubbleContentBase extends BaseComponent<ITeachingBubbleProp
       );
     }
 
-    if (hasCloseIcon) {
+    if (hasCloseButton) {
       closeButton = (
         <IconButton
           className={classNames.closeButton}

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
@@ -1,0 +1,592 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`] = `
+<div
+  className=
+      ms-TeachingBubble-content
+      {
+        animation-duration: 300ms;
+        animation-fill-mode: both;
+        animation-name: keyframes 0%{opacity:0;animation-timing-function:cubic-bezier(.1,.9,.2,1);transform:scale3d(.90,.90,.90);}100%{opacity:1;transform:scale3d(1,1,1);};
+        animation-timing-function: linear;
+        border: 0px;
+        display: block;
+        max-width: 364px;
+        outline: transparent;
+        width: calc(100% + 1px);
+      }
+  data-is-focusable={true}
+  role="dialog"
+  tabIndex={-1}
+>
+  <div
+    onBlur={[Function]}
+    onFocus={[Function]}
+    onFocusCapture={[Function]}
+  >
+    <div
+      data-is-visible={true}
+      onFocus={[Function]}
+      style={
+        Object {
+          "pointerEvents": "none",
+          "position": "fixed",
+        }
+      }
+      tabIndex={0}
+    />
+    <div
+      className=
+          ms-TeachingBubble-bodycontent
+          {
+            padding-bottom: 20px;
+            padding-left: 24px;
+            padding-right: 24px;
+            padding-top: 20px;
+          }
+    >
+      <div
+        className=
+            ms-TeachingBubble-header
+            ms-TeachingBubble-header--large
+            {
+              margin-right: 24px;
+            }
+            &:not(:last-child) {
+              margin-bottom: 14px;
+            }
+      >
+        <p
+          className=
+              ms-TeachingBubble-headline
+              {
+                color: #ffffff;
+                font-size: 20px;
+                font-weight: 600;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+              }
+          role="heading"
+        >
+          Test Title
+        </p>
+      </div>
+      <div
+        className=
+            ms-TeachingBubble-body
+            &:not(:last-child) {
+              margin-bottom: 20px;
+            }
+      >
+        <p
+          className=
+              ms-TeachingBubble-subText
+              {
+                color: #ffffff;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+              }
+        >
+          Content
+        </p>
+      </div>
+      <div
+        className=
+            ms-Stack
+            ms-TeachingBubble-footer
+            {
+              align-items: center;
+              box-sizing: border-box;
+              color: #ffffff;
+              display: flex;
+              flex-direction: row;
+              flex-wrap: nowrap;
+              flex: auto;
+              height: auto;
+              justify-content: flex-end;
+              width: auto;
+            }
+            & > * {
+              text-overflow: ellipsis;
+            }
+            & > *:not(:first-child) {
+              margin-left: 0px;
+            }
+            & > *:not(.ms-StackItem) {
+              flex-shrink: 1;
+            }
+            & .ms-Button:not(:first-child) {
+              margin-left: 10px;
+            }
+      >
+        <div
+          className=
+              ms-StackItem
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-self: center;
+                flex-shrink: 1;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: auto;
+                width: auto;
+              }
+        >
+          <span />
+        </div>
+        <div
+          className=
+              ms-StackItem
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                flex-shrink: 1;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                height: auto;
+                width: auto;
+              }
+        >
+          <button
+            className=
+                ms-Button
+                ms-Button--default
+                ms-TeachingBubble-secondaryButton
+                secondary-className
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #0078d4;
+                  border-color: #ffffff;
+                  border-radius: 2px;
+                  border: 1px solid #8a8886;
+                  box-sizing: border-box;
+                  color: #323130;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: 1px solid transparent;
+                  bottom: 2px;
+                  content: "";
+                  left: 2px;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 2px;
+                  top: 2px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                &:hover {
+                  background-color: #106ebe;
+                  border-color: #ffffff;
+                  color: #201f1e;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  border-color: Highlight;
+                  color: Highlight;
+                }
+                &:focus {
+                  background-color: #106ebe;
+                  border-color: #ffffff;
+                }
+                &:active {
+                  background-color: #0078d4;
+                  border-color: #ffffff;
+                  color: #201f1e;
+                }
+                & .ms-Button-label {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  color: #ffffff;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+              data-automationid="splitbuttonprimary"
+            >
+              <span
+                className=
+                    ms-Button-textContainer
+                    {
+                      display: block;
+                      flex-grow: 1;
+                    }
+              >
+                <span
+                  className=
+                      ms-Button-label
+                      {
+                        display: block;
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
+                  id="id__0"
+                >
+                  Test Secondary Button
+                </span>
+              </span>
+            </span>
+          </button>
+          <button
+            className=
+                ms-Button
+                ms-Button--primary
+                ms-TeachingBubble-primaryButton
+                primary-className
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  background-color: #ffffff;
+                  border-color: #ffffff;
+                  border-radius: 2px;
+                  border: none;
+                  box-sizing: border-box;
+                  color: #0078d4;
+                  cursor: pointer;
+                  display: inline-block;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 32px;
+                  min-width: 80px;
+                  outline: transparent;
+                  padding-bottom: 0;
+                  padding-left: 16px;
+                  padding-right: 16px;
+                  padding-top: 0;
+                  position: relative;
+                  text-align: center;
+                  text-decoration: none;
+                  user-select: none;
+                  vertical-align: top;
+                  white-space: nowrap;
+                }
+                &::-moz-focus-inner {
+                  border: 0;
+                }
+                .ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: 2px;
+                  content: "";
+                  left: 2px;
+                  outline-color: #ffffff;
+                  outline: 1px solid #605e5c;
+                  position: absolute;
+                  right: 2px;
+                  top: 2px;
+                  z-index: 1;
+                }
+                @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+                  border: none;
+                  bottom: -2px;
+                  left: -2px;
+                  outline-color: ButtonText;
+                  right: -2px;
+                  top: -2px;
+                }
+                &:active > * {
+                  left: 0px;
+                  position: relative;
+                  top: 0px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  -ms-high-contrast-adjust: none;
+                  background-color: WindowText;
+                  color: Window;
+                }
+                &:hover {
+                  background-color: #deecf9;
+                  border-color: #deecf9;
+                  color: #0078d4;
+                }
+                @media screen and (-ms-high-contrast: active){&:hover {
+                  background-color: Highlight;
+                  color: Window;
+                }
+                &:focus {
+                  background-color: #deecf9;
+                  border-color: #ffffff;
+                }
+                &:active {
+                  background-color: #ffffff;
+                  border-color: #ffffff;
+                  color: #0078d4;
+                }
+                @media screen and (-ms-high-contrast: active){&:active {
+                  -ms-high-contrast-adjust: none;
+                  background-color: WindowText;
+                  color: Window;
+                }
+                & .ms-Button-label {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                }
+            data-is-focusable={true}
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onKeyPress={[Function]}
+            onKeyUp={[Function]}
+            onMouseDown={[Function]}
+            onMouseUp={[Function]}
+            type="button"
+          >
+            <span
+              className=
+                  ms-Button-flexContainer
+                  {
+                    align-items: center;
+                    display: flex;
+                    flex-wrap: nowrap;
+                    height: 100%;
+                    justify-content: center;
+                  }
+              data-automationid="splitbuttonprimary"
+            >
+              <span
+                className=
+                    ms-Button-textContainer
+                    {
+                      display: block;
+                      flex-grow: 1;
+                    }
+              >
+                <span
+                  className=
+                      ms-Button-label
+                      {
+                        display: block;
+                        font-weight: 600;
+                        line-height: 100%;
+                        margin-bottom: 0;
+                        margin-left: 4px;
+                        margin-right: 4px;
+                        margin-top: 0;
+                      }
+                  id="id__3"
+                >
+                  Test Primary Button
+                </span>
+              </span>
+            </span>
+          </button>
+        </div>
+      </div>
+      <button
+        className=
+            ms-Button
+            ms-Button--icon
+            ms-TeachingBubble-closebutton
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              background-color: transparent;
+              border-radius: 0px;
+              border: none;
+              box-sizing: border-box;
+              color: #ffffff;
+              cursor: pointer;
+              display: inline-block;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 12px;
+              font-weight: 400;
+              height: 32px;
+              margin-bottom: 0;
+              margin-left: 0;
+              margin-right: 15px;
+              margin-top: 15px;
+              outline: transparent;
+              padding-bottom: 0;
+              padding-left: 4px;
+              padding-right: 4px;
+              padding-top: 0;
+              position: absolute;
+              right: 0px;
+              text-align: center;
+              text-decoration: none;
+              top: 0px;
+              user-select: none;
+              vertical-align: top;
+              width: 32px;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid transparent;
+              bottom: 2px;
+              content: "";
+              left: 2px;
+              outline: 1px solid #605e5c;
+              position: absolute;
+              right: 2px;
+              top: 2px;
+              z-index: 1;
+            }
+            @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+              border: none;
+              bottom: -2px;
+              left: -2px;
+              outline-color: ButtonText;
+              right: -2px;
+              top: -2px;
+            }
+            &:active > * {
+              left: 0px;
+              position: relative;
+              top: 0px;
+            }
+            &:hover {
+              background-color: #f3f2f1;
+              background: #106ebe;
+              color: #ffffff;
+            }
+            @media screen and (-ms-high-contrast: active){&:hover {
+              border-color: Highlight;
+              color: Highlight;
+            }
+            &:focus {
+              border: 1px solid #edebe9;
+            }
+            &:active {
+              background-color: #edebe9;
+              background: #005a9e;
+              color: #ffffff;
+            }
+        data-is-focusable={true}
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onKeyPress={[Function]}
+        onKeyUp={[Function]}
+        onMouseDown={[Function]}
+        onMouseUp={[Function]}
+        type="button"
+      >
+        <span
+          className=
+              ms-Button-flexContainer
+              {
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                height: 100%;
+                justify-content: center;
+              }
+          data-automationid="splitbuttonprimary"
+        >
+          <i
+            aria-hidden={true}
+            className=
+                ms-Icon
+                ms-Button-icon
+                {
+                  display: inline-block;
+                }
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  font-family: "FabricMDL2Icons";
+                  font-style: normal;
+                  font-weight: normal;
+                  speak: none;
+                }
+                {
+                  flex-shrink: 0;
+                  font-size: 16px;
+                  height: 16px;
+                  line-height: 16px;
+                  margin-bottom: 0;
+                  margin-left: 4px;
+                  margin-right: 4px;
+                  margin-top: 0;
+                  text-align: center;
+                  vertical-align: middle;
+                }
+            data-icon-name="Cancel"
+            role="presentation"
+          >
+            
+          </i>
+        </span>
+      </button>
+    </div>
+    <div
+      data-is-visible={true}
+      onFocus={[Function]}
+      style={
+        Object {
+          "pointerEvents": "none",
+          "position": "fixed",
+        }
+      }
+      tabIndex={0}
+    />
+  </div>
+</div>
+`;

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -317,6 +317,9 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
         className=
             ms-TeachingBubble-header
             ms-TeachingBubble-header--large
+            {
+              margin-right: 24px;
+            }
             &:not(:last-child) {
               margin-bottom: 14px;
             }
@@ -912,7 +915,6 @@ exports[`TeachingBubble renders TeachingBubbleContent with condensed headline co
               font-size: 14px;
               font-weight: 600;
               margin-bottom: 14px;
-              margin-right: 24px;
             }
       >
         <p
@@ -1321,7 +1323,6 @@ exports[`TeachingBubble renders TeachingBubbleContent with small headline correc
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 600;
-              margin-right: 24px;
             }
             &:not(:last-child) {
               margin-bottom: 14px;

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/examples/TeachingBubble.Condensed.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/examples/TeachingBubble.Condensed.Example.tsx
@@ -36,7 +36,7 @@ export class TeachingBubbleCondensedExample extends React.Component<{}, ITeachin
               target={'#buttonId'}
               hasCondensedHeadline={true}
               onDismiss={this._onDismiss}
-              hasCloseIcon={true}
+              hasCloseButton={true}
               closeButtonAriaLabel="Close"
               headline="Discover what’s trending around you"
             >

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/examples/TeachingBubble.SmallHeadline.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/examples/TeachingBubble.SmallHeadline.Example.tsx
@@ -41,7 +41,7 @@ export class TeachingBubbleSmallHeadlineExample extends React.Component<{}, ITea
               target={this._menuButtonElement}
               hasSmallHeadline={true}
               onDismiss={this._onDismiss}
-              hasCloseIcon={true}
+              hasCloseButton={true}
               closeButtonAriaLabel="Close"
               primaryButtonProps={examplePrimaryButton}
               headline="Discover what’s trending around you"

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/examples/TeachingBubble.Wide.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/examples/TeachingBubble.Wide.Example.tsx
@@ -38,7 +38,7 @@ export class TeachingBubbleWideExample extends React.Component<{}, ITeachingBubb
             <TeachingBubble
               calloutProps={{ directionalHint: DirectionalHint.bottomCenter }}
               isWide={true}
-              hasCloseIcon={true}
+              hasCloseButton={true}
               closeButtonAriaLabel="Close"
               target={this._menuButtonElement}
               onDismiss={this._onDismiss}

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/examples/TeachingBubble.WideIllustration.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/examples/TeachingBubble.WideIllustration.Example.tsx
@@ -49,7 +49,7 @@ export class TeachingBubbleWideIllustrationExample extends React.Component<{}, I
               calloutProps={{ directionalHint: DirectionalHint.bottomCenter }}
               isWide={true}
               hasSmallHeadline={true}
-              hasCloseIcon={true}
+              hasCloseButton={true}
               closeButtonAriaLabel="Close"
               target={this._menuButtonElement}
               primaryButtonProps={examplePrimaryButton}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
@@ -896,6 +896,9 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                                             className=
                                                 ms-TeachingBubble-header
                                                 ms-TeachingBubble-header--large
+                                                {
+                                                  margin-right: 24px;
+                                                }
                                                 &:not(:last-child) {
                                                   margin-bottom: 14px;
                                                 }


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ yarn change`

#### Description of changes

1. Deprecating `hasCloseIcon` in favor of `hasCloseButton`.
2. Tweaking comments.
3. Conditionalizing the right padding based on if a close button is present.

Before:

![image](https://user-images.githubusercontent.com/1110944/69589411-db7fef00-0fa0-11ea-98a0-8af01d03e646.png)

After, header has adequate padding:

![image](https://user-images.githubusercontent.com/1110944/69589499-1a15a980-0fa1-11ea-960c-498fed764990.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11307)