### PR TITLE
Fix iteration of Sticky items in ScrollablePane

### DIFF
--- a/change/office-ui-fabric-react-2019-12-12-22-28-03-scrollable-pane.json
+++ b/change/office-ui-fabric-react-2019-12-12-22-28-03-scrollable-pane.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix iteration of Sticky items in ScrollablePane",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "commit": "499a13dcb8eceec4b06291e7266830b3d8f9cb68",
+  "date": "2019-12-13T06:28:03.850Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ScrollablePane/ScrollablePane.base.tsx
@@ -350,9 +350,9 @@ export class ScrollablePaneBase extends BaseComponent<IScrollablePaneProps, IScr
 
         // Get first element that has a distance from top that is further than our sticky that is being added
         let targetStickyToAppendBefore: Sticky | undefined = undefined;
-        for (const i in stickyListSorted) {
-          if ((stickyListSorted[i].state.distanceFromTop || 0) >= (sticky.state.distanceFromTop || 0)) {
-            targetStickyToAppendBefore = stickyListSorted[i];
+        for (const stickyListItem of stickyListSorted) {
+          if ((stickyListItem.state.distanceFromTop || 0) >= (sticky.state.distanceFromTop || 0)) {
+            targetStickyToAppendBefore = stickyListItem;
             break;
           }
         }


### PR DESCRIPTION
Fixed an issue where the `Sticky` items in a `ScrollablePane` were being iterated directly via JavaScript object field enumeration rather than array item enumeration. In the case where `Array.prototype` is extended, this can cause non-item values to be enumerated.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11453)