### PR TITLE
PersonaCoin: make divs role presentation

### DIFF
--- a/change/@uifabric-experiments-2019-12-13-16-32-32-personaCoin-presentation.json
+++ b/change/@uifabric-experiments-2019-12-13-16-32-32-personaCoin-presentation.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "PersonaCoin: make divs role presentation",
+  "packageName": "@uifabric/experiments",
+  "email": "micahgodbolt@gmail.com",
+  "commit": "f491aa022d50b489b2a9bd49ef29ee48870213ef",
+  "date": "2019-12-14T00:32:32.423Z"
+}

--- a/change/office-ui-fabric-react-2019-12-13-11-12-23-personaCoin-presentation.json
+++ b/change/office-ui-fabric-react-2019-12-13-11-12-23-personaCoin-presentation.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "PersonaCoin: make divs role presentation",
+  "packageName": "office-ui-fabric-react",
+  "email": "micahgodbolt@gmail.com",
+  "commit": "c6290045f0f34b3dba3e0b16b5c31a8536f8c6ea",
+  "date": "2019-12-13T19:12:22.991Z"
+}

--- a/packages/experiments/src/components/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/experiments/src/components/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -238,6 +238,7 @@ exports[`PersonaCoin renders presence correctly when a very large coin is render
           background-color: WindowText;
           border-color: Window;
         }
+    role="presentation"
     style={
       Object {
         "height": "33.333333333333336px",
@@ -335,6 +336,7 @@ exports[`PersonaCoin renders presence when it is passed 1`] = `
           background-color: WindowText;
           border-color: Window;
         }
