### PR TITLE
Nav: Allow falsy values of title to be passed into items

### DIFF
--- a/change/office-ui-fabric-react-2019-12-11-14-34-16-nav-null-title.json
+++ b/change/office-ui-fabric-react-2019-12-11-14-34-16-nav-null-title.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Nav: Allow falsy values of title to be passed into items",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "a4845e8b662cbaedbef12a80169e05a349d3ede2",
+  "date": "2019-12-11T22:34:16.848Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -111,7 +111,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
         href={link.url || (link.forceAnchor ? '#' : undefined)}
         iconProps={link.iconProps || { iconName: link.icon }}
         onClick={link.onClick ? this._onNavButtonLinkClicked.bind(this, link) : this._onNavAnchorLinkClicked.bind(this, link)}
-        title={link.title || link.name}
+        title={link.title !== undefined ? link.title : link.name}
         target={link.target}
         rel={rel}
         disabled={link.disabled}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11413


#### Description of changes
Falsy/empty values of title were ignored and name was used instead making it impossible to have an empty title.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11435)