### PR TITLE
Update Modal KeyUp to not only register in componentWillReceiveProps

### DIFF
--- a/change/office-ui-fabric-react-2019-11-26-11-31-46-sareiff-modalKeyUp.json
+++ b/change/office-ui-fabric-react-2019-11-26-11-31-46-sareiff-modalKeyUp.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update Modal onKeyUp to also register in componentDidMount",
+  "packageName": "office-ui-fabric-react",
+  "email": "sareiff@microsoft.com",
+  "commit": "43091a0a918dfac18ce651255d52eef2cee5eeff",
+  "date": "2019-11-26T19:31:45.897Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -3852,8 +3852,6 @@ export interface IDialogState {
     // (undocumented)
     hasBeenOpened?: boolean;
     // (undocumented)
-    hasRegisteredKeyUp?: boolean;
-    // (undocumented)
     id?: string;
     // (undocumented)
     isInKeyboardMoveMode?: boolean;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -3852,6 +3852,8 @@ export interface IDialogState {
     // (undocumented)
     hasBeenOpened?: boolean;
     // (undocumented)
+    hasRegisteredKeyUp?: boolean;
+    // (undocumented)
     id?: string;
     // (undocumented)
     isInKeyboardMoveMode?: boolean;
@@ -8122,6 +8124,8 @@ export const Modal: React.StatelessComponent<IModalProps>;
 // @public (undocumented)
 export class ModalBase extends BaseComponent<IModalProps, IDialogState> implements IModal {
     constructor(props: IModalProps);
+    // (undocumented)
+    componentDidMount(): void;
     // (undocumented)
     componentDidUpdate(prevProps: IModalProps, prevState: IDialogState): void;
     // (undocumented)

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
@@ -28,7 +28,6 @@ export interface IDialogState {
   isInKeyboardMoveMode?: boolean;
   x: number;
   y: number;
-  hasRegisteredKeyUp?: boolean;
 }
 
 const getClassNames = classNamesFunction<IModalStyleProps, IModalStyles>();
@@ -48,6 +47,7 @@ export class ModalBase extends BaseComponent<IModalProps, IDialogState> implemen
   private _scrollableContent: HTMLDivElement | null;
   private _lastSetX: number;
   private _lastSetY: number;
+  private _hasRegisteredKeyUp: boolean;
 
   constructor(props: IModalProps) {
     super(props);
@@ -80,11 +80,9 @@ export class ModalBase extends BaseComponent<IModalProps, IDialogState> implemen
           isOpen: true
         });
         // Add a keyUp handler for all key up events when the dialog is open
-        if (newProps.dragOptions && !this.state.hasRegisteredKeyUp) {
+        if (newProps.dragOptions && !this._hasRegisteredKeyUp) {
           this._events.on(window, 'keyup', this._onKeyUp, true /* useCapture */);
-          this.setState({
-            hasRegisteredKeyUp: true
-          });
+          this._hasRegisteredKeyUp = true;
         }
       } else {
         // Modal has been opened
@@ -119,11 +117,9 @@ export class ModalBase extends BaseComponent<IModalProps, IDialogState> implemen
   public componentDidMount() {
     // Not all modals show just by updating their props. Some only render when they are mounted and pass in
     // isOpen as true. We need to add the keyUp handler in componentDidMount if we are in that case.
-    if (this.state.isOpen && this.state.isVisible && !this.state.hasRegisteredKeyUp) {
+    if (this.state.isOpen && this.state.isVisible && !this._hasRegisteredKeyUp) {
       this._events.on(window, 'keyup', this._onKeyUp, true /* useCapture */);
-      this.setState({
-        hasRegisteredKeyUp: true
-      });
+      this._hasRegisteredKeyUp = true;
     }
   }
 
@@ -299,7 +295,7 @@ export class ModalBase extends BaseComponent<IModalProps, IDialogState> implemen
       y: 0
     });
 
-    if (this.props.dragOptions && this.state.hasRegisteredKeyUp) {
+    if (this.props.dragOptions && this._hasRegisteredKeyUp) {
       this._events.off(window, 'keyup', this._onKeyUp, true /* useCapture */);
     }
 

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
@@ -80,9 +80,8 @@ export class ModalBase extends BaseComponent<IModalProps, IDialogState> implemen
           isOpen: true
         });
         // Add a keyUp handler for all key up events when the dialog is open
-        if (newProps.dragOptions && !this._hasRegisteredKeyUp) {
-          this._events.on(window, 'keyup', this._onKeyUp, true /* useCapture */);
-          this._hasRegisteredKeyUp = true;
+        if (newProps.dragOptions) {
+          this._registerForKeyUp();
         }
       } else {
         // Modal has been opened
@@ -117,9 +116,8 @@ export class ModalBase extends BaseComponent<IModalProps, IDialogState> implemen
   public componentDidMount() {
     // Not all modals show just by updating their props. Some only render when they are mounted and pass in
     // isOpen as true. We need to add the keyUp handler in componentDidMount if we are in that case.
-    if (this.state.isOpen && this.state.isVisible && !this._hasRegisteredKeyUp) {
-      this._events.on(window, 'keyup', this._onKeyUp, true /* useCapture */);
-      this._hasRegisteredKeyUp = true;
+    if (this.state.isOpen && this.state.isVisible) {
+      this._registerForKeyUp();
     }
   }
 
@@ -428,5 +426,12 @@ export class ModalBase extends BaseComponent<IModalProps, IDialogState> implemen
     this._lastSetY = 0;
     this.setState({ isInKeyboardMoveMode: false });
     this._events.off(window, 'keydown', this._onKeyDown, true /* useCapture */);
+  };
+
+  private _registerForKeyUp = (): void => {
+    if (!this._hasRegisteredKeyUp) {
+      this._events.on(window, 'keyup', this._onKeyUp, true /* useCapture */);
+      this._hasRegisteredKeyUp = true;
+    }
   };
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x ] Include a change request file using `$ yarn change`

#### Description of changes
Not all modals and dialogs mount when the page loads and show based on updating isOpen in the props form false (onMount) to true (gets it to show). Some dialogs (like the ones in Office) mount when they are ready to show and pass in isOpen is true.

However, the onKeyUp event is added in UNSAFE_componentWillReceiveProps which is not always called when the modal mounts. This means any modal that does not update the props to show and shows when they mount the component, will not register for onKeyUp events. To fix this, I added componentDidMount which checks to see if the modal is open and visible before registering for onKeyUp. Additionally, I added some checks to make sure that we only register for the event once by updating the state.

Unfortunately all of Fabric's dialog and modal examples are mounted when the page loads so they do not repro this issue. The dialogs in the office repo do not all mount when the page loads so some experience this issue when they are created/renders based on a button click.


#### Focus areas to test

Dialogs and Modals.

I have verified the dialogs/modals in fabric still open the move/close menu as before. I also verified this works in the office repo to ensure it fixes the issue we were seeing.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11315)