+    role="presentation"
     style={
       Object {
         "height": "16px",

--- a/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
+++ b/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
@@ -236,6 +236,7 @@ Array [
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -247,6 +248,7 @@ Array [
                     text-align: center;
                     width: 32px;
                   }
+              role="presentation"
             >
               <div
                 aria-hidden="true"
@@ -745,6 +747,7 @@ Array [
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -756,6 +759,7 @@ Array [
                     text-align: center;
                     width: 32px;
                   }
+              role="presentation"
             >
               <div
                 aria-hidden="true"

--- a/packages/office-ui-fabric-react/src/components/ActivityItem/__snapshots__/ActivityItem.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ActivityItem/__snapshots__/ActivityItem.test.tsx.snap
@@ -77,6 +77,7 @@ exports[`ActivityItem renders compact with a single persona correctly 1`] = `
               overflow: visible;
               width: 8px;
             }
+        role="presentation"
         style={
           Object {
             "display": "inline-block",
@@ -96,6 +97,7 @@ exports[`ActivityItem renders compact with a single persona correctly 1`] = `
                 text-align: center;
                 width: 16px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -352,6 +354,7 @@ exports[`ActivityItem renders compact with animation correctly 1`] = `
               overflow: visible;
               width: 8px;
             }
+        role="presentation"
         style={
           Object {
             "display": "inline-block",
@@ -371,6 +374,7 @@ exports[`ActivityItem renders compact with animation correctly 1`] = `
                 text-align: center;
                 width: 16px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -513,6 +517,7 @@ exports[`ActivityItem renders compact with multiple personas correctly 1`] = `
               overflow: visible;
               width: 8px;
             }
+        role="presentation"
         style={
           Object {
             "display": "inline-block",
@@ -532,6 +537,7 @@ exports[`ActivityItem renders compact with multiple personas correctly 1`] = `
                 text-align: center;
                 width: 16px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -579,6 +585,7 @@ exports[`ActivityItem renders compact with multiple personas correctly 1`] = `
               overflow: visible;
               width: 8px;
             }
+        role="presentation"
         style={
           Object {
             "display": "inline-block",
@@ -598,6 +605,7 @@ exports[`ActivityItem renders compact with multiple personas correctly 1`] = `
                 text-align: center;
                 width: 16px;
               }
+          role="presentation"
         >
           <div
             className=
@@ -669,6 +677,7 @@ exports[`ActivityItem renders compact with multiple personas correctly 1`] = `
               overflow: visible;
               width: 8px;
             }
+        role="presentation"
         style={
           Object {
             "display": "inline-block",
@@ -688,6 +697,7 @@ exports[`ActivityItem renders compact with multiple personas correctly 1`] = `
                 text-align: center;
                 width: 16px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -801,6 +811,7 @@ exports[`ActivityItem renders with a single persona correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -812,6 +823,7 @@ exports[`ActivityItem renders with a single persona correctly 1`] = `
                 text-align: center;
                 width: 32px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -1041,6 +1053,7 @@ exports[`ActivityItem renders with multiple personas correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -1052,6 +1065,7 @@ exports[`ActivityItem renders with multiple personas correctly 1`] = `
                 text-align: center;
                 width: 16px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -1096,6 +1110,7 @@ exports[`ActivityItem renders with multiple personas correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -1107,6 +1122,7 @@ exports[`ActivityItem renders with multiple personas correctly 1`] = `
                 text-align: center;
                 width: 16px;
               }
+          role="presentation"
         >
           <div
             className=
@@ -1175,6 +1191,7 @@ exports[`ActivityItem renders with multiple personas correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -1186,6 +1203,7 @@ exports[`ActivityItem renders with multiple personas correctly 1`] = `
                 text-align: center;
                 width: 16px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -1230,6 +1248,7 @@ exports[`ActivityItem renders with multiple personas correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -1241,6 +1260,7 @@ exports[`ActivityItem renders with multiple personas correctly 1`] = `
                 text-align: center;
                 width: 16px;
               }
+          role="presentation"
         >
           <div
             className=

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
@@ -137,6 +137,7 @@ exports[`DocumentCard renders DocumentCard correctly 1`] = `
                   text-align: center;
                   width: 32px;
                 }
+            role="presentation"
           >
             <div
               aria-hidden="true"

--- a/packages/office-ui-fabric-react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Facepile/__snapshots__/Facepile.test.tsx.snap
@@ -92,6 +92,7 @@ exports[`Facepile renders Facepile correctly 1`] = `
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -103,6 +104,7 @@ exports[`Facepile renders Facepile correctly 1`] = `
                     text-align: center;
                     width: 32px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -214,6 +216,7 @@ exports[`Facepile renders Facepile correctly 1`] = `
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -225,6 +228,7 @@ exports[`Facepile renders Facepile correctly 1`] = `
                     text-align: center;
                     width: 32px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -392,6 +396,7 @@ exports[`Facepile renders Facepile correctly 1`] = `
                     font-size: 14px;
                     font-weight: 400;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -403,6 +408,7 @@ exports[`Facepile renders Facepile correctly 1`] = `
                       text-align: center;
                       width: 32px;
                     }
+                role="presentation"
               >
                 <div
                   aria-hidden="true"

--- a/packages/office-ui-fabric-react/src/components/Icon/Icon.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/Icon.base.tsx
@@ -36,7 +36,7 @@ export class IconBase extends React.Component<IIconProps, IIconState> {
       isPlaceholder
     });
 
-    const RootType = isImage ? 'div' : 'i';
+    const RootType = isImage ? 'span' : 'i';
     const nativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(this.props, htmlElementProperties, ['aria-label']);
     const { imageLoadError } = this.state;
     const imageProps: IImageProps = {

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
@@ -100,10 +100,10 @@ export class PersonaCoinBase extends BaseComponent<IPersonaCoinProps, IPersonaSt
     );
 
     return (
-      <div {...divProps} className={classNames.coin}>
+      <div role="presentation" {...divProps} className={classNames.coin}>
         {// Render PersonaCoin if size is not size8. size10 and tiny need to removed after a deprecation cleanup.
         size !== PersonaSize.size8 && size !== PersonaSize.size10 && size !== PersonaSize.tiny ? (
-          <div {...divCoinProps} className={classNames.imageArea} style={coinSizeStyle}>
+          <div role="presentation" {...divCoinProps} className={classNames.imageArea} style={coinSizeStyle}>
             {shouldRenderInitials && (
               <div
                 className={mergeStyles(

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.deprecated.test.tsx.snap
@@ -12,6 +12,7 @@ exports[`PersonaCoin renders correctly 1`] = `
         font-size: 14px;
         font-weight: 400;
       }
+  role="presentation"
 >
   <div
     className=
@@ -23,6 +24,7 @@ exports[`PersonaCoin renders correctly 1`] = `
           text-align: center;
           width: 48px;
         }
+    role="presentation"
   >
     <div
       aria-hidden="true"
@@ -82,6 +84,7 @@ exports[`PersonaCoin renders correctly with image 1`] = `
         font-size: 14px;
         font-weight: 400;
       }
+  role="presentation"
 >
   <div
     className=
@@ -93,6 +96,7 @@ exports[`PersonaCoin renders correctly with image 1`] = `
           text-align: center;
           width: 48px;
         }
+    role="presentation"
   >
     <div
       className=
@@ -162,6 +166,7 @@ exports[`PersonaCoin renders correctly with provided initials 1`] = `
         font-size: 14px;
         font-weight: 400;
       }
+  role="presentation"
 >
   <div
     className=
@@ -173,6 +178,7 @@ exports[`PersonaCoin renders correctly with provided initials 1`] = `
           text-align: center;
           width: 48px;
         }
+    role="presentation"
   >
     <div
       aria-hidden="true"
@@ -218,6 +224,7 @@ exports[`PersonaCoin renders correctly with text 1`] = `
         font-size: 14px;
         font-weight: 400;
       }
+  role="presentation"
 >
   <div
     className=
@@ -229,6 +236,7 @@ exports[`PersonaCoin renders correctly with text 1`] = `
           text-align: center;
           width: 48px;
         }
+    role="presentation"
   >
     <div
       aria-hidden="true"

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -43,6 +43,7 @@ exports[`Persona renders Persona children correctly 1`] = `
           font-size: 14px;
           font-weight: 400;
         }
+    role="presentation"
   >
     <div
       className=
@@ -54,6 +55,7 @@ exports[`Persona renders Persona children correctly 1`] = `
             text-align: center;
             width: 48px;
           }
+      role="presentation"
     >
       <div
         aria-hidden="true"
@@ -223,6 +225,7 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
           font-size: 14px;
           font-weight: 400;
         }
+    role="presentation"
   >
     <div
       className=
@@ -234,6 +237,7 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
             text-align: center;
             width: 48px;
           }
+      role="presentation"
     >
       <div
         aria-hidden="true"
@@ -414,6 +418,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
           font-size: 14px;
           font-weight: 400;
         }
+    role="presentation"
   >
     <div
       className=
@@ -425,6 +430,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
             text-align: center;
             width: 48px;
           }
+      role="presentation"
     >
       <div
         className=
@@ -615,6 +621,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
           font-size: 14px;
           font-weight: 400;
         }
+    role="presentation"
   >
     <div
       className=
@@ -626,6 +633,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
             text-align: center;
             width: 48px;
           }
+      role="presentation"
     >
       <div
         aria-hidden="true"
@@ -792,6 +800,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
           font-size: 14px;
           font-weight: 400;
         }
+    role="presentation"
   >
     <div
       className=
@@ -803,6 +812,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
             text-align: center;
             width: 48px;
           }
+      role="presentation"
     >
       <div
         aria-hidden="true"
@@ -969,6 +979,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
           font-size: 14px;
           font-weight: 400;
         }
+    role="presentation"
   >
     <div
       className=
@@ -980,6 +991,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
             text-align: center;
             width: 100px;
           }
+      role="presentation"
     >
       <div
         aria-hidden="true"
@@ -1067,6 +1079,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
               top: 1px;
               width: calc(100% - 2px);
             }
+        role="presentation"
       >
         <i
           aria-hidden={true}
@@ -1457,6 +1470,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
           font-size: 14px;
           font-weight: 400;
         }
+    role="presentation"
   >
     <div
       className=
@@ -1468,6 +1482,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
             text-align: center;
             width: 100px;
           }
+      role="presentation"
     >
       <div
         className=
@@ -1576,6 +1591,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
               top: 1px;
               width: calc(100% - 2px);
             }
+        role="presentation"
       >
         <i
           aria-hidden={true}
@@ -1747,6 +1763,7 @@ exports[`PersonaCoin does not render the initials when showInitialsUntilImageLoa
         font-size: 14px;
         font-weight: 400;
       }
+  role="presentation"
 >
   <div
     className=
@@ -1758,6 +1775,7 @@ exports[`PersonaCoin does not render the initials when showInitialsUntilImageLoa
           text-align: center;
           width: 48px;
         }
+    role="presentation"
   >
     <div
       className=
@@ -1827,6 +1845,7 @@ exports[`PersonaCoin renders correctly 1`] = `
         font-size: 14px;
         font-weight: 400;
       }
+  role="presentation"
 >
   <div
     className=
@@ -1838,6 +1857,7 @@ exports[`PersonaCoin renders correctly 1`] = `
           text-align: center;
           width: 48px;
         }
+    role="presentation"
   >
     <div
       aria-hidden="true"
@@ -1897,6 +1917,7 @@ exports[`PersonaCoin renders correctly with image 1`] = `
         font-size: 14px;
         font-weight: 400;
       }
