### PR TITLE
ComboBox: Fixing icon position when disabled

### DIFF
--- a/change/office-ui-fabric-react-2019-11-27-11-31-09-comboBoxDisabledIcon.json
+++ b/change/office-ui-fabric-react-2019-11-27-11-31-09-comboBoxDisabledIcon.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "ComboBox: Fixing icon position when disabled.",
+  "packageName": "office-ui-fabric-react",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "commit": "4bb65cfa615c48411a56daa64eaa0ce0a4827d5d",
+  "date": "2019-11-27T19:31:09.581Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -236,7 +236,12 @@ export const getCaretDownButtonStyles = memoizeFunction(
         },
         buttonHighContrastStyles
       ],
-      rootDisabled: getDisabledStyles(theme)
+      rootDisabled: [
+        getDisabledStyles(theme),
+        {
+          position: 'absolute'
+        }
+      ]
     };
     return concatStyleSets(styles, customStyles);
   }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -4521,7 +4521,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               padding-right: 4px;
               padding-top: 0;
               pointer-events: none;
-              position: relative;
+              position: absolute;
               text-align: center;
               text-decoration: none;
               user-select: none;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11319 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR fixes an issue where the caret down icon was not showing on disabled `ComboBoxes` because its `position` was not being set to `absolute`.

__Before:__

![image](https://user-images.githubusercontent.com/7798177/69754005-b5299300-1109-11ea-99d4-f9ed86afcf64.png)

__After:__

![image](https://user-images.githubusercontent.com/7798177/69754015-bb1f7400-1109-11ea-88ce-d72b06e2b179.png)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11327)