### PR TITLE
FocusZone: Escape readOnly input on arrow clicks

### DIFF
--- a/change/office-ui-fabric-react-2019-12-11-13-32-59-focuszone-readonly-inputs.json
+++ b/change/office-ui-fabric-react-2019-12-11-13-32-59-focuszone-readonly-inputs.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "FocusZone: Escape readOnly input on arrow clicks",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "7bcce389cacf0686f679ec630ce3d0712f0bc05b",
+  "date": "2019-12-11T21:32:59.251Z"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
@@ -1631,7 +1631,7 @@ describe('FocusZone', () => {
       <div {...{ onFocusCapture: _onFocus }}>
         <FocusZone isInnerZoneKeystroke={isInnerZoneKeystroke}>
           <input className="a" />
-          <input readOnly value="foo" className="b" />
+          <input readOnly defaultValue="foo" className="b" />
           <input className="c" />
         </FocusZone>
       </div>

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
@@ -1670,20 +1670,13 @@ describe('FocusZone', () => {
       }
     });
 
-    // inputA should be focussed.
-    ReactTestUtils.Simulate.focus(inputA);
-    expect(lastFocusedElement).toBe(inputA);
-
-    // Pressing right should go to b.
-    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
-    expect(lastFocusedElement).toBe(inputB);
-
+    ReactTestUtils.Simulate.focus(inputB);
     // Pressing right should go to c.
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
     expect(lastFocusedElement).toBe(inputC);
 
-    // Pressing left from b should go back to a
     ReactTestUtils.Simulate.focus(inputB);
+    // Pressing left from b should go back to a
     ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
     expect(lastFocusedElement).toBe(inputA);
   });

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.test.tsx
@@ -1624,6 +1624,70 @@ describe('FocusZone', () => {
     expect(lastFocusedElement).toBe(buttonB);
   });
 
