### PR TITLE
DetailList: Screen Reader is reading wrong column header with associated cell value for single-select list

### DIFF
--- a/change/office-ui-fabric-react-2019-12-02-18-41-57-master.json
+++ b/change/office-ui-fabric-react-2019-12-02-18-41-57-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix scan mode for list item",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "153203d03b2612359bdcd61ae4fd45ef71be680e",
+  "date": "2019-12-03T02:41:57.509Z"
+}

--- a/change/office-ui-fabric-react-2019-12-02-18-41-57-master.json
+++ b/change/office-ui-fabric-react-2019-12-02-18-41-57-master.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix scan mode for list item",
+  "comment": "Screen Reader is reading wrong column header with associated cell value for single-select detail list",
   "packageName": "office-ui-fabric-react",
   "email": "xgao@microsoft.com",
   "commit": "153203d03b2612359bdcd61ae4fd45ef71be680e",

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.styles.ts
@@ -57,16 +57,7 @@ export const getCellStyles = (props: { theme: ITheme; cellStyleProps?: ICellStyl
 };
 
 export const getStyles = (props: IDetailsHeaderStyleProps): IDetailsHeaderStyles => {
-  const {
-    theme,
-    className,
-    isSelectAllHidden,
-    isAllSelected,
-    isResizingColumn,
-    isSizing,
-    isAllCollapsed,
-    cellStyleProps = DEFAULT_CELL_STYLE_PROPS
-  } = props;
+  const { theme, className, isAllSelected, isResizingColumn, isSizing, isAllCollapsed, cellStyleProps = DEFAULT_CELL_STYLE_PROPS } = props;
 
   const { semanticColors, palette, fonts } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
@@ -115,13 +106,6 @@ export const getStyles = (props: IDetailsHeaderStyleProps): IDetailsHeaderStyles
         }
       },
       isAllSelected && classNames.isAllSelected,
-      isSelectAllHidden && {
-        selectors: {
-          [`& .${classNames.cellIsCheck}`]: {
-            visibility: 'hidden'
-          }
-        }
-      },
       isResizingColumn && classNames.isResizingColumn,
       className
     ],

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -943,9 +943,6 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
       & .ms-TooltipHost .ms-DetailsHeader-checkTooltip {
         display: block;
       }
-      & .ms-DetailsHeader-cellIsCheck {
-        visibility: hidden;
-      }
   data-automationid="DetailsHeader"
   data-focuszone-id="FocusZone3"
   onFocus={[Function]}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11348
- [x] Include a change request file using `$ yarn change`

#### Description of changes
`aria-colindex` is not being respected when narrator is reading the header name for each row value. (the multi-line cross-reference scenario). 
This issue seems to something lacking by narrator. Here is a minimal repro in codepen to better demo this bug & my fix: https://codepen.io/xugao/pen/WNbNaVW
The fix I can find is to __not__ hide the empty checkbox header column. Then narrator will count it as a column by default, and header name will be correct since header row has same number of columns as other rows.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11365)