### PR TITLE
Date picker styles

### DIFF
--- a/change/@uifabric-date-time-2019-12-02-14-29-37-datePickerStyles.json
+++ b/change/@uifabric-date-time-2019-12-02-14-29-37-datePickerStyles.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "DatePicker: Making styles accept functions and objects and not only functions.",
+  "packageName": "@uifabric/date-time",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "70a9d673ea890e14275f57548e01b9c6d1e7c07e",
+  "date": "2019-12-02T22:29:34.305Z"
+}

--- a/change/office-ui-fabric-react-2019-12-02-14-29-37-datePickerStyles.json
+++ b/change/office-ui-fabric-react-2019-12-02-14-29-37-datePickerStyles.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "DatePicker: Making styles accept functions and objects and not only functions.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "70a9d673ea890e14275f57548e01b9c6d1e7c07e",
+  "date": "2019-12-02T22:29:37.460Z"
+}

--- a/packages/date-time/etc/date-time.api.md
+++ b/packages/date-time/etc/date-time.api.md
@@ -17,7 +17,6 @@ import { IProcessedStyleSet } from '@uifabric/styling';
 import { IRefObject } from '@uifabric/utilities';
 import { IRefObject as IRefObject_2 } from 'office-ui-fabric-react/lib/Utilities';
 import { IStyle } from '@uifabric/styling';
-import { IStyleFunction } from '@uifabric/utilities';
 import { IStyleFunctionOrObject } from '@uifabric/utilities';
 import { IStyleFunctionOrObject as IStyleFunctionOrObject_2 } from 'office-ui-fabric-react/lib/Utilities';
 import { ITextFieldProps } from 'office-ui-fabric-react/lib/TextField';
@@ -283,7 +282,7 @@ export interface IDatePickerProps extends IBaseProps<IDatePicker>, React.HTMLAtt
     showMonthPickerAsOverlay?: boolean;
     showWeekNumbers?: boolean;
     strings?: IDatePickerStrings;
-    styles?: IStyleFunction<IDatePickerStyleProps, IDatePickerStyles>;
+    styles?: IStyleFunctionOrObject<IDatePickerStyleProps, IDatePickerStyles>;
     tabIndex?: number;
     textField?: ITextFieldProps;
     theme?: ITheme;

--- a/packages/date-time/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/date-time/src/components/DatePicker/DatePicker.types.ts
@@ -3,7 +3,7 @@ import { DayOfWeek, ICalendarProps } from '../../Calendar';
 import { FirstWeekOfYear } from 'office-ui-fabric-react/lib/utilities/dateValues/DateValues';
 import { ICalendarFormatDateCallbacks, ICalendarStrings } from '../Calendar/Calendar.types';
 import { IStyle, ITheme } from '@uifabric/styling';
-import { IRefObject, IBaseProps, IStyleFunction, IComponentAs } from '@uifabric/utilities';
+import { IRefObject, IBaseProps, IStyleFunctionOrObject, IComponentAs } from '@uifabric/utilities';
 import { ICalloutProps } from 'office-ui-fabric-react/lib/Callout';
 import { ITextFieldProps } from 'office-ui-fabric-react/lib/TextField';
 
@@ -31,7 +31,7 @@ export interface IDatePickerProps extends IBaseProps<IDatePicker>, React.HTMLAtt
   /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */
-  styles?: IStyleFunction<IDatePickerStyleProps, IDatePickerStyles>;
+  styles?: IStyleFunctionOrObject<IDatePickerStyleProps, IDatePickerStyles>;
 
   /**
    * Theme provided by High-Order Component.

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -3184,7 +3184,7 @@ export interface IDatePickerProps extends IBaseProps<IDatePicker>, React.HTMLAtt
     showMonthPickerAsOverlay?: boolean;
     showWeekNumbers?: boolean;
     strings?: IDatePickerStrings;
-    styles?: IStyleFunction<IDatePickerStyleProps, IDatePickerStyles>;
+    styles?: IStyleFunctionOrObject<IDatePickerStyleProps, IDatePickerStyles>;
     tabIndex?: number;
     textField?: ITextFieldProps;
     theme?: ITheme;

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.types.ts
@@ -3,7 +3,7 @@ import { DayOfWeek, ICalendarProps } from '../../Calendar';
 import { FirstWeekOfYear } from '../../utilities/dateValues/DateValues';
 import { ICalendarFormatDateCallbacks, ICalendarStrings } from '../Calendar/Calendar.types';
 import { IStyle, ITheme } from '../../Styling';
-import { IRefObject, IBaseProps, IStyleFunction, IComponentAs } from '../../Utilities';
+import { IRefObject, IBaseProps, IStyleFunctionOrObject, IComponentAs } from '../../Utilities';
 import { ICalloutProps } from '../Callout/Callout.types';
 import { ITextFieldProps } from '../TextField/TextField.types';
 
@@ -31,7 +31,7 @@ export interface IDatePickerProps extends IBaseProps<IDatePicker>, React.HTMLAtt
   /**
    * Call to provide customized styling that will layer on top of the variant rules.
    */
-  styles?: IStyleFunction<IDatePickerStyleProps, IDatePickerStyles>;
+  styles?: IStyleFunctionOrObject<IDatePickerStyleProps, IDatePickerStyles>;
 
   /**
    * Theme provided by High-Order Component.


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11337
- [x] Include a change request file using `$ yarn change`

#### Description of changes

`DatePicker` was not accepting objects, only functions, for its `styles` prop. This PR fixes this omission by making the `styles` prop accept both objects and functions.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11350)