### PR TITLE
Preserve modal selection state when navigating between selected items

### DIFF
--- a/change/office-ui-fabric-react-2019-11-27-21-47-59-modal-select.json
+++ b/change/office-ui-fabric-react-2019-11-27-21-47-59-modal-select.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Ensure that navigating between selected items doesn't clear modal state",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "commit": "26017212a790aab5f921a3ee59bf66df025400b4",
+  "date": "2019-11-28T05:47:59.136Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -6673,6 +6673,12 @@ export interface ISelectionZoneProps extends React.ClassAttributes<SelectionZone
 }
 
 // @public (undocumented)
+export interface ISelectionZoneState {
+    // (undocumented)
+    isModal: boolean | undefined;
+}
+
+// @public (undocumented)
 export interface ISeparator {
 }
 
@@ -8754,14 +8760,19 @@ export { SelectionDirection }
 export { SelectionMode }
 
 // @public (undocumented)
-export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
+export class SelectionZone extends BaseComponent<ISelectionZoneProps, ISelectionZoneState> {
+    constructor(props: ISelectionZoneProps);
     // (undocumented)
     componentDidMount(): void;
+    // (undocumented)
+    componentDidUpdate(previousProps: ISelectionZoneProps): void;
     // (undocumented)
     static defaultProps: {
         isSelectedOnFocus: boolean;
         selectionMode: SelectionMode;
     };
+    // (undocumented)
+    static getDerivedStateFromProps(nextProps: ISelectionZoneProps, prevState: ISelectionZoneState): ISelectionZoneState;
     ignoreNextFocus: () => void;
     // (undocumented)
     render(): JSX.Element;

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.test.tsx
@@ -7,7 +7,7 @@ import { SelectionZone } from './SelectionZone';
 import { Selection } from './Selection';
 import { SelectionMode, IObjectWithKey } from './interfaces';
 
-import { KeyCodes } from '../../Utilities';
+import { KeyCodes, EventGroup } from '../../Utilities';
 
 let _selection: Selection;
 let _selectionZone: any;
@@ -34,6 +34,7 @@ function _initializeSelection(selectionMode = SelectionMode.multiple): void {
       selection={_selection}
       selectionMode={selectionMode}
       disableAutoSelectOnInputElements={true}
+      enterModalOnTouch={true}
       // tslint:disable-next-line:jsx-no-lambda
       onItemInvoked={(item: IObjectWithKey) => {
         _onItemInvokeCalled++;
@@ -274,6 +275,47 @@ describe('SelectionZone', () => {
   it('selects an item when a button is clicked that has data-selection-select', () => {
     ReactTestUtils.Simulate.keyDown(_select1, { which: KeyCodes.enter });
     expect(_selection.isIndexSelected(1)).toEqual(true);
+  });
+
+  it('enters modal selection state when commanded', () => {
+    _selection.setModal(true);
+    expect(_componentElement.getAttribute('data-selection-is-modal')).toEqual('true');
+
+    _selection.setModal(false);
+    expect(_componentElement.getAttribute('data-selection-is-modal')).toBeNull();
+  });
+
+  it('exits modal selection state when the last item is deselected', () => {
+    _selection.setModal(true);
+    expect(_componentElement.getAttribute('data-selection-is-modal')).toEqual('true');
+
+    _selection.setIndexSelected(1, true, false);
+    expect(_componentElement.getAttribute('data-selection-is-modal')).toEqual('true');
+
+    _selection.setIndexSelected(1, false, false);
+    expect(_componentElement.getAttribute('data-selection-is-modal')).toBeNull();
+  });
+
+  it('preserves modal state when switching selection', () => {
+    _selection.setModal(true);
+    expect(_componentElement.getAttribute('data-selection-is-modal')).toEqual('true');
+
+    _simulateClick(_surface0);
+    expect(_selection.getSelectedIndices()).toEqual([0]);
+    expect(_componentElement.getAttribute('data-selection-is-modal')).toEqual('true');
+
+    _simulateClick(_surface1);
+    expect(_selection.getSelectedIndices()).toEqual([1]);
+    expect(_componentElement.getAttribute('data-selection-is-modal')).toEqual('true');
+  });
+
+  it('enters modal selection state on a touch event', () => {
+    EventGroup.raise(document.body, 'touchstart', {}, true);
+
+    ReactTestUtils.Simulate.focus(_surface0);
+    ReactTestUtils.Simulate.click(_surface0);
+    expect(_selection.isIndexSelected(0)).toEqual(true);
+    expect(_componentElement.getAttribute('data-selection-is-modal')).toEqual('true');
   });
 });
 

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -577,12 +577,17 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, {}> {
     const isAlreadySingleSelected = selection.getSelectedCount() === 1 && selection.isIndexSelected(index);
 
     if (!isAlreadySingleSelected) {
+      const isModal = selection.isModal && selection.isModal();
       selection.setChangeEvents(false);
       selection.setAllSelected(false);
       selection.setIndexSelected(index, true, true);
-      if (this.props.enterModalOnTouch && this._isTouch && selection.setModal) {
-        selection.setModal(true);
-        this._setIsTouch(false);
+      if (isModal || (this.props.enterModalOnTouch && this._isTouch)) {
+        if (selection.setModal) {
+          selection.setModal(true);
+        }
+        if (this._isTouch) {
+          this._setIsTouch(false);
+        }
       }
       selection.setChangeEvents(true);
     }

--- a/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/selection/SelectionZone.tsx
@@ -7,7 +7,8 @@ import {
   getParent,
   getDocument,
   getWindow,
-  isElementTabbable
+  isElementTabbable,
+  css
 } from '../../Utilities';
 import { ISelection, SelectionMode, IObjectWithKey } from './interfaces';
 
@@ -136,6 +137,7 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, ISelection
 
     const { selection } = this.props;
 
+    // Reflect the initial modal state of selection into the state.
     const isModal = selection.isModal && selection.isModal();
 
     this.state = {
@@ -152,13 +154,18 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, ISelection
     this._events.on(document.body, 'touchstart', this._onTouchStartCapture, true);
     this._events.on(document.body, 'touchend', this._onTouchStartCapture, true);
 
+    // Subscribe to the selection to keep modal state updated.
     this._events.on(this.props.selection, 'change', this._onSelectionChange);
   }
 
   public render(): JSX.Element {
+    const { isModal } = this.state;
+
     return (
       <div
-        className="ms-SelectionZone"
+        className={css('ms-SelectionZone', {
+          'ms-SelectionZone--modal': !!isModal
+        })}
         ref={this._root}
         onKeyDown={this._onKeyDown}
         onMouseDown={this._onMouseDown}
@@ -169,7 +176,7 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, ISelection
         onContextMenu={this._onContextMenu}
         onMouseDownCapture={this._onMouseDownCapture}
         onFocusCapture={this._onFocus}
-        data-selection-is-modal={this.state.isModal ? true : undefined}
+        data-selection-is-modal={isModal ? true : undefined}
       >
         {this.props.children}
       </div>
@@ -180,6 +187,7 @@ export class SelectionZone extends BaseComponent<ISelectionZoneProps, ISelection
     const { selection } = this.props;
 
     if (selection !== previousProps.selection) {
+      // Whenever selection changes, update the subscripton to keep modal state updated.
       this._events.off(previousProps.selection);
       this._events.on(selection, 'change', this._onSelectionChange);
     }


### PR DESCRIPTION
Fixed an issue where modal selection state would get cleared when navigating selected items using the arrow keys. Since `_clearAndSelectIndex` invokes `setAllSelected(false)` and that clears modal state internally, the `SelectionZone` needs to restore `isModal` once it is done modifying selection.
This is already done elsewhere in `SelectionZone` but this pathway was missed.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11332)