+  it('Focus is not affected by readOnly inputs with values', () => {
+    const isInnerZoneKeystroke = (e: React.KeyboardEvent<HTMLElement>): boolean => e.which === KeyCodes.enter;
+
+    const component = ReactTestUtils.renderIntoDocument(
+      <div {...{ onFocusCapture: _onFocus }}>
+        <FocusZone isInnerZoneKeystroke={isInnerZoneKeystroke}>
+          <input className="a" />
+          <input readOnly value="foo" className="b" />
+          <input className="c" />
+        </FocusZone>
+      </div>
+    );
+
+    const focusZone = ReactDOM.findDOMNode((component as unknown) as React.ReactInstance)!.firstChild as Element;
+
+    const inputA = focusZone.querySelector('.a') as HTMLElement;
+    const inputB = focusZone.querySelector('.b') as HTMLElement;
+    const inputC = focusZone.querySelector('.c') as HTMLElement;
+
+    setupElement(inputA, {
+      clientRect: {
+        top: 0,
+        bottom: 20,
+        left: 0,
+        right: 20
+      }
+    });
+
+    setupElement(inputB, {
+      clientRect: {
+        top: 0,
+        bottom: 20,
+        left: 20,
+        right: 40
+      }
+    });
+
+    setupElement(inputC, {
+      clientRect: {
+        top: 0,
+        bottom: 20,
+        left: 40,
+        right: 60
+      }
+    });
+
+    // inputA should be focussed.
+    ReactTestUtils.Simulate.focus(inputA);
+    expect(lastFocusedElement).toBe(inputA);
+
+    // Pressing right should go to b.
+    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    expect(lastFocusedElement).toBe(inputB);
+
+    // Pressing right should go to c.
+    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.right });
+    expect(lastFocusedElement).toBe(inputC);
+
+    // Pressing left from b should go back to a
+    ReactTestUtils.Simulate.focus(inputB);
+    ReactTestUtils.Simulate.keyDown(focusZone, { which: KeyCodes.left });
+    expect(lastFocusedElement).toBe(inputA);
+  });
+
   it('removes tab-index of previous element when another one is selected (mouse & keyboard)', () => {
     let focusZone: FocusZone | null = null;
     let buttonA: HTMLButtonElement | null = null;

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -1036,18 +1036,19 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
       const selectionEnd = element.selectionEnd;
       const isRangeSelected = selectionStart !== selectionEnd;
       const inputValue = element.value;
+      const isReadonly = element.readOnly;
 
       // We shouldn't lose focus in the following cases:
       // 1. There is range selected.
-      // 2. When selection start is larger than 0 and it is backward.
+      // 2. When selection start is larger than 0 and it is backward and not readOnly.
       // 3. when selection start is not the end of length and it is forward.
       // 4. We press any of the arrow keys when our handleTabKey isn't none or undefined (only losing focus if we hit tab)
       // and if shouldInputLoseFocusOnArrowKey is defined, if scenario prefers to not loose the focus which is determined by calling the
       // callback shouldInputLoseFocusOnArrowKey
       if (
         isRangeSelected ||
-        (selectionStart! > 0 && !isForward) ||
-        (selectionStart !== inputValue.length && isForward) ||
+        (selectionStart! > 0 && !isForward && !isReadonly) ||
+        (selectionStart !== inputValue.length && isForward && !isReadonly) ||
         (!!this.props.handleTabKey && !(this.props.shouldInputLoseFocusOnArrowKey && this.props.shouldInputLoseFocusOnArrowKey(element)))
       ) {
         return false;

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -1041,7 +1041,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
       // We shouldn't lose focus in the following cases:
       // 1. There is range selected.
       // 2. When selection start is larger than 0 and it is backward and not readOnly.
-      // 3. when selection start is not the end of length and it is forward.
+      // 3. when selection start is not the end of length, it is forward and not readOnly.
       // 4. We press any of the arrow keys when our handleTabKey isn't none or undefined (only losing focus if we hit tab)
       // and if shouldInputLoseFocusOnArrowKey is defined, if scenario prefers to not loose the focus which is determined by calling the
       // callback shouldInputLoseFocusOnArrowKey

--- a/packages/office-ui-fabric-react/src/components/FocusZone/examples/FocusZone.List.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/examples/FocusZone.List.Example.tsx
@@ -22,23 +22,23 @@ const COLUMNS: IColumn[] = [
   {
     key: 'link',
     name: 'Link',
-    fieldName: 'url',
+    fieldName: '',
     minWidth: 100,
     onRender: item => <Link href={item.url}>{item.url}</Link>
   },
   {
     key: 'textfield',
     name: 'Link',
-    fieldName: 'url',
+    fieldName: '',
     minWidth: 130,
-    onRender: item => <TextField readOnly value={'ReadOnly ' + item.name} />
+    onRender: item => <TextField readOnly defaultValue={'ReadOnly ' + item.name} />
   },
   {
-    key: 'textfield',
-    name: 'Link',
-    fieldName: 'url',
+    key: 'textfield2',
+    name: 'Link2',
+    fieldName: '',
     minWidth: 130,
-    onRender: item => <TextField value={item.name} />
+    onRender: item => <TextField defaultValue={item.name} />
   }
 ];
 

--- a/packages/office-ui-fabric-react/src/components/FocusZone/examples/FocusZone.List.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/examples/FocusZone.List.Example.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { KeyCodes, createArray, getRTLSafeKeyCode } from 'office-ui-fabric-react/lib/Utilities';
 import { useConst } from '@uifabric/react-hooks';
-import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
+import { TextField } from 'office-ui-fabric-react';
 import { Link } from 'office-ui-fabric-react/lib/Link';
 import { FocusZone, FocusZoneDirection } from 'office-ui-fabric-react/lib/FocusZone';
 import { DetailsRow, IColumn, Selection, SelectionMode } from 'office-ui-fabric-react/lib/DetailsList';
@@ -9,7 +9,7 @@ import { DetailsRow, IColumn, Selection, SelectionMode } from 'office-ui-fabric-
 const ITEMS = createArray(10, index => ({
   key: index.toString(),
   name: 'Item-' + index,
-  url: 'http://placehold.it/100x' + (200 + index!)
+  url: 'http://placehold.it/100x' + (100 + index!)
 }));
 
 const COLUMNS: IColumn[] = [
@@ -27,11 +27,18 @@ const COLUMNS: IColumn[] = [
     onRender: item => <Link href={item.url}>{item.url}</Link>
   },
   {
-    key: 'defaultButton',
+    key: 'textfield',
     name: 'Link',
     fieldName: 'url',
-    minWidth: 100,
-    onRender: item => <DefaultButton>{item.url}</DefaultButton>
+    minWidth: 130,
+    onRender: item => <TextField readOnly value={'ReadOnly ' + item.name} />
+  },
+  {
+    key: 'textfield',
+    name: 'Link',
+    fieldName: 'url',
+    minWidth: 130,
+    onRender: item => <TextField value={item.name} />
   }
 ];
 

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
@@ -251,10 +251,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
-          href="http://placehold.it/100x200"
+          href="http://placehold.it/100x100"
           onClick={[Function]}
         >
-          http://placehold.it/100x200
+          http://placehold.it/100x100
         </a>
       </div>
       <div
@@ -302,7 +302,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-        data-automation-key="defaultButton"
+        data-automation-key="textfield"
         data-automationid="DetailsRowCell"
         role="gridcell"
         style={
@@ -311,123 +311,338 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           }
         }
       >
-        <button
+        <div
           className=
-              ms-Button
-              ms-Button--default
+              ms-TextField
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 2px;
-                border: 1px solid #8a8886;
+                box-shadow: none;
                 box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 32px;
-                min-width: 80px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 16px;
-                padding-right: 16px;
-                padding-top: 0;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
                 position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid transparent;
-                bottom: 2px;
-                content: "";
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: absolute;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
         >
-          <span
+          <div
             className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-            data-automationid="splitbuttonprimary"
+                ms-TextField-wrapper
+
           >
-            <span
+            <div
               className=
-                  ms-Button-textContainer
+                  ms-TextField-fieldGroup
                   {
-                    display: block;
-                    flex-grow: 1;
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
                   }
             >
-              <span
+              <input
+                aria-invalid={false}
                 className=
-                    ms-Button-label
+                    ms-TextField-field
                     {
-                      display: block;
-                      font-weight: 600;
-                      line-height: 100%;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
                     }
-                id="id__2"
-              >
-                http://placehold.it/100x200
-              </span>
-            </span>
-          </span>
-        </button>
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField2"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                readOnly={true}
+                type="text"
+                value="ReadOnly Item-0"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-colindex={4}
+        className=
+            ms-DetailsRow-cell
+            {
+              box-sizing: border-box;
+              display: inline-block;
+              min-height: 42px;
+              outline: transparent;
+              overflow: hidden;
+              padding-bottom: 11px;
+              padding-left: 12px;
+              padding-top: 11px;
+              position: relative;
+              text-overflow: ellipsis;
+              vertical-align: top;
+              white-space: nowrap;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #605e5c;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #ffffff;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            & > button {
+              max-width: 100%;
+            }
+            & [data-is-focusable='true'] {
+              outline: transparent;
+              position: relative;
+            }
+            & [data-is-focusable='true']::-moz-focus-inner {
+              border: 0;
+            }
+            {
+              padding-right: 8px;
+            }
+        data-automation-key="textfield2"
+        data-automationid="DetailsRowCell"
+        role="gridcell"
+        style={
+          Object {
+            "width": "auto",
+          }
+        }
+      >
+        <div
+          className=
+              ms-TextField
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+        >
+          <div
+            className=
+                ms-TextField-wrapper
+
+          >
+            <div
+              className=
+                  ms-TextField-fieldGroup
+                  {
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                  }
+            >
+              <input
+                aria-invalid={false}
+                className=
+                    ms-TextField-field
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
+                    }
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField5"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                type="text"
+                value="Item-0"
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <span
@@ -513,7 +728,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           opacity: 1;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone5"
+    data-focuszone-id="FocusZone8"
     data-is-focusable={true}
     data-item-index={1}
     data-selection-index={1}
@@ -684,10 +899,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
-          href="http://placehold.it/100x201"
+          href="http://placehold.it/100x101"
           onClick={[Function]}
         >
-          http://placehold.it/100x201
+          http://placehold.it/100x101
         </a>
       </div>
       <div
@@ -735,7 +950,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-        data-automation-key="defaultButton"
+        data-automation-key="textfield"
         data-automationid="DetailsRowCell"
         role="gridcell"
         style={
@@ -744,123 +959,338 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           }
         }
       >
