### PR TITLE
Update SpinButton prop check

### DIFF
--- a/change/office-ui-fabric-react-2019-11-27-10-06-29-sareiff-spinButton.json
+++ b/change/office-ui-fabric-react-2019-11-27-10-06-29-sareiff-spinButton.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update spinbutton check",
+  "packageName": "office-ui-fabric-react",
+  "email": "sareiff@microsoft.com",
+  "commit": "4b2b14b537356681abe29877d667fe6ea2279e28",
+  "date": "2019-11-27T18:06:29.752Z"
+}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -119,7 +119,7 @@ export class SpinButton extends React.Component<ISpinButtonProps, ISpinButtonSta
   // tslint:disable-next-line function-name
   public UNSAFE_componentWillReceiveProps(newProps: ISpinButtonProps): void {
     this._lastValidValue = this.state.value;
-    let value: string = newProps.value ? newProps.value : String(newProps.min);
+    let value: string = newProps.value !== undefined ? newProps.value : String(newProps.min);
     if (newProps.defaultValue) {
       value = String(Math.max(newProps.min as number, Math.min(newProps.max as number, Number(newProps.defaultValue))));
     }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
We have a case in office online where we want a spin button with an empty value in there. To do this, we set the reserved value to be "". However, when we update the state and pass through "" as the value, the check within componentWillReceiveProps will default to using the min props since our value check is not for undefined even though the check below is for undefined.

I have updated the check and verified this now works for my scenario.


#### Focus areas to test

spin buttons


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11324)