### PR TITLE
Panel: onLightDismissClick now properly prevents light dismiss

### DIFF
--- a/change/office-ui-fabric-react-2019-12-12-09-06-23-panel-lightdismiss-fix.json
+++ b/change/office-ui-fabric-react-2019-12-12-09-06-23-panel-lightdismiss-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Panel: onLightDismissClick now properly prevents light dismiss",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "b291e1361a914558025560c9193296202cd95d1d",
+  "date": "2019-12-12T17:06:23.328Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -276,6 +276,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
   };
 
   private _shouldListenForOuterClick(props: IPanelProps): boolean {
+    console.log(props);
     return !!props.isBlocking && !!props.isOpen;
   }
 
@@ -375,6 +376,9 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
       if (!elementContains(panel, ev.target)) {
         if (this.props.onOuterClick) {
           this.props.onOuterClick();
+          ev.preventDefault();
+        } else if (this.props.onLightDismissClick) {
+          this.props.onLightDismissClick();
           ev.preventDefault();
         } else {
           this.dismiss();

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -276,7 +276,6 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
   };
 
   private _shouldListenForOuterClick(props: IPanelProps): boolean {
-    console.log(props);
     return !!props.isBlocking && !!props.isOpen;
   }
 

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -371,13 +371,10 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
 
   private _dismissOnOuterClick(ev: any): void {
     const panel = this._panel.current;
-    if (this.isActive && panel) {
+    if (this.isActive && panel && !ev.defaultPrevented()) {
       if (!elementContains(panel, ev.target)) {
         if (this.props.onOuterClick) {
           this.props.onOuterClick();
-          ev.preventDefault();
-        } else if (this.props.onLightDismissClick) {
-          this.props.onLightDismissClick();
           ev.preventDefault();
         } else {
           this.dismiss();

--- a/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.LightDismissCustom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/examples/Panel.LightDismissCustom.Example.tsx
@@ -21,7 +21,10 @@ export const PanelLightDismissCustomExample: React.FunctionComponent = () => {
   const openPanel = useConstCallback(() => setIsPanelOpen(true));
   const dismissPanel = useConstCallback(() => setIsPanelOpen(false));
   const showDialog = useConstCallback(() => setIsDialogVisible(true));
-  const hideDialog = useConstCallback(() => setIsDialogVisible(false));
+  const hideDialog = useConstCallback(ev => {
+    ev.preventDefault();
+    setIsDialogVisible(false);
+  });
   const hideDialogAndPanel = useConstCallback(() => {
     setIsPanelOpen(false);
     setIsDialogVisible(false);


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #11437
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

onLightDismissClick was billed as "Optional custom function to handle clicks outside the panel in lightdismiss mode", but clicks outside the panel were still calling dismiss even with that function passed through. This issue was evident in our light dismiss with 'Confirm light dismiss' example. 

My solution was to check for a preventDefault on the event so that button clicks in modal buttons (like the example) wouldn't always close the panel. 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11443)