-        <button
+        <div
           className=
-              ms-Button
-              ms-Button--default
+              ms-TextField
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 2px;
-                border: 1px solid #8a8886;
+                box-shadow: none;
                 box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 32px;
-                min-width: 80px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 16px;
-                padding-right: 16px;
-                padding-top: 0;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
                 position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid transparent;
-                bottom: 2px;
-                content: "";
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: absolute;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
         >
-          <span
+          <div
             className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-            data-automationid="splitbuttonprimary"
+                ms-TextField-wrapper
+
           >
-            <span
+            <div
               className=
-                  ms-Button-textContainer
+                  ms-TextField-fieldGroup
                   {
-                    display: block;
-                    flex-grow: 1;
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
                   }
             >
-              <span
+              <input
+                aria-invalid={false}
                 className=
-                    ms-Button-label
+                    ms-TextField-field
                     {
-                      display: block;
-                      font-weight: 600;
-                      line-height: 100%;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
                     }
-                id="id__6"
-              >
-                http://placehold.it/100x201
-              </span>
-            </span>
-          </span>
-        </button>
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField9"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                readOnly={true}
+                type="text"
+                value="ReadOnly Item-1"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-colindex={4}
+        className=
+            ms-DetailsRow-cell
+            {
+              box-sizing: border-box;
+              display: inline-block;
+              min-height: 42px;
+              outline: transparent;
+              overflow: hidden;
+              padding-bottom: 11px;
+              padding-left: 12px;
+              padding-top: 11px;
+              position: relative;
+              text-overflow: ellipsis;
+              vertical-align: top;
+              white-space: nowrap;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #605e5c;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #ffffff;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            & > button {
+              max-width: 100%;
+            }
+            & [data-is-focusable='true'] {
+              outline: transparent;
+              position: relative;
+            }
+            & [data-is-focusable='true']::-moz-focus-inner {
+              border: 0;
+            }
+            {
+              padding-right: 8px;
+            }
+        data-automation-key="textfield2"
+        data-automationid="DetailsRowCell"
+        role="gridcell"
+        style={
+          Object {
+            "width": "auto",
+          }
+        }
+      >
+        <div
+          className=
+              ms-TextField
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+        >
+          <div
+            className=
+                ms-TextField-wrapper
+
+          >
+            <div
+              className=
+                  ms-TextField-fieldGroup
+                  {
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                  }
+            >
+              <input
+                aria-invalid={false}
+                className=
+                    ms-TextField-field
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
+                    }
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField12"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                type="text"
+                value="Item-1"
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <span
@@ -946,7 +1376,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           opacity: 1;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone9"
+    data-focuszone-id="FocusZone15"
     data-is-focusable={true}
     data-item-index={2}
     data-selection-index={2}
@@ -1117,10 +1547,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
-          href="http://placehold.it/100x202"
+          href="http://placehold.it/100x102"
           onClick={[Function]}
         >
-          http://placehold.it/100x202
+          http://placehold.it/100x102
         </a>
       </div>
       <div
@@ -1168,7 +1598,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-        data-automation-key="defaultButton"
+        data-automation-key="textfield"
         data-automationid="DetailsRowCell"
         role="gridcell"
         style={
@@ -1177,123 +1607,338 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           }
         }
       >
-        <button
+        <div
           className=
-              ms-Button
-              ms-Button--default
+              ms-TextField
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 2px;
-                border: 1px solid #8a8886;
+                box-shadow: none;
                 box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 32px;
-                min-width: 80px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 16px;
-                padding-right: 16px;
-                padding-top: 0;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
                 position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid transparent;
-                bottom: 2px;
-                content: "";
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: absolute;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
         >
-          <span
+          <div
             className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-            data-automationid="splitbuttonprimary"
+                ms-TextField-wrapper
+
           >
-            <span
+            <div
               className=
-                  ms-Button-textContainer
+                  ms-TextField-fieldGroup
                   {
-                    display: block;
-                    flex-grow: 1;
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
                   }
             >
-              <span
+              <input
+                aria-invalid={false}
                 className=
-                    ms-Button-label
+                    ms-TextField-field
                     {
-                      display: block;
-                      font-weight: 600;
-                      line-height: 100%;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
                     }