+  role="presentation"
 >
   <div
     className=
@@ -1908,6 +1929,7 @@ exports[`PersonaCoin renders correctly with image 1`] = `
           text-align: center;
           width: 48px;
         }
+    role="presentation"
   >
     <div
       className=
@@ -1977,6 +1999,7 @@ exports[`PersonaCoin renders correctly with onRender callback 1`] = `
         font-size: 14px;
         font-weight: 400;
       }
+  role="presentation"
 >
   <div
     className=
@@ -1988,6 +2011,7 @@ exports[`PersonaCoin renders correctly with onRender callback 1`] = `
           text-align: center;
           width: 100px;
         }
+    role="presentation"
   >
     <div
       aria-hidden="true"
@@ -2033,6 +2057,7 @@ exports[`PersonaCoin renders correctly with provided initials 1`] = `
         font-size: 14px;
         font-weight: 400;
       }
+  role="presentation"
 >
   <div
     className=
@@ -2044,6 +2069,7 @@ exports[`PersonaCoin renders correctly with provided initials 1`] = `
           text-align: center;
           width: 48px;
         }
+    role="presentation"
   >
     <div
       aria-hidden="true"
@@ -2089,6 +2115,7 @@ exports[`PersonaCoin renders correctly with text 1`] = `
         font-size: 14px;
         font-weight: 400;
       }
+  role="presentation"
 >
   <div
     className=
@@ -2100,6 +2127,7 @@ exports[`PersonaCoin renders correctly with text 1`] = `
           text-align: center;
           width: 48px;
         }
+    role="presentation"
   >
     <div
       aria-hidden="true"
@@ -2145,6 +2173,7 @@ exports[`PersonaCoin renders the initials before the image is loaded 1`] = `
         font-size: 14px;
         font-weight: 400;
       }
+  role="presentation"
 >
   <div
     className=
@@ -2156,6 +2185,7 @@ exports[`PersonaCoin renders the initials before the image is loaded 1`] = `
           text-align: center;
           width: 48px;
         }
+    role="presentation"
   >
     <div
       aria-hidden="true"

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaPresence/PersonaPresence.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaPresence/PersonaPresence.base.tsx
@@ -68,7 +68,7 @@ export class PersonaPresenceBase extends BaseComponent<IPersonaPresenceProps, {}
     }
 
     return (
-      <div className={classNames.presence} style={coinSizeWithPresenceStyle} title={presenceTitle}>
+      <div role="presentation" className={classNames.presence} style={coinSizeWithPresenceStyle} title={presenceTitle}>
         {renderIcon && this._onRenderIcon(classNames.presenceIcon, coinSizeWithPresenceIconStyle)}
       </div>
     );

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaPresence/__snapshots__/PersonaPresence.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaPresence/__snapshots__/PersonaPresence.test.tsx.snap
@@ -41,6 +41,7 @@ exports[`PersonaPresence renders available + out of office 1`] = `
         top: 1px;
         width: calc(100% - 2px);
       }
+  role="presentation"
 >
   <i
     aria-hidden={true}
@@ -93,6 +94,7 @@ exports[`PersonaPresence renders available 1`] = `
         background-color: Highlight;
         border-color: Window;
       }
+  role="presentation"
 >
   <i
     aria-hidden={true}
@@ -162,6 +164,7 @@ exports[`PersonaPresence renders away + out of office 1`] = `
         top: 1px;
         width: calc(100% - 2px);
       }
+  role="presentation"
 >
   <i
     aria-hidden={true}
@@ -215,6 +218,7 @@ exports[`PersonaPresence renders away 1`] = `
         background-color: WindowText;
         border-color: Window;
       }
+  role="presentation"
 >
   <i
     aria-hidden={true}
@@ -291,6 +295,7 @@ exports[`PersonaPresence renders blocked + out of office 1`] = `
         top: 1px;
         width: calc(100% - 2px);
       }
+  role="presentation"
 >
   <i
     aria-hidden={true}
@@ -359,6 +364,7 @@ exports[`PersonaPresence renders blocked 1`] = `
         top: 1px;
         width: calc(100% - 2px);
       }
+  role="presentation"
 >
   <i
     aria-hidden={true}
@@ -422,6 +428,7 @@ exports[`PersonaPresence renders busy + out of office 1`] = `
         top: 1px;
         width: calc(100% - 2px);
       }
+  role="presentation"
 >
   <i
     aria-hidden={true}
@@ -468,6 +475,7 @@ exports[`PersonaPresence renders busy 1`] = `
         background-color: WindowText;
         border-color: Window;
       }
+  role="presentation"
 >
   <i
     aria-hidden={true}
@@ -531,6 +539,7 @@ exports[`PersonaPresence renders do not disturb + out of office 1`] = `
         top: 1px;
         width: calc(100% - 2px);
       }
+  role="presentation"
 >
   <i
     aria-hidden={true}
@@ -583,6 +592,7 @@ exports[`PersonaPresence renders do not disturb 1`] = `
         background-color: WindowText;
         border-color: Window;
       }
+  role="presentation"
 >
   <i
     aria-hidden={true}
@@ -656,6 +666,7 @@ exports[`PersonaPresence renders offline + out of office 1`] = `
         top: 1px;
         width: calc(100% - 2px);
       }
+  role="presentation"
 >
   <i
     aria-hidden={true}
@@ -726,6 +737,7 @@ exports[`PersonaPresence renders offline 1`] = `
         top: 1px;
         width: calc(100% - 2px);
       }
+  role="presentation"
 >
   <i
     aria-hidden={true}

--- a/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
@@ -43,6 +43,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
           font-size: 14px;
           font-weight: 400;
         }
+    role="presentation"
   >
     <div
       className=
@@ -54,6 +55,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
             text-align: center;
             width: 48px;
           }
+      role="presentation"
     >
       <div
         className=
@@ -244,6 +246,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
           font-size: 14px;
           font-weight: 400;
         }
+    role="presentation"
   >
     <div
       className=
@@ -255,6 +258,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
             text-align: center;
             width: 48px;
           }
+      role="presentation"
     >
       <div
         aria-hidden="true"
@@ -421,6 +425,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
           font-size: 14px;
           font-weight: 400;
         }
+    role="presentation"
   >
     <div
       className=
@@ -432,6 +437,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
             text-align: center;
             width: 48px;
           }
+      role="presentation"
     >
       <div
         aria-hidden="true"

--- a/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
@@ -43,6 +43,7 @@ exports[`Persona renders Persona children correctly 1`] = `
           font-size: 14px;
           font-weight: 400;
         }
+    role="presentation"
   >
     <div
       className=
