### PR TITLE
Stack: Adding documentation about Stack Items in the Stack overview

### DIFF
--- a/change/office-ui-fabric-react-2019-12-10-15-12-35-stackItemDocs.json
+++ b/change/office-ui-fabric-react-2019-12-10-15-12-35-stackItemDocs.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Stack: Adding documentation about Stack Items in the Stack overview.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "3488c442e457b72ba94e43e93047ee46ccc0076e",
+  "date": "2019-12-10T23:12:35.261Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Stack/docs/StackOverview.md
+++ b/packages/office-ui-fabric-react/src/components/Stack/docs/StackOverview.md
@@ -1,17 +1,25 @@
-A Stack is a container-type component that abstracts the implementation of a flexbox in order to define the layout of its children components.
+A `Stack` is a container-type component that abstracts the implementation of a flexbox in order to define the layout of its children components.
 
 ## Stack Properties
 
-Although Stack has a number of different properties, there are three in particular that define the overall layout that the component has:
+Although the `Stack` component has a number of different properties, there are three in particular that define the overall layout that the component has:
 
-1. Direction: Refers to whether the stacking of children components is horizontal or vertical. By default the Stack component is vertical, but can be turned horizontal by adding the `horizontal` property when using the component.
-2. Alignment: Refers to how the children components are aligned inside the container. This is controlled via the `verticalAlign` and `horizontalAlign` properties. One thing to notice here is that while flexbox containers align always across the cross axis, Stack aims to remove the mental strain involved in this process by making the `verticalAlign` and `horizontalAlign` properties always follow the vertical and horizontal axes, respectively, regardless of the direction of the Stack.
-3. Spacing: Refers to the space that exists between children components inside the Stack. This is controlled via the `gap` and `verticalGap` properties.
+1. Direction: Refers to whether the stacking of children components is horizontal or vertical. By default the `Stack` component is vertical, but can be turned horizontal by adding the `horizontal` property when using the component.
+2. Alignment: Refers to how the children components are aligned inside the container. This is controlled via the `verticalAlign` and `horizontalAlign` properties. One thing to notice here is that while flexbox containers align always across the cross axis, `Stack` aims to remove the mental strain involved in this process by making the `verticalAlign` and `horizontalAlign` properties always follow the vertical and horizontal axes, respectively, regardless of the direction of the `Stack`.
+3. Spacing: Refers to the space that exists between children components inside the `Stack`. This is controlled via the `gap` and `verticalGap` properties.
+
+# Stack Items
+
+The `Stack` component provides an abstraction of a flexbox container but there are some flexbox related properties that are applied on specific children of the flexbox instead of being applied on the container. This is where `Stack Items` comes into play.
+
+A `Stack Item` abstracts those properties that are or can be specifically applied on flexbox's children, like `grow` and `shrink`.
+
+To use a `Stack Item` in an application, the `Stack` component should be imported and `Stack.Item` should be used. This is done so that the existence of the `Stack Item` is inherently linked to the `Stack` component, since it doesn't make sense for a `Stack Item` to exist outside of the context of a `Stack`.
 
 ## Stack Wrapping
 
-Aside from the previously mentioned properties, there is another property called `wrap` that determines if items overflow the Stack container or wrap around it. The wrap property only works in the direction of the Stack, which means that the children components can still overflow in the perpendicular direction (i.e. in a Vertical Stack, items might overflow horizontally and vice versa).
+Aside from the previously mentioned properties, there is another property called `wrap` that determines if items overflow the `Stack` container or wrap around it. The wrap property only works in the direction of the `Stack`, which means that the children components can still overflow in the perpendicular direction (i.e. in a `Vertical Stack`, items might overflow horizontally and vice versa).
 
 ## Stack Nesting
 
-Stacks can be nested inside one another in order to be able to configure the layout of the application as desired.
+`Stacks` can be nested inside one another in order to be able to configure the layout of the application as desired.

--- a/packages/office-ui-fabric-react/src/components/Stack/docs/StackOverview.md
+++ b/packages/office-ui-fabric-react/src/components/Stack/docs/StackOverview.md
@@ -14,7 +14,7 @@ The `Stack` component provides an abstraction of a flexbox container but there a
 
 A `Stack Item` abstracts those properties that are or can be specifically applied on flexbox's children, like `grow` and `shrink`.
 
-To use a `Stack Item` in an application, the `Stack` component should be imported and `Stack.Item` should be used. This is done so that the existence of the `Stack Item` is inherently linked to the `Stack` component, since it doesn't make sense for a `Stack Item` to exist outside of the context of a `Stack`.
+To use a `Stack Item` in an application, the `Stack` component should be imported and `Stack.Item` should be used inside of a `Stack`. This is done so that the existence of the `Stack Item` is inherently linked to the `Stack` component.
 
 ## Stack Wrapping
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11405
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Documentation about the `StackItem` component was missing from our website. This PR adds such documentation under the `Overview` section of the `Stack` component docs.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11423)