-                id="id__10"
-              >
-                http://placehold.it/100x202
-              </span>
-            </span>
-          </span>
-        </button>
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField16"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                readOnly={true}
+                type="text"
+                value="ReadOnly Item-2"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-colindex={4}
+        className=
+            ms-DetailsRow-cell
+            {
+              box-sizing: border-box;
+              display: inline-block;
+              min-height: 42px;
+              outline: transparent;
+              overflow: hidden;
+              padding-bottom: 11px;
+              padding-left: 12px;
+              padding-top: 11px;
+              position: relative;
+              text-overflow: ellipsis;
+              vertical-align: top;
+              white-space: nowrap;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #605e5c;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #ffffff;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            & > button {
+              max-width: 100%;
+            }
+            & [data-is-focusable='true'] {
+              outline: transparent;
+              position: relative;
+            }
+            & [data-is-focusable='true']::-moz-focus-inner {
+              border: 0;
+            }
+            {
+              padding-right: 8px;
+            }
+        data-automation-key="textfield2"
+        data-automationid="DetailsRowCell"
+        role="gridcell"
+        style={
+          Object {
+            "width": "auto",
+          }
+        }
+      >
+        <div
+          className=
+              ms-TextField
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+        >
+          <div
+            className=
+                ms-TextField-wrapper
+
+          >
+            <div
+              className=
+                  ms-TextField-fieldGroup
+                  {
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                  }
+            >
+              <input
+                aria-invalid={false}
+                className=
+                    ms-TextField-field
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
+                    }
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField19"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                type="text"
+                value="Item-2"
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <span
@@ -1379,7 +2024,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           opacity: 1;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone13"
+    data-focuszone-id="FocusZone22"
     data-is-focusable={true}
     data-item-index={3}
     data-selection-index={3}
@@ -1550,10 +2195,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
-          href="http://placehold.it/100x203"
+          href="http://placehold.it/100x103"
           onClick={[Function]}
         >
-          http://placehold.it/100x203
+          http://placehold.it/100x103
         </a>
       </div>
       <div
@@ -1601,7 +2246,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-        data-automation-key="defaultButton"
+        data-automation-key="textfield"
         data-automationid="DetailsRowCell"
         role="gridcell"
         style={
@@ -1610,123 +2255,338 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           }
         }
       >
-        <button
+        <div
           className=
-              ms-Button
-              ms-Button--default
+              ms-TextField
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 2px;
-                border: 1px solid #8a8886;
+                box-shadow: none;
                 box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 32px;
-                min-width: 80px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 16px;
-                padding-right: 16px;
-                padding-top: 0;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
                 position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid transparent;
-                bottom: 2px;
-                content: "";
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: absolute;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
         >
-          <span
+          <div
             className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-            data-automationid="splitbuttonprimary"
+                ms-TextField-wrapper
+
           >
-            <span
+            <div
               className=
-                  ms-Button-textContainer
+                  ms-TextField-fieldGroup
                   {
-                    display: block;
-                    flex-grow: 1;
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
                   }
             >
-              <span
+              <input
+                aria-invalid={false}
                 className=
-                    ms-Button-label
+                    ms-TextField-field
                     {
-                      display: block;
-                      font-weight: 600;
-                      line-height: 100%;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
                     }
-                id="id__14"
-              >
-                http://placehold.it/100x203
-              </span>
-            </span>
-          </span>
-        </button>
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField23"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                readOnly={true}
+                type="text"
+                value="ReadOnly Item-3"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-colindex={4}
+        className=
+            ms-DetailsRow-cell
+            {
+              box-sizing: border-box;
+              display: inline-block;
+              min-height: 42px;
+              outline: transparent;
+              overflow: hidden;
+              padding-bottom: 11px;
+              padding-left: 12px;
+              padding-top: 11px;
+              position: relative;
+              text-overflow: ellipsis;
+              vertical-align: top;
+              white-space: nowrap;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #605e5c;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #ffffff;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            & > button {
+              max-width: 100%;
+            }
+            & [data-is-focusable='true'] {
+              outline: transparent;
+              position: relative;
+            }
+            & [data-is-focusable='true']::-moz-focus-inner {
+              border: 0;
+            }
+            {
+              padding-right: 8px;
+            }
+        data-automation-key="textfield2"
+        data-automationid="DetailsRowCell"
+        role="gridcell"
+        style={
+          Object {
+            "width": "auto",
+          }
+        }
+      >
+        <div
+          className=
+              ms-TextField
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+        >
+          <div
+            className=
+                ms-TextField-wrapper
+
+          >
+            <div
+              className=
+                  ms-TextField-fieldGroup
+                  {
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                  }
+            >
+              <input
+                aria-invalid={false}
+                className=
+                    ms-TextField-field
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
+                    }
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField26"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                type="text"
+                value="Item-3"
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <span
@@ -1812,7 +2672,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           opacity: 1;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone17"
+    data-focuszone-id="FocusZone29"
     data-is-focusable={true}
     data-item-index={4}
     data-selection-index={4}
@@ -1983,10 +2843,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
-          href="http://placehold.it/100x204"
+          href="http://placehold.it/100x104"
           onClick={[Function]}
         >
-          http://placehold.it/100x204
+          http://placehold.it/100x104
         </a>
       </div>
       <div
@@ -2034,7 +2894,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-        data-automation-key="defaultButton"
+        data-automation-key="textfield"
         data-automationid="DetailsRowCell"
         role="gridcell"
         style={
@@ -2043,123 +2903,338 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           }
         }
       >
-        <button
+        <div
           className=
-              ms-Button
-              ms-Button--default
+              ms-TextField
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 2px;
-                border: 1px solid #8a8886;
+                box-shadow: none;
                 box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 32px;
-                min-width: 80px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 16px;
-                padding-right: 16px;
-                padding-top: 0;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
                 position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid transparent;
-                bottom: 2px;
-                content: "";
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: absolute;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
         >
-          <span
+          <div
             className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-            data-automationid="splitbuttonprimary"
+                ms-TextField-wrapper
+
           >
-            <span
+            <div
               className=
-                  ms-Button-textContainer
+                  ms-TextField-fieldGroup
                   {
-                    display: block;
-                    flex-grow: 1;
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
                   }
             >
