### PR TITLE
Joou/embedded panel

### DIFF
--- a/change/office-ui-fabric-react-2019-11-26-14-46-49-joou-embedded-panel.json
+++ b/change/office-ui-fabric-react-2019-11-26-14-46-49-joou-embedded-panel.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Fix feature request #10918 by implementing a new panel type",
+  "packageName": "office-ui-fabric-react",
+  "email": "kuzhou@microsoft.com",
+  "commit": "8efd18b6ae4457a588b96641a1fd961496478ca3",
+  "date": "2019-11-26T06:46:49.680Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -8232,6 +8232,7 @@ export enum PanelType {
     large = 4,
     largeFixed = 5,
     medium = 3,
+    samllRelativeFar = 9,
     smallFixedFar = 1,
     smallFixedNear = 2,
     smallFluid = 0

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -149,7 +149,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
     const nativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties);
     const isOpen = this.isActive;
     const isAnimating = visibility === PanelVisibilityState.animatingClosed || visibility === PanelVisibilityState.animatingOpen;
-    const isNoOverlay = type === PanelType.smallEmbedded;
+    const isNoOverlay = type === PanelType.samllRelativeFar;
 
     if (!isOpen && !isAnimating && !isHiddenOnDismiss) {
       return null;
@@ -221,8 +221,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
     );
 
     if (isNoOverlay) {
-      // TODO: add classes and styles
-      return <div>{body}</div>;
+      return <>{body}</>;
     }
 
     return <Layer {...layerProps}>{body}</Layer>;

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -149,6 +149,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
     const nativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties);
     const isOpen = this.isActive;
     const isAnimating = visibility === PanelVisibilityState.animatingClosed || visibility === PanelVisibilityState.animatingOpen;
+    const isNoOverlay = type === PanelType.smallEmbedded;
 
     if (!isOpen && !isAnimating && !isHiddenOnDismiss) {
       return null;
@@ -184,43 +185,47 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
     }
 
     const header = onRenderHeader(this.props, this._onRenderHeader, headerTextId);
