### PR TITLE
Made input border semantic slot accessible

### DIFF
--- a/change/@uifabric-date-time-2019-12-03-13-10-37-fix_textfield_dropdown_combo_spin_restStates.json
+++ b/change/@uifabric-date-time-2019-12-03-13-10-37-fix_textfield_dropdown_combo_spin_restStates.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "updated snapshots",
+  "packageName": "@uifabric/date-time",
+  "email": "betrue@microsoft.com",
+  "commit": "287bff63b4a7803d0c8ff21bc9f927777fc2ceb3",
+  "date": "2019-12-03T21:10:07.013Z"
+}

--- a/change/@uifabric-experiments-2019-12-03-13-10-37-fix_textfield_dropdown_combo_spin_restStates.json
+++ b/change/@uifabric-experiments-2019-12-03-13-10-37-fix_textfield_dropdown_combo_spin_restStates.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "updated snapshots",
+  "packageName": "@uifabric/experiments",
+  "email": "betrue@microsoft.com",
+  "commit": "287bff63b4a7803d0c8ff21bc9f927777fc2ceb3",
+  "date": "2019-12-03T21:10:26.852Z"
+}

--- a/change/@uifabric-styling-2019-12-03-11-55-48-fix_textfield_dropdown_combo_spin_restStates.json
+++ b/change/@uifabric-styling-2019-12-03-11-55-48-fix_textfield_dropdown_combo_spin_restStates.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Making rest state accessible",
+  "packageName": "@uifabric/styling",
+  "email": "betrue@microsoft.com",
+  "commit": "ff294c712714651495c128c74e2ad9bff5336dee",
+  "date": "2019-12-03T19:55:48.654Z"
+}

--- a/change/office-ui-fabric-react-2019-12-03-13-10-37-fix_textfield_dropdown_combo_spin_restStates.json
+++ b/change/office-ui-fabric-react-2019-12-03-13-10-37-fix_textfield_dropdown_combo_spin_restStates.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "updated snapshots",
+  "packageName": "office-ui-fabric-react",
+  "email": "betrue@microsoft.com",
+  "commit": "287bff63b4a7803d0c8ff21bc9f927777fc2ceb3",
+  "date": "2019-12-03T21:10:37.904Z"
+}

--- a/packages/date-time/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/date-time/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                 align-items: stretch;
                 background: #ffffff;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: text;

--- a/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -1370,7 +1370,7 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             background-color: #ffffff;
-            border-color: #8a8886;
+            border-color: #605e5c;
             border-radius: 2px;
             border-style: solid;
             border-width: 1px;
