### PR TITLE
Folder And Filetype Updates (brought to Fabric7)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -100,7 +100,7 @@ DocumentCard/ @yiminwu
 Dropdown/ @joschect
 Fabric/ @dzearing
 Facepile/ @markionium @mtennoe
-FolderCover/ @ThomasMichon
+FolderCover/ @ThomasMichon @bigbadcapers
 FocusTrapZone/ @JasonGore
 FocusZone/ @JasonGore
 GroupedList/  @aditima @KevinTCoughlin

--- a/change/@uifabric-experiments-2019-12-10-11-25-59-caperez-folder_and_filemap_updates_f7.json
+++ b/change/@uifabric-experiments-2019-12-10-11-25-59-caperez-folder_and_filemap_updates_f7.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Refining typography and signal icon on top of Folder Icon, filetype mapping updates",
+  "packageName": "@uifabric/experiments",
+  "email": "caperez@microsoft.com",
+  "commit": "4d72a330013373ac60292c9cb3ef8787ad2fd408",
+  "date": "2019-12-10T19:25:45.235Z"
+}

--- a/change/@uifabric-file-type-icons-2019-12-10-11-25-59-caperez-folder_and_filemap_updates_f7.json
+++ b/change/@uifabric-file-type-icons-2019-12-10-11-25-59-caperez-folder_and_filemap_updates_f7.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Refining typography and signal icon on top of Folder Icon, filetype mapping updates",
+  "packageName": "@uifabric/file-type-icons",
+  "email": "caperez@microsoft.com",
+  "commit": "4d72a330013373ac60292c9cb3ef8787ad2fd408",
+  "date": "2019-12-10T19:25:59.433Z"
+}

--- a/packages/experiments/src/components/FolderCover/FolderCover.scss
+++ b/packages/experiments/src/components/FolderCover/FolderCover.scss
@@ -1,5 +1,7 @@
 @import '~office-ui-fabric-react/src/common/common';
 
+$folder-accent: #bf5712;
+
 .root {
   display: inline-flex;
   position: relative;
@@ -87,19 +89,19 @@
 
   .isFluent & {
     @include text-align(left);
-    color: $ms-color-yellowDark;
+    color: $folder-accent;
   }
 
   &,
   &.isSmall {
     font-size: $ms-font-size-s;
-    margin-bottom: 3px;
+    margin-bottom: 1px;
     @include margin-left(4px);
   }
 
   .isLarge & {
     font-size: $ms-font-size-m;
-    margin-bottom: 6px;
+    margin-bottom: 4px;
     @include margin-left(8px);
   }
 }
@@ -111,15 +113,20 @@
   @include margin-left(8px);
   @include margin-right(4px);
 
+  // Added :first-child to CSS selector because a rule from Signal.scss affecting the Icon will otherwise trample this color change.
+  .isFluent & :first-child {
+    color: $folder-accent;
+  }
+
   &,
   &.isSmall {
-    font-size: $ms-font-size-l;
-    margin-bottom: 3px;
+    @include ms-fontSize-16;
+    margin-bottom: 1px;
   }
 
   .isLarge & {
-    font-size: $ms-font-size-xl;
-    margin-bottom: 6px;
+    @include ms-fontSize-16;
+    margin-bottom: 4px;
     @include margin-right(7px);
   }
 }

--- a/packages/experiments/src/components/signals/Signal.scss
+++ b/packages/experiments/src/components/signals/Signal.scss
@@ -12,10 +12,6 @@
     color: $ms-color-white;
   }
 
-  .isFluent & {
-    color: $ms-color-yellowDark;
-  }
-
   &:first-child {
     @include margin-left(0);
   }

--- a/packages/file-type-icons/src/FileTypeIconMap.ts
+++ b/packages/file-type-icons/src/FileTypeIconMap.ts
@@ -36,7 +36,6 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
       'wv'
     ]
   },
-  channelfolder: {},
   calendar: {
     extensions: ['ical', 'icalendar', 'ics', 'ifb', 'vcs']
   },
@@ -249,7 +248,7 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   contact: {
     extensions: ['vcf']
   },
-  css: {}, // we dont have the icon yet, but i believe we want it, snapping to 'code' for now
+  /*  css: {},  not broken out yet, snapping to 'code' for now */
   csv: {
     extensions: ['csv']
   },
@@ -393,6 +392,7 @@ export const FileTypeIconMap: { [key: string]: { extensions?: string[] } } = {
   spreadsheet: {
     extensions: ['odc', 'ods', 'gsheet', 'numbers']
   },
+  stream: {},
   rtf: {
     extensions: ['epub', 'gdoc', 'odt', 'rtf', 'wri', 'pages']
   },

--- a/packages/file-type-icons/src/initializeFileTypeIcons.tsx
+++ b/packages/file-type-icons/src/initializeFileTypeIcons.tsx
@@ -12,7 +12,7 @@ const ICON_SIZES: number[] = [16, 20, 24, 32, 40, 48, 64, 96];
 // (though most users will see them within a week). To force immediate refresh, append a
 // unique string to the end of the URL. The CDN uses the URL as the cache key, so passing a
 // new URL will cause the CDN to create a new cache key.
-const REFRESH_STRING = '?v5';
+const REFRESH_STRING = '?v6';
 
 export function initializeFileTypeIcons(baseUrl: string = DEFAULT_BASE_URL, options?: Partial<IIconOptions>): void {
   ICON_SIZES.forEach((size: number) => {


### PR DESCRIPTION

- [x] Replaces the filetype icon salt to ensure new Fluid icon is visible
- [x] Makes the signal icon and the itemcount in the folder tile view accessible and better laid out
- [x] Adds bigbadcapers to codeowners for the foldercover because masochism
- [x] Include a change request file using `$ yarn change`
- [x] Fabric 7 version of PR https://github.com/OfficeDev/office-ui-fabric-react/pull/11125


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11434)