-              <span
+              <input
+                aria-invalid={false}
                 className=
-                    ms-Button-label
+                    ms-TextField-field
                     {
-                      display: block;
-                      font-weight: 600;
-                      line-height: 100%;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
                     }
-                id="id__18"
-              >
-                http://placehold.it/100x204
-              </span>
-            </span>
-          </span>
-        </button>
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField30"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                readOnly={true}
+                type="text"
+                value="ReadOnly Item-4"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-colindex={4}
+        className=
+            ms-DetailsRow-cell
+            {
+              box-sizing: border-box;
+              display: inline-block;
+              min-height: 42px;
+              outline: transparent;
+              overflow: hidden;
+              padding-bottom: 11px;
+              padding-left: 12px;
+              padding-top: 11px;
+              position: relative;
+              text-overflow: ellipsis;
+              vertical-align: top;
+              white-space: nowrap;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #605e5c;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #ffffff;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            & > button {
+              max-width: 100%;
+            }
+            & [data-is-focusable='true'] {
+              outline: transparent;
+              position: relative;
+            }
+            & [data-is-focusable='true']::-moz-focus-inner {
+              border: 0;
+            }
+            {
+              padding-right: 8px;
+            }
+        data-automation-key="textfield2"
+        data-automationid="DetailsRowCell"
+        role="gridcell"
+        style={
+          Object {
+            "width": "auto",
+          }
+        }
+      >
+        <div
+          className=
+              ms-TextField
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+        >
+          <div
+            className=
+                ms-TextField-wrapper
+
+          >
+            <div
+              className=
+                  ms-TextField-fieldGroup
+                  {
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                  }
+            >
+              <input
+                aria-invalid={false}
+                className=
+                    ms-TextField-field
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
+                    }
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField33"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                type="text"
+                value="Item-4"
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <span
@@ -2245,7 +3320,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           opacity: 1;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone21"
+    data-focuszone-id="FocusZone36"
     data-is-focusable={true}
     data-item-index={5}
     data-selection-index={5}
@@ -2416,10 +3491,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
-          href="http://placehold.it/100x205"
+          href="http://placehold.it/100x105"
           onClick={[Function]}
         >
-          http://placehold.it/100x205
+          http://placehold.it/100x105
         </a>
       </div>
       <div
@@ -2467,7 +3542,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-        data-automation-key="defaultButton"
+        data-automation-key="textfield"
         data-automationid="DetailsRowCell"
         role="gridcell"
         style={
@@ -2476,123 +3551,338 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           }
         }
       >
-        <button
+        <div
           className=
-              ms-Button
-              ms-Button--default
+              ms-TextField
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 2px;
-                border: 1px solid #8a8886;
+                box-shadow: none;
                 box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 32px;
-                min-width: 80px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 16px;
-                padding-right: 16px;
-                padding-top: 0;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
                 position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid transparent;
-                bottom: 2px;
-                content: "";
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: absolute;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
         >
-          <span
+          <div
             className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-            data-automationid="splitbuttonprimary"
+                ms-TextField-wrapper
+
           >
-            <span
+            <div
               className=
-                  ms-Button-textContainer
+                  ms-TextField-fieldGroup
                   {
-                    display: block;
-                    flex-grow: 1;
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
                   }
             >
-              <span
+              <input
+                aria-invalid={false}
                 className=
-                    ms-Button-label
+                    ms-TextField-field
                     {
-                      display: block;
-                      font-weight: 600;
-                      line-height: 100%;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
                     }
-                id="id__22"
-              >
-                http://placehold.it/100x205
-              </span>
-            </span>
-          </span>
-        </button>
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField37"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                readOnly={true}
+                type="text"
+                value="ReadOnly Item-5"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-colindex={4}
+        className=
+            ms-DetailsRow-cell
+            {
+              box-sizing: border-box;
+              display: inline-block;
+              min-height: 42px;
+              outline: transparent;
+              overflow: hidden;
+              padding-bottom: 11px;
+              padding-left: 12px;
+              padding-top: 11px;
+              position: relative;
+              text-overflow: ellipsis;
+              vertical-align: top;
+              white-space: nowrap;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #605e5c;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #ffffff;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            & > button {
+              max-width: 100%;
+            }
+            & [data-is-focusable='true'] {
+              outline: transparent;
+              position: relative;
+            }
+            & [data-is-focusable='true']::-moz-focus-inner {
+              border: 0;
+            }
+            {
+              padding-right: 8px;
+            }
+        data-automation-key="textfield2"
+        data-automationid="DetailsRowCell"
+        role="gridcell"
+        style={
+          Object {
+            "width": "auto",
+          }
+        }
+      >
+        <div
+          className=
+              ms-TextField
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+        >
+          <div
+            className=
+                ms-TextField-wrapper
+
+          >
+            <div
+              className=
+                  ms-TextField-fieldGroup
+                  {
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                  }
+            >
+              <input
+                aria-invalid={false}
+                className=
+                    ms-TextField-field
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
+                    }
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField40"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                type="text"
+                value="Item-5"
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <span
@@ -2678,7 +3968,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           opacity: 1;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone25"
+    data-focuszone-id="FocusZone43"
     data-is-focusable={true}
     data-item-index={6}
     data-selection-index={6}
@@ -2849,10 +4139,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
-          href="http://placehold.it/100x206"
+          href="http://placehold.it/100x106"
           onClick={[Function]}
         >
-          http://placehold.it/100x206
+          http://placehold.it/100x106
         </a>
       </div>
       <div
@@ -2900,7 +4190,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-        data-automation-key="defaultButton"
+        data-automation-key="textfield"
         data-automationid="DetailsRowCell"
         role="gridcell"
         style={
@@ -2909,123 +4199,338 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           }
         }
       >