@@ -54,6 +55,7 @@ exports[`Persona renders Persona children correctly 1`] = `
             text-align: center;
             width: 48px;
           }
+      role="presentation"
     >
       <div
         aria-hidden="true"
@@ -223,6 +225,7 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
           font-size: 14px;
           font-weight: 400;
         }
+    role="presentation"
   >
     <div
       className=
@@ -234,6 +237,7 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
             text-align: center;
             width: 48px;
           }
+      role="presentation"
     >
       <div
         aria-hidden="true"
@@ -414,6 +418,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
           font-size: 14px;
           font-weight: 400;
         }
+    role="presentation"
   >
     <div
       className=
@@ -425,6 +430,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
             text-align: center;
             width: 48px;
           }
+      role="presentation"
     >
       <div
         className=
@@ -615,6 +621,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
           font-size: 14px;
           font-weight: 400;
         }
+    role="presentation"
   >
     <div
       className=
@@ -626,6 +633,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
             text-align: center;
             width: 48px;
           }
+      role="presentation"
     >
       <div
         aria-hidden="true"
@@ -792,6 +800,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
           font-size: 14px;
           font-weight: 400;
         }
+    role="presentation"
   >
     <div
       className=
@@ -803,6 +812,7 @@ exports[`Persona renders Persona correctly with no props 1`] = `
             text-align: center;
             width: 48px;
           }
+      role="presentation"
     >
       <div
         aria-hidden="true"
@@ -969,6 +979,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
           font-size: 14px;
           font-weight: 400;
         }
+    role="presentation"
   >
     <div
       className=
@@ -980,6 +991,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
             text-align: center;
             width: 100px;
           }
+      role="presentation"
     >
       <div
         aria-hidden="true"
@@ -1067,6 +1079,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
               top: 1px;
               width: calc(100% - 2px);
             }
+        role="presentation"
       >
         <i
           aria-hidden={true}
@@ -1457,6 +1470,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
           font-size: 14px;
           font-weight: 400;
         }
+    role="presentation"
   >
     <div
       className=
@@ -1468,6 +1482,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
             text-align: center;
             width: 100px;
           }
+      role="presentation"
     >
       <div
         className=
@@ -1576,6 +1591,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
               top: 1px;
               width: calc(100% - 2px);
             }
+        role="presentation"
       >
         <i
           aria-hidden={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Compact.Example.tsx.shot
@@ -79,6 +79,7 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
                 overflow: visible;
                 width: 8px;
               }
