### PR TITLE
DetailsList: Pass column styles to DetailsColumn

### DIFF
--- a/change/office-ui-fabric-react-2019-12-09-16-03-27-details-list-header-styles.json
+++ b/change/office-ui-fabric-react-2019-12-09-16-03-27-details-list-header-styles.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "DetailsList: Pass column styles to DetailsColumn",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "4b433e866c2d4d73975abcabcbdaadef3fc998f4",
+  "date": "2019-12-10T00:03:27.868Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -2698,6 +2698,7 @@ export interface IColumn {
     onRenderDivider?: IRenderFunction<IDetailsColumnProps>;
     sortAscendingAriaLabel?: string;
     sortDescendingAriaLabel?: string;
+    styles?: IStyleFunctionOrObject<IDetailsColumnStyleProps, IDetailsColumnStyles>;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -5,9 +5,8 @@ import { ColumnActionsMode } from './DetailsList.types';
 
 import { ITooltipHostProps } from '../../Tooltip';
 import { IDragDropOptions } from './../../utilities/dragdrop/interfaces';
-import { IDetailsColumnStyles } from './DetailsColumn.types';
 import { DEFAULT_CELL_STYLE_PROPS } from './DetailsRow.styles';
-import { IDetailsColumnStyleProps, IDetailsColumnProps } from './DetailsColumn.types';
+import { IDetailsColumnStyleProps, IDetailsColumnProps, IDetailsColumnStyles } from './DetailsColumn.types';
 
 const MOUSEDOWN_PRIMARY_BUTTON = 0; // for mouse down event we are using ev.button property, 0 means left button
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.base.tsx
@@ -268,6 +268,7 @@ export class DetailsHeaderBase extends React.Component<IDetailsHeaderBaseProps, 
               this._renderDropHint(columnIndex),
             <DetailsColumn
               column={column}
+              styles={column.styles}
               key={column.key}
               columnIndex={(showCheckbox ? 2 : 1) + columnIndex}
               parentId={this._id}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.types.ts
@@ -11,8 +11,8 @@ import { IWithViewportProps, IViewport } from '../../utilities/decorators/withVi
 import { IList, IListProps, ScrollToMode } from '../List/index';
 import { ITheme, IStyle } from '../../Styling';
 import { ICellStyleProps, IDetailsItemProps } from './DetailsRow.types';
-import { IDetailsColumnProps } from './DetailsColumn';
 import { IDetailsCheckboxProps } from './DetailsRowCheck.types';
+import { IDetailsColumnStyleProps, IDetailsColumnProps, IDetailsColumnStyles } from './DetailsColumn.types';
 
 export {
   IDetailsHeaderProps,
@@ -354,6 +354,11 @@ export interface IColumn {
    * An optional class name to stick on the column cell within each row.
    */
   className?: string;
+
+  /**
+   * Style function to be passed in to override the themed or default styles
+   */
+  styles?: IStyleFunctionOrObject<IDetailsColumnStyleProps, IDetailsColumnStyles>;
 
   /**
    * Minimum width for the column.


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #11401
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

While DetailsHeader accepted and properly mixed in a styles prop, there was no way to pass styles to the column via the DetailsList columns array. 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11404)