### PR TITLE
SpinButton: Correct SpinButton default max value in documentation

### DIFF
--- a/change/office-ui-fabric-react-2019-12-04-20-55-08-master.json
+++ b/change/office-ui-fabric-react-2019-12-04-20-55-08-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Correct SpinButton default max value in documentation",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "e2ee601bb1439348f60626962e835ca466d176cb",
+  "date": "2019-12-05T04:55:08.773Z"
+}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -46,6 +46,7 @@ export interface ISpinButtonState {
   keyboardSpinDirection: KeyboardSpinDirection;
 }
 
+// TODO (Fabric Next): remove default min/max values (issue #11358).
 export type DefaultProps = Required<
   Pick<ISpinButtonProps, 'step' | 'min' | 'max' | 'disabled' | 'labelPosition' | 'label' | 'incrementButtonIcon' | 'decrementButtonIcon'>
 >;

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.types.ts
@@ -55,7 +55,7 @@ export interface ISpinButtonProps extends React.HTMLAttributes<HTMLDivElement> {
 
   /**
    * The max value of the SpinButton.
-   * @defaultvalue 10
+   * @defaultvalue 100
    */
   max?: number;
 


### PR DESCRIPTION
#### Pull request checklist

- [X] Include a change request file using `$ yarn change`

#### Description of changes
Correct SpinButton default max value in documentation. Should be `100` instead of `10`

[Related PR](https://github.com/OfficeDev/office-ui-fabric-react/pull/11368)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11380)