-        <button
+        <div
           className=
-              ms-Button
-              ms-Button--default
+              ms-TextField
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 2px;
-                border: 1px solid #8a8886;
+                box-shadow: none;
                 box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 32px;
-                min-width: 80px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 16px;
-                padding-right: 16px;
-                padding-top: 0;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
                 position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid transparent;
-                bottom: 2px;
-                content: "";
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: absolute;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
         >
-          <span
+          <div
             className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-            data-automationid="splitbuttonprimary"
+                ms-TextField-wrapper
+
           >
-            <span
+            <div
               className=
-                  ms-Button-textContainer
+                  ms-TextField-fieldGroup
                   {
-                    display: block;
-                    flex-grow: 1;
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
                   }
             >
-              <span
+              <input
+                aria-invalid={false}
                 className=
-                    ms-Button-label
+                    ms-TextField-field
                     {
-                      display: block;
-                      font-weight: 600;
-                      line-height: 100%;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
                     }
-                id="id__26"
-              >
-                http://placehold.it/100x206
-              </span>
-            </span>
-          </span>
-        </button>
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField44"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                readOnly={true}
+                type="text"
+                value="ReadOnly Item-6"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-colindex={4}
+        className=
+            ms-DetailsRow-cell
+            {
+              box-sizing: border-box;
+              display: inline-block;
+              min-height: 42px;
+              outline: transparent;
+              overflow: hidden;
+              padding-bottom: 11px;
+              padding-left: 12px;
+              padding-top: 11px;
+              position: relative;
+              text-overflow: ellipsis;
+              vertical-align: top;
+              white-space: nowrap;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #605e5c;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #ffffff;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            & > button {
+              max-width: 100%;
+            }
+            & [data-is-focusable='true'] {
+              outline: transparent;
+              position: relative;
+            }
+            & [data-is-focusable='true']::-moz-focus-inner {
+              border: 0;
+            }
+            {
+              padding-right: 8px;
+            }
+        data-automation-key="textfield2"
+        data-automationid="DetailsRowCell"
+        role="gridcell"
+        style={
+          Object {
+            "width": "auto",
+          }
+        }
+      >
+        <div
+          className=
+              ms-TextField
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+        >
+          <div
+            className=
+                ms-TextField-wrapper
+
+          >
+            <div
+              className=
+                  ms-TextField-fieldGroup
+                  {
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                  }
+            >
+              <input
+                aria-invalid={false}
+                className=
+                    ms-TextField-field
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
+                    }
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField47"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                type="text"
+                value="Item-6"
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <span
@@ -3111,7 +4616,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           opacity: 1;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone29"
+    data-focuszone-id="FocusZone50"
     data-is-focusable={true}
     data-item-index={7}
     data-selection-index={7}
@@ -3282,10 +4787,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
-          href="http://placehold.it/100x207"
+          href="http://placehold.it/100x107"
           onClick={[Function]}
         >
-          http://placehold.it/100x207
+          http://placehold.it/100x107
         </a>
       </div>
       <div
@@ -3333,7 +4838,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-        data-automation-key="defaultButton"
+        data-automation-key="textfield"
         data-automationid="DetailsRowCell"
         role="gridcell"
         style={
@@ -3342,123 +4847,338 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           }
         }
       >
-        <button
+        <div
           className=
-              ms-Button
-              ms-Button--default
+              ms-TextField
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 2px;
-                border: 1px solid #8a8886;
+                box-shadow: none;
                 box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 32px;
-                min-width: 80px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 16px;
-                padding-right: 16px;
-                padding-top: 0;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
                 position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid transparent;
-                bottom: 2px;
-                content: "";
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: absolute;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
         >
-          <span
+          <div
             className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-            data-automationid="splitbuttonprimary"
+                ms-TextField-wrapper
+
           >
-            <span
+            <div
               className=
-                  ms-Button-textContainer
+                  ms-TextField-fieldGroup
                   {
-                    display: block;
-                    flex-grow: 1;
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
                   }
             >
-              <span
+              <input
+                aria-invalid={false}
                 className=
-                    ms-Button-label
+                    ms-TextField-field
                     {
-                      display: block;
-                      font-weight: 600;
-                      line-height: 100%;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
                     }
-                id="id__30"
-              >
-                http://placehold.it/100x207
-              </span>
-            </span>
-          </span>
-        </button>
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField51"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                readOnly={true}
+                type="text"
+                value="ReadOnly Item-7"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-colindex={4}
+        className=
+            ms-DetailsRow-cell
+            {
+              box-sizing: border-box;
+              display: inline-block;
+              min-height: 42px;
+              outline: transparent;
+              overflow: hidden;
+              padding-bottom: 11px;
+              padding-left: 12px;
+              padding-top: 11px;
+              position: relative;
+              text-overflow: ellipsis;
+              vertical-align: top;
+              white-space: nowrap;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #605e5c;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #ffffff;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            & > button {
+              max-width: 100%;
+            }
+            & [data-is-focusable='true'] {
+              outline: transparent;
+              position: relative;
+            }
+            & [data-is-focusable='true']::-moz-focus-inner {
+              border: 0;
+            }
+            {
+              padding-right: 8px;
+            }
+        data-automation-key="textfield2"
+        data-automationid="DetailsRowCell"
+        role="gridcell"
+        style={
+          Object {
+            "width": "auto",
+          }
+        }
+      >
+        <div
+          className=
+              ms-TextField
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+        >
+          <div
+            className=
+                ms-TextField-wrapper
+
+          >
+            <div
+              className=
+                  ms-TextField-fieldGroup
+                  {
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                  }
+            >
+              <input
+                aria-invalid={false}
+                className=
+                    ms-TextField-field
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
+                    }
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField54"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                type="text"
+                value="Item-7"
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <span
@@ -3544,7 +5264,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           opacity: 1;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone33"
+    data-focuszone-id="FocusZone57"
     data-is-focusable={true}
     data-item-index={8}
     data-selection-index={8}
