### PR TITLE
Pickers forcecomplete

### DIFF
--- a/change/office-ui-fabric-react-2019-11-26-16-44-32-pickers-forcecomplete.json
+++ b/change/office-ui-fabric-react-2019-11-26-16-44-32-pickers-forcecomplete.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Pickers: Allow force resolve when no match found",
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com",
+  "commit": "a1eab542869ceeb70c1b2c7f9a1fc10c6f0f89df",
+  "date": "2019-11-27T00:44:31.997Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -276,7 +276,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
     // (undocumented)
     protected canAddItems(): boolean;
     // (undocumented)
-    completeSuggestion(): void;
+    completeSuggestion(forceComplete?: boolean): void;
     // (undocumented)
     componentDidMount(): void;
     // (undocumented)
@@ -1661,6 +1661,7 @@ export type IBaseFloatingPickerSuggestionProps = Pick<ISuggestionsControlProps<a
 
 // @public
 export interface IBasePicker<T> {
+    completeSuggestion: (forceComplete?: boolean) => void;
     focus: () => void;
     focusInput: () => void;
     items: T[] | undefined;
@@ -1745,7 +1746,7 @@ export interface IBasePickerStyles {
 }
 
 // @public
-export interface IBasePickerSuggestionsProps<T = any> extends Pick<ISuggestionsProps<T>, 'onRenderNoResultFound' | 'suggestionsHeaderText' | 'mostRecentlyUsedHeaderText' | 'noResultsFoundText' | 'className' | 'suggestionsClassName' | 'suggestionsItemClassName' | 'searchForMoreText' | 'forceResolveText' | 'loadingText' | 'searchingText' | 'resultsFooterFull' | 'resultsFooter' | 'resultsMaximumNumber' | 'showRemoveButtons' | 'suggestionsAvailableAlertText' | 'suggestionsContainerAriaLabel'> {
+export interface IBasePickerSuggestionsProps<T = any> extends Pick<ISuggestionsProps<T>, 'onRenderNoResultFound' | 'suggestionsHeaderText' | 'mostRecentlyUsedHeaderText' | 'noResultsFoundText' | 'className' | 'suggestionsClassName' | 'suggestionsItemClassName' | 'searchForMoreText' | 'forceResolveText' | 'loadingText' | 'searchingText' | 'resultsFooterFull' | 'resultsFooter' | 'resultsMaximumNumber' | 'showRemoveButtons' | 'suggestionsAvailableAlertText' | 'suggestionsContainerAriaLabel' | 'showForceResolve'> {
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -193,11 +193,13 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
     this.setState({ suggestionsVisible: false });
   };
 
-  public completeSuggestion() {
+  public completeSuggestion(forceComplete?: boolean) {
     if (this.suggestionStore.hasSelectedSuggestion() && this.input.current) {
       this.addItem(this.suggestionStore.currentSuggestion!.item);
       this.updateValue('');
       this.input.current.clear();
+    } else if (forceComplete) {
+      this._completeGenericSuggestion();
     }
   }
 
@@ -332,6 +334,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
           refocusSuggestions={this.refocusSuggestions}
           removeSuggestionAriaLabel={this.props.removeButtonAriaLabel}
           suggestionsListId={this._ariaMap.suggestionList}
+          createGenericItem={this._completeGenericSuggestion}
           {...this.props.pickerSuggestionsProps}
         />
       </Callout>
@@ -605,7 +608,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
           ev.preventDefault();
           ev.stopPropagation();
         } else {
-          this._onValidateInput();
+          this._completeGenericSuggestion();
         }
 
         break;
@@ -800,7 +803,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
   protected onBackspace(ev: React.KeyboardEvent<HTMLElement>) {
     if (
       (this.state.items.length && !this.input.current) ||
-      (this.input.current && (!this.input.current.isValueSelected && this.input.current.cursorLocation === 0))
+      (this.input.current && !this.input.current.isValueSelected && this.input.current.cursorLocation === 0)
     ) {
       if (this.selection.getSelectedCount() > 0) {
         this.removeItems(this.selection.getSelection());
@@ -906,7 +909,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
     }
   }
 
-  private _onValidateInput(): void {
+  private _completeGenericSuggestion = (): void => {
     if (
       this.props.onValidateInput &&
       this.input.current &&
@@ -917,7 +920,7 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
       this.suggestionStore.createGenericSuggestion(itemToConvert);
       this.completeSuggestion();
     }
-  }
+  };
 
   private _getTextFromItem(item: T, currentValue?: string): string {
     if (this.props.getTextFromItem) {

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.types.ts
@@ -20,6 +20,14 @@ export interface IBasePicker<T> {
 
   /** Set focus to the input */
   focusInput: () => void;
+
+  /**
+   * When called, will take the currently selected suggestion and complete it.
+   * If called with forceComplete true, it will attempt to force the current suggestion
+   * to complete, must provide both createGenericSuggestion, so the text can be turned into
+   * an object in the right shape,.and onValidateInput, so the object knows if it's correct or not.
+   */
+  completeSuggestion: (forceComplete?: boolean) => void;
 }
 
 /**
@@ -230,6 +238,7 @@ export interface IBasePickerSuggestionsProps<T = any>
     | 'showRemoveButtons'
     | 'suggestionsAvailableAlertText'
     | 'suggestionsContainerAriaLabel'
+    | 'showForceResolve'
   > {}
 
 /**

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -155,6 +155,7 @@ export class Suggestions<T> extends BaseComponent<ISuggestionsProps<T>, ISuggest
             componentRef={this._forceResolveButton}
             className={this._classNames.forceResolveButton}
             onClick={this._forceResolve}
+            data-automationid={'sug-forceResolve'}
           >
             {forceResolveText}
           </CommandButton>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11255
- [x] Include a change request file using `$ yarn change`

#### Description of changes

There were several public methods and existing props in the pickers that weren't exposed. This pr just enables users to have more control over pickers by accessing api's that, for the most part, already existed but weren't exposed.

Also cleaned up the pickers tests, just a bit.

Also added test

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11317)