### PR TITLE
Add alignItems props to <LayoutGroup />

### DIFF
--- a/change/@uifabric-experiments-2019-12-04-16-38-56-huaxi-layout-group.json
+++ b/change/@uifabric-experiments-2019-12-04-16-38-56-huaxi-layout-group.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "add alignItems for layout group to provide more flexibility",
+  "packageName": "@uifabric/experiments",
+  "email": "huaxi@microsoft.com",
+  "commit": "20e519c2a24262a144394106042d3cae3d0e7f4b",
+  "date": "2019-12-05T00:38:56.540Z",
+  "file": "C:\\Git\\office-ui-fabric-react\\change\\@uifabric-experiments-2019-12-04-16-38-56-huaxi-layout-group.json"
+}

--- a/packages/experiments/src/components/LayoutGroup/LayoutGroup.tsx
+++ b/packages/experiments/src/components/LayoutGroup/LayoutGroup.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { ILayoutGroupProps } from './LayoutGroup.types';
+import { ILayoutGroupProps, AlignItems } from './LayoutGroup.types';
 import { IRawStyle, mergeStyles } from 'office-ui-fabric-react/lib/Styling';
 import { getNativeProps, divProperties } from 'office-ui-fabric-react/lib/Utilities';
 
@@ -7,11 +7,12 @@ export class LayoutGroup extends React.Component<ILayoutGroupProps, {}> {
   public static defaultProps: ILayoutGroupProps = {
     layoutGap: 8,
     direction: 'vertical',
-    justify: 'start'
+    justify: 'start',
+    alignItems: AlignItems.START
   };
 
   public render(): JSX.Element | null {
-    const { children, direction, layoutGap, justify } = this.props;
+    const { children, direction, layoutGap, justify, alignItems } = this.props;
 
     const divProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, divProperties);
 
@@ -51,7 +52,8 @@ export class LayoutGroup extends React.Component<ILayoutGroupProps, {}> {
         className={mergeStyles('ms-LayoutGroup', {
           display: 'flex',
           flexDirection: direction === 'horizontal' ? 'row' : 'column',
-          justifyContent: this._getJustify(justify)
+          justifyContent: this._getJustify(justify),
+          alignItems: alignItems || 'flex-start'
         } as IRawStyle)}
       >
         {group}

--- a/packages/experiments/src/components/LayoutGroup/LayoutGroup.types.ts
+++ b/packages/experiments/src/components/LayoutGroup/LayoutGroup.types.ts
@@ -2,6 +2,14 @@ import * as React from 'react';
 import { IBaseProps } from 'office-ui-fabric-react/lib/Utilities';
 import { LayoutGroup } from './LayoutGroup';
 
+export enum AlignItems {
+  START = 'flex-start',
+  END = 'flex-end',
+  CENTER = 'center',
+  STRETCH = 'strech',
+  BASELINE = 'baseline'
+}
+
 export interface ILayoutGroupProps extends IBaseProps, React.HTMLAttributes<LayoutGroup | HTMLDivElement> {
   /**
    * Direction in which the child elements will be layed out.
@@ -20,4 +28,11 @@ export interface ILayoutGroupProps extends IBaseProps, React.HTMLAttributes<Layo
    * @default start
    */
   justify?: 'start' | 'end' | 'center' | 'fill';
+
+  /**
+   * Defines the default behavior for how items are laid out along the cross axis
+   * (perpendicular to the main axis).
+   * @default flex-start;
+   */
+  alignItems?: AlignItems;
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
There is no way to align items cross axis currently in LayoutGroup; thus, added `alignItems` props to provide more flexibility.

#### Focus areas to test
<LayoutGroup />

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11379)