-
-    return (
-      <Layer {...layerProps}>
-        <Popup
-          role="dialog"
-          aria-modal="true"
-          ariaLabelledBy={header ? headerTextId : undefined}
-          onDismiss={this.dismiss}
-          className={_classNames.hiddenPanel}
-        >
-          <div aria-hidden={!isOpen && isAnimating} {...nativeProps} ref={this._panel} className={_classNames.root}>
-            {overlay}
-            <FocusTrapZone
-              ignoreExternalFocusing={ignoreExternalFocusing}
-              forceFocusInsideTrap={!isBlocking || (isHiddenOnDismiss && !isOpen) ? false : forceFocusInsideTrap}
-              firstFocusableSelector={firstFocusableSelector}
-              isClickableOutsideFocusTrap={true}
-              {...focusTrapZoneProps}
-              className={_classNames.main}
-              style={customWidthStyles}
-              elementToFocusOnDismiss={elementToFocusOnDismiss}
-            >
-              <div className={_classNames.commands} data-is-visible={true}>
-                {onRenderNavigation(this.props, this._onRenderNavigation)}
+    const body = (
+      <Popup
+        role="dialog"
+        aria-modal="true"
+        ariaLabelledBy={header ? headerTextId : undefined}
+        onDismiss={this.dismiss}
+        className={_classNames.hiddenPanel}
+      >
+        <div aria-hidden={!isOpen && isAnimating} {...nativeProps} ref={this._panel} className={_classNames.root}>
+          {overlay}
+          <FocusTrapZone
+            ignoreExternalFocusing={ignoreExternalFocusing}
+            forceFocusInsideTrap={!isBlocking || (isHiddenOnDismiss && !isOpen) ? false : forceFocusInsideTrap}
+            firstFocusableSelector={firstFocusableSelector}
+            isClickableOutsideFocusTrap={true}
+            {...focusTrapZoneProps}
+            className={_classNames.main}
+            style={customWidthStyles}
+            elementToFocusOnDismiss={elementToFocusOnDismiss}
+          >
+            <div className={_classNames.commands} data-is-visible={true}>
+              {onRenderNavigation(this.props, this._onRenderNavigation)}
+            </div>
+            <div className={_classNames.contentInner}>
+              {header}
+              <div ref={this._allowScrollOnPanel} className={_classNames.scrollableContent} data-is-scrollable={true}>
+                {onRenderBody(this.props, this._onRenderBody)}
               </div>
-              <div className={_classNames.contentInner}>
-                {header}
-                <div ref={this._allowScrollOnPanel} className={_classNames.scrollableContent} data-is-scrollable={true}>
-                  {onRenderBody(this.props, this._onRenderBody)}
-                </div>
-                {onRenderFooter(this.props, this._onRenderFooter)}
-              </div>
-            </FocusTrapZone>
-          </div>
-        </Popup>
-      </Layer>
+              {onRenderFooter(this.props, this._onRenderFooter)}
+            </div>
+          </FocusTrapZone>
+        </div>
+      </Popup>
     );
+
+    if (isNoOverlay) {
+      // TODO: add classes and styles
+      return <div>{body}</div>;
+    }
+
+    return <Layer {...layerProps}>{body}</Layer>;
   }
 
   public open() {

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.doc.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { IDocPageProps } from '../../common/DocPage.types';
 import { PanelBasicExample } from './examples/Panel.Basic.Example';
+import { PanelRelativeExample } from './examples/Panel.Relative.Example';
 import { PanelConfirmDismissExample } from './examples/Panel.ConfirmDismiss.Example';
 import { PanelControlledExample } from './examples/Panel.Controlled.Example';
 import { PanelFooterExample } from './examples/Panel.Footer.Example';
@@ -13,6 +14,7 @@ import { PanelNonModalExample } from './examples/Panel.NonModal.Example';
 import { PanelSizesExample } from './examples/Panel.Sizes.Example';
 
 const PanelBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.Basic.Example.tsx') as string;
+const PanelRelativeExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.Relative.Example.tsx') as string;
 const PanelSizesExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.Sizes.Example.tsx') as string;
 const PanelConfirmDismissExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.ConfirmDismiss.Example.tsx') as string;
 const PanelControlledExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Panel/examples/Panel.Controlled.Example.tsx') as string;
@@ -33,6 +35,11 @@ export const PanelPageProps: IDocPageProps = {
       title: 'Basic',
       code: PanelBasicExampleCode,
       view: <PanelBasicExample />
+    },
+    {
+      title: 'Relative layout',
+      code: PanelRelativeExampleCode,
+      view: <PanelRelativeExample />
     },
     {
       title: 'Size options',

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -110,6 +110,7 @@ const getPanelBreakpoints = (type: PanelType): { [x: string]: IStyle } | undefin
   // and have the checks done separately in the `getStyles` function below.
   switch (type) {
     case PanelType.smallFixedFar:
+    case PanelType.smallEmbedded:
       selectors = {
         ...smallPanelSelectors
       };

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -110,7 +110,7 @@ const getPanelBreakpoints = (type: PanelType): { [x: string]: IStyle } | undefin
   // and have the checks done separately in the `getStyles` function below.
   switch (type) {
     case PanelType.smallFixedFar:
-    case PanelType.smallEmbedded:
+    case PanelType.samllRelativeFar:
       selectors = {
         ...smallPanelSelectors
       };

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -335,7 +335,18 @@ export enum PanelType {
    * - When screen width reaches the `customWidth` value it will behave like a fluid width Panel
    * taking up 100% of the viewport width
    */
-  customNear = 8
+  customNear = 8,
+
+  /**
+   * Renders the Panel under father container in `small` size, anchored to the far side (right in LTR mode).
+   * Recommended for use on small screen breakpoints.
+   * - Small (320-479): full screen width, 16px left/right padding
+   * - Medium (480-639): full screen width, 16px left/right padding
+   * - Large (640-1023): full screen width, 32px left/right padding
+   * - XLarge (1024-1365): full screen width, 32px left/right padding
+   * - XXLarge (1366-up): full screen width, 40px left/right padding
+   */
+  smallEmbedded = 9
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -338,7 +338,7 @@ export enum PanelType {
   customNear = 8,
 
   /**
-   * Renders the Panel under father container in `small` size, anchored to the far side (right in LTR mode).
+   * Renders the Panel takes its father element as container in `small` size, anchored to the far side (right in LTR mode).
    * Recommended for use on small screen breakpoints.
    * - Small (320-479): full screen width, 16px left/right padding
    * - Medium (480-639): full screen width, 16px left/right padding
@@ -346,7 +346,7 @@ export enum PanelType {
    * - XLarge (1024-1365): full screen width, 32px left/right padding
    * - XXLarge (1366-up): full screen width, 40px left/right padding
    */
-  smallEmbedded = 9
+  samllRelativeFar = 9
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Relative.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Relative.Example.tsx
@@ -1,0 +1,35 @@
+import * as React from 'react';
+import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { Panel, PanelType } from 'office-ui-fabric-react/lib/Panel';
+import { useConstCallback } from '@uifabric/react-hooks';
+
+const explanation =
+  'This panel takes its father element instead of the "body" element as container, ' +
+  'so the overlay only blocks interaction with partial view.';
+
+export const PanelRelativeExample: React.FunctionComponent = () => {
+  const [isOpen, setIsOpen] = React.useState(false);
+
+  const openPanel = useConstCallback(() => setIsOpen(true));
+  const dismissPanel = useConstCallback(() => setIsOpen(false));
+  const containerStyle = { height: 300 };
+
+  return (
+    <div style={containerStyle}>
+      {explanation}
+      <br />
+      <br />
+      <DefaultButton text="Open panel" onClick={openPanel} />
+      <Panel
+        headerText="Sample panel"
+        isOpen={isOpen}
+        onDismiss={dismissPanel}
+        type={PanelType.samllRelativeFar}
+        // You MUST provide this prop! Otherwise screen readers will just say "button" with no label.
+        closeButtonAriaLabel="Close"
+      >
+        <span>Content goes here.</span>
+      </Panel>
+    </div>
+  );
+};

--- a/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Sizes.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Sizes.Example.tsx
@@ -46,8 +46,7 @@ const options: IDropdownOption[] = [
   { text: 'Extra large', key: String(PanelType.extraLarge) },
   { text: 'Full-width (fluid)', key: String(PanelType.smallFluid) },
   { text: 'Custom (example: 888px)', key: String(PanelType.custom) },
-  { text: 'Custom (example: 888px), near side', key: String(PanelType.customNear) },
-  { text: 'Embedded (relative to its container)', key: String(PanelType.smallEmbedded) }
+  { text: 'Custom (example: 888px), near side', key: String(PanelType.customNear) }
 ];
 const dropdownStyles = { root: { maxWidth: 250, marginBottom: 16 } };
 const firstPStyle = { marginTop: 0 };

--- a/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Sizes.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.Sizes.Example.tsx
@@ -46,7 +46,8 @@ const options: IDropdownOption[] = [
   { text: 'Extra large', key: String(PanelType.extraLarge) },
   { text: 'Full-width (fluid)', key: String(PanelType.smallFluid) },
   { text: 'Custom (example: 888px)', key: String(PanelType.custom) },
-  { text: 'Custom (example: 888px), near side', key: String(PanelType.customNear) }
+  { text: 'Custom (example: 888px), near side', key: String(PanelType.customNear) },
+  { text: 'Embedded (relative to its container)', key: String(PanelType.smallEmbedded) }
 ];
 const dropdownStyles = { root: { maxWidth: 250, marginBottom: 16 } };
 const firstPStyle = { marginTop: 0 };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10918
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Implementing a new type named `smallRelativeFar`, this type can make the panel showed under its father element container.

![demo](https://user-images.githubusercontent.com/8896124/69605722-ddf34f00-105b-11ea-8097-4a5a05139593.gif)

#### Focus areas to test

It's my first time to contribute to Fabric UI project, I have ran unit test locally and did some manual tests, maybe A11Y test should be focused because I'm new to this area.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11311)