### PR TITLE
ContexualMenu: Fix SplitButton text is not being read by screen reader

### DIFF
--- a/change/office-ui-fabric-react-2019-12-09-15-55-40-xgao-a11y-bug-fix-2.json
+++ b/change/office-ui-fabric-react-2019-12-09-15-55-40-xgao-a11y-bug-fix-2.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix contextual menu split button cannot be read by screen reader bug",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "26105362a59563dd559eae94960bed01a7f2103c",
+  "date": "2019-12-09T23:55:40.485Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
@@ -120,8 +120,7 @@ export class ContextualMenuSplitButton extends ContextualMenuItemWrapper {
       isChecked: item.isChecked,
       checked: item.checked,
       iconProps: item.iconProps,
-      'data-is-focusable': false,
-      'aria-hidden': true
+      'data-is-focusable': false
     };
 
     const { itemProps: itemComponentProps } = item;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuSplitButton.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuSplitButton.deprecated.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`ContextualMenuSplitButton creates a normal split button renders the con
   tabIndex={0}
 >
   <button
-    aria-hidden={true}
     className="splitPrimary"
     data-is-focusable={false}
   >

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuSplitButton.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuSplitButton.test.tsx.snap
@@ -17,7 +17,6 @@ exports[`ContextualMenuSplitButton creates a normal split button renders the con
   tabIndex={0}
 >
   <button
-    aria-hidden={true}
     className="splitPrimary"
     data-is-focusable={false}
   >


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10837
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Contexual Menu Split button text is not being read by screen reader due to it's `aria-hidden=true`



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11408)