### PR TITLE
OverflowSet: Vertical layout now uses menu instead of menubar

### DIFF
--- a/change/office-ui-fabric-react-2019-12-05-15-27-02-overflow-vertical-menu.json
+++ b/change/office-ui-fabric-react-2019-12-05-15-27-02-overflow-vertical-menu.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "OverflowSet: Vertical layout now uses menu instead of menubar",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "6feb1b112efeefb7d63d9e1cfd8d812cb7b0150a",
+  "date": "2019-12-05T23:27:02.240Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -8204,8 +8204,6 @@ export class OverflowSetBase extends BaseComponent<IOverflowSetProps, {}> implem
     componentDidUpdate(): void;
     // (undocumented)
     componentWillUnmount(): void;
-    // (undocumented)
-    static defaultProps: Pick<IOverflowSetProps, 'vertical' | 'role'>;
     focus(forceIntoFirstElement?: boolean): boolean;
     focusElement(childElement?: HTMLElement): boolean;
     // (undocumented)

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.base.tsx
@@ -10,11 +10,6 @@ import { IOverflowSet, IOverflowSetItemProps, IOverflowSetProps, IOverflowSetSty
 const getClassNames = classNamesFunction<IOverflowSetStyleProps, IOverflowSetStyles>();
 
 export class OverflowSetBase extends BaseComponent<IOverflowSetProps, {}> implements IOverflowSet {
-  public static defaultProps: Pick<IOverflowSetProps, 'vertical' | 'role'> = {
-    vertical: false,
-    role: 'menubar'
-  };
-
   private _focusZone = React.createRef<IFocusZone>();
   private _persistedKeytips: { [uniqueID: string]: IKeytipProps } = {};
   private _keytipManager: KeytipManager = KeytipManager.getInstance();
@@ -32,9 +27,11 @@ export class OverflowSetBase extends BaseComponent<IOverflowSetProps, {}> implem
   }
 
   public render(): JSX.Element {
-    const { items, overflowItems, className, focusZoneProps, styles, vertical, role, doNotContainWithinFocusZone } = this.props;
+    const { items, overflowItems, className, focusZoneProps, styles, vertical, doNotContainWithinFocusZone } = this.props;
 
     this._classNames = getClassNames(styles, { className, vertical });
+
+    const role = this.props.role || vertical ? 'menu' : 'menubar';
 
     let Tag;
     let uniqueComponentProps;

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.types.ts
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.types.ts
@@ -49,6 +49,7 @@ export interface IOverflowSetProps extends React.ClassAttributes<OverflowSetBase
 
   /**
    * Change item layout direction to vertical/stacked.
+   * Setting vertical to true also changes default role to "menu"
    * @defaultvalue false
    */
   vertical?: boolean;

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.types.ts
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.types.ts
@@ -49,7 +49,7 @@ export interface IOverflowSetProps extends React.ClassAttributes<OverflowSetBase
 
   /**
    * Change item layout direction to vertical/stacked.
-   * Setting vertical to true also changes default role to "menu"
+   * Setting vertical to true also changes default role to "menu".
    * @defaultvalue false
    */
   vertical?: boolean;

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/__snapshots__/OverflowSet.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/__snapshots__/OverflowSet.test.tsx.snap
@@ -65,6 +65,6 @@ exports[`OverflowSet snapshot tests snapshot with classname and vertical layout 
   onFocus={[Function]}
   onKeyDown={[Function]}
   onMouseDownCapture={[Function]}
-  role="menubar"
+  role="menu"
 />
 `;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Vertical.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Vertical.Example.tsx.shot
@@ -20,7 +20,7 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
   onFocus={[Function]}
   onKeyDown={[Function]}
   onMouseDownCapture={[Function]}
-  role="menubar"
+  role="menu"
 >
   <div
     className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.VerticalOverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.VerticalOverflowSet.Example.tsx.shot
@@ -44,7 +44,7 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
         onFocus={[Function]}
         onKeyDown={[Function]}
         onMouseDownCapture={[Function]}
-        role="menubar"
+        role="menu"
       >
         <div
           className=


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11389
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

(give an overview)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11390)