### PR TITLE
Explicit checks for RTL based on theme context.

### DIFF
--- a/change/@uifabric-utilities-2019-12-12-12-10-04-rtl-update.json
+++ b/change/@uifabric-utilities-2019-12-12-12-10-04-rtl-update.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "getRTL uses RTL flag on theme if present.",
+  "packageName": "@uifabric/utilities",
+  "email": "jdh@microsoft.com",
+  "commit": "3bfff30ef0a5a091100d67ab970e470cb3e696fb",
+  "date": "2019-12-12T20:10:04.735Z"
+}

--- a/change/office-ui-fabric-react-2019-12-11-13-32-59-focuszone-readonly-inputs.json
+++ b/change/office-ui-fabric-react-2019-12-11-13-32-59-focuszone-readonly-inputs.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "FocusZone: Escape readOnly input on arrow clicks",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "7bcce389cacf0686f679ec630ce3d0712f0bc05b",
+  "date": "2019-12-11T21:32:59.251Z"
+}

--- a/change/office-ui-fabric-react-2019-12-11-14-34-16-nav-null-title.json
+++ b/change/office-ui-fabric-react-2019-12-11-14-34-16-nav-null-title.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Nav: Allow falsy values of title to be passed into items",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "a4845e8b662cbaedbef12a80169e05a349d3ede2",
+  "date": "2019-12-11T22:34:16.848Z"
+}

--- a/change/office-ui-fabric-react-2019-12-12-09-06-23-panel-lightdismiss-fix.json
+++ b/change/office-ui-fabric-react-2019-12-12-09-06-23-panel-lightdismiss-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Panel: onLightDismissClick now properly prevents light dismiss",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "b291e1361a914558025560c9193296202cd95d1d",
+  "date": "2019-12-12T17:06:23.328Z"
+}

--- a/change/office-ui-fabric-react-2019-12-12-12-10-04-rtl-update.json
+++ b/change/office-ui-fabric-react-2019-12-12-12-10-04-rtl-update.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "getRTL uses RTL flag on theme if present.",
+  "packageName": "office-ui-fabric-react",
+  "email": "jdh@microsoft.com",
+  "commit": "3bfff30ef0a5a091100d67ab970e470cb3e696fb",
+  "date": "2019-12-12T20:09:57.969Z"
+}

--- a/packages/office-ui-fabric-react/.vscode/settings.json
+++ b/packages/office-ui-fabric-react/.vscode/settings.json
@@ -38,5 +38,6 @@
   // Defines space handling after opening and before closing JSX expression braces. Requires TypeScript >= 2.0.6.
   "typescript.format.insertSpaceAfterOpeningAndBeforeClosingJsxExpressionBraces": true,
   "editor.formatOnSave": true,
-  "typescript.tsdk": "../../node_modules/typescript/lib"
+  "typescript.tsdk": "../../node_modules/typescript/lib",
+  "jest.pathToJest": "./../../node_modules/.bin/jest"
 }

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/Breadcrumb.base.tsx
@@ -139,7 +139,11 @@ export class BreadcrumbBase extends React.Component<IBreadcrumbProps, any> {
       <li className={this._classNames.listItem} key={item.key || String(index)}>
         {onRenderItem(item, this._onRenderItem)}
         {(index !== lastItemIndex || (hasOverflowItems && index === overflowIndex! - 1)) && (
-          <DividerType className={this._classNames.chevron} iconName={getRTL() ? 'ChevronLeft' : 'ChevronRight'} item={item} />
+          <DividerType
+            className={this._classNames.chevron}
+            iconName={getRTL(this.props.theme) ? 'ChevronLeft' : 'ChevronRight'}
+            item={item}
+          />
         )}
       </li>
     ));
