### PR TITLE
Autocomplete: Allow value to be overriden

### DIFF
--- a/change/office-ui-fabric-react-2019-12-09-17-38-21-autocomplete-override.json
+++ b/change/office-ui-fabric-react-2019-12-09-17-38-21-autocomplete-override.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Autocomplete: Allow value to be overriden",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "cd4f87ccb3261f7a26c6a183b4cec33a64ed9be2",
+  "date": "2019-12-10T01:38:21.436Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
+++ b/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
@@ -119,8 +119,9 @@ export class Autofill extends BaseComponent<IAutofillProps, IAutofillState> impl
     const nativeProps = getNativeProps<React.InputHTMLAttributes<HTMLInputElement>>(this.props, inputProperties);
     return (
       <input
-        autoCapitalize={'off'}
-        autoComplete={'off'}
+        autoCapitalize="off"
+        autoComplete="off"
+        aria-autocomplete={'both'}
         {...nativeProps}
         ref={this._inputElement}
         value={displayValue}

--- a/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
+++ b/packages/office-ui-fabric-react/src/components/Autofill/Autofill.tsx
@@ -119,11 +119,11 @@ export class Autofill extends BaseComponent<IAutofillProps, IAutofillState> impl
     const nativeProps = getNativeProps<React.InputHTMLAttributes<HTMLInputElement>>(this.props, inputProperties);
     return (
       <input
+        autoCapitalize={'off'}
+        autoComplete={'off'}
         {...nativeProps}
         ref={this._inputElement}
         value={displayValue}
-        autoCapitalize={'off'}
-        autoComplete={'off'}
         onCompositionStart={this._onCompositionStart}
         onCompositionUpdate={this._onCompositionUpdate}
         onCompositionEnd={this._onCompositionEnd}

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -117,6 +117,8 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extend
               {this.renderSelectedItemsList()}
               {this.canAddItems() && (
                 <Autofill
+                  autoCapitalize="off"
+                  autoComplete="off"
                   {...inputProps as IInputProps}
                   className={css('ms-BasePicker-input', styles.pickerInput)}
                   ref={this.input}
@@ -127,8 +129,6 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extend
                   aria-owns={isExpanded ? 'suggestion-list' : undefined}
                   aria-expanded={isExpanded}
                   aria-haspopup="true"
-                  autoCapitalize="off"
-                  autoComplete="off"
                   role="combobox"
                   disabled={disabled}
                   onPaste={this.onPaste}

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/BaseExtendedPicker.tsx
@@ -117,8 +117,6 @@ export class BaseExtendedPicker<T, P extends IBaseExtendedPickerProps<T>> extend
               {this.renderSelectedItemsList()}
               {this.canAddItems() && (
                 <Autofill
-                  autoCapitalize="off"
-                  autoComplete="off"
                   {...inputProps as IInputProps}
                   className={css('ms-BasePicker-input', styles.pickerInput)}
                   ref={this.input}

--- a/packages/office-ui-fabric-react/src/components/ExtendedPicker/__snapshots__/BaseExtendedPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ExtendedPicker/__snapshots__/BaseExtendedPicker.test.tsx.snap
@@ -34,6 +34,7 @@ exports[`Pickers BasePicker renders BaseExtendedPicker correctly with no items 1
         role="list"
       >
         <input
+          aria-autocomplete="both"
           aria-expanded={false}
           aria-haspopup="true"
           autoCapitalize="off"
@@ -103,6 +104,7 @@ exports[`Pickers BasePicker renders BaseExtendedPicker correctly with selected a
            
         </div>
         <input
+          aria-autocomplete="both"
           aria-expanded={false}
           aria-haspopup="true"
           autoCapitalize="off"

--- a/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/Items/EditingItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/SelectedItemsList/SelectedPeopleList/Items/EditingItem.tsx
@@ -45,10 +45,10 @@ export class EditingItem extends BaseComponent<IEditingSelectedPeopleItemProps, 
     return (
       <div aria-labelledby={'editingItemPersona-' + itemId} className={css('ms-EditingItem', styles.editingContainer)}>
         <input
-          {...nativeProps}
-          ref={this._resolveInputRef}
           autoCapitalize={'off'}
           autoComplete={'off'}
+          {...nativeProps}
+          ref={this._resolveInputRef}
           onChange={this._onInputChange}
           onKeyDown={this._onInputKeyDown}
           onBlur={this._onInputBlur}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Basic.Example.tsx.shot
@@ -54,6 +54,7 @@ exports[`Component Examples renders ExtendedPeoplePicker.Basic.Example.tsx corre
             To:
           </div>
           <input
+            aria-autocomplete="both"
             aria-expanded={false}
             aria-haspopup="true"
             aria-label="People Picker"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Controlled.Example.tsx.shot
@@ -54,6 +54,7 @@ exports[`Component Examples renders ExtendedPeoplePicker.Controlled.Example.tsx 
             To:
           </div>
           <input
+            aria-autocomplete="both"
             aria-expanded={false}
             aria-haspopup="true"
             aria-label="People Picker"

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -272,9 +272,6 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
               {this.canAddItems() && (
                 <Autofill
                   spellCheck={false}
-                  autoCapitalize="off"
-                  autoComplete="off"
-                  aria-autocomplete={'both'}
                   {...inputProps as any}
                   className={classNames.input}
                   componentRef={this.input}
@@ -980,8 +977,6 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
             role="combobox"
           >
             <Autofill
-              autoCapitalize="off"
-              autoComplete="off"
               {...inputProps as any}
               className={classNames.input}
               componentRef={this.input}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.tsx
@@ -272,6 +272,9 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
               {this.canAddItems() && (
                 <Autofill
                   spellCheck={false}
+                  autoCapitalize="off"
+                  autoComplete="off"
+                  aria-autocomplete={'both'}
                   {...inputProps as any}
                   className={classNames.input}
                   componentRef={this.input}
@@ -283,11 +286,8 @@ export class BasePicker<T, P extends IBasePickerProps<T>> extends BaseComponent<
                   aria-describedby={items.length > 0 ? this._ariaMap.selectedItems : undefined}
                   aria-controls={`${suggestionsAvailable} ${selectedSuggestionAlertId}` || undefined}
                   aria-activedescendant={this.getActiveDescendant()}
-                  autoCapitalize="off"
-                  autoComplete="off"
                   role={'textbox'}
                   disabled={disabled}
-                  aria-autocomplete={'both'}
                   onInputChange={this.props.onInputChange}
                 />
               )}
@@ -980,6 +980,8 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
             role="combobox"
           >
             <Autofill
+              autoCapitalize="off"
+              autoComplete="off"
               {...inputProps as any}
               className={classNames.input}
               componentRef={this.input}
@@ -989,8 +991,6 @@ export class BasePickerListBelow<T, P extends IBasePickerProps<T>> extends BaseP
               onInputValueChange={this.onInputChange}
               suggestedDisplayValue={suggestedDisplayValue}
               aria-activedescendant={this.getActiveDescendant()}
-              autoCapitalize="off"
-              autoComplete="off"
               role="textbox"
               disabled={disabled}
               aria-controls={`${suggestionsAvailable} ${selectedSuggestionAlertId}` || undefined}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes


Moved autoCapitalize (and other static values) above the nativeInput props to allow those values to be overriden. 


Issue came up #11403. Will cherry pick this back to 6 to resolve that specific issue. 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11409)