@@ -3715,10 +5435,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
-          href="http://placehold.it/100x208"
+          href="http://placehold.it/100x108"
           onClick={[Function]}
         >
-          http://placehold.it/100x208
+          http://placehold.it/100x108
         </a>
       </div>
       <div
@@ -3766,7 +5486,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-        data-automation-key="defaultButton"
+        data-automation-key="textfield"
         data-automationid="DetailsRowCell"
         role="gridcell"
         style={
@@ -3775,123 +5495,338 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           }
         }
       >
-        <button
+        <div
           className=
-              ms-Button
-              ms-Button--default
+              ms-TextField
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 2px;
-                border: 1px solid #8a8886;
+                box-shadow: none;
                 box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 32px;
-                min-width: 80px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 16px;
-                padding-right: 16px;
-                padding-top: 0;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
                 position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid transparent;
-                bottom: 2px;
-                content: "";
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: absolute;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
         >
-          <span
+          <div
             className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-            data-automationid="splitbuttonprimary"
+                ms-TextField-wrapper
+
           >
-            <span
+            <div
               className=
-                  ms-Button-textContainer
+                  ms-TextField-fieldGroup
                   {
-                    display: block;
-                    flex-grow: 1;
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
                   }
             >
-              <span
+              <input
+                aria-invalid={false}
                 className=
-                    ms-Button-label
+                    ms-TextField-field
                     {
-                      display: block;
-                      font-weight: 600;
-                      line-height: 100%;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
                     }
-                id="id__34"
-              >
-                http://placehold.it/100x208
-              </span>
-            </span>
-          </span>
-        </button>
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField58"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                readOnly={true}
+                type="text"
+                value="ReadOnly Item-8"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-colindex={4}
+        className=
+            ms-DetailsRow-cell
+            {
+              box-sizing: border-box;
+              display: inline-block;
+              min-height: 42px;
+              outline: transparent;
+              overflow: hidden;
+              padding-bottom: 11px;
+              padding-left: 12px;
+              padding-top: 11px;
+              position: relative;
+              text-overflow: ellipsis;
+              vertical-align: top;
+              white-space: nowrap;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #605e5c;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #ffffff;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            & > button {
+              max-width: 100%;
+            }
+            & [data-is-focusable='true'] {
+              outline: transparent;
+              position: relative;
+            }
+            & [data-is-focusable='true']::-moz-focus-inner {
+              border: 0;
+            }
+            {
+              padding-right: 8px;
+            }
+        data-automation-key="textfield2"
+        data-automationid="DetailsRowCell"
+        role="gridcell"
+        style={
+          Object {
+            "width": "auto",
+          }
+        }
+      >
+        <div
+          className=
+              ms-TextField
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+        >
+          <div
+            className=
+                ms-TextField-wrapper
+
+          >
+            <div
+              className=
+                  ms-TextField-fieldGroup
+                  {
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                  }
+            >
+              <input
+                aria-invalid={false}
+                className=
+                    ms-TextField-field
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
+                    }
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField61"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                type="text"
+                value="Item-8"
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <span
@@ -3977,7 +5912,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           opacity: 1;
         }
     data-automationid="DetailsRow"
-    data-focuszone-id="FocusZone37"
+    data-focuszone-id="FocusZone64"
     data-is-focusable={true}
     data-item-index={9}
     data-selection-index={9}
@@ -4148,10 +6083,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               &:focus {
                 color: #0078d4;
               }
-          href="http://placehold.it/100x209"
+          href="http://placehold.it/100x109"
           onClick={[Function]}
         >
-          http://placehold.it/100x209
+          http://placehold.it/100x109
         </a>
       </div>
       <div
@@ -4199,7 +6134,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
             {
               padding-right: 8px;
             }
-        data-automation-key="defaultButton"
+        data-automation-key="textfield"
         data-automationid="DetailsRowCell"
         role="gridcell"
         style={
@@ -4208,123 +6143,338 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
           }
         }
       >
-        <button
+        <div
           className=
-              ms-Button
-              ms-Button--default
+              ms-TextField
               {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
-                background-color: #ffffff;
-                border-radius: 2px;
-                border: 1px solid #8a8886;
+                box-shadow: none;
                 box-sizing: border-box;
-                color: #323130;
-                cursor: pointer;
-                display: inline-block;
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 32px;
-                min-width: 80px;
-                outline: transparent;
-                padding-bottom: 0;
-                padding-left: 16px;
-                padding-right: 16px;
-                padding-top: 0;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
                 position: relative;
-                text-align: center;
-                text-decoration: none;
-                user-select: none;
-                vertical-align: top;
               }