@@ -1400,7 +1400,7 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
             margin-bottom: 8px;
           }
           &.is-open {
-            border-color: #8a8886;
+            border-color: #605e5c;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -378,7 +378,7 @@ exports[`ColorPicker renders correctly 1`] = `
                         align-items: stretch;
                         background: #ffffff;
                         border-radius: 2px;
-                        border: 1px solid #8a8886;
+                        border: 1px solid #605e5c;
                         box-shadow: none;
                         box-sizing: border-box;
                         cursor: text;
@@ -542,7 +542,7 @@ exports[`ColorPicker renders correctly 1`] = `
                         align-items: stretch;
                         background: #ffffff;
                         border-radius: 2px;
-                        border: 1px solid #8a8886;
+                        border: 1px solid #605e5c;
                         box-shadow: none;
                         box-sizing: border-box;
                         cursor: text;
@@ -706,7 +706,7 @@ exports[`ColorPicker renders correctly 1`] = `
                         align-items: stretch;
                         background: #ffffff;
                         border-radius: 2px;
-                        border: 1px solid #8a8886;
+                        border: 1px solid #605e5c;
                         box-shadow: none;
                         box-sizing: border-box;
                         cursor: text;
@@ -870,7 +870,7 @@ exports[`ColorPicker renders correctly 1`] = `
                         align-items: stretch;
                         background: #ffffff;
                         border-radius: 2px;
-                        border: 1px solid #8a8886;
+                        border: 1px solid #605e5c;
                         box-shadow: none;
                         box-sizing: border-box;
                         cursor: text;
@@ -1034,7 +1034,7 @@ exports[`ColorPicker renders correctly 1`] = `
                         align-items: stretch;
                         background: #ffffff;
                         border-radius: 2px;
-                        border: 1px solid #8a8886;
+                        border: 1px solid #605e5c;
                         box-shadow: none;
                         box-sizing: border-box;
                         cursor: text;

--- a/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -11,7 +11,7 @@ exports[`ComboBox Renders correctly 1`] = `
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
           background-color: #ffffff;
-          border-color: #8a8886;
+          border-color: #605e5c;
           border-radius: 2px;
           border-style: solid;
           border-width: 1px;
@@ -41,7 +41,7 @@ exports[`ComboBox Renders correctly 1`] = `
           margin-bottom: 8px;
         }
         &.is-open {
-          border-color: #8a8886;
+          border-color: #605e5c;
         }
         @media screen and (-ms-high-contrast: active){&.is-open {
           -ms-high-contrast-adjust: none;
@@ -389,7 +389,7 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
           background-color: #ffffff;
-          border-color: #8a8886;
+          border-color: #605e5c;
           border-radius: 2px;
           border-style: solid;
           border-width: 1px;
@@ -419,7 +419,7 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
           margin-bottom: 8px;
         }
         &.is-open {
-          border-color: #8a8886;
+          border-color: #605e5c;
         }
         @media screen and (-ms-high-contrast: active){&.is-open {
           -ms-high-contrast-adjust: none;

--- a/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                 align-items: stretch;
                 background: #ffffff;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: text;

--- a/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -111,7 +111,7 @@ exports[`Dropdown multi-select Renders multiselect Dropdown correctly 1`] = `
           ms-Dropdown-titleIsPlaceHolder
           {
             background-color: #ffffff;
-            border-color: #8a8886;
+            border-color: #605e5c;
             border-radius: 2px;
             border-style: solid;
             border-width: 1px;
@@ -287,7 +287,7 @@ exports[`Dropdown single-select Renders single-select Dropdown correctly 1`] = `
           ms-Dropdown-titleIsPlaceHolder
           {
             background-color: #ffffff;
-            border-color: #8a8886;
+            border-color: #605e5c;
             border-radius: 2px;
             border-style: solid;
             border-width: 1px;

--- a/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
@@ -10,7 +10,7 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
         align-items: stretch;
         background-color: #ffffff;
         border-radius: 2px;
-        border: 1px solid #8a8886;
+        border: 1px solid #605e5c;
         box-shadow: none;
         box-sizing: border-box;
         color: #323130;
@@ -144,7 +144,7 @@ exports[`SearchBox renders SearchBox without animation correctly 1`] = `
         align-items: stretch;
         background-color: #ffffff;
         border-radius: 2px;
-        border: 1px solid #8a8886;
+        border: 1px solid #605e5c;
         box-shadow: none;
         box-sizing: border-box;
         color: #323130;

--- a/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
@@ -59,7 +59,7 @@ exports[`SpinButton renders SpinButton correctly 1`] = `
 
         {
           border-radius: 2px;
-          border: 1px solid #8a8886;
+          border: 1px solid #605e5c;
           box-sizing: border-box;
           display: flex;
           height: 32px;
@@ -479,7 +479,7 @@ exports[`SpinButton renders SpinButton correctly with values that the user passe
 
         {
           border-radius: 2px;
-          border: 1px solid #8a8886;
+          border: 1px solid #605e5c;
           box-sizing: border-box;
           display: flex;
           height: 32px;

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
@@ -64,7 +64,7 @@ exports[`MaskedTextField renders correctly 1`] = `
             align-items: stretch;
             background: #ffffff;
             border-radius: 2px;
-            border: 1px solid #8a8886;
+            border: 1px solid #605e5c;
             box-shadow: none;
             box-sizing: border-box;
             cursor: text;

--- a/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -65,7 +65,7 @@ exports[`TextField snapshots renders correctly 1`] = `
             align-items: stretch;
             background: #ffffff;
             border-radius: 2px;
-            border: 1px solid #8a8886;
+            border: 1px solid #605e5c;
             box-shadow: none;
             box-sizing: border-box;
             cursor: text;
@@ -736,7 +736,7 @@ exports[`TextField snapshots renders multiline resizable correctly 1`] = `
             align-items: stretch;
             background: #ffffff;
             border-radius: 2px;
-            border: 1px solid #8a8886;
+            border: 1px solid #605e5c;
             box-shadow: none;
             box-sizing: border-box;
             cursor: text;
@@ -912,7 +912,7 @@ exports[`TextField snapshots renders multiline unresizable correctly 1`] = `
             align-items: stretch;
             background: #ffffff;
             border-radius: 2px;
-            border: 1px solid #8a8886;
+            border: 1px solid #605e5c;
             box-shadow: none;
             box-sizing: border-box;
             cursor: text;
@@ -1090,7 +1090,7 @@ exports[`TextField snapshots renders multiline with placeholder correctly 1`] = 
             align-items: stretch;
             background: #ffffff;
             border-radius: 2px;
-            border: 1px solid #8a8886;
+            border: 1px solid #605e5c;
             box-shadow: none;
             box-sizing: border-box;
             cursor: text;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.SearchResults.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.SearchResults.Example.tsx.shot
@@ -78,7 +78,7 @@ exports[`Component Examples renders Announced.SearchResults.Example.tsx correctl
               {
                 align-items: center;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-sizing: border-box;
                 display: flex;
                 flex-wrap: wrap;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
@@ -154,7 +154,7 @@ Array [
               ms-Dropdown-title
               {
                 background-color: #ffffff;
-                border-color: #8a8886;
+                border-color: #605e5c;
                 border-radius: 2px;
                 border-style: solid;
                 border-width: 1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
@@ -839,7 +839,7 @@ Array [
               ms-Dropdown-title
               {
                 background-color: #ffffff;
-                border-color: #8a8886;
+                border-color: #605e5c;
                 border-radius: 2px;
                 border-style: solid;
                 border-width: 1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -290,7 +290,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                       ms-Dropdown-title
                       {
                         background-color: #f3f2f1;
-                        border-color: #8a8886;
+                        border-color: #605e5c;
                         border-radius: 2px;
                         border-style: solid;
                         border-width: 1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
@@ -153,7 +153,7 @@ exports[`Component Examples renders Coachmark.Basic.Example.tsx correctly 1`] = 
               ms-Dropdown-title
               {
                 background-color: #ffffff;
-                border-color: #8a8886;
+                border-color: #605e5c;
                 border-radius: 2px;
                 border-style: solid;
                 border-width: 1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -414,7 +414,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                           align-items: stretch;
                           background: #ffffff;
                           border-radius: 2px;
-                          border: 1px solid #8a8886;
+                          border: 1px solid #605e5c;
                           box-shadow: none;
                           box-sizing: border-box;
                           cursor: text;
@@ -578,7 +578,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                           align-items: stretch;
                           background: #ffffff;
                           border-radius: 2px;
-                          border: 1px solid #8a8886;
+                          border: 1px solid #605e5c;
                           box-shadow: none;
                           box-sizing: border-box;
                           cursor: text;
@@ -742,7 +742,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                           align-items: stretch;
                           background: #ffffff;
                           border-radius: 2px;
-                          border: 1px solid #8a8886;
+                          border: 1px solid #605e5c;
                           box-shadow: none;
                           box-sizing: border-box;
                           cursor: text;
@@ -906,7 +906,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                           align-items: stretch;
                           background: #ffffff;
                           border-radius: 2px;
-                          border: 1px solid #8a8886;
+                          border: 1px solid #605e5c;
                           box-shadow: none;
                           box-sizing: border-box;
                           cursor: text;
@@ -1070,7 +1070,7 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                           align-items: stretch;
                           background: #ffffff;
                           border-radius: 2px;
-                          border: 1px solid #8a8886;
+                          border: 1px solid #605e5c;
                           box-shadow: none;
                           box-sizing: border-box;
                           cursor: text;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -70,7 +70,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
               background-color: #ffffff;
-              border-color: #8a8886;
+              border-color: #605e5c;
               border-radius: 2px;
               border-style: solid;
               border-width: 1px;
@@ -100,7 +100,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               margin-bottom: 8px;
             }
             &.is-open {
-              border-color: #8a8886;
+              border-color: #605e5c;
             }
             @media screen and (-ms-high-contrast: active){&.is-open {
               -ms-high-contrast-adjust: none;
@@ -610,7 +610,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             background-color: #ffffff;
-            border-color: #8a8886;
+            border-color: #605e5c;
             border-radius: 2px;
             border-style: solid;
             border-width: 1px;
@@ -640,7 +640,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             margin-bottom: 8px;
           }
           &.is-open {
-            border-color: #8a8886;
+            border-color: #605e5c;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
@@ -1015,7 +1015,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             background-color: #ffffff;
-            border-color: #8a8886;
+            border-color: #605e5c;
             border-radius: 2px;
             border-style: solid;
             border-width: 1px;
@@ -1045,7 +1045,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             margin-bottom: 8px;
           }
           &.is-open {
-            border-color: #8a8886;
+            border-color: #605e5c;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
@@ -1421,7 +1421,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             background-color: #ffffff;
-            border-color: #8a8886;
+            border-color: #605e5c;
             border-radius: 2px;
             border-style: solid;
             border-width: 1px;
@@ -1451,7 +1451,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             margin-bottom: 8px;
           }
           &.is-open {
-            border-color: #8a8886;
+            border-color: #605e5c;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
@@ -3663,7 +3663,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             margin-bottom: 8px;
           }
           &.is-open {
-            border-color: #8a8886;
+            border-color: #605e5c;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
@@ -3964,7 +3964,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             background-color: #ffffff;
-            border-color: #8a8886;
+            border-color: #605e5c;
             border-radius: 2px;
             border-style: solid;
             border-width: 1px;
@@ -3994,7 +3994,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             margin-bottom: 8px;
           }
           &.is-open {
-            border-color: #8a8886;
+            border-color: #605e5c;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
@@ -4404,7 +4404,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             margin-bottom: 8px;
           }
           &.is-open {
-            border-color: #8a8886;
+            border-color: #605e5c;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
@@ -67,7 +67,7 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             background-color: #ffffff;
-            border-color: #8a8886;
+            border-color: #605e5c;
             border-radius: 2px;
             border-style: solid;
             border-width: 1px;
@@ -97,7 +97,7 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
             margin-bottom: 8px;
           }
           &.is-open {
-            border-color: #8a8886;
+            border-color: #605e5c;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
@@ -472,7 +472,7 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             background-color: #ffffff;
-            border-color: #8a8886;
+            border-color: #605e5c;
             border-radius: 2px;
             border-style: solid;
             border-width: 1px;
@@ -502,7 +502,7 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
             margin-bottom: 8px;
           }
           &.is-open {
-            border-color: #8a8886;
+            border-color: #605e5c;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
@@ -71,7 +71,7 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             background-color: #b4a0ff;
-            border-color: #8a8886;
+            border-color: #605e5c;
             border-radius: 2px;
             border-style: solid;
             border-width: 1px;
@@ -101,7 +101,7 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
             margin-bottom: 8px;
           }
           &.is-open {
-            border-color: #8a8886;
+            border-color: #605e5c;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
@@ -476,7 +476,7 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             background-color: #ffffff;
-            border-color: #8a8886;
+            border-color: #605e5c;
             border-radius: 2px;
             border-style: solid;
             border-width: 1px;
@@ -506,7 +506,7 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
             margin-bottom: 8px;
           }
           &.is-open {
-            border-color: #8a8886;
+            border-color: #605e5c;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -68,7 +68,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             background-color: #ffffff;
-            border-color: #8a8886;
+            border-color: #605e5c;
             border-radius: 2px;
             border-style: solid;
             border-width: 1px;
@@ -98,7 +98,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
             margin-bottom: 8px;
           }
           &.is-open {
-            border-color: #8a8886;
+            border-color: #605e5c;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
@@ -62,7 +62,7 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             background-color: #ffffff;
-            border-color: #8a8886;
+            border-color: #605e5c;
             border-radius: 2px;
             border-style: solid;
             border-width: 1px;
@@ -93,7 +93,7 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
             margin-bottom: 8px;
           }
           &.is-open {
-            border-color: #8a8886;
+            border-color: #605e5c;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
@@ -297,7 +297,7 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
               ms-Dropdown-title
               {
                 background-color: #ffffff;
-                border-color: #8a8886;
+                border-color: #605e5c;
                 border-radius: 2px;
                 border-style: solid;
                 border-width: 1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
@@ -68,7 +68,7 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
               align-items: stretch;
               background: #ffffff;
               border-radius: 2px;
-              border: 1px solid #8a8886;
+              border: 1px solid #605e5c;
               box-shadow: none;
               box-sizing: border-box;
               cursor: text;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
@@ -69,7 +69,7 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
                   align-items: stretch;
                   background: #ffffff;
                   border-radius: 2px;
-                  border: 1px solid #8a8886;
+                  border: 1px solid #605e5c;
                   box-shadow: none;
                   box-sizing: border-box;
                   cursor: text;
@@ -363,7 +363,7 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
             ms-Dropdown-title
             {
               background-color: #ffffff;
-              border-color: #8a8886;
+              border-color: #605e5c;
               border-radius: 2px;
               border-style: solid;
               border-width: 1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
@@ -74,7 +74,7 @@ Fri, 06 Jan 2017 04:41:20 GMT-Fri, 06 Jan 2017 04:41:20 GMT
                   align-items: stretch;
                   background: #ffffff;
                   border-radius: 2px;
-                  border: 1px solid #8a8886;
+                  border: 1px solid #605e5c;
                   box-shadow: none;
                   box-sizing: border-box;
                   cursor: text;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Disabled.Example.tsx.shot
@@ -71,7 +71,7 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                   background: #ffffff;
                   border-color: #f3f2f1;
                   border-radius: 2px;
-                  border: 1px solid #8a8886;
+                  border: 1px solid #605e5c;
                   box-shadow: none;
                   box-sizing: border-box;
                   cursor: default;
@@ -312,7 +312,7 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                   background: #ffffff;
                   border-color: #f3f2f1;
                   border-radius: 2px;
-                  border: 1px solid #8a8886;
+                  border: 1px solid #605e5c;
                   box-shadow: none;
                   box-sizing: border-box;
                   cursor: default;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
@@ -101,7 +101,7 @@ exports[`Component Examples renders DatePicker.Format.Example.tsx correctly 1`] 
                   align-items: stretch;
                   background: #ffffff;
                   border-radius: 2px;
-                  border: 1px solid #8a8886;
+                  border: 1px solid #605e5c;
                   box-shadow: none;
                   box-sizing: border-box;
                   cursor: text;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
@@ -101,7 +101,7 @@ exports[`Component Examples renders DatePicker.Input.Example.tsx correctly 1`] =
                   align-items: stretch;
                   background: #ffffff;
                   border-radius: 2px;
-                  border: 1px solid #8a8886;
+                  border: 1px solid #605e5c;
                   box-shadow: none;
                   box-sizing: border-box;
                   cursor: text;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
@@ -107,7 +107,7 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                   align-items: stretch;
                   background: #ffffff;
                   border-radius: 2px;
-                  border: 1px solid #8a8886;
+                  border: 1px solid #605e5c;
                   box-shadow: none;
                   box-sizing: border-box;
                   cursor: text;
@@ -318,7 +318,7 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                   align-items: stretch;
                   background: #ffffff;
                   border-radius: 2px;
-                  border: 1px solid #8a8886;
+                  border: 1px solid #605e5c;
                   box-shadow: none;
                   box-sizing: border-box;
                   cursor: text;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
@@ -69,7 +69,7 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
                   align-items: stretch;
                   background: #ffffff;
                   border-radius: 2px;
-                  border: 1px solid #8a8886;
+                  border: 1px solid #605e5c;
                   box-shadow: none;
                   box-sizing: border-box;
                   cursor: text;
@@ -363,7 +363,7 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
             ms-Dropdown-title
             {
               background-color: #ffffff;
-              border-color: #8a8886;
+              border-color: #605e5c;
               border-radius: 2px;
               border-style: solid;
               border-width: 1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -97,7 +97,7 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
               align-items: stretch;
               background: #ffffff;
               border-radius: 2px;
-              border: 1px solid #8a8886;
+              border: 1px solid #605e5c;
               box-shadow: none;
               box-sizing: border-box;
               cursor: text;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -97,7 +97,7 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
               align-items: stretch;
               background: #ffffff;
               border-radius: 2px;
-              border: 1px solid #8a8886;
+              border: 1px solid #605e5c;
               box-shadow: none;
               box-sizing: border-box;
               cursor: text;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -440,7 +440,7 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                 align-items: stretch;
                 background: #ffffff;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: text;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -251,7 +251,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                 align-items: stretch;
                 background: #ffffff;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: text;
@@ -420,7 +420,7 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                 align-items: stretch;
                 background: #ffffff;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: text;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
@@ -165,7 +165,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             ms-Dropdown-titleIsPlaceHolder
             {
               background-color: #ffffff;
-              border-color: #8a8886;
+              border-color: #605e5c;
               border-radius: 2px;
               border-style: solid;
               border-width: 1px;
@@ -353,7 +353,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             ms-Dropdown-title
             {
               background-color: #f3f2f1;
-              border-color: #8a8886;
+              border-color: #605e5c;
               border-radius: 2px;
               border-style: solid;
               border-width: 1px;
@@ -563,7 +563,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             ms-Dropdown-title
             {
               background-color: #ffffff;
-              border-color: #8a8886;
+              border-color: #605e5c;
               border-radius: 2px;
               border-style: solid;
               border-width: 1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Controlled.Example.tsx.shot
@@ -145,7 +145,7 @@ exports[`Component Examples renders Dropdown.Controlled.Example.tsx correctly 1`
           ms-Dropdown-titleIsPlaceHolder
           {
             background-color: #ffffff;
-            border-color: #8a8886;
+            border-color: #605e5c;
             border-radius: 2px;
             border-style: solid;
             border-width: 1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.ControlledMulti.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.ControlledMulti.Example.tsx.shot
@@ -143,7 +143,7 @@ exports[`Component Examples renders Dropdown.ControlledMulti.Example.tsx correct
           ms-Dropdown-titleIsPlaceHolder
           {
             background-color: #ffffff;
-            border-color: #8a8886;
+            border-color: #605e5c;
             border-radius: 2px;
             border-style: solid;
             border-width: 1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
@@ -165,7 +165,7 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
             ms-Dropdown-titleIsPlaceHolder
             {
               background-color: #ffffff;
-              border-color: #8a8886;
+              border-color: #605e5c;
               border-radius: 2px;
               border-style: solid;
               border-width: 1px;
@@ -528,7 +528,7 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
             ms-Dropdown-titleIsPlaceHolder
             {
               background-color: #ffffff;
-              border-color: #8a8886;
+              border-color: #605e5c;
               border-radius: 2px;
               border-style: solid;
               border-width: 1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
@@ -337,7 +337,7 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
             ms-Dropdown-titleIsPlaceHolder
             {
               background-color: #ffffff;
-              border-color: #8a8886;
+              border-color: #605e5c;
               border-radius: 2px;
               border-style: solid;
               border-width: 1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
@@ -195,7 +195,7 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
               ms-Dropdown-titleIsPlaceHolder
               {
                 background-color: #ffffff;
-                border-color: #8a8886;
+                border-color: #605e5c;
                 border-radius: 2px;
                 border-style: solid;
                 border-width: 1px;
@@ -514,7 +514,7 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
             ms-Dropdown-titleIsPlaceHolder
             {
               background-color: #ffffff;
-              border-color: #8a8886;
+              border-color: #605e5c;
               border-radius: 2px;
               border-style: solid;
               border-width: 1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -1035,7 +1035,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
               ms-Dropdown-title
               {
                 background-color: #ffffff;
-                border-color: #8a8886;
+                border-color: #605e5c;
                 border-radius: 2px;
                 border-style: solid;
                 border-width: 1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
@@ -1144,7 +1144,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
               ms-Dropdown-title
               {
                 background-color: #ffffff;
-                border-color: #8a8886;
+                border-color: #605e5c;
                 border-radius: 2px;
                 border-style: solid;
                 border-width: 1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
@@ -18,7 +18,7 @@ exports[`Component Examples renders FloatingPeoplePicker.Basic.Example.tsx corre
             align-items: stretch;
             background-color: #ffffff;
             border-radius: 2px;
-            border: 1px solid #8a8886;
+            border: 1px solid #605e5c;
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -277,7 +277,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
                 align-items: stretch;
                 background: #ffffff;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: text;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -462,7 +462,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
                   align-items: stretch;
                   background: #ffffff;
                   border-radius: 2px;
-                  border: 1px solid #8a8886;
+                  border: 1px solid #605e5c;
                   box-shadow: none;
                   box-sizing: border-box;
                   cursor: text;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -462,7 +462,7 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
                   align-items: stretch;
                   background: #ffffff;
                   border-radius: 2px;
-                  border: 1px solid #8a8886;
+                  border: 1px solid #605e5c;
                   box-shadow: none;
                   box-sizing: border-box;
                   cursor: text;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Disabled.Example.tsx.shot
@@ -328,7 +328,7 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                   align-items: stretch;
                   background: #ffffff;
                   border-radius: 2px;
-                  border: 1px solid #8a8886;
+                  border: 1px solid #605e5c;
                   box-shadow: none;
                   box-sizing: border-box;
                   cursor: text;
@@ -976,7 +976,7 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
               align-items: stretch;
               background: #ffffff;
               border-radius: 2px;
-              border: 1px solid #8a8886;
+              border: 1px solid #605e5c;
               box-shadow: none;
               box-sizing: border-box;
               cursor: text;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
@@ -328,7 +328,7 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                   align-items: stretch;
                   background: #ffffff;
                   border-radius: 2px;
-                  border: 1px solid #8a8886;
+                  border: 1px solid #605e5c;
                   box-shadow: none;
                   box-sizing: border-box;
                   cursor: text;
@@ -1184,7 +1184,7 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                   align-items: stretch;
                   background: #ffffff;
                   border-radius: 2px;
-                  border: 1px solid #8a8886;
+                  border: 1px solid #605e5c;
                   box-shadow: none;
                   box-sizing: border-box;
                   cursor: text;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -630,7 +630,7 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
 
                   {
                     border-radius: 2px;
-                    border: 1px solid #8a8886;
+                    border: 1px solid #605e5c;
                     box-sizing: border-box;
                     display: flex;
                     height: 32px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Label.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Label.Basic.Example.tsx.shot
@@ -153,7 +153,7 @@ exports[`Component Examples renders Label.Basic.Example.tsx correctly 1`] = `
               align-items: stretch;
               background: #ffffff;
               border-radius: 2px;
-              border: 1px solid #8a8886;
+              border: 1px solid #605e5c;
               box-shadow: none;
               box-sizing: border-box;
               cursor: text;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Types.Example.tsx.shot
@@ -42,7 +42,7 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
               {
                 align-items: center;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-sizing: border-box;
                 display: flex;
                 flex-wrap: wrap;
@@ -251,7 +251,7 @@ exports[`Component Examples renders PeoplePicker.Types.Example.tsx correctly 1`]
               ms-Dropdown-title
               {
                 background-color: #ffffff;
-                border-color: #8a8886;
+                border-color: #605e5c;
                 border-radius: 2px;
                 border-style: solid;
                 border-width: 1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -4092,7 +4092,7 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                 ms-Dropdown-title
                 {
                   background-color: #ffffff;
-                  border-color: #8a8886;
+                  border-color: #605e5c;
                   border-radius: 2px;
                   border-style: solid;
                   border-width: 1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.CustomIcon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.CustomIcon.Example.tsx.shot
@@ -10,7 +10,7 @@ exports[`Component Examples renders SearchBox.CustomIcon.Example.tsx correctly 1
         align-items: stretch;
         background-color: #ffffff;
         border-radius: 2px;
-        border: 1px solid #8a8886;
+        border: 1px solid #605e5c;
         box-shadow: none;
         box-sizing: border-box;
         color: #323130;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
@@ -33,7 +33,7 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
           background-color: #f3f2f1;
           border-color: #f3f2f1;
           border-radius: 2px;
-          border: 1px solid #8a8886;
+          border: 1px solid #605e5c;
           box-shadow: none;
           box-sizing: border-box;
           color: #323130;
@@ -174,7 +174,7 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
           border-color: #f3f2f1;
           border-radius: 0px;
           border-width: 0 0 1px 0;
-          border: 1px solid #8a8886;
+          border: 1px solid #605e5c;
           box-shadow: none;
           box-sizing: border-box;
           color: #323130;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
@@ -31,7 +31,7 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
           align-items: stretch;
           background-color: #ffffff;
           border-radius: 2px;
-          border: 1px solid #8a8886;
+          border: 1px solid #605e5c;
           box-shadow: none;
           box-sizing: border-box;
           color: #323130;
@@ -164,7 +164,7 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
           align-items: stretch;
           background-color: #ffffff;
           border-radius: 2px;
-          border: 1px solid #8a8886;
+          border: 1px solid #605e5c;
           box-shadow: none;
           box-sizing: border-box;
           color: #323130;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
@@ -10,7 +10,7 @@ exports[`Component Examples renders SearchBox.Small.Example.tsx correctly 1`] = 
         align-items: stretch;
         background-color: #ffffff;
         border-radius: 2px;
-        border: 1px solid #8a8886;
+        border: 1px solid #605e5c;
         box-shadow: none;
         box-sizing: border-box;
         color: #323130;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
@@ -12,7 +12,7 @@ exports[`Component Examples renders SearchBox.Underlined.Example.tsx correctly 1
         background-color: #ffffff;
         border-radius: 0px;
         border-width: 0 0 1px 0;
-        border: 1px solid #8a8886;
+        border: 1px solid #605e5c;
         box-shadow: none;
         box-sizing: border-box;
         color: #323130;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Basic.Example.tsx.shot
@@ -88,7 +88,7 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
 
           {
             border-radius: 2px;
-            border: 1px solid #8a8886;
+            border: 1px solid #605e5c;
             box-sizing: border-box;
             display: flex;
             height: 32px;
@@ -507,7 +507,7 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
 
           {
             border-radius: 2px;
-            border: 1px solid #8a8886;
+            border: 1px solid #605e5c;
             box-sizing: border-box;
             display: flex;
             height: 32px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
@@ -71,7 +71,7 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
             background-color: #f3f2f1;
             border-color: #f3f2f1;
             border-radius: 2px;
-            border: 1px solid #8a8886;
+            border: 1px solid #605e5c;
             box-sizing: border-box;
             color: #a19f9d;
             cursor: default;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithEndPosition.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithEndPosition.Example.tsx.shot
@@ -88,7 +88,7 @@ exports[`Component Examples renders SpinButton.BasicWithEndPosition.Example.tsx 
 
           {
             border-radius: 2px;
-            border: 1px solid #8a8886;
+            border: 1px solid #605e5c;
             box-sizing: border-box;
             display: flex;
             height: 32px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIcon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIcon.Example.tsx.shot
@@ -88,7 +88,7 @@ exports[`Component Examples renders SpinButton.BasicWithIcon.Example.tsx correct
 
           {
             border-radius: 2px;
-            border: 1px solid #8a8886;
+            border: 1px solid #605e5c;
             box-sizing: border-box;
             display: flex;
             height: 32px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
@@ -94,7 +94,7 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
             background-color: #f3f2f1;
             border-color: #f3f2f1;
             border-radius: 2px;
-            border: 1px solid #8a8886;
+            border: 1px solid #605e5c;
             box-sizing: border-box;
             color: #a19f9d;
             cursor: default;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.CustomStyled.Example.tsx.shot
@@ -60,7 +60,7 @@ exports[`Component Examples renders SpinButton.CustomStyled.Example.tsx correctl
 
           {
             border-radius: 2px;
-            border: 1px solid #8a8886;
+            border: 1px solid #605e5c;
             box-sizing: border-box;
             display: flex;
             height: 32px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Stateful.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Stateful.Example.tsx.shot
@@ -66,7 +66,7 @@ exports[`Component Examples renders SpinButton.Stateful.Example.tsx correctly 1`
 
           {
             border-radius: 2px;
-            border: 1px solid #8a8886;
+            border: 1px solid #605e5c;
             box-sizing: border-box;
             display: flex;
             height: 32px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
@@ -3140,7 +3140,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 ms-Dropdown-title
                 {
                   background-color: #ffffff;
-                  border-color: #8a8886;
+                  border-color: #605e5c;
                   border-radius: 2px;
                   border-style: solid;
                   border-width: 1px;
@@ -3362,7 +3362,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 ms-Dropdown-title
                 {
                   background-color: #ffffff;
-                  border-color: #8a8886;
+                  border-color: #605e5c;
                   border-radius: 2px;
                   border-style: solid;
                   border-width: 1px;
@@ -3660,7 +3660,7 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   align-items: stretch;
                   background: #ffffff;
                   border-radius: 2px;
-                  border: 1px solid #8a8886;
+                  border: 1px solid #605e5c;
                   box-shadow: none;
                   box-sizing: border-box;
                   cursor: text;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapAdvanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapAdvanced.Example.tsx.shot
@@ -776,7 +776,7 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
                 ms-Dropdown-title
                 {
                   background-color: #ffffff;
-                  border-color: #8a8886;
+                  border-color: #605e5c;
                   border-radius: 2px;
                   border-style: solid;
                   border-width: 1px;
@@ -999,7 +999,7 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
                 ms-Dropdown-title
                 {
                   background-color: #ffffff;
-                  border-color: #8a8886;
+                  border-color: #605e5c;
                   border-radius: 2px;
                   border-style: solid;
                   border-width: 1px;
@@ -1222,7 +1222,7 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
                 ms-Dropdown-title
                 {
                   background-color: #ffffff;
-                  border-color: #8a8886;
+                  border-color: #605e5c;
                   border-radius: 2px;
                   border-style: solid;
                   border-width: 1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
@@ -1851,7 +1851,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       ms-Dropdown-title
                       {
                         background-color: #ffffff;
-                        border-color: #8a8886;
+                        border-color: #605e5c;
                         border-radius: 2px;
                         border-style: solid;
                         border-width: 1px;
@@ -2074,7 +2074,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       ms-Dropdown-title
                       {
                         background-color: #ffffff;
-                        border-color: #8a8886;
+                        border-color: #605e5c;
                         border-radius: 2px;
                         border-style: solid;
                         border-width: 1px;
@@ -2373,7 +2373,7 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                         align-items: stretch;
                         background: #ffffff;
                         border-radius: 2px;
-                        border: 1px solid #8a8886;
+                        border: 1px solid #605e5c;
                         box-shadow: none;
                         box-sizing: border-box;
                         cursor: text;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapAdvanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapAdvanced.Example.tsx.shot
@@ -776,7 +776,7 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
                 ms-Dropdown-title
                 {
                   background-color: #ffffff;
-                  border-color: #8a8886;
+                  border-color: #605e5c;
                   border-radius: 2px;
                   border-style: solid;
                   border-width: 1px;
@@ -999,7 +999,7 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
                 ms-Dropdown-title
                 {
                   background-color: #ffffff;
-                  border-color: #8a8886;
+                  border-color: #605e5c;
                   border-radius: 2px;
                   border-style: solid;
                   border-width: 1px;
@@ -1222,7 +1222,7 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
                 ms-Dropdown-title
                 {
                   background-color: #ffffff;
-                  border-color: #8a8886;
+                  border-color: #605e5c;
                   border-radius: 2px;
                   border-style: solid;
                   border-width: 1px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -194,7 +194,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
               {
                 align-items: center;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-sizing: border-box;
                 display: flex;
                 flex-wrap: wrap;
@@ -293,7 +293,7 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
               {
                 align-items: center;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-sizing: border-box;
                 display: flex;
                 flex-wrap: wrap;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -106,7 +106,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 align-items: stretch;
                 background: #ffffff;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: text;
@@ -279,7 +279,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 background: #ffffff;
                 border-color: #f3f2f1;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: default;
@@ -446,7 +446,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 align-items: stretch;
                 background: #ffffff;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: text;
@@ -621,7 +621,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 align-items: stretch;
                 background: #ffffff;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: text;
@@ -762,7 +762,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 align-items: stretch;
                 background: #ffffff;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: text;
@@ -941,7 +941,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 background: #ffffff;
                 border-color: #a4262c;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: text;
@@ -1139,7 +1139,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 align-items: stretch;
                 background: #ffffff;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: text;
@@ -1311,7 +1311,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 align-items: stretch;
                 background: #ffffff;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: text;
@@ -1503,7 +1503,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 align-items: stretch;
                 background: #ffffff;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: text;
@@ -1677,7 +1677,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 background: #ffffff;
                 border-color: #f3f2f1;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: default;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
@@ -70,7 +70,7 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
         className=
             ms-TextField-wrapper
             {
-              border-bottom: 1px solid #8a8886;
+              border-bottom: 1px solid #605e5c;
               display: flex;
               width: 100%;
             }
@@ -256,7 +256,7 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
             ms-TextField-wrapper
             {
               border-bottom-color: #f3f2f1;
-              border-bottom: 1px solid #8a8886;
+              border-bottom: 1px solid #605e5c;
               display: flex;
               width: 100%;
             }
@@ -442,7 +442,7 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
         className=
             ms-TextField-wrapper
             {
-              border-bottom: 1px solid #8a8886;
+              border-bottom: 1px solid #605e5c;
               display: flex;
               width: 100%;
             }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Controlled.Example.tsx.shot
@@ -85,7 +85,7 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
               align-items: stretch;
               background: #ffffff;
               border-radius: 2px;
-              border: 1px solid #8a8886;
+              border: 1px solid #605e5c;
               box-shadow: none;
               box-sizing: border-box;
               cursor: text;
@@ -254,7 +254,7 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
               align-items: stretch;
               background: #ffffff;
               border-radius: 2px;
-              border: 1px solid #8a8886;
+              border: 1px solid #605e5c;
               box-shadow: none;
               box-sizing: border-box;
               cursor: text;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
@@ -214,7 +214,7 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
               align-items: stretch;
               background: #ffffff;
               border-radius: 2px;
-              border: 1px solid #8a8886;
+              border: 1px solid #605e5c;
               box-shadow: none;
               box-sizing: border-box;
               cursor: text;
@@ -443,7 +443,7 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
               align-items: stretch;
               background: #ffffff;
               border-radius: 2px;
-              border: 1px solid #8a8886;
+              border: 1px solid #605e5c;
               box-shadow: none;
               box-sizing: border-box;
               cursor: text;
@@ -611,7 +611,7 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
               align-items: stretch;
               background: #ffffff;
               border-radius: 2px;
-              border: 1px solid #8a8886;
+              border: 1px solid #605e5c;
               box-shadow: none;
               box-sizing: border-box;
               cursor: text;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Masked.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Masked.Example.tsx.shot
@@ -89,7 +89,7 @@ exports[`Component Examples renders TextField.Masked.Example.tsx correctly 1`] =
               align-items: stretch;
               background: #ffffff;
               border-radius: 2px;
-              border: 1px solid #8a8886;
+              border: 1px solid #605e5c;
               box-shadow: none;
               box-sizing: border-box;
               cursor: text;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
@@ -107,7 +107,7 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 align-items: stretch;
                 background: #ffffff;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: text;
@@ -286,7 +286,7 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 background: #ffffff;
                 border-color: #f3f2f1;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: default;
@@ -459,7 +459,7 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 align-items: stretch;
                 background: #ffffff;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: text;
@@ -656,7 +656,7 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 align-items: stretch;
                 background: #ffffff;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: text;
@@ -828,7 +828,7 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 align-items: stretch;
                 background: #ffffff;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: text;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.PrefixAndSuffix.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.PrefixAndSuffix.Example.tsx.shot
@@ -106,7 +106,7 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                 align-items: stretch;
                 background: #ffffff;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: text;
@@ -307,7 +307,7 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                 background: #ffffff;
                 border-color: #f3f2f1;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: default;
@@ -524,7 +524,7 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                 align-items: stretch;
                 background: #ffffff;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: text;
@@ -720,7 +720,7 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                 align-items: stretch;
                 background: #ffffff;
                 border-radius: 2px;
-                border: 1px solid #8a8886;
+                border: 1px solid #605e5c;
                 box-shadow: none;
                 box-sizing: border-box;
                 cursor: text;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Styled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Styled.Example.tsx.shot
@@ -110,7 +110,7 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
               background: #ffffff;
               border-radius: 2px;
               border-top-color: #a4262c;
-              border: 1px solid #8a8886;
+              border: 1px solid #605e5c;
               box-shadow: none;
               box-sizing: border-box;
               cursor: text;
@@ -287,7 +287,7 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
               align-items: stretch;
               background: #ffffff;
               border-radius: 2px;
-              border: 1px solid #8a8886;
+              border: 1px solid #605e5c;
               box-shadow: none;
               box-sizing: border-box;
               cursor: text;

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`PeoplePicker renders correctly 1`] = `
             {
               align-items: center;
               border-radius: 2px;
-              border: 1px solid #8a8886;
+              border: 1px solid #605e5c;
               box-sizing: border-box;
               display: flex;
               flex-wrap: wrap;
@@ -138,7 +138,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
             {
               align-items: center;
               border-radius: 2px;
-              border: 1px solid #8a8886;
+              border: 1px solid #605e5c;
               box-sizing: border-box;
               display: flex;
               flex-wrap: wrap;

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
@@ -40,7 +40,7 @@ exports[`TagPicker renders correctly 1`] = `
             {
               align-items: center;
               border-radius: 2px;
-              border: 1px solid #8a8886;
+              border: 1px solid #605e5c;
               box-sizing: border-box;
               display: flex;
               flex-wrap: wrap;
@@ -348,7 +348,7 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
             {
               align-items: center;
               border-radius: 2px;
-              border: 1px solid #8a8886;
+              border: 1px solid #605e5c;
               box-sizing: border-box;
               display: flex;
               flex-wrap: wrap;

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -236,7 +236,7 @@ function _makeSemanticColorsFromPalette(p: IPalette, isInverted: boolean, depCom
     accentButtonText: p.white,
 
     // INPUTS
-    inputBorder: p.neutralSecondaryAlt,
+    inputBorder: p.neutralSecondary,
     inputBorderHovered: p.neutralPrimary,
     inputBackground: p.white,
     inputBackgroundChecked: p.themePrimary,


### PR DESCRIPTION
- [x] Include a change request file using `$ yarn change`

Updated input rest states to have an accessible border by changing the inputborder semantic slot from neutralSecondaryAlt to neutralSecondary.

![image](https://user-images.githubusercontent.com/20363037/70085261-b9035c80-15c4-11ea-9c96-7d4be4621c7e.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11361)