### PR TITLE
GroupedList _getGroupHeight is now calculated with recursion for children

### DIFF
--- a/change/office-ui-fabric-react-2019-12-03-20-40-54-grouped-list-recursive-height.json
+++ b/change/office-ui-fabric-react-2019-12-03-20-40-54-grouped-list-recursive-height.json
@@ -1,0 +1,8 @@
+{
+  "type": "major",
+  "comment": "GroupedList _getGroupHeight is now calculated with recursion for children",
+  "packageName": "office-ui-fabric-react",
+  "email": "marwankhalili@hotmail.com",
+  "commit": "a34d714a150b0c02f7ea95e57aa84acf0f0414f1",
+  "date": "2019-12-03T19:40:54.780Z"
+}

--- a/change/office-ui-fabric-react-2019-12-03-20-40-54-grouped-list-recursive-height.json
+++ b/change/office-ui-fabric-react-2019-12-03-20-40-54-grouped-list-recursive-height.json
@@ -1,5 +1,5 @@
 {
-  "type": "major",
+  "type": "patch",
   "comment": "GroupedList _getGroupHeight is now calculated with recursion for children",
   "packageName": "office-ui-fabric-react",
   "email": "marwankhalili@hotmail.com",

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -231,8 +231,12 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
 
   private _getGroupHeight = (group: IGroup): number => {
     const rowHeight = this.props.compact ? COMPACT_ROW_HEIGHT : ROW_HEIGHT;
-    if (group.isCollapsed) return rowHeight;
-    if (!group.children || !group.children.length) return rowHeight + rowHeight * this._getGroupItemLimit(group);
+    if (group.isCollapsed) {
+      return rowHeight;
+    }
+    if (!group.children || !group.children.length) {
+      return rowHeight + rowHeight * this._getGroupItemLimit(group);
+    }
     return group.children.reduce((acc, child) => acc + this._getGroupHeight(child), rowHeight);
   };
 

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.base.tsx
@@ -231,8 +231,9 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
 
   private _getGroupHeight = (group: IGroup): number => {
     const rowHeight = this.props.compact ? COMPACT_ROW_HEIGHT : ROW_HEIGHT;
-
-    return rowHeight + (group.isCollapsed ? 0 : rowHeight * this._getGroupItemLimit(group));
+    if (group.isCollapsed) return rowHeight;
+    if (!group.children || !group.children.length) return rowHeight + rowHeight * this._getGroupItemLimit(group);
+    return group.children.reduce((acc, child) => acc + this._getGroupHeight(child), rowHeight);
   };
 
   private _getPageHeight: IListProps['getPageHeight'] = (itemIndex: number) => {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11359
- [x] Include a change request file using `$ yarn change`

#### Description of changes

GroupedList was not calculating the height correctly if the group was not collapsed but had children that were collapsed. `_getGroupHeight` now calculates the height using recursion if the group is not collapsed and has at least one children.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11360)