-              &::-moz-focus-inner {
-                border: 0;
-              }
-              .ms-Fabric--isFocusVisible &:focus:after {
-                border: 1px solid transparent;
-                bottom: 2px;
-                content: "";
-                left: 2px;
-                outline: 1px solid #605e5c;
-                position: absolute;
-                right: 2px;
-                top: 2px;
-                z-index: 1;
-              }
-              @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-                border: none;
-                bottom: -2px;
-                left: -2px;
-                outline-color: ButtonText;
-                right: -2px;
-                top: -2px;
-              }
-              &:active > * {
-                left: 0px;
-                position: relative;
-                top: 0px;
-              }
-              &:hover {
-                background-color: #f3f2f1;
-                color: #201f1e;
-              }
-              @media screen and (-ms-high-contrast: active){&:hover {
-                border-color: Highlight;
-                color: Highlight;
-              }
-              &:active {
-                background-color: #edebe9;
-                color: #201f1e;
-              }
-          data-is-focusable={true}
-          onClick={[Function]}
-          onKeyDown={[Function]}
-          onKeyPress={[Function]}
-          onKeyUp={[Function]}
-          onMouseDown={[Function]}
-          onMouseUp={[Function]}
-          type="button"
         >
-          <span
+          <div
             className=
-                ms-Button-flexContainer
-                {
-                  align-items: center;
-                  display: flex;
-                  flex-wrap: nowrap;
-                  height: 100%;
-                  justify-content: center;
-                }
-            data-automationid="splitbuttonprimary"
+                ms-TextField-wrapper
+
           >
-            <span
+            <div
               className=
-                  ms-Button-textContainer
+                  ms-TextField-fieldGroup
                   {
-                    display: block;
-                    flex-grow: 1;
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
                   }
             >
-              <span
+              <input
+                aria-invalid={false}
                 className=
-                    ms-Button-label
+                    ms-TextField-field
                     {
-                      display: block;
-                      font-weight: 600;
-                      line-height: 100%;
-                      margin-bottom: 0;
-                      margin-left: 4px;
-                      margin-right: 4px;
-                      margin-top: 0;
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
                     }
-                id="id__38"
-              >
-                http://placehold.it/100x209
-              </span>
-            </span>
-          </span>
-        </button>
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField65"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                readOnly={true}
+                type="text"
+                value="ReadOnly Item-9"
+              />
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        aria-colindex={4}
+        className=
+            ms-DetailsRow-cell
+            {
+              box-sizing: border-box;
+              display: inline-block;
+              min-height: 42px;
+              outline: transparent;
+              overflow: hidden;
+              padding-bottom: 11px;
+              padding-left: 12px;
+              padding-top: 11px;
+              position: relative;
+              text-overflow: ellipsis;
+              vertical-align: top;
+              white-space: nowrap;
+            }
+            &::-moz-focus-inner {
+              border: 0;
+            }
+            .ms-Fabric--isFocusVisible &:focus:after {
+              border: 1px solid #605e5c;
+              bottom: 0px;
+              content: "";
+              left: 0px;
+              outline: 1px solid #ffffff;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+              z-index: 1;
+            }
+            & > button {
+              max-width: 100%;
+            }
+            & [data-is-focusable='true'] {
+              outline: transparent;
+              position: relative;
+            }
+            & [data-is-focusable='true']::-moz-focus-inner {
+              border: 0;
+            }
+            {
+              padding-right: 8px;
+            }
+        data-automation-key="textfield2"
+        data-automationid="DetailsRowCell"
+        role="gridcell"
+        style={
+          Object {
+            "width": "auto",
+          }
+        }
+      >
+        <div
+          className=
+              ms-TextField
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                box-shadow: none;
+                box-sizing: border-box;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                margin-bottom: 0px;
+                margin-left: 0px;
+                margin-right: 0px;
+                margin-top: 0px;
+                padding-bottom: 0px;
+                padding-left: 0px;
+                padding-right: 0px;
+                padding-top: 0px;
+                position: relative;
+              }
+        >
+          <div
+            className=
+                ms-TextField-wrapper
+
+          >
+            <div
+              className=
+                  ms-TextField-fieldGroup
+                  {
+                    align-items: stretch;
+                    background: #ffffff;
+                    border-radius: 2px;
+                    border: 1px solid #605e5c;
+                    box-shadow: none;
+                    box-sizing: border-box;
+                    cursor: text;
+                    display: flex;
+                    flex-direction: row;
+                    height: 32px;
+                    margin-bottom: 0px;
+                    margin-left: 0px;
+                    margin-right: 0px;
+                    margin-top: 0px;
+                    padding-bottom: 0px;
+                    padding-left: 0px;
+                    padding-right: 0px;
+                    padding-top: 0px;
+                    position: relative;
+                  }
+                  &:hover {
+                    border-color: #323130;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:hover {
+                    border-color: Highlight;
+                  }
+            >
+              <input
+                aria-invalid={false}
+                className=
+                    ms-TextField-field
+                    {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      background-color: transparent;
+                      background: none;
+                      border-radius: 0px;
+                      border: none;
+                      box-shadow: none;
+                      box-sizing: border-box;
+                      color: #323130;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      margin-bottom: 0px;
+                      margin-left: 0px;
+                      margin-right: 0px;
+                      margin-top: 0px;
+                      min-width: 0px;
+                      outline: 0px;
+                      padding-bottom: 0;
+                      padding-left: 8px;
+                      padding-right: 8px;
+                      padding-top: 0;
+                      text-overflow: ellipsis;
+                      width: 100%;
+                    }
+                    &:active {
+                      outline: 0px;
+                    }
+                    &:focus {
+                      outline: 0px;
+                    }
+                    &:hover {
+                      outline: 0px;
+                    }
+                    &::-ms-clear {
+                      display: none;
+                    }
+                    &::placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &:-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                    &::-ms-input-placeholder {
+                      -moz-osx-font-smoothing: grayscale;
+                      -webkit-font-smoothing: antialiased;
+                      color: #605e5c;
+                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                      font-size: 14px;
+                      font-weight: 400;
+                      opacity: 1;
+                    }
+                id="TextField68"
+                onBlur={[Function]}
+                onChange={[Function]}
+                onFocus={[Function]}
+                onInput={[Function]}
+                type="text"
+                value="Item-9"
+              />
+            </div>
+          </div>
+        </div>
       </div>
     </div>
     <span


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11425

#### Description of changes

readOnly inputs take focus, but arrow keys don't move the cursor. This makes FocusZones get stuck inside of them. 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11433)