### PR TITLE
Add calloutProps to HoverCard

### DIFF
--- a/change/office-ui-fabric-react-2019-11-25-17-23-39-hoverCard-calloutOptions.json
+++ b/change/office-ui-fabric-react-2019-11-25-17-23-39-hoverCard-calloutOptions.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add calloutProps",
+  "packageName": "office-ui-fabric-react",
+  "email": "anihan@microsoft.com",
+  "commit": "db9c6eea4e1697d2b7ffe9233b81f42f0f5804e8",
+  "date": "2019-11-26T01:23:39.401Z"
+}

--- a/change/office-ui-fabric-react-2019-11-25-17-23-39-hoverCard-calloutOptions.json
+++ b/change/office-ui-fabric-react-2019-11-25-17-23-39-hoverCard-calloutOptions.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add calloutProps",
+  "comment": "Add calloutProps to HoverCard",
   "packageName": "office-ui-fabric-react",
   "email": "anihan@microsoft.com",
   "commit": "db9c6eea4e1697d2b7ffe9233b81f42f0f5804e8",

--- a/packages/office-ui-fabric-react/src/components/HoverCard/BaseCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/BaseCard.types.ts
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { DirectionalHint } from '../../common/DirectionalHint';
 import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
 import { IStyle, ITheme } from '../../Styling';
-import { ICalloutProps } from '../Callout';
+import { ICalloutProps } from '../../Callout';
 
 /**
  * Interface containing props common for all types of cards.

--- a/packages/office-ui-fabric-react/src/components/HoverCard/BaseCard.types.ts
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/BaseCard.types.ts
@@ -3,6 +3,7 @@ import * as React from 'react';
 import { DirectionalHint } from '../../common/DirectionalHint';
 import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
 import { IStyle, ITheme } from '../../Styling';
+import { ICalloutProps } from '../Callout';
 
 /**
  * Interface containing props common for all types of cards.
@@ -76,6 +77,11 @@ export interface IBaseCardProps<TComponent, TStyles, TStyleProps> extends React.
    * Trap focus or not
    */
   trapFocus?: boolean;
+
+  /**
+   * Custom overriding props to Callout
+   */
+  calloutProps?: ICalloutProps;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/HoverCard/CardCallout/CardCallout.tsx
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/CardCallout/CardCallout.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 
 import { divProperties, getNativeProps } from '../../../Utilities';
-import { Callout } from '../../../Callout';
 import { DirectionalHint } from '../../../common/DirectionalHint';
 import { IBaseCardProps } from '../BaseCard.types';
-import { FocusTrapCallout, ICalloutProps } from '../../../Callout';
+import { Callout, FocusTrapCallout, ICalloutProps } from '../../../Callout';
 
 export interface ICardCalloutProps extends IBaseCardProps<{}, {}, {}> {
   finalHeight?: number;
@@ -22,10 +21,11 @@ export const CardCallout = (props: ICardCalloutProps) => {
     onLeave,
     className,
     finalHeight,
-    content
+    content,
+    calloutProps
   } = props;
 
-  const calloutProps: ICalloutProps = {
+  const mergedCalloutProps: ICalloutProps = {
     ...getNativeProps(props, divProperties),
     className: className,
     target: targetElement,
@@ -35,14 +35,15 @@ export const CardCallout = (props: ICardCalloutProps) => {
     finalHeight: finalHeight,
     minPagePadding: 24,
     onDismiss: onLeave,
-    gapSpace: gapSpace
+    gapSpace: gapSpace,
+    ...calloutProps
   };
 
   return (
     <React.Fragment>
       {trapFocus ? (
         <FocusTrapCallout
-          {...calloutProps}
+          {...mergedCalloutProps}
           focusTrapProps={{
             forceFocusInsideTrap: false,
             isClickableOutsideFocusTrap: true,
@@ -52,7 +53,7 @@ export const CardCallout = (props: ICardCalloutProps) => {
           {content}
         </FocusTrapCallout>
       ) : (
-        <Callout {...calloutProps}>{content}</Callout>
+        <Callout {...mergedCalloutProps}>{content}</Callout>
       )}
     </React.Fragment>
   );

--- a/packages/office-ui-fabric-react/src/components/HoverCard/examples/HoverCard.Target.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/examples/HoverCard.Target.Example.tsx
@@ -109,7 +109,10 @@ export class HoverCardTargetExample extends React.Component<{}, {}> {
       onRenderExpandedCard: this._onRenderExpandedCard,
       renderData: item,
       directionalHint: DirectionalHint.rightTopEdge,
-      gapSpace: 16
+      gapSpace: 16,
+      calloutProps: {
+        isBeakVisible: true
+      }
     };
 
     if (column.key === 'key') {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11272
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Added an optional prop `calloutProps` to `IBaseCardProps` to support finer customization of underlying Callout component in both HoverCard types (i.e. Plain and Expanding).

Updated an example to illustrate use of the new prop.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11310)