### PR TITLE
Cherrypicking BasePickerListBelow a11y fix (#10867) to Fabric 6

### DIFF
--- a/change/office-ui-fabric-react-2019-10-16-08-58-09-BasePickerListBelowRole.json
+++ b/change/office-ui-fabric-react-2019-10-16-08-58-09-BasePickerListBelowRole.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": " Added role to the selection list for BasePickerListBelow control so screen readers will read off \"n\" of \"m\" when arrowing through the list.",
+  "packageName": "office-ui-fabric-react",
+  "email": "malind@microsoft.com",
+  "commit": "adfbe74c57a96e8b75b16c0ee11397ab06a3fd5f",
+  "date": "2019-10-16T15:58:09.775Z"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -931,6 +931,7 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
             direction={FocusZoneDirection.bidirectional}
             isInnerZoneKeystroke={this._isFocusZoneInnerKeystroke}
             id={this._ariaMap.selectedItems}
+            role={'list'}
           >
             {this.renderItems()}
           </FocusZone>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

We are having one accessibility work item (Bug 3797473) and to fix this we need to add a change in Fabric.
 
But we noticed some one has already added a fix for this and released that In 7.55.3 (PR #10867). Since it may take some time to migrate to Fabric 7 this PR is cherrypicking/backporting this change to Fabric 6.


#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11387)