@@ -167,7 +171,7 @@ export class BreadcrumbBase extends React.Component<IBreadcrumbProps, any> {
           {overflowIndex !== lastItemIndex + 1 && (
             <DividerType
               className={this._classNames.chevron}
-              iconName={getRTL() ? 'ChevronLeft' : 'ChevronRight'}
+              iconName={getRTL(this.props.theme) ? 'ChevronLeft' : 'ChevronRight'}
               item={renderedOverflowItems[renderedOverflowItems.length - 1]}
             />
           )}

--- a/packages/office-ui-fabric-react/src/components/Check/Check.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Check/Check.styles.ts
@@ -14,7 +14,7 @@ export const getStyles = (props: ICheckStyleProps): ICheckStyles => {
   const { height = props.checkBoxHeight || '18px', checked, className, theme } = props;
 
   const { palette, semanticColors, fonts } = theme;
-  const isRTL = getRTL();
+  const isRTL = getRTL(theme);
 
   const classNames = getGlobalClassNames(CheckGlobalClassNames, theme);
 

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.base.tsx
@@ -523,14 +523,14 @@ export class CoachmarkBase extends BaseComponent<ICoachmarkProps, ICoachmarkStat
         }
 
         if (this._beakDirection === RectangleEdge.left) {
-          if (getRTL()) {
+          if (getRTL(this.props.theme)) {
             beakRight = distanceAdjustment;
           } else {
             beakLeft = distanceAdjustment;
           }
           transformOriginX = 'left';
         } else {
-          if (getRTL()) {
+          if (getRTL(this.props.theme)) {
             beakLeft = distanceAdjustment;
           } else {
             beakRight = distanceAdjustment;

--- a/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Coachmark/Coachmark.styles.ts
@@ -167,7 +167,7 @@ export function getStyles(props: ICoachmarkStyleProps): ICoachmarkStyles {
         position: 'absolute',
         top: '50%',
         left: '50%',
-        transform: getRTL() ? 'translate(50%, -50%)' : 'translate(-50%, -50%)',
+        transform: getRTL(theme) ? 'translate(50%, -50%)' : 'translate(-50%, -50%)',
         width: '0px',
         height: '0px',
         borderRadius: '225px',

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -851,7 +851,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
    * Checks if the submenu should be closed
    */
   private _shouldCloseSubMenu = (ev: React.KeyboardEvent<HTMLElement>): boolean => {
-    const submenuCloseKey = getRTL() ? KeyCodes.right : KeyCodes.left;
+    const submenuCloseKey = getRTL(this.props.theme) ? KeyCodes.right : KeyCodes.left;
 
     if (ev.which !== submenuCloseKey || !this.props.isSubMenu) {
       return false;
@@ -1079,7 +1079,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
   };
 
   private _onItemKeyDown = (item: any, ev: React.KeyboardEvent<HTMLElement>): void => {
-    const openKey = getRTL() ? KeyCodes.left : KeyCodes.right;
+    const openKey = getRTL(this.props.theme) ? KeyCodes.left : KeyCodes.right;
 
     if (
       !item.disabled &&
@@ -1131,7 +1131,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
         id: this.state.subMenuId,
         shouldFocusOnMount: true,
         shouldFocusOnContainer: this.state.expandedByMouseClick,
-        directionalHint: getRTL() ? DirectionalHint.leftTopEdge : DirectionalHint.rightTopEdge,
+        directionalHint: getRTL(this.props.theme) ? DirectionalHint.leftTopEdge : DirectionalHint.rightTopEdge,
         className: this.props.className,
         gapSpace: 0,
         isBeakVisible: false

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.base.tsx
@@ -45,9 +45,9 @@ const renderSecondaryText = ({ item, classNames }: IContextualMenuItemProps) => 
   return null;
 };
 
-const renderSubMenuIcon = ({ item, classNames }: IContextualMenuItemProps) => {
+const renderSubMenuIcon = ({ item, classNames, theme }: IContextualMenuItemProps) => {
   if (hasSubmenu(item)) {
-    return <Icon iconName={getRTL() ? 'ChevronLeft' : 'ChevronRight'} {...item.submenuIconProps} className={classNames.subMenuIcon} />;
+    return <Icon iconName={getRTL(theme) ? 'ChevronLeft' : 'ChevronRight'} {...item.submenuIconProps} className={classNames.subMenuIcon} />;
   }
   return null;
 };

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -175,7 +175,7 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
     const classNames = this._classNames;
     const IconComponent = useFastIcons ? FontIcon : Icon;
 
-    const isRTL = getRTL();
+    const isRTL = getRTL(theme);
     return (
       <FocusZone
         role="row"
@@ -464,6 +464,7 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
    * Based on the given cursor position, finds the nearest drop hint and updates the state to make it visible
    */
   private _computeDropHintToBeShown = (clientX: number): void => {
+    const isRtl = getRTL(this.props.theme);
     if (this._rootElement) {
       const clientRect = this._rootElement.getBoundingClientRect();
       const headerOriginX = clientRect.left;
@@ -472,6 +473,7 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
       if (this._isValidCurrentDropHintIndex()) {
         if (
           _liesBetween(
+            isRtl,
             eventXRelativePosition,
             this._dropHintDetails[currentDropHintIndex!].startX,
             this._dropHintDetails[currentDropHintIndex!].endX
@@ -489,14 +491,15 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
       const currentIndex: number = frozenColumnCountFromStart;
       const lastValidColumn = columns.length - frozenColumnCountFromEnd;
       let indexToUpdate = -1;
-      if (_isBefore(eventXRelativePosition, this._dropHintDetails[currentIndex].endX)) {
+      if (_isBefore(isRtl, eventXRelativePosition, this._dropHintDetails[currentIndex].endX)) {
         indexToUpdate = currentIndex;
-      } else if (_isAfter(eventXRelativePosition, this._dropHintDetails[lastValidColumn].startX)) {
+      } else if (_isAfter(isRtl, eventXRelativePosition, this._dropHintDetails[lastValidColumn].startX)) {
         indexToUpdate = lastValidColumn;
       } else if (this._isValidCurrentDropHintIndex()) {
         if (
           this._dropHintDetails[currentDropHintIndex! + 1] &&
           _liesBetween(
+            isRtl,
             eventXRelativePosition,
             this._dropHintDetails[currentDropHintIndex! + 1].startX,
             this._dropHintDetails[currentDropHintIndex! + 1].endX
@@ -506,6 +509,7 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
         } else if (
           this._dropHintDetails[currentDropHintIndex! - 1] &&
           _liesBetween(
+            isRtl,
             eventXRelativePosition,
             this._dropHintDetails[currentDropHintIndex! - 1].startX,
             this._dropHintDetails[currentDropHintIndex! - 1].endX
@@ -519,12 +523,14 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
         let endIndex = lastValidColumn;
         while (startIndex < endIndex) {
           const middleIndex = Math.ceil((endIndex + startIndex!) / 2);
-          if (_liesBetween(eventXRelativePosition, this._dropHintDetails[middleIndex].startX, this._dropHintDetails[middleIndex].endX)) {
+          if (
+            _liesBetween(isRtl, eventXRelativePosition, this._dropHintDetails[middleIndex].startX, this._dropHintDetails[middleIndex].endX)
+          ) {
             indexToUpdate = middleIndex;
             break;
-          } else if (_isBefore(eventXRelativePosition, this._dropHintDetails[middleIndex].originX)) {
+          } else if (_isBefore(isRtl, eventXRelativePosition, this._dropHintDetails[middleIndex].originX)) {
             endIndex = middleIndex;
-          } else if (_isAfter(eventXRelativePosition, this._dropHintDetails[middleIndex].originX)) {
+          } else if (_isAfter(isRtl, eventXRelativePosition, this._dropHintDetails[middleIndex].originX)) {
             startIndex = middleIndex;
           }
         }
@@ -715,9 +721,9 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
         ev.preventDefault();
         ev.stopPropagation();
       } else if (ev.which === KeyCodes.left) {
-        increment = getRTL() ? 1 : -1;
+        increment = getRTL(this.props.theme) ? 1 : -1;
       } else if (ev.which === KeyCodes.right) {
-        increment = getRTL() ? -1 : 1;
+        increment = getRTL(this.props.theme) ? -1 : 1;
       }
 
       if (increment) {
@@ -772,7 +778,7 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
     if (onColumnResized) {
       let movement = ev.clientX - columnResizeDetails!.originX!;
 
-      if (getRTL()) {
+      if (getRTL(this.props.theme)) {
         movement = -movement;
       }
 
@@ -838,14 +844,14 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
   };
 }
 
-function _liesBetween(target: number, left: number, right: number): boolean {
-  return getRTL() ? target <= left && target >= right : target >= left && target <= right;
+function _liesBetween(rtl: boolean, target: number, left: number, right: number): boolean {
+  return rtl ? target <= left && target >= right : target >= left && target <= right;
 }
-function _isBefore(a: number, b: number): boolean {
-  return getRTL() ? a >= b : a <= b;
+function _isBefore(rtl: boolean, a: number, b: number): boolean {
+  return rtl ? a >= b : a <= b;
 }
-function _isAfter(a: number, b: number): boolean {
-  return getRTL() ? a <= b : a >= b;
+function _isAfter(rtl: boolean, a: number, b: number): boolean {
+  return rtl ? a <= b : a >= b;
 }
 
 function _stopPropagation(ev: React.MouseEvent<HTMLElement>): void {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -270,7 +270,7 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
       shouldForceUpdates = true;
     }
 
-    if (isAllGroupsCollapsed === undefined && (newProps.groupProps && newProps.groupProps.isAllGroupsCollapsed !== undefined)) {
+    if (isAllGroupsCollapsed === undefined && newProps.groupProps && newProps.groupProps.isAllGroupsCollapsed !== undefined) {
       this.setState({
         isCollapsed: newProps.groupProps.isAllGroupsCollapsed,
         isSomeGroupExpanded: !newProps.groupProps.isAllGroupsCollapsed
@@ -468,7 +468,7 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
               componentRef={this._focusZone}
               className={classNames.focusZone}
               direction={FocusZoneDirection.vertical}
-              isInnerZoneKeystroke={isRightArrow}
+              isInnerZoneKeystroke={this.isRightArrow}
               onActiveElementChanged={this._onActiveRowChanged}
               onBlur={this._onBlur}
             >
@@ -1082,6 +1082,10 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
       onRenderHeader
     };
   }
+
+  private isRightArrow = (event: React.KeyboardEvent<HTMLElement>) => {
+    return event.which === getRTLSafeKeyCode(KeyCodes.right, this.props.theme);
+  };
 }
 
 export function buildColumns(
@@ -1122,10 +1126,6 @@ export function buildColumns(
   }
 
   return columns;
-}
-
-function isRightArrow(event: React.KeyboardEvent<HTMLElement>): boolean {
-  return event.which === getRTLSafeKeyCode(KeyCodes.right);
 }
 
 function getPaddedWidth(column: IColumn, isFirst: boolean, props: IDetailsListProps): number {

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
@@ -1624,6 +1624,63 @@ describe('FocusZone', () => {
     expect(lastFocusedElement).toBe(buttonB);
   });
 
+  it('Focus is not affected by readOnly inputs with values', () => {
+    const isInnerZoneKeystroke = (e: React.KeyboardEvent<HTMLElement>): boolean => e.which === KeyCodes.enter;
+
+    const component = ReactTestUtils.renderIntoDocument(
+      <div {...{ onFocusCapture: _onFocus }}>
+        <FocusZone isInnerZoneKeystroke={isInnerZoneKeystroke}>
+          <input className="a" />
+          <input readOnly defaultValue="foo" className="b" />
+          <input className="c" />
+        </FocusZone>
+      </div>
+    );
+
+    const focusZone = ReactDOM.findDOMNode((component as unknown) as React.ReactInstance)!.firstChild as Element;
+
+    const inputA = focusZone.querySelector('.a') as HTMLElement;
+    const inputB = focusZone.querySelector('.b') as HTMLElement;
+    const inputC = focusZone.querySelector('.c') as HTMLElement;
+
+    setupElement(inputA, {
+      clientRect: {
+        top: 0,
+        bottom: 20,
+        left: 0,
+        right: 20
+      }
+    });
+
+    setupElement(inputB, {
+      clientRect: {
+        top: 0,
+        bottom: 20,
+        left: 20,
+        right: 40
+      }
+    });
+
+    setupElement(inputC, {
+      clientRect: {
+        top: 0,
+        bottom: 20,
+        left: 40,
+        right: 60
+      }
+    });
+
+    ReactTestUtils.Simulate.focus(inputB);
+    // Pressing right should go to c.
+    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    expect(lastFocusedElement).toBe(inputC);
+
+    ReactTestUtils.Simulate.focus(inputB);
+    // Pressing left from b should go back to a
+    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    expect(lastFocusedElement).toBe(inputA);
+  });
+
   it('removes tab-index of previous element when another one is selected (mouse & keyboard)', () => {
     let focusZone: FocusZone | null = null;
     let buttonA: HTMLButtonElement | null = null;

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -1036,18 +1036,19 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
       const selectionEnd = element.selectionEnd;
       const isRangeSelected = selectionStart !== selectionEnd;
       const inputValue = element.value;
+      const isReadonly = element.readOnly;
 
       // We shouldn't lose focus in the following cases:
       // 1. There is range selected.
-      // 2. When selection start is larger than 0 and it is backward.
-      // 3. when selection start is not the end of length and it is forward.
+      // 2. When selection start is larger than 0 and it is backward and not readOnly.
+      // 3. when selection start is not the end of length, it is forward and not readOnly.
       // 4. We press any of the arrow keys when our handleTabKey isn't none or undefined (only losing focus if we hit tab)
       // and if shouldInputLoseFocusOnArrowKey is defined, if scenario prefers to not loose the focus which is determined by calling the
       // callback shouldInputLoseFocusOnArrowKey
       if (
         isRangeSelected ||
-        (selectionStart! > 0 && !isForward) ||
-        (selectionStart !== inputValue.length && isForward) ||
+        (selectionStart! > 0 && !isForward && !isReadonly) ||
+        (selectionStart !== inputValue.length && isForward && !isReadonly) ||
         (!!this.props.handleTabKey && !(this.props.shouldInputLoseFocusOnArrowKey && this.props.shouldInputLoseFocusOnArrowKey(element)))
       ) {
         return false;

--- a/packages/office-ui-fabric-react/src/components/FocusZone/examples/FocusZone.List.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/examples/FocusZone.List.Example.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { KeyCodes, createArray, getRTLSafeKeyCode } from 'office-ui-fabric-react/lib/Utilities';
 import { useConst } from '@uifabric/react-hooks';
-import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { TextField } from 'office-ui-fabric-react';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import { FocusZone, FocusZoneDirection } from 'office-ui-fabric-react/lib/FocusZone';
 import { DetailsRow, IColumn, Selection, SelectionMode } from 'office-ui-fabric-react/lib/DetailsList';
@@ -9,7 +9,7 @@ import { DetailsRow, IColumn, Selection, SelectionMode } from 'office-ui-fabric-
 const ITEMS = createArray(10, index => ({
   key: index.toString(),
   name: 'Item-' + index,
-  url: 'http://placehold.it/100x' + (200 + index!)
+  url: 'http://placehold.it/100x' + (100 + index!)
 }));
 
 const COLUMNS: IColumn[] = [
@@ -22,16 +22,23 @@ const COLUMNS: IColumn[] = [
   {
     key: 'link',
     name: 'Link',
-    fieldName: 'url',
+    fieldName: '',
     minWidth: 100,
     onRender: item => <Link href={item.url}>{item.url}</Link>
   },
   {
-    key: 'defaultButton',
+    key: 'textfield',
     name: 'Link',
-    fieldName: 'url',
-    minWidth: 100,
-    onRender: item => <DefaultButton>{item.url}</DefaultButton>
+    fieldName: '',
+    minWidth: 130,
+    onRender: item => <TextField readOnly defaultValue={'ReadOnly ' + item.name} />
+  },
+  {
+    key: 'textfield2',
+    name: 'Link2',
+    fieldName: '',
+    minWidth: 130,
+    onRender: item => <TextField defaultValue={item.name} />
   }
 ];
 

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
@@ -72,7 +72,7 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
     const isSelectionCheckVisible = canSelectGroup && (isCollapsedGroupSelectVisible || !(group && group.isCollapsed));
     const currentlySelected = isSelected || selected;
 
-    const isRTL = getRTL();
+    const isRTL = getRTL(theme);
 
     this._classNames = getClassNames(styles, {
       theme: theme!,

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
@@ -109,7 +109,7 @@ export class MarqueeSelectionBase extends BaseComponent<IMarqueeSelectionProps, 
       const targetRect = targetElement.getBoundingClientRect();
 
       // Check vertical scroll
-      if (getRTL()) {
+      if (getRTL(this.props.theme)) {
         if (ev.clientX < targetRect.left + targetScrollbarWidth) {
           return true;
         }

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -111,7 +111,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
         href={link.url || (link.forceAnchor ? '#' : undefined)}
         iconProps={link.iconProps || { iconName: link.icon }}
         onClick={link.onClick ? this._onNavButtonLinkClicked.bind(this, link) : this._onNavAnchorLinkClicked.bind(this, link)}
-        title={link.title || link.name}
+        title={link.title !== undefined ? link.title : link.name}
         target={link.target}
         rel={rel}
         disabled={link.disabled}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -142,7 +142,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
     } = this.props;
     const { isFooterSticky, visibility, id } = this.state;
     const isLeft = type === PanelType.smallFixedNear || type === PanelType.customNear ? true : false;
-    const isRTL = getRTL();
+    const isRTL = getRTL(theme);
     const isOnRightSide = isRTL ? isLeft : !isLeft;
     const headerTextId = headerText && id + '-headerText';
     const customWidthStyles = type === PanelType.custom || type === PanelType.customNear ? { width: customWidth } : {};

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -371,7 +371,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
 
   private _dismissOnOuterClick(ev: any): void {
     const panel = this._panel.current;
-    if (this.isActive && panel) {
+    if (this.isActive && panel && !ev.defaultPrevented()) {
       if (!elementContains(panel, ev.target)) {
         if (this.props.onOuterClick) {
           this.props.onOuterClick();

--- a/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.LightDismissCustom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.LightDismissCustom.Example.tsx
@@ -21,7 +21,10 @@ export const PanelLightDismissCustomExample: React.FunctionComponent = () => {
   const openPanel = useConstCallback(() => setIsPanelOpen(true));
   const dismissPanel = useConstCallback(() => setIsPanelOpen(false));
   const showDialog = useConstCallback(() => setIsDialogVisible(true));
-  const hideDialog = useConstCallback(() => setIsDialogVisible(false));
+  const hideDialog = useConstCallback(ev => {
+    ev.preventDefault();
+    setIsDialogVisible(false);
+  });
   const hideDialogAndPanel = useConstCallback(() => {
     setIsPanelOpen(false);
     setIsDialogVisible(false);

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
@@ -179,7 +179,7 @@ export class PersonaCoinBase extends BaseComponent<IPersonaCoinProps, IPersonaSt
       return <Icon iconName="Help" />;
     }
 
-    const isRTL = getRTL();
+    const isRTL = getRTL(this.props.theme);
 
     imageInitials = imageInitials || getInitials(this._getText(), isRTL, allowPhoneInitials);
 

--- a/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ProgressIndicator/ProgressIndicator.styles.ts
@@ -29,7 +29,7 @@ const IndeterminateProgressRTL = keyframes({
 });
 
 export const getStyles = (props: IProgressIndicatorStyleProps): IProgressIndicatorStyles => {
-  const isRTL = getRTL();
+  const isRTL = getRTL(props.theme);
   const { className, indeterminate, theme, barHeight = 2 } = props;
 
   const { palette, semanticColors, fonts } = theme;

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -394,7 +394,7 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
   private _getStickyContainerStyle = (height: number, isTop: boolean): React.CSSProperties => {
     return {
       height: height,
-      ...(getRTL()
+      ...(getRTL(this.props.theme)
         ? {
             right: '0',
             left: `${this.state.scrollbarWidth || this._getScrollbarWidth() || 0}px`

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
@@ -170,7 +170,7 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
             color: inputIconAltHovered
           },
           '.ms-Button': {
-            borderRadius: getRTL() ? '1px 0 0 1px' : '0 1px 1px 0'
+            borderRadius: getRTL(theme) ? '1px 0 0 1px' : '0 1px 1px 0'
           },
           '.ms-Button-icon': {
             color: inputIconAlt

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.styles.ts
@@ -35,7 +35,7 @@ export function getStyles(props: IShimmerStyleProps): IShimmerStyles {
   const { semanticColors } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
 
-  const isRTL = getRTL();
+  const isRTL = getRTL(theme);
 
   return {
     root: [

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
@@ -179,7 +179,7 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
   };
 
   private _getStyleUsingOffsetPercent(vertical: boolean | undefined, thumbOffsetPercent: number): any {
-    const direction: string = vertical ? 'bottom' : getRTL() ? 'right' : 'left';
+    const direction: string = vertical ? 'bottom' : getRTL(this.props.theme) ? 'right' : 'left';
     return {
       [direction]: thumbOffsetPercent + '%'
     };
@@ -211,7 +211,7 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
 
     if (!this.props.vertical) {
       const left: number | undefined = this._getPosition(event, this.props.vertical);
-      distance = getRTL() ? sliderPositionRect.right - left! : left! - sliderPositionRect.left;
+      distance = getRTL(this.props.theme) ? sliderPositionRect.right - left! : left! - sliderPositionRect.left;
       currentSteps = distance / stepLength;
     } else {
       const bottom: number | undefined = this._getPosition(event, this.props.vertical);
@@ -304,7 +304,7 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
     let diff: number | undefined = 0;
 
     switch (event.which) {
-      case getRTLSafeKeyCode(KeyCodes.left):
+      case getRTLSafeKeyCode(KeyCodes.left, this.props.theme):
       case KeyCodes.down:
         diff = -(step as number);
 
@@ -312,7 +312,7 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
         this._setOnKeyDownTimer(event);
 
         break;
-      case getRTLSafeKeyCode(KeyCodes.right):
+      case getRTLSafeKeyCode(KeyCodes.right, this.props.theme):
       case KeyCodes.up:
         diff = step;
 

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.styles.ts
@@ -179,7 +179,7 @@ export const getStyles = (props: ISliderStyleProps): ISliderStyles => {
           }
         : {
             top: -6,
-            transform: getRTL() ? 'translateX(50%)' : 'translateX(-50%)'
+            transform: getRTL(theme) ? 'translateX(50%)' : 'translateX(-50%)'
           },
       showTransitions && {
         transition: `left ${AnimationVariables.durationValue3} ${AnimationVariables.easeFunction1}`
@@ -293,7 +293,7 @@ export const getStyles = (props: ISliderStyleProps): ISliderStyles => {
         ? {
             width: '16px',
             height: '1px',
-            transform: getRTL() ? 'translateX(6px)' : 'translateX(-6px)'
+            transform: getRTL(theme) ? 'translateX(6px)' : 'translateX(-6px)'
           }
         : {
             width: '1px',

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
@@ -251,10 +251,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
-          href="http://placehold.it/100x200"
+          href="http://placehold.it/100x100"
           onClick={[Function]}
         >
-          http://placehold.it/100x200
+          http://placehold.it/100x100
         </a>
       </div>
       <div
@@ -302,7 +302,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-        data-automation-key="defaultButton"
+        data-automation-key="textfield"
         data-automationid="DetailsRowCell"
         role="gridcell"
         style={
@@ -311,123 +311,338 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           }
         }
       >
-        <button
+        <div
           className=
-              ms-Button
-              ms-Button--default
+              ms-TextField
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 2px;
-                border: 1px solid #8a8886;
+                box-shadow: none;
                 box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 32px;
-                min-width: 80px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 16px;
-                padding-right: 16px;
-                padding-top: 0;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
                 position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid transparent;
-                bottom: 2px;
-                content: "";
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: absolute;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
         >
-          <span
+          <div
             className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-            data-automationid="splitbuttonprimary"
+                ms-TextField-wrapper
+
           >
-            <span
+            <div
               className=
-                  ms-Button-textContainer
+                  ms-TextField-fieldGroup
                   {
-                    display: block;
-                    flex-grow: 1;
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
                   }
             >
-              <span
+              <input
+                aria-invalid={false}
                 className=
-                    ms-Button-label
+                    ms-TextField-field
                     {
-                      display: block;
-                      font-weight: 600;
-                      line-height: 100%;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
                     }
-                id="id__2"
-              >
-                http://placehold.it/100x200
-              </span>
-            </span>
-          </span>
-        </button>
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField2"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                readOnly={true}
+                type="text"
+                value="ReadOnly Item-0"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-colindex={4}
+        className=
+            ms-DetailsRow-cell
+            {
+              box-sizing: border-box;
+              display: inline-block;
+              min-height: 42px;
+              outline: transparent;
+              overflow: hidden;
+              padding-bottom: 11px;
+              padding-left: 12px;
+              padding-top: 11px;
+              position: relative;
+              text-overflow: ellipsis;
+              vertical-align: top;
+              white-space: nowrap;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #605e5c;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #ffffff;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            & > button {
+              max-width: 100%;
+            }
+            & [data-is-focusable='true'] {
+              outline: transparent;
+              position: relative;
+            }
+            & [data-is-focusable='true']::-moz-focus-inner {
+              border: 0;
+            }
+            {
+              padding-right: 8px;
+            }
+        data-automation-key="textfield2"
+        data-automationid="DetailsRowCell"
+        role="gridcell"
+        style={
+          Object {
+            "width": "auto",
+          }
+        }
+      >
+        <div
+          className=
+              ms-TextField
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+        >
+          <div
+            className=
+                ms-TextField-wrapper
+
+          >
+            <div
+              className=
+                  ms-TextField-fieldGroup
+                  {
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                  }
+            >
+              <input
+                aria-invalid={false}
+                className=
+                    ms-TextField-field
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
+                    }
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField5"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                type="text"
+                value="Item-0"
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <span
@@ -513,7 +728,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           opacity: 1;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone5"
+    data-focuszone-id="FocusZone8"
     data-is-focusable={true}
     data-item-index={1}
     data-selection-index={1}
@@ -684,10 +899,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
-          href="http://placehold.it/100x201"
+          href="http://placehold.it/100x101"
           onClick={[Function]}
         >
-          http://placehold.it/100x201
+          http://placehold.it/100x101
         </a>
       </div>
       <div
@@ -735,7 +950,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-        data-automation-key="defaultButton"
+        data-automation-key="textfield"
         data-automationid="DetailsRowCell"
         role="gridcell"
         style={
@@ -744,123 +959,338 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           }
         }
       >
-        <button
+        <div
           className=
-              ms-Button
-              ms-Button--default
+              ms-TextField
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 2px;
-                border: 1px solid #8a8886;
+                box-shadow: none;
                 box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 32px;
-                min-width: 80px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 16px;
-                padding-right: 16px;
-                padding-top: 0;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
                 position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid transparent;
-                bottom: 2px;
-                content: "";
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: absolute;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
         >
-          <span
+          <div
             className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-            data-automationid="splitbuttonprimary"
+                ms-TextField-wrapper
+
           >
-            <span
+            <div
               className=
-                  ms-Button-textContainer
+                  ms-TextField-fieldGroup
                   {
-                    display: block;
-                    flex-grow: 1;
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
                   }
             >
-              <span
+              <input
+                aria-invalid={false}
                 className=
-                    ms-Button-label
+                    ms-TextField-field
                     {
-                      display: block;
-                      font-weight: 600;
-                      line-height: 100%;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
                     }
-                id="id__6"
-              >
-                http://placehold.it/100x201
-              </span>
-            </span>
-          </span>
-        </button>
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField9"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                readOnly={true}
+                type="text"
+                value="ReadOnly Item-1"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-colindex={4}
+        className=
+            ms-DetailsRow-cell
+            {
+              box-sizing: border-box;
+              display: inline-block;
+              min-height: 42px;
+              outline: transparent;
+              overflow: hidden;
+              padding-bottom: 11px;
+              padding-left: 12px;
+              padding-top: 11px;
+              position: relative;
+              text-overflow: ellipsis;
+              vertical-align: top;
+              white-space: nowrap;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #605e5c;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #ffffff;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            & > button {
+              max-width: 100%;
+            }
+            & [data-is-focusable='true'] {
+              outline: transparent;
+              position: relative;
+            }
+            & [data-is-focusable='true']::-moz-focus-inner {
+              border: 0;
+            }
+            {
+              padding-right: 8px;
+            }
+        data-automation-key="textfield2"
+        data-automationid="DetailsRowCell"
+        role="gridcell"
+        style={
+          Object {
+            "width": "auto",
+          }
+        }
+      >
+        <div
+          className=
+              ms-TextField
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+        >
+          <div
+            className=
+                ms-TextField-wrapper
+
+          >
+            <div
+              className=
+                  ms-TextField-fieldGroup
+                  {
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                  }
+            >
+              <input
+                aria-invalid={false}
+                className=
+                    ms-TextField-field
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
+                    }
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField12"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                type="text"
+                value="Item-1"
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <span
@@ -946,7 +1376,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           opacity: 1;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone9"
+    data-focuszone-id="FocusZone15"
     data-is-focusable={true}
     data-item-index={2}
     data-selection-index={2}
@@ -1117,10 +1547,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
-          href="http://placehold.it/100x202"
+          href="http://placehold.it/100x102"
           onClick={[Function]}
         >
-          http://placehold.it/100x202
+          http://placehold.it/100x102
         </a>
       </div>
       <div
@@ -1168,7 +1598,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-        data-automation-key="defaultButton"
+        data-automation-key="textfield"
         data-automationid="DetailsRowCell"
         role="gridcell"
         style={
@@ -1177,123 +1607,338 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           }
         }
       >
-        <button
+        <div
           className=
-              ms-Button
-              ms-Button--default
+              ms-TextField
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 2px;
-                border: 1px solid #8a8886;
+                box-shadow: none;
                 box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 32px;
-                min-width: 80px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 16px;
-                padding-right: 16px;
-                padding-top: 0;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
                 position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid transparent;
-                bottom: 2px;
-                content: "";
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: absolute;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
         >
-          <span
+          <div
             className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-            data-automationid="splitbuttonprimary"
+                ms-TextField-wrapper
+
           >
-            <span
+            <div
               className=
-                  ms-Button-textContainer
+                  ms-TextField-fieldGroup
                   {
-                    display: block;
-                    flex-grow: 1;
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
                   }
             >
-              <span
+              <input
+                aria-invalid={false}
                 className=
-                    ms-Button-label
+                    ms-TextField-field
                     {
-                      display: block;
-                      font-weight: 600;
-                      line-height: 100%;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
                     }
-                id="id__10"
-              >
-                http://placehold.it/100x202
-              </span>
-            </span>
-          </span>
-        </button>
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField16"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                readOnly={true}
+                type="text"
+                value="ReadOnly Item-2"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-colindex={4}
+        className=
+            ms-DetailsRow-cell
+            {
+              box-sizing: border-box;
+              display: inline-block;
+              min-height: 42px;
+              outline: transparent;
+              overflow: hidden;
+              padding-bottom: 11px;
+              padding-left: 12px;
+              padding-top: 11px;
+              position: relative;
+              text-overflow: ellipsis;
+              vertical-align: top;
+              white-space: nowrap;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #605e5c;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #ffffff;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            & > button {
+              max-width: 100%;
+            }
+            & [data-is-focusable='true'] {
+              outline: transparent;
+              position: relative;
+            }
+            & [data-is-focusable='true']::-moz-focus-inner {
+              border: 0;
+            }
+            {
+              padding-right: 8px;
+            }
+        data-automation-key="textfield2"
+        data-automationid="DetailsRowCell"
+        role="gridcell"
+        style={
+          Object {
+            "width": "auto",
+          }
+        }
+      >
+        <div
+          className=
+              ms-TextField
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+        >
+          <div
+            className=
+                ms-TextField-wrapper
+
+          >
+            <div
+              className=
+                  ms-TextField-fieldGroup
+                  {
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                  }
+            >
+              <input
+                aria-invalid={false}
+                className=
+                    ms-TextField-field
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
+                    }
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField19"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                type="text"
+                value="Item-2"
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <span
@@ -1379,7 +2024,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           opacity: 1;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone13"
+    data-focuszone-id="FocusZone22"
     data-is-focusable={true}
     data-item-index={3}
     data-selection-index={3}
@@ -1550,10 +2195,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
-          href="http://placehold.it/100x203"
+          href="http://placehold.it/100x103"
           onClick={[Function]}
         >
-          http://placehold.it/100x203
+          http://placehold.it/100x103
         </a>
       </div>
       <div
@@ -1601,7 +2246,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-        data-automation-key="defaultButton"
+        data-automation-key="textfield"
         data-automationid="DetailsRowCell"
         role="gridcell"
         style={
@@ -1610,123 +2255,338 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           }
         }
       >
-        <button
+        <div
           className=
-              ms-Button
-              ms-Button--default
+              ms-TextField
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 2px;
-                border: 1px solid #8a8886;
+                box-shadow: none;
                 box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 32px;
-                min-width: 80px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 16px;
-                padding-right: 16px;
-                padding-top: 0;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
                 position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid transparent;
-                bottom: 2px;
-                content: "";
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: absolute;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
         >
-          <span
+          <div
             className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-            data-automationid="splitbuttonprimary"
+                ms-TextField-wrapper
+
           >
-            <span
+            <div
               className=
-                  ms-Button-textContainer
+                  ms-TextField-fieldGroup
                   {
-                    display: block;
-                    flex-grow: 1;
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
                   }
             >
-              <span
+              <input
+                aria-invalid={false}
                 className=
-                    ms-Button-label
+                    ms-TextField-field
                     {
-                      display: block;
-                      font-weight: 600;
-                      line-height: 100%;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
                     }
-                id="id__14"
-              >
-                http://placehold.it/100x203
-              </span>
-            </span>
-          </span>
-        </button>
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField23"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                readOnly={true}
+                type="text"
+                value="ReadOnly Item-3"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-colindex={4}
+        className=
+            ms-DetailsRow-cell
+            {
+              box-sizing: border-box;
+              display: inline-block;
+              min-height: 42px;
+              outline: transparent;
+              overflow: hidden;
+              padding-bottom: 11px;
+              padding-left: 12px;
+              padding-top: 11px;
+              position: relative;
+              text-overflow: ellipsis;
+              vertical-align: top;
+              white-space: nowrap;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #605e5c;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #ffffff;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            & > button {
+              max-width: 100%;
+            }
+            & [data-is-focusable='true'] {
+              outline: transparent;
+              position: relative;
+            }
+            & [data-is-focusable='true']::-moz-focus-inner {
+              border: 0;
+            }
+            {
+              padding-right: 8px;
+            }
+        data-automation-key="textfield2"
+        data-automationid="DetailsRowCell"
+        role="gridcell"
+        style={
+          Object {
+            "width": "auto",
+          }
+        }
+      >
+        <div
+          className=
+              ms-TextField
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+        >
+          <div
+            className=
+                ms-TextField-wrapper
+
+          >
+            <div
+              className=
+                  ms-TextField-fieldGroup
+                  {
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                  }
+            >
+              <input
+                aria-invalid={false}
+                className=
+                    ms-TextField-field
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
+                    }
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField26"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                type="text"
+                value="Item-3"
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <span
@@ -1812,7 +2672,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           opacity: 1;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone17"
+    data-focuszone-id="FocusZone29"
     data-is-focusable={true}
     data-item-index={4}
     data-selection-index={4}
@@ -1983,10 +2843,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
-          href="http://placehold.it/100x204"
+          href="http://placehold.it/100x104"
           onClick={[Function]}
         >
-          http://placehold.it/100x204
+          http://placehold.it/100x104
         </a>
       </div>
       <div
@@ -2034,7 +2894,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-        data-automation-key="defaultButton"
+        data-automation-key="textfield"
         data-automationid="DetailsRowCell"
         role="gridcell"
         style={
@@ -2043,123 +2903,338 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           }
         }
       >
-        <button
+        <div
           className=
-              ms-Button
-              ms-Button--default
+              ms-TextField
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 2px;
-                border: 1px solid #8a8886;
+                box-shadow: none;
                 box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 32px;
-                min-width: 80px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 16px;
-                padding-right: 16px;
-                padding-top: 0;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
                 position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid transparent;
-                bottom: 2px;
-                content: "";
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: absolute;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
         >
-          <span
+          <div
             className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-            data-automationid="splitbuttonprimary"
+                ms-TextField-wrapper
+
           >
-            <span
+            <div
               className=
-                  ms-Button-textContainer
+                  ms-TextField-fieldGroup
                   {
-                    display: block;
-                    flex-grow: 1;
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
                   }
             >
-              <span
+              <input
+                aria-invalid={false}
                 className=
-                    ms-Button-label
+                    ms-TextField-field
                     {
-                      display: block;
-                      font-weight: 600;
-                      line-height: 100%;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
                     }
-                id="id__18"
-              >
-                http://placehold.it/100x204
-              </span>
-            </span>
-          </span>
-        </button>
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField30"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                readOnly={true}
+                type="text"
+                value="ReadOnly Item-4"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-colindex={4}
+        className=
+            ms-DetailsRow-cell
+            {
+              box-sizing: border-box;
+              display: inline-block;
+              min-height: 42px;
+              outline: transparent;
+              overflow: hidden;
+              padding-bottom: 11px;
+              padding-left: 12px;
+              padding-top: 11px;
+              position: relative;
+              text-overflow: ellipsis;
+              vertical-align: top;
+              white-space: nowrap;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #605e5c;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #ffffff;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            & > button {
+              max-width: 100%;
+            }
+            & [data-is-focusable='true'] {
+              outline: transparent;
+              position: relative;
+            }
+            & [data-is-focusable='true']::-moz-focus-inner {
+              border: 0;
+            }
+            {
+              padding-right: 8px;
+            }
+        data-automation-key="textfield2"
+        data-automationid="DetailsRowCell"
+        role="gridcell"
+        style={
+          Object {
+            "width": "auto",
+          }
+        }
+      >
+        <div
+          className=
+              ms-TextField
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+        >
+          <div
+            className=
+                ms-TextField-wrapper
+
+          >
+            <div
+              className=
+                  ms-TextField-fieldGroup
+                  {
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                  }
+            >
+              <input
+                aria-invalid={false}
+                className=
+                    ms-TextField-field
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
+                    }
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField33"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                type="text"
+                value="Item-4"
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <span
@@ -2245,7 +3320,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           opacity: 1;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone21"
+    data-focuszone-id="FocusZone36"
     data-is-focusable={true}
     data-item-index={5}
     data-selection-index={5}
@@ -2416,10 +3491,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
-          href="http://placehold.it/100x205"
+          href="http://placehold.it/100x105"
           onClick={[Function]}
         >
-          http://placehold.it/100x205
+          http://placehold.it/100x105
         </a>
       </div>
       <div
@@ -2467,7 +3542,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-        data-automation-key="defaultButton"
+        data-automation-key="textfield"
         data-automationid="DetailsRowCell"
         role="gridcell"
         style={
@@ -2476,123 +3551,338 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           }
         }
       >
-        <button
+        <div
           className=
-              ms-Button
-              ms-Button--default
+              ms-TextField
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 2px;
-                border: 1px solid #8a8886;
+                box-shadow: none;
                 box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 32px;
-                min-width: 80px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 16px;
-                padding-right: 16px;
-                padding-top: 0;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
                 position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid transparent;
-                bottom: 2px;
-                content: "";
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: absolute;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
         >
-          <span
+          <div
             className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-            data-automationid="splitbuttonprimary"
+                ms-TextField-wrapper
+
           >
-            <span
+            <div
               className=
-                  ms-Button-textContainer
+                  ms-TextField-fieldGroup
                   {
-                    display: block;
-                    flex-grow: 1;
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
                   }
             >
-              <span
+              <input
+                aria-invalid={false}
                 className=
-                    ms-Button-label
+                    ms-TextField-field
                     {
-                      display: block;
-                      font-weight: 600;
-                      line-height: 100%;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
                     }
-                id="id__22"
-              >
-                http://placehold.it/100x205
-              </span>
-            </span>
-          </span>
-        </button>
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField37"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                readOnly={true}
+                type="text"
+                value="ReadOnly Item-5"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-colindex={4}
+        className=
+            ms-DetailsRow-cell
+            {
+              box-sizing: border-box;
+              display: inline-block;
+              min-height: 42px;
+              outline: transparent;
+              overflow: hidden;
+              padding-bottom: 11px;
+              padding-left: 12px;
+              padding-top: 11px;
+              position: relative;
+              text-overflow: ellipsis;
+              vertical-align: top;
+              white-space: nowrap;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #605e5c;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #ffffff;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            & > button {
+              max-width: 100%;
+            }
+            & [data-is-focusable='true'] {
+              outline: transparent;
+              position: relative;
+            }
+            & [data-is-focusable='true']::-moz-focus-inner {
+              border: 0;
+            }
+            {
+              padding-right: 8px;
+            }
+        data-automation-key="textfield2"
+        data-automationid="DetailsRowCell"
+        role="gridcell"
+        style={
+          Object {
+            "width": "auto",
+          }
+        }
+      >
+        <div
+          className=
+              ms-TextField
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+        >
+          <div
+            className=
+                ms-TextField-wrapper
+
+          >
+            <div
+              className=
+                  ms-TextField-fieldGroup
+                  {
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                  }
+            >
+              <input
+                aria-invalid={false}
+                className=
+                    ms-TextField-field
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
+                    }
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField40"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                type="text"
+                value="Item-5"
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <span
@@ -2678,7 +3968,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           opacity: 1;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone25"
+    data-focuszone-id="FocusZone43"
     data-is-focusable={true}
     data-item-index={6}
     data-selection-index={6}
@@ -2849,10 +4139,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
-          href="http://placehold.it/100x206"
+          href="http://placehold.it/100x106"
           onClick={[Function]}
         >
-          http://placehold.it/100x206
+          http://placehold.it/100x106
         </a>
       </div>
       <div
@@ -2900,7 +4190,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-        data-automation-key="defaultButton"
+        data-automation-key="textfield"
         data-automationid="DetailsRowCell"
         role="gridcell"
         style={
@@ -2909,123 +4199,338 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           }
         }
       >
-        <button
+        <div
           className=
-              ms-Button
-              ms-Button--default
+              ms-TextField
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 2px;
-                border: 1px solid #8a8886;
+                box-shadow: none;
                 box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 32px;
-                min-width: 80px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 16px;
-                padding-right: 16px;
-                padding-top: 0;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
                 position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid transparent;
-                bottom: 2px;
-                content: "";
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: absolute;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
         >
-          <span
+          <div
             className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-            data-automationid="splitbuttonprimary"
+                ms-TextField-wrapper
+
           >
-            <span
+            <div
               className=
-                  ms-Button-textContainer
+                  ms-TextField-fieldGroup
                   {
-                    display: block;
-                    flex-grow: 1;
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
                   }
             >
-              <span
+              <input
+                aria-invalid={false}
                 className=
-                    ms-Button-label
+                    ms-TextField-field
                     {
-                      display: block;
-                      font-weight: 600;
-                      line-height: 100%;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
                     }
-                id="id__26"
-              >
-                http://placehold.it/100x206
-              </span>
-            </span>
-          </span>
-        </button>
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField44"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                readOnly={true}
+                type="text"
+                value="ReadOnly Item-6"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-colindex={4}
+        className=
+            ms-DetailsRow-cell
+            {
+              box-sizing: border-box;
+              display: inline-block;
+              min-height: 42px;
+              outline: transparent;
+              overflow: hidden;
+              padding-bottom: 11px;
+              padding-left: 12px;
+              padding-top: 11px;
+              position: relative;
+              text-overflow: ellipsis;
+              vertical-align: top;
+              white-space: nowrap;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #605e5c;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #ffffff;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            & > button {
+              max-width: 100%;
+            }
+            & [data-is-focusable='true'] {
+              outline: transparent;
+              position: relative;
+            }
+            & [data-is-focusable='true']::-moz-focus-inner {
+              border: 0;
+            }
+            {
+              padding-right: 8px;
+            }
+        data-automation-key="textfield2"
+        data-automationid="DetailsRowCell"
+        role="gridcell"
+        style={
+          Object {
+            "width": "auto",
+          }
+        }
+      >
+        <div
+          className=
+              ms-TextField
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+        >
+          <div
+            className=
+                ms-TextField-wrapper
+
+          >
+            <div
+              className=
+                  ms-TextField-fieldGroup
+                  {
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                  }
+            >
+              <input
+                aria-invalid={false}
+                className=
+                    ms-TextField-field
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
+                    }
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField47"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                type="text"
+                value="Item-6"
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <span
@@ -3111,7 +4616,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           opacity: 1;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone29"
+    data-focuszone-id="FocusZone50"
     data-is-focusable={true}
     data-item-index={7}
     data-selection-index={7}
@@ -3282,10 +4787,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
-          href="http://placehold.it/100x207"
+          href="http://placehold.it/100x107"
           onClick={[Function]}
         >
-          http://placehold.it/100x207
+          http://placehold.it/100x107
         </a>
       </div>
       <div
@@ -3333,7 +4838,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-        data-automation-key="defaultButton"
+        data-automation-key="textfield"
         data-automationid="DetailsRowCell"
         role="gridcell"
         style={
@@ -3342,123 +4847,338 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           }
         }
       >
-        <button
+        <div
           className=
-              ms-Button
-              ms-Button--default
+              ms-TextField
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 2px;
-                border: 1px solid #8a8886;
+                box-shadow: none;
                 box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 32px;
-                min-width: 80px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 16px;
-                padding-right: 16px;
-                padding-top: 0;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
                 position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid transparent;
-                bottom: 2px;
-                content: "";
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: absolute;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
         >
-          <span
+          <div
             className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-            data-automationid="splitbuttonprimary"
+                ms-TextField-wrapper
+
           >
-            <span
+            <div
               className=
-                  ms-Button-textContainer
+                  ms-TextField-fieldGroup
                   {
-                    display: block;
-                    flex-grow: 1;
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
                   }
             >
-              <span
+              <input
+                aria-invalid={false}
                 className=
-                    ms-Button-label
+                    ms-TextField-field
                     {
-                      display: block;
-                      font-weight: 600;
-                      line-height: 100%;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
                     }
-                id="id__30"
-              >
-                http://placehold.it/100x207
-              </span>
-            </span>
-          </span>
-        </button>
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField51"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                readOnly={true}
+                type="text"
+                value="ReadOnly Item-7"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-colindex={4}
+        className=
+            ms-DetailsRow-cell
+            {
+              box-sizing: border-box;
+              display: inline-block;
+              min-height: 42px;
+              outline: transparent;
+              overflow: hidden;
+              padding-bottom: 11px;
+              padding-left: 12px;
+              padding-top: 11px;
+              position: relative;
+              text-overflow: ellipsis;
+              vertical-align: top;
+              white-space: nowrap;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #605e5c;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #ffffff;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            & > button {
+              max-width: 100%;
+            }
+            & [data-is-focusable='true'] {
+              outline: transparent;
+              position: relative;
+            }
+            & [data-is-focusable='true']::-moz-focus-inner {
+              border: 0;
+            }
+            {
+              padding-right: 8px;
+            }
+        data-automation-key="textfield2"
+        data-automationid="DetailsRowCell"
+        role="gridcell"
+        style={
+          Object {
+            "width": "auto",
+          }
+        }
+      >
+        <div
+          className=
+              ms-TextField
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+        >
+          <div
+            className=
+                ms-TextField-wrapper
+
+          >
+            <div
+              className=
+                  ms-TextField-fieldGroup
+                  {
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                  }
+            >
+              <input
+                aria-invalid={false}
+                className=
+                    ms-TextField-field
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
+                    }
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField54"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                type="text"
+                value="Item-7"
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <span
@@ -3544,7 +5264,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           opacity: 1;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone33"
+    data-focuszone-id="FocusZone57"
     data-is-focusable={true}
     data-item-index={8}
     data-selection-index={8}
@@ -3715,10 +5435,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
-          href="http://placehold.it/100x208"
+          href="http://placehold.it/100x108"
           onClick={[Function]}
         >
-          http://placehold.it/100x208
+          http://placehold.it/100x108
         </a>
       </div>
       <div
@@ -3766,7 +5486,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-        data-automation-key="defaultButton"
+        data-automation-key="textfield"
         data-automationid="DetailsRowCell"
         role="gridcell"
         style={
@@ -3775,123 +5495,338 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           }
         }
       >
-        <button
+        <div
           className=
-              ms-Button
-              ms-Button--default
+              ms-TextField
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 2px;
-                border: 1px solid #8a8886;
+                box-shadow: none;
                 box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 32px;
-                min-width: 80px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 16px;
-                padding-right: 16px;
-                padding-top: 0;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
                 position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid transparent;
-                bottom: 2px;
-                content: "";
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: absolute;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
         >
-          <span
+          <div
             className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-            data-automationid="splitbuttonprimary"
+                ms-TextField-wrapper
+
           >
-            <span
+            <div
               className=
-                  ms-Button-textContainer
+                  ms-TextField-fieldGroup
                   {
-                    display: block;
-                    flex-grow: 1;
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
                   }
             >
-              <span
+              <input
+                aria-invalid={false}
                 className=
-                    ms-Button-label
+                    ms-TextField-field
                     {
-                      display: block;
-                      font-weight: 600;
-                      line-height: 100%;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
                     }
-                id="id__34"
-              >
-                http://placehold.it/100x208
-              </span>
-            </span>
-          </span>
-        </button>
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField58"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                readOnly={true}
+                type="text"
+                value="ReadOnly Item-8"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-colindex={4}
+        className=
+            ms-DetailsRow-cell
+            {
+              box-sizing: border-box;
+              display: inline-block;
+              min-height: 42px;
+              outline: transparent;
+              overflow: hidden;
+              padding-bottom: 11px;
+              padding-left: 12px;
+              padding-top: 11px;
+              position: relative;
+              text-overflow: ellipsis;
+              vertical-align: top;
+              white-space: nowrap;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #605e5c;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #ffffff;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            & > button {
+              max-width: 100%;
+            }
+            & [data-is-focusable='true'] {
+              outline: transparent;
+              position: relative;
+            }
+            & [data-is-focusable='true']::-moz-focus-inner {
+              border: 0;
+            }
+            {
+              padding-right: 8px;
+            }
+        data-automation-key="textfield2"
+        data-automationid="DetailsRowCell"
+        role="gridcell"
+        style={
+          Object {
+            "width": "auto",
+          }
+        }
+      >
+        <div
+          className=
+              ms-TextField
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+        >
+          <div
+            className=
+                ms-TextField-wrapper
+
+          >
+            <div
+              className=
+                  ms-TextField-fieldGroup
+                  {
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                  }
+            >
+              <input
+                aria-invalid={false}
+                className=
+                    ms-TextField-field
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
+                    }
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField61"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                type="text"
+                value="Item-8"
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <span
@@ -3977,7 +5912,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           opacity: 1;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone37"
+    data-focuszone-id="FocusZone64"
     data-is-focusable={true}
     data-item-index={9}
     data-selection-index={9}
@@ -4148,10 +6083,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
-          href="http://placehold.it/100x209"
+          href="http://placehold.it/100x109"
           onClick={[Function]}
         >
-          http://placehold.it/100x209
+          http://placehold.it/100x109
         </a>
       </div>
       <div
@@ -4199,7 +6134,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-        data-automation-key="defaultButton"
+        data-automation-key="textfield"
         data-automationid="DetailsRowCell"
         role="gridcell"
         style={
@@ -4208,123 +6143,338 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           }
         }
       >
-        <button
+        <div
           className=
-              ms-Button
-              ms-Button--default
+              ms-TextField
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 2px;
-                border: 1px solid #8a8886;
+                box-shadow: none;
                 box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 32px;
-                min-width: 80px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 16px;
-                padding-right: 16px;
-                padding-top: 0;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
                 position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid transparent;
-                bottom: 2px;
-                content: "";
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: absolute;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
         >
-          <span
+          <div
             className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-            data-automationid="splitbuttonprimary"
+                ms-TextField-wrapper
+
           >
-            <span
+            <div
               className=
-                  ms-Button-textContainer
+                  ms-TextField-fieldGroup
                   {
-                    display: block;
-                    flex-grow: 1;
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
                   }
             >
-              <span
+              <input
+                aria-invalid={false}
                 className=
-                    ms-Button-label
+                    ms-TextField-field
                     {
-                      display: block;
-                      font-weight: 600;
-                      line-height: 100%;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
                     }
-                id="id__38"
-              >
-                http://placehold.it/100x209
-              </span>
-            </span>
-          </span>
-        </button>
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField65"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                readOnly={true}
+                type="text"
+                value="ReadOnly Item-9"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-colindex={4}
+        className=
+            ms-DetailsRow-cell
+            {
+              box-sizing: border-box;
+              display: inline-block;
+              min-height: 42px;
+              outline: transparent;
+              overflow: hidden;
+              padding-bottom: 11px;
+              padding-left: 12px;
+              padding-top: 11px;
+              position: relative;
+              text-overflow: ellipsis;
+              vertical-align: top;
+              white-space: nowrap;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #605e5c;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #ffffff;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            & > button {
+              max-width: 100%;
+            }
+            & [data-is-focusable='true'] {
+              outline: transparent;
+              position: relative;
+            }
+            & [data-is-focusable='true']::-moz-focus-inner {
+              border: 0;
+            }
+            {
+              padding-right: 8px;
+            }
+        data-automation-key="textfield2"
+        data-automationid="DetailsRowCell"
+        role="gridcell"
+        style={
+          Object {
+            "width": "auto",
+          }
+        }
+      >
+        <div
+          className=
+              ms-TextField
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+        >
+          <div
+            className=
+                ms-TextField-wrapper
+
+          >
+            <div
+              className=
+                  ms-TextField-fieldGroup
+                  {
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                  }
+            >
+              <input
+                aria-invalid={false}
+                className=
+                    ms-TextField-field
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
+                    }
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField68"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                type="text"
+                value="Item-9"
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <span

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.styles.ts
@@ -99,7 +99,7 @@ export function getStyles(props: ITagItemStyleProps): ITagItemStyles {
         width: 30,
         height: '100%',
         flex: '0 0 auto',
-        borderRadius: getRTL()
+        borderRadius: getRTL(theme)
           ? `${effects.roundedCorner2} 0 0 ${effects.roundedCorner2}`
           : `0 ${effects.roundedCorner2} ${effects.roundedCorner2} 0`,
         selectors: {

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -331,10 +331,14 @@ export function getRect(element: HTMLElement | Window | null): IRectangle | unde
 export function getResourceUrl(url: string): string;
 
 // @public
-export function getRTL(): boolean;
+export function getRTL(theme?: {
+    rtl?: boolean;
+}): boolean;
 
 // @public
-export function getRTLSafeKeyCode(key: number): number;
+export function getRTLSafeKeyCode(key: number, theme?: {
+    rtl?: boolean;
+}): number;
 
 // @public
 export function getScrollbarWidth(): number;

--- a/packages/utilities/src/rtl.test.ts
+++ b/packages/utilities/src/rtl.test.ts
@@ -80,4 +80,25 @@ describe('getRTL', () => {
 
     jest.restoreAllMocks();
   });
+
+  describe('theme support', () => {
+    it('returns document default (ltr) when called with no theme', () => {
+      expect(RTL.getRTL()).toBeFalsy();
+    });
+
+    it('returns document default (ltr) when called theme not specifying direction', () => {
+      const theme = {};
+      expect(RTL.getRTL(theme)).toBeFalsy();
+    });
+
+    it('returns ltr when called theme specifying ltr', () => {
+      const theme = { rtl: false };
+      expect(RTL.getRTL(theme)).toBeFalsy();
+    });
+
+    it('returns rtl when called theme specifying rtl', () => {
+      const theme = { rtl: true };
+      expect(RTL.getRTL(theme)).toBeTruthy();
+    });
+  });
 });

--- a/packages/utilities/src/rtl.ts
+++ b/packages/utilities/src/rtl.ts
@@ -11,7 +11,10 @@ let _isRTL: boolean | undefined;
 /**
  * Gets the rtl state of the page (returns true if in rtl.)
  */
-export function getRTL(): boolean {
+export function getRTL(theme: { rtl?: boolean } = {}): boolean {
+  if (theme.rtl !== undefined) {
+    return theme.rtl;
+  }
   if (_isRTL === undefined) {
     // Fabric supports persisting the RTL setting between page refreshes via session storage
     let savedRTL = getItem(RTL_LOCAL_STORAGE_KEY);
@@ -50,8 +53,8 @@ export function setRTL(isRTL: boolean, persistSetting: boolean = false): void {
 /**
  * Returns the given key, but flips right/left arrows if necessary.
  */
-export function getRTLSafeKeyCode(key: number): number {
-  if (getRTL()) {
+export function getRTLSafeKeyCode(key: number, theme: { rtl?: boolean } = {}): number {
+  if (getRTL(theme)) {
     if (key === KeyCodes.left) {
       key = KeyCodes.right;
     } else if (key === KeyCodes.right) {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ yarn change`


#### Description of changes

Follow up to #11295 , adds an explicit reference to the theme context in several calls to `getRTL()`. There are still a few open work items to finish this, but this is a good checkpoint and releasable as-is.

For the components affected, they will now work when they are rendered in this style:

```tsx
<Fabric dir="rtl">
  <Slider {...} />
</Fabric>
```

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11349)