+          role="presentation"
           style={
             Object {
               "display": "inline-block",
@@ -98,6 +99,7 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
                   text-align: center;
                   width: 16px;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -268,6 +270,7 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
                 overflow: visible;
                 width: 8px;
               }
+          role="presentation"
           style={
             Object {
               "display": "inline-block",
@@ -287,6 +290,7 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
                   text-align: center;
                   width: 16px;
                 }
+            role="presentation"
           >
             <div
               aria-hidden="true"
@@ -334,6 +338,7 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
                 overflow: visible;
                 width: 8px;
               }
+          role="presentation"
           style={
             Object {
               "display": "inline-block",
@@ -353,6 +358,7 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
                   text-align: center;
                   width: 16px;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -424,6 +430,7 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
                 overflow: visible;
                 width: 8px;
               }
+          role="presentation"
           style={
             Object {
               "display": "inline-block",
@@ -443,6 +450,7 @@ exports[`Component Examples renders ActivityItem.Compact.Example.tsx correctly 1
                   text-align: center;
                   width: 16px;
                 }
+            role="presentation"
           >
             <div
               aria-hidden="true"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
@@ -53,6 +53,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 font-size: 14px;
                 font-weight: 400;
               }
+          role="presentation"
         >
           <div
             className=
@@ -64,6 +65,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                   text-align: center;
                   width: 32px;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -295,6 +297,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               &:first-child {
                 align-self: flex-end;
               }
+          role="presentation"
         >
           <div
             className=
@@ -306,6 +309,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                   text-align: center;
                   width: 16px;
                 }
+            role="presentation"
           >
             <div
               aria-hidden="true"
@@ -353,6 +357,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               &:first-child {
                 align-self: flex-end;
               }
+          role="presentation"
         >
           <div
             className=
@@ -364,6 +369,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                   text-align: center;
                   width: 16px;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -707,6 +713,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 font-size: 14px;
                 font-weight: 400;
               }
+          role="presentation"
         >
           <div
             className=
@@ -718,6 +725,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                   text-align: center;
                   width: 16px;
                 }
+            role="presentation"
           >
             <div
               aria-hidden="true"
@@ -762,6 +770,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 font-size: 14px;
                 font-weight: 400;
               }
+          role="presentation"
         >
           <div
             className=
@@ -773,6 +782,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                   text-align: center;
                   width: 16px;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -841,6 +851,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 font-size: 14px;
                 font-weight: 400;
               }
+          role="presentation"
         >
           <div
             className=
@@ -852,6 +863,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                   text-align: center;
                   width: 16px;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -1130,6 +1142,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 font-size: 14px;
                 font-weight: 400;
               }
+          role="presentation"
         >
           <div
             className=
@@ -1141,6 +1154,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                   text-align: center;
                   width: 16px;
                 }
+            role="presentation"
           >
             <div
               aria-hidden="true"
@@ -1185,6 +1199,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 font-size: 14px;
                 font-weight: 400;
               }
+          role="presentation"
         >
           <div
             className=
@@ -1196,6 +1211,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                   text-align: center;
                   width: 16px;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -1264,6 +1280,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 font-size: 14px;
                 font-weight: 400;
               }
+          role="presentation"
         >
           <div
             className=
@@ -1275,6 +1292,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                   text-align: center;
                   width: 16px;
                 }
+            role="presentation"
           >
             <div
               aria-hidden="true"
@@ -1319,6 +1337,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 font-size: 14px;
                 font-weight: 400;
               }
+          role="presentation"
         >
           <div
             className=
@@ -1330,6 +1349,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                   text-align: center;
                   width: 16px;
                 }
+            role="presentation"
           >
             <div
               className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Basic.Example.tsx.shot
@@ -248,6 +248,7 @@ exports[`Component Examples renders DocumentCard.Basic.Example.tsx correctly 1`]
                   text-align: center;
                   width: 32px;
                 }
+            role="presentation"
           >
             <div
               className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
@@ -295,6 +295,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                       text-align: center;
                       width: 32px;
                     }
+                role="presentation"
               >
                 <div
                   aria-hidden="true"
@@ -870,6 +871,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                       text-align: center;
                       width: 32px;
                     }
+                role="presentation"
               >
                 <div
                   className=
@@ -1206,6 +1208,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                       text-align: center;
                       width: 32px;
                     }
+                role="presentation"
               >
                 <div
                   className=
@@ -1544,6 +1547,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                       text-align: center;
                       width: 32px;
                     }
+                role="presentation"
               >
                 <div
                   aria-hidden="true"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
@@ -489,6 +489,7 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
                   text-align: center;
                   width: 32px;
                 }
+            role="presentation"
           >
             <div
               className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Conversation.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Conversation.Example.tsx.shot
@@ -265,6 +265,7 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
                     text-align: center;
                     width: 32px;
                   }
+              role="presentation"
             >
               <div
                 aria-hidden="true"
@@ -345,6 +346,7 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
                     text-align: center;
                     width: 32px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -702,6 +704,7 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
                     text-align: center;
                     width: 32px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -806,6 +809,7 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
                     text-align: center;
                     width: 32px;
                   }
+              role="presentation"
             >
               <div
                 aria-hidden="true"
@@ -1108,6 +1112,7 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
                     text-align: center;
                     width: 32px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -1212,6 +1217,7 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
                     text-align: center;
                     width: 32px;
                   }
+              role="presentation"
             >
               <div
                 aria-hidden="true"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Image.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Image.Example.tsx.shot
@@ -250,6 +250,7 @@ exports[`Component Examples renders DocumentCard.Image.Example.tsx correctly 1`]
                     text-align: center;
                     width: 32px;
                   }
+              role="presentation"
             >
               <div
                 aria-hidden="true"
@@ -330,6 +331,7 @@ exports[`Component Examples renders DocumentCard.Image.Example.tsx correctly 1`]
                     text-align: center;
                     width: 32px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -644,6 +646,7 @@ exports[`Component Examples renders DocumentCard.Image.Example.tsx correctly 1`]
                     text-align: center;
                     width: 32px;
                   }
+              role="presentation"
             >
               <div
                 aria-hidden="true"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.AddFace.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.AddFace.Example.tsx.shot
@@ -149,6 +149,7 @@ exports[`Component Examples renders Facepile.AddFace.Example.tsx correctly 1`] =
                 font-size: 14px;
                 font-weight: 400;
               }
+          role="presentation"
         >
           <div
             className=
@@ -160,6 +161,7 @@ exports[`Component Examples renders Facepile.AddFace.Example.tsx correctly 1`] =
                   text-align: center;
                   width: 32px;
                 }
+            role="presentation"
           >
             <div
               aria-hidden="true"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -178,6 +178,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                     }
+                role="presentation"
               >
                 <div
                   className=
@@ -189,6 +190,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                         text-align: center;
                         width: 32px;
                       }
+                  role="presentation"
                 >
                   <div
                     className=
@@ -264,6 +266,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                           background-color: WindowText;
                           border-color: Window;
                         }
+                    role="presentation"
                   />
                 </div>
               </div>
@@ -324,6 +327,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                     font-size: 14px;
                     font-weight: 400;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -335,6 +339,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                       text-align: center;
                       width: 32px;
                     }
+                role="presentation"
               >
                 <div
                   className=
@@ -410,6 +415,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                         background-color: Highlight;
                         border-color: Window;
                       }
+                  role="presentation"
                 />
               </div>
             </div>
@@ -525,6 +531,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                     }
+                role="presentation"
               >
                 <div
                   className=
@@ -536,6 +543,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                         text-align: center;
                         width: 32px;
                       }
+                  role="presentation"
                 >
                   <div
                     aria-hidden="true"
@@ -605,6 +613,7 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                           top: 1px;
                           width: calc(100% - 2px);
                         }
+                    role="presentation"
                   />
                 </div>
               </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
@@ -178,6 +178,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                       font-size: 14px;
                       font-weight: 400;
                     }
+                role="presentation"
               >
                 <div
                   className=
@@ -189,6 +190,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                         text-align: center;
                         width: 32px;
                       }
+                  role="presentation"
                 >
                   <div
                     className=
@@ -301,6 +303,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                     font-size: 14px;
                     font-weight: 400;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -312,6 +315,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                       text-align: center;
                       width: 32px;
                     }
+                role="presentation"
               >
                 <div
                   className=
@@ -479,6 +483,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                       font-size: 14px;
                       font-weight: 400;
                     }
+                role="presentation"
               >
                 <div
                   className=
@@ -490,6 +495,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                         text-align: center;
                         width: 32px;
                       }
+                  role="presentation"
                 >
                   <div
                     aria-hidden="true"
@@ -578,6 +584,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                     font-size: 14px;
                     font-weight: 400;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -589,6 +596,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                       text-align: center;
                       width: 32px;
                     }
+                role="presentation"
               >
                 <div
                   aria-hidden="true"
@@ -676,6 +684,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                     font-size: 14px;
                     font-weight: 400;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -687,6 +696,7 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                       text-align: center;
                       width: 32px;
                     }
+                role="presentation"
               >
                 <div
                   aria-hidden="true"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Alternate.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Alternate.Example.tsx.shot
@@ -64,6 +64,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -75,6 +76,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               text-align: center;
               width: 24px;
             }
+        role="presentation"
       >
         <div
           className=
@@ -314,6 +316,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -325,6 +328,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               text-align: center;
               width: 28px;
             }
+        role="presentation"
       >
         <div
           className=
@@ -565,6 +569,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -576,6 +581,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               text-align: center;
               width: 32px;
             }
+        role="presentation"
       >
         <div
           className=
@@ -651,6 +657,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
                 background-color: Highlight;
                 border-color: Window;
               }
+          role="presentation"
         />
       </div>
     </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Basic.Example.tsx.shot
@@ -252,6 +252,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <i
         aria-hidden={true}
@@ -483,6 +484,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -527,6 +529,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               top: 1px;
               width: calc(100% - 2px);
             }
+        role="presentation"
       />
     </div>
     <div
@@ -736,6 +739,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -747,6 +751,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-align: center;
               width: 24px;
             }
+        role="presentation"
       >
         <div
           className=
@@ -822,6 +827,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
                 background-color: Highlight;
                 border-color: Window;
               }
+          role="presentation"
         />
       </div>
     </div>
@@ -1031,6 +1037,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -1042,6 +1049,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-align: center;
               width: 32px;
             }
+        role="presentation"
       >
         <div
           className=
@@ -1117,6 +1125,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
                 background-color: Highlight;
                 border-color: Window;
               }
+          role="presentation"
         />
       </div>
     </div>
@@ -1326,6 +1335,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -1337,6 +1347,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-align: center;
               width: 40px;
             }
+        role="presentation"
       >
         <div
           className=
@@ -1412,6 +1423,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
                 background-color: WindowText;
                 border-color: Window;
               }
+          role="presentation"
         >
           <i
             aria-hidden={true}
@@ -1647,6 +1659,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -1658,6 +1671,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-align: center;
               width: 48px;
             }
+        role="presentation"
       >
         <div
           className=
@@ -1733,6 +1747,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
                 background-color: WindowText;
                 border-color: Window;
               }
+          role="presentation"
         >
           <i
             aria-hidden={true}
@@ -1960,6 +1975,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -1971,6 +1987,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-align: center;
               width: 56px;
             }
+        role="presentation"
       >
         <div
           className=
@@ -2046,6 +2063,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
                 background-color: Highlight;
                 border-color: Window;
               }
+          role="presentation"
         >
           <i
             aria-hidden={true}
@@ -2279,6 +2297,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -2290,6 +2309,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-align: center;
               width: 72px;
             }
+        role="presentation"
       >
         <div
           className=
@@ -2365,6 +2385,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
                 background-color: WindowText;
                 border-color: Window;
               }
+          role="presentation"
         >
           <i
             aria-hidden={true}
@@ -2598,6 +2619,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -2609,6 +2631,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-align: center;
               width: 100px;
             }
+        role="presentation"
       >
         <div
           className=
@@ -2717,6 +2740,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
                 top: 1px;
                 width: calc(100% - 2px);
               }
+          role="presentation"
         >
           <i
             aria-hidden={true}
@@ -2944,6 +2968,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -2955,6 +2980,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               text-align: center;
               width: 120px;
             }
+        role="presentation"
       >
         <div
           className=
@@ -3030,6 +3056,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
                 background-color: WindowText;
                 border-color: Window;
               }
+          role="presentation"
         >
           <i
             aria-hidden={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Colors.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Colors.Example.tsx.shot
@@ -84,6 +84,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -95,6 +96,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
                 text-align: center;
                 width: 100px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -259,6 +261,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -270,6 +273,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
                 text-align: center;
                 width: 100px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -434,6 +438,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -445,6 +450,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
                 text-align: center;
                 width: 100px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -609,6 +615,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -620,6 +627,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
                 text-align: center;
                 width: 100px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -784,6 +792,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -795,6 +804,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
                 text-align: center;
                 width: 100px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -959,6 +969,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -970,6 +981,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
                 text-align: center;
                 width: 100px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -1134,6 +1146,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -1145,6 +1158,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
                 text-align: center;
                 width: 100px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -1309,6 +1323,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -1320,6 +1335,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
                 text-align: center;
                 width: 100px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -1484,6 +1500,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -1495,6 +1512,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
                 text-align: center;
                 width: 100px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -1659,6 +1677,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -1670,6 +1689,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
                 text-align: center;
                 width: 100px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -1834,6 +1854,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -1845,6 +1866,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
                 text-align: center;
                 width: 100px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -2009,6 +2031,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -2020,6 +2043,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
                 text-align: center;
                 width: 100px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -2184,6 +2208,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -2195,6 +2220,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
                 text-align: center;
                 width: 100px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -2359,6 +2385,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -2370,6 +2397,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
                 text-align: center;
                 width: 100px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -2534,6 +2562,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -2545,6 +2574,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
                 text-align: center;
                 width: 100px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -2709,6 +2739,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -2720,6 +2751,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
                 text-align: center;
                 width: 100px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -2884,6 +2916,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -2895,6 +2928,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
                 text-align: center;
                 width: 100px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -3059,6 +3093,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -3070,6 +3105,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
                 text-align: center;
                 width: 100px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -3234,6 +3270,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -3245,6 +3282,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
                 text-align: center;
                 width: 100px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"
@@ -3409,6 +3447,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -3420,6 +3459,7 @@ exports[`Component Examples renders Persona.Colors.Example.tsx correctly 1`] = `
                 text-align: center;
                 width: 100px;
               }
+          role="presentation"
         >
           <div
             aria-hidden="true"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.CustomCoinRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.CustomCoinRender.Example.tsx.shot
@@ -74,6 +74,7 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -85,6 +86,7 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
               text-align: center;
               width: 72px;
             }
+        role="presentation"
         style={
           Object {
             "height": 72,
@@ -126,6 +128,7 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
                 background-color: Highlight;
                 border-color: Window;
               }
+          role="presentation"
           style={
             Object {
               "height": "24px",

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.CustomRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.CustomRender.Example.tsx.shot
@@ -68,6 +68,7 @@ exports[`Component Examples renders Persona.CustomRender.Example.tsx correctly 1
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -79,6 +80,7 @@ exports[`Component Examples renders Persona.CustomRender.Example.tsx correctly 1
               text-align: center;
               width: 72px;
             }
+        role="presentation"
       >
         <div
           className=
@@ -172,6 +174,7 @@ exports[`Component Examples renders Persona.CustomRender.Example.tsx correctly 1
                 top: 1px;
                 width: calc(100% - 2px);
               }
+          role="presentation"
         >
           <i
             aria-hidden={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Initials.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Initials.Example.tsx.shot
@@ -64,6 +64,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -75,6 +76,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-align: center;
               width: 24px;
             }
+        role="presentation"
       >
         <div
           aria-hidden="true"
@@ -284,6 +286,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -295,6 +298,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-align: center;
               width: 24px;
             }
+        role="presentation"
       >
         <div
           aria-hidden="true"
@@ -504,6 +508,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -515,6 +520,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-align: center;
               width: 32px;
             }
+        role="presentation"
       >
         <div
           aria-hidden="true"
@@ -724,6 +730,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -735,6 +742,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-align: center;
               width: 32px;
             }
+        role="presentation"
       >
         <div
           aria-hidden="true"
@@ -944,6 +952,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -955,6 +964,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-align: center;
               width: 40px;
             }
+        role="presentation"
       >
         <div
           aria-hidden="true"
@@ -1163,6 +1173,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -1174,6 +1185,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-align: center;
               width: 40px;
             }
+        role="presentation"
       >
         <div
           aria-hidden="true"
@@ -1396,6 +1408,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -1407,6 +1420,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-align: center;
               width: 48px;
             }
+        role="presentation"
       >
         <div
           aria-hidden="true"
@@ -1615,6 +1629,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -1626,6 +1641,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-align: center;
               width: 48px;
             }
+        role="presentation"
       >
         <div
           aria-hidden="true"
@@ -1848,6 +1864,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -1859,6 +1876,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-align: center;
               width: 56px;
             }
+        role="presentation"
       >
         <div
           aria-hidden="true"
@@ -2081,6 +2099,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -2092,6 +2111,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-align: center;
               width: 56px;
             }
+        role="presentation"
       >
         <div
           aria-hidden="true"
@@ -2314,6 +2334,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -2325,6 +2346,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-align: center;
               width: 72px;
             }
+        role="presentation"
       >
         <div
           aria-hidden="true"
@@ -2533,6 +2555,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -2544,6 +2567,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-align: center;
               width: 100px;
             }
+        role="presentation"
       >
         <div
           aria-hidden="true"
@@ -2758,6 +2782,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -2769,6 +2794,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               text-align: center;
               width: 150px;
             }
+        role="presentation"
         style={
           Object {
             "height": 150,

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Presence.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Presence.Example.tsx.shot
@@ -144,6 +144,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -170,6 +171,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     border: 1px solid WindowText;
                     top: 9px;
                   }
+              role="presentation"
             />
           </div>
           <div
@@ -292,6 +294,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -303,6 +306,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 24px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -378,6 +382,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       background-color: Highlight;
                       border-color: Window;
                     }
+                role="presentation"
               />
             </div>
           </div>
@@ -425,6 +430,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -436,6 +442,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 48px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -511,6 +518,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       background-color: Highlight;
                       border-color: Window;
                     }
+                role="presentation"
               >
                 <i
                   aria-hidden={true}
@@ -583,6 +591,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -594,6 +603,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 72px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -669,6 +679,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       background-color: Highlight;
                       border-color: Window;
                     }
+                role="presentation"
               >
                 <i
                   aria-hidden={true}
@@ -812,6 +823,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -856,6 +868,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     top: 1px;
                     width: calc(100% - 2px);
                   }
+              role="presentation"
             />
           </div>
           <div
@@ -978,6 +991,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -989,6 +1003,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 24px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -1082,6 +1097,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       top: 1px;
                       width: calc(100% - 2px);
                     }
+                role="presentation"
               />
             </div>
           </div>
@@ -1129,6 +1145,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -1140,6 +1157,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 48px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -1233,6 +1251,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       top: 1px;
                       width: calc(100% - 2px);
                     }
+                role="presentation"
               >
                 <i
                   aria-hidden={true}
@@ -1306,6 +1325,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -1317,6 +1337,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 72px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -1410,6 +1431,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       top: 1px;
                       width: calc(100% - 2px);
                     }
+                role="presentation"
               >
                 <i
                   aria-hidden={true}
@@ -1576,6 +1598,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -1602,6 +1625,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     border: 1px solid WindowText;
                     top: 9px;
                   }
+              role="presentation"
             />
           </div>
           <div
@@ -1724,6 +1748,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -1735,6 +1760,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 24px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -1810,6 +1836,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       background-color: WindowText;
                       border-color: Window;
                     }
+                role="presentation"
               />
             </div>
           </div>
@@ -1857,6 +1884,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -1868,6 +1896,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 48px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -1943,6 +1972,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       background-color: WindowText;
                       border-color: Window;
                     }
+                role="presentation"
               >
                 <i
                   aria-hidden={true}
@@ -2017,6 +2047,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -2028,6 +2059,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 72px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -2103,6 +2135,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       background-color: WindowText;
                       border-color: Window;
                     }
+                role="presentation"
               >
                 <i
                   aria-hidden={true}
@@ -2248,6 +2281,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -2292,6 +2326,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     top: 1px;
                     width: calc(100% - 2px);
                   }
+              role="presentation"
             />
           </div>
           <div
@@ -2414,6 +2449,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -2425,6 +2461,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 24px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -2518,6 +2555,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       top: 1px;
                       width: calc(100% - 2px);
                     }
+                role="presentation"
               />
             </div>
           </div>
@@ -2565,6 +2603,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -2576,6 +2615,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 48px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -2669,6 +2709,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       top: 1px;
                       width: calc(100% - 2px);
                     }
+                role="presentation"
               >
                 <i
                   aria-hidden={true}
@@ -2743,6 +2784,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -2754,6 +2796,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 72px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -2847,6 +2890,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       top: 1px;
                       width: calc(100% - 2px);
                     }
+                role="presentation"
               >
                 <i
                   aria-hidden={true}
@@ -3014,6 +3058,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -3040,6 +3085,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     border: 1px solid WindowText;
                     top: 9px;
                   }
+              role="presentation"
             />
           </div>
           <div
@@ -3162,6 +3208,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -3173,6 +3220,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 24px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -3248,6 +3296,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       background-color: WindowText;
                       border-color: Window;
                     }
+                role="presentation"
               />
             </div>
           </div>
@@ -3295,6 +3344,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -3306,6 +3356,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 48px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -3381,6 +3432,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       background-color: WindowText;
                       border-color: Window;
                     }
+                role="presentation"
               >
                 <i
                   aria-hidden={true}
@@ -3447,6 +3499,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -3458,6 +3511,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 72px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -3533,6 +3587,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       background-color: WindowText;
                       border-color: Window;
                     }
+                role="presentation"
               >
                 <i
                   aria-hidden={true}
@@ -3670,6 +3725,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -3714,6 +3770,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     top: 1px;
                     width: calc(100% - 2px);
                   }
+              role="presentation"
             />
           </div>
           <div
@@ -3836,6 +3893,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -3847,6 +3905,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 24px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -3940,6 +3999,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       top: 1px;
                       width: calc(100% - 2px);
                     }
+                role="presentation"
               />
             </div>
           </div>
@@ -3987,6 +4047,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -3998,6 +4059,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 48px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -4091,6 +4153,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       top: 1px;
                       width: calc(100% - 2px);
                     }
+                role="presentation"
               >
                 <i
                   aria-hidden={true}
@@ -4158,6 +4221,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -4169,6 +4233,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 72px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -4262,6 +4327,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       top: 1px;
                       width: calc(100% - 2px);
                     }
+                role="presentation"
               >
                 <i
                   aria-hidden={true}
@@ -4422,6 +4488,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -4448,6 +4515,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     border: 1px solid WindowText;
                     top: 9px;
                   }
+              role="presentation"
             />
           </div>
           <div
@@ -4570,6 +4638,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -4581,6 +4650,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 24px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -4656,6 +4726,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       background-color: WindowText;
                       border-color: Window;
                     }
+                role="presentation"
               />
             </div>
           </div>
@@ -4703,6 +4774,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -4714,6 +4786,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 48px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -4789,6 +4862,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       background-color: WindowText;
                       border-color: Window;
                     }
+                role="presentation"
               >
                 <i
                   aria-hidden={true}
@@ -4861,6 +4935,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -4872,6 +4947,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 72px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -4947,6 +5023,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       background-color: WindowText;
                       border-color: Window;
                     }
+                role="presentation"
               >
                 <i
                   aria-hidden={true}
@@ -5090,6 +5167,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -5134,6 +5212,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     top: 1px;
                     width: calc(100% - 2px);
                   }
+              role="presentation"
             />
           </div>
           <div
@@ -5256,6 +5335,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -5267,6 +5347,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 24px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -5360,6 +5441,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       top: 1px;
                       width: calc(100% - 2px);
                     }
+                role="presentation"
               />
             </div>
           </div>
@@ -5407,6 +5489,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -5418,6 +5501,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 48px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -5511,6 +5595,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       top: 1px;
                       width: calc(100% - 2px);
                     }
+                role="presentation"
               >
                 <i
                   aria-hidden={true}
@@ -5584,6 +5669,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -5595,6 +5681,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 72px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -5688,6 +5775,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       top: 1px;
                       width: calc(100% - 2px);
                     }
+                role="presentation"
               >
                 <i
                   aria-hidden={true}
@@ -5812,6 +5900,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -5861,6 +5950,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 top: 1px;
                 width: calc(100% - 2px);
               }
+          role="presentation"
         />
       </div>
       <div
@@ -5983,6 +6073,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -5994,6 +6085,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 text-align: center;
                 width: 24px;
               }
+          role="presentation"
         >
           <div
             className=
@@ -6092,6 +6184,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   top: 1px;
                   width: calc(100% - 2px);
                 }
+            role="presentation"
           />
         </div>
       </div>
@@ -6139,6 +6232,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -6150,6 +6244,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 text-align: center;
                 width: 48px;
               }
+          role="presentation"
         >
           <div
             className=
@@ -6258,6 +6353,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   top: 1px;
                   width: calc(100% - 2px);
                 }
+            role="presentation"
           >
             <i
               aria-hidden={true}
@@ -6324,6 +6420,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
               font-size: 14px;
               font-weight: 400;
             }
+        role="presentation"
       >
         <div
           className=
@@ -6335,6 +6432,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 text-align: center;
                 width: 72px;
               }
+          role="presentation"
         >
           <div
             className=
@@ -6443,6 +6541,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   top: 1px;
                   width: calc(100% - 2px);
                 }
+            role="presentation"
           >
             <i
               aria-hidden={true}
@@ -6600,6 +6699,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -6644,6 +6744,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     top: 1px;
                     width: calc(100% - 2px);
                   }
+              role="presentation"
             />
           </div>
           <div
@@ -6766,6 +6867,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -6777,6 +6879,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 24px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -6870,6 +6973,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       top: 1px;
                       width: calc(100% - 2px);
                     }
+                role="presentation"
               />
             </div>
           </div>
@@ -6917,6 +7021,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -6928,6 +7033,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 48px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -7021,6 +7127,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       top: 1px;
                       width: calc(100% - 2px);
                     }
+                role="presentation"
               >
                 <i
                   aria-hidden={true}
@@ -7088,6 +7195,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -7099,6 +7207,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 72px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -7192,6 +7301,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       top: 1px;
                       width: calc(100% - 2px);
                     }
+                role="presentation"
               >
                 <i
                   aria-hidden={true}
@@ -7330,6 +7440,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -7374,6 +7485,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     top: 1px;
                     width: calc(100% - 2px);
                   }
+              role="presentation"
             />
           </div>
           <div
@@ -7496,6 +7608,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -7507,6 +7620,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 24px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -7600,6 +7714,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       top: 1px;
                       width: calc(100% - 2px);
                     }
+                role="presentation"
               />
             </div>
           </div>
@@ -7647,6 +7762,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -7658,6 +7774,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 48px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -7751,6 +7868,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       top: 1px;
                       width: calc(100% - 2px);
                     }
+                role="presentation"
               >
                 <i
                   aria-hidden={true}
@@ -7824,6 +7942,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                   font-size: 14px;
                   font-weight: 400;
                 }
+            role="presentation"
           >
             <div
               className=
@@ -7835,6 +7954,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                     text-align: center;
                     width: 72px;
                   }
+              role="presentation"
             >
               <div
                 className=
@@ -7928,6 +8048,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                       top: 1px;
                       width: calc(100% - 2px);
                     }
+                role="presentation"
               >
                 <i
                   aria-hidden={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.UnknownPersona.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.UnknownPersona.Example.tsx.shot
@@ -64,6 +64,7 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -75,6 +76,7 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
               text-align: center;
               width: 40px;
             }
+        role="presentation"
       >
         <div
           aria-hidden="true"
@@ -267,6 +269,7 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
             font-size: 14px;
             font-weight: 400;
           }
+      role="presentation"
     >
       <div
         className=
@@ -278,6 +281,7 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
               text-align: center;
               width: 72px;
             }
+        role="presentation"
       >
         <div
           aria-hidden="true"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SelectedPeopleList.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SelectedPeopleList.Controlled.Example.tsx.shot
@@ -373,6 +373,7 @@ exports[`Component Examples renders SelectedPeopleList.Controlled.Example.tsx co
                         font-size: 14px;
                         font-weight: 400;
                       }
+                  role="presentation"
                 >
                   <div
                     className=
@@ -384,6 +385,7 @@ exports[`Component Examples renders SelectedPeopleList.Controlled.Example.tsx co
                           text-align: center;
                           width: 32px;
                         }
+                    role="presentation"
                   >
                     <div
                       aria-hidden="true"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
@@ -989,6 +989,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
                 font-size: 14px;
                 font-weight: 400;
               }
+          role="presentation"
         >
           <div
             className=
@@ -1000,6 +1001,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
                   text-align: center;
                   width: 40px;
                 }
+            role="presentation"
           >
             <div
               aria-hidden="true"
@@ -1065,6 +1067,7 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
                     background-color: WindowText;
                     border-color: Window;
                   }
+              role="presentation"
             >
               <i
                 aria-hidden={true}

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -261,6 +261,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                         font-size: 14px;
                         font-weight: 400;
                       }
+                  role="presentation"
                 >
                   <div
                     className=
@@ -272,6 +273,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                           text-align: center;
                           width: 24px;
                         }
+                    role="presentation"
                   >
                     <div
                       className=
@@ -347,6 +349,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                             background-color: Highlight;
                             border-color: Window;
                           }
+                      role="presentation"
                     />
                   </div>
                 </div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11461

#### Description of changes

Persona coin is often used inside of buttons, but buttons are only supposed to have phrasing content (not flow). We can either change all of the divs to spans, make the elements configurable, or simply add role="presentation" because they are only there for layout.

This PR adds role="presentation" to all of the non aria-hidden divs. 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11462)