### PR TITLE
List: always render last page in list so user can 'End' key nav to the real last item in the list

### DIFF
--- a/apps/vr-tests/src/stories/ScrollablePane.GroupedDetailsList.stories.tsx
+++ b/apps/vr-tests/src/stories/ScrollablePane.GroupedDetailsList.stories.tsx
@@ -239,6 +239,7 @@ storiesOf('ScrollablePane Grouped Details List', module)
   .addDecorator(story => (
     <Screener
       steps={new Screener.Steps()
+        .wait(100)
         .snapshot('default: scrollbars should be visible', cropTo)
         .executeScript(`${getElement}.scrollTop = 100`)
         .snapshot('Scrollbars visibility when header is sticky', cropTo)

--- a/change/office-ui-fabric-react-2019-12-13-12-28-37-xgao-detaillist-2.json
+++ b/change/office-ui-fabric-react-2019-12-13-12-28-37-xgao-detaillist-2.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "List: always render last page in list so user can 'End' key nav to the real last item in the list",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "4c022384a7f3c8d60d3b466fee57975c4da81e1e",
+  "date": "2019-12-13T20:28:37.263Z"
+}

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -796,13 +796,21 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
       const isPageVisible = (!isFirstRender && (isPageInRequiredRange || (isPageInAllowedRange && isPageRendered))) || !shouldVirtualize;
       const isPageFocused = focusedIndex >= itemIndex && focusedIndex < itemIndex + itemsPerPage;
       const isFirstPage = itemIndex === startIndex;
+      const isLastPage = items ? itemIndex + itemsPerPage >= items.length : false;
 
-      // console.log('building page', itemIndex, 'pageTop: ' + pageTop, 'inAllowed: ' +
-      // isPageInAllowedRange, 'inRequired: ' + isPageInRequiredRange);
+      console.log(
+        'building page',
+        itemIndex,
+        'pageTop: ' + pageTop,
+        'inAllowed: ' + isPageInAllowedRange,
+        'inRequired: ' + isPageInRequiredRange,
+        isFirstPage,
+        isLastPage
+      );
 
-      // Only render whats visible, focused, or first page,
+      // Only render whats visible, focused, first page, or last page,
       // or when running in fast rendering mode (not in virtualized mode), we render all current items in pages
-      if (isPageVisible || isPageFocused || isFirstPage) {
+      if (isPageVisible || isPageFocused || isFirstPage || isLastPage) {
         if (currentSpacer) {
           pages.push(currentSpacer);
           currentSpacer = null;

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -798,15 +798,13 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
       const isFirstPage = itemIndex === startIndex;
       const isLastPage = items ? itemIndex + itemsPerPage >= items.length : false;
 
-      console.log(
-        'building page',
-        itemIndex,
-        'pageTop: ' + pageTop,
-        'inAllowed: ' + isPageInAllowedRange,
-        'inRequired: ' + isPageInRequiredRange,
-        isFirstPage,
-        isLastPage
-      );
+      // console.log(
+      //   'building page',
+      //   itemIndex,
+      //   'pageTop: ' + pageTop,
+      //   'inAllowed: ' + isPageInAllowedRange,
+      //   'inRequired: ' + isPageInRequiredRange
+      // );
 
       // Only render whats visible, focused, first page, or last page,
       // or when running in fast rendering mode (not in virtualized mode), we render all current items in pages

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -973,7 +973,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone4"
+                                  data-focuszone-id="FocusZone5"
                                   data-is-focusable={true}
                                   data-item-index={0}
                                   data-selection-index={0}
@@ -1377,7 +1377,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone5"
+                                  data-focuszone-id="FocusZone6"
                                   data-is-focusable={true}
                                   data-item-index={1}
                                   data-selection-index={1}
@@ -1781,7 +1781,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone6"
+                                  data-focuszone-id="FocusZone7"
                                   data-is-focusable={true}
                                   data-item-index={2}
                                   data-selection-index={2}
@@ -2185,7 +2185,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone7"
+                                  data-focuszone-id="FocusZone8"
                                   data-is-focusable={true}
                                   data-item-index={3}
                                   data-selection-index={3}
@@ -2589,7 +2589,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone8"
+                                  data-focuszone-id="FocusZone9"
                                   data-is-focusable={true}
                                   data-item-index={4}
                                   data-selection-index={4}
@@ -2993,7 +2993,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone9"
+                                  data-focuszone-id="FocusZone10"
                                   data-is-focusable={true}
                                   data-item-index={5}
                                   data-selection-index={5}
@@ -3397,7 +3397,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone10"
+                                  data-focuszone-id="FocusZone11"
                                   data-is-focusable={true}
                                   data-item-index={6}
                                   data-selection-index={6}
@@ -3801,7 +3801,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone11"
+                                  data-focuszone-id="FocusZone12"
                                   data-is-focusable={true}
                                   data-item-index={7}
                                   data-selection-index={7}
@@ -4205,7 +4205,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone12"
+                                  data-focuszone-id="FocusZone13"
                                   data-is-focusable={true}
                                   data-item-index={8}
                                   data-selection-index={8}
@@ -4609,7 +4609,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone13"
+                                  data-focuszone-id="FocusZone14"
                                   data-is-focusable={true}
                                   data-item-index={9}
                                   data-selection-index={9}
@@ -4971,10 +4971,4290 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                     role="presentation"
                     style={
                       Object {
-                        "height": 18411,
+                        "height": 17442,
                       }
                     }
                   />
+                  <div
+                    className="ms-List-page"
+                    role="presentation"
+                    style={Object {}}
+                  >
+                    <div
+                      className="ms-List-cell"
+                      data-automationid="ListCell"
+                      data-list-index={19}
+                      role="presentation"
+                    >
+                      <div
+                        className=
+                            ms-GroupedList-group
+                            {
+                              transition: background-color 0.267s cubic-bezier(0.445, 0.050, 0.550, 0.950);
+                            }
+                        role="presentation"
+                      >
+                        <div
+                          className=
+
+                              {
+                                background: #faf9f8;
+                                border-bottom: 1px solid #d2d0ce;
+                                border-top: 1px solid #d2d0ce;
+                                margin-bottom: 8px;
+                                margin-left: 0;
+                                margin-right: 0;
+                                margin-top: 8px;
+                                padding-bottom: 8px;
+                                padding-left: 8px;
+                                padding-right: 8px;
+                                padding-top: 8px;
+                                position: relative;
+                                z-index: 100;
+                              }
+                        >
+                          <div
+                            className=
+
+                                {
+                                  -moz-osx-font-smoothing: grayscale;
+                                  -webkit-font-smoothing: antialiased;
+                                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                  font-size: 20px;
+                                  font-weight: 600;
+                                  padding-bottom: 4px;
+                                  padding-left: 0;
+                                  padding-right: 0;
+                                  padding-top: 4px;
+                                }
+                          >
+                            Custom header for group 19
+                          </div>
+                          <div
+                            className=
+
+                                {
+                                  margin-bottom: 4px;
+                                  margin-left: -8px;
+                                  margin-right: -8px;
+                                  margin-top: 4px;
+                                }
+                          >
+                            <button
+                              className=
+                                  ms-Link
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    background-color: transparent;
+                                    background: none;
+                                    border-bottom: 1px solid transparent;
+                                    border: none;
+                                    color: #0078d4;
+                                    cursor: pointer;
+                                    display: inline;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: inherit;
+                                    font-weight: inherit;
+                                    margin-bottom: 0;
+                                    margin-left: 8px;
+                                    margin-right: 8px;
+                                    margin-top: 0;
+                                    outline: none;
+                                    overflow: inherit;
+                                    padding-bottom: 0px;
+                                    padding-left: 0px;
+                                    padding-right: 0px;
+                                    padding-top: 0px;
+                                    text-align: left;
+                                    text-overflow: inherit;
+                                    user-select: text;
+                                  }
+                                  .ms-Fabric--isFocusVisible &:focus {
+                                    box-shadow: 0 0 0 1px #605e5c inset;
+                                  }
+                                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                                    outline: 1px solid WindowText;
+                                  }
+                                  @media screen and (-ms-high-contrast: active){& {
+                                    border-bottom: none;
+                                  }
+                                  @media screen and (-ms-high-contrast: white-on-black){& {
+                                    color: #FFFF00;
+                                  }
+                                  @media screen and (-ms-high-contrast: black-on-white){& {
+                                    color: #00009F;
+                                  }
+                                  &:active {
+                                    color: #004578;
+                                    text-decoration: underline;
+                                  }
+                                  &:hover {
+                                    color: #004578;
+                                    text-decoration: underline;
+                                  }
+                                  &:active:hover {
+                                    color: #004578;
+                                    text-decoration: underline;
+                                  }
+                                  &:focus {
+                                    color: #0078d4;
+                                  }
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              Select group
+                            </button>
+                            <button
+                              className=
+                                  ms-Link
+                                  {
+                                    -moz-osx-font-smoothing: grayscale;
+                                    -webkit-font-smoothing: antialiased;
+                                    background-color: transparent;
+                                    background: none;
+                                    border-bottom: 1px solid transparent;
+                                    border: none;
+                                    color: #0078d4;
+                                    cursor: pointer;
+                                    display: inline;
+                                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                    font-size: inherit;
+                                    font-weight: inherit;
+                                    margin-bottom: 0;
+                                    margin-left: 8px;
+                                    margin-right: 8px;
+                                    margin-top: 0;
+                                    outline: none;
+                                    overflow: inherit;
+                                    padding-bottom: 0px;
+                                    padding-left: 0px;
+                                    padding-right: 0px;
+                                    padding-top: 0px;
+                                    text-align: left;
+                                    text-overflow: inherit;
+                                    user-select: text;
+                                  }
+                                  .ms-Fabric--isFocusVisible &:focus {
+                                    box-shadow: 0 0 0 1px #605e5c inset;
+                                  }
+                                  @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
+                                    outline: 1px solid WindowText;
+                                  }
+                                  @media screen and (-ms-high-contrast: active){& {
+                                    border-bottom: none;
+                                  }
+                                  @media screen and (-ms-high-contrast: white-on-black){& {
+                                    color: #FFFF00;
+                                  }
+                                  @media screen and (-ms-high-contrast: black-on-white){& {
+                                    color: #00009F;
+                                  }
+                                  &:active {
+                                    color: #004578;
+                                    text-decoration: underline;
+                                  }
+                                  &:hover {
+                                    color: #004578;
+                                    text-decoration: underline;
+                                  }
+                                  &:active:hover {
+                                    color: #004578;
+                                    text-decoration: underline;
+                                  }
+                                  &:focus {
+                                    color: #0078d4;
+                                  }
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              Collapse group
+                            </button>
+                          </div>
+                        </div>
+                        <div
+                          className="ms-List"
+                          id="GroupedListSection4"
+                          role="grid"
+                        >
+                          <div
+                            className="ms-List-surface"
+                            role="presentation"
+                          >
+                            <div
+                              className="ms-List-page"
+                              role="presentation"
+                              style={Object {}}
+                            >
+                              <div
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={380}
+                                role="presentation"
+                              >
+                                <div
+                                  aria-rowindex={381}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone15"
+                                  data-is-focusable={true}
+                                  data-item-index={380}
+                                  data-selection-index={380}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 100,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    aria-colindex={1}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 1px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
+                                  >
+                                    <div
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
+                                      className=
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
+
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
+                                            box-sizing: border-box;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
+                                            outline: transparent;
+                                            padding-bottom: 0px;
+                                            padding-left: 0px;
+                                            padding-right: 0px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="thumbnail"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      //placehold.it/150x150
+                                    </div>
+                                  </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={381}
+                                role="presentation"
+                              >
+                                <div
+                                  aria-rowindex={382}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone16"
+                                  data-is-focusable={true}
+                                  data-item-index={381}
+                                  data-selection-index={381}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 100,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    aria-colindex={1}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 1px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
+                                  >
+                                    <div
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
+                                      className=
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
+
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
+                                            box-sizing: border-box;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
+                                            outline: transparent;
+                                            padding-bottom: 0px;
+                                            padding-left: 0px;
+                                            padding-right: 0px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="thumbnail"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      //placehold.it/150x150
+                                    </div>
+                                  </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={382}
+                                role="presentation"
+                              >
+                                <div
+                                  aria-rowindex={383}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone17"
+                                  data-is-focusable={true}
+                                  data-item-index={382}
+                                  data-selection-index={382}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 100,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    aria-colindex={1}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 1px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
+                                  >
+                                    <div
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
+                                      className=
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
+
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
+                                            box-sizing: border-box;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
+                                            outline: transparent;
+                                            padding-bottom: 0px;
+                                            padding-left: 0px;
+                                            padding-right: 0px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="thumbnail"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      //placehold.it/150x150
+                                    </div>
+                                  </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={383}
+                                role="presentation"
+                              >
+                                <div
+                                  aria-rowindex={384}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone18"
+                                  data-is-focusable={true}
+                                  data-item-index={383}
+                                  data-selection-index={383}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 100,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    aria-colindex={1}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 1px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
+                                  >
+                                    <div
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
+                                      className=
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
+
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
+                                            box-sizing: border-box;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
+                                            outline: transparent;
+                                            padding-bottom: 0px;
+                                            padding-left: 0px;
+                                            padding-right: 0px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="thumbnail"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      //placehold.it/150x150
+                                    </div>
+                                  </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={384}
+                                role="presentation"
+                              >
+                                <div
+                                  aria-rowindex={385}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone19"
+                                  data-is-focusable={true}
+                                  data-item-index={384}
+                                  data-selection-index={384}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 100,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    aria-colindex={1}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 1px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
+                                  >
+                                    <div
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
+                                      className=
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
+
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
+                                            box-sizing: border-box;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
+                                            outline: transparent;
+                                            padding-bottom: 0px;
+                                            padding-left: 0px;
+                                            padding-right: 0px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="thumbnail"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      //placehold.it/150x150
+                                    </div>
+                                  </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={385}
+                                role="presentation"
+                              >
+                                <div
+                                  aria-rowindex={386}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone20"
+                                  data-is-focusable={true}
+                                  data-item-index={385}
+                                  data-selection-index={385}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 100,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    aria-colindex={1}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 1px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
+                                  >
+                                    <div
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
+                                      className=
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
+
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
+                                            box-sizing: border-box;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
+                                            outline: transparent;
+                                            padding-bottom: 0px;
+                                            padding-left: 0px;
+                                            padding-right: 0px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="thumbnail"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      //placehold.it/150x150
+                                    </div>
+                                  </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={386}
+                                role="presentation"
+                              >
+                                <div
+                                  aria-rowindex={387}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone21"
+                                  data-is-focusable={true}
+                                  data-item-index={386}
+                                  data-selection-index={386}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 100,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    aria-colindex={1}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 1px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
+                                  >
+                                    <div
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
+                                      className=
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
+
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
+                                            box-sizing: border-box;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
+                                            outline: transparent;
+                                            padding-bottom: 0px;
+                                            padding-left: 0px;
+                                            padding-right: 0px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="thumbnail"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      //placehold.it/150x150
+                                    </div>
+                                  </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={387}
+                                role="presentation"
+                              >
+                                <div
+                                  aria-rowindex={388}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone22"
+                                  data-is-focusable={true}
+                                  data-item-index={387}
+                                  data-selection-index={387}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 100,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    aria-colindex={1}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 1px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
+                                  >
+                                    <div
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
+                                      className=
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
+
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
+                                            box-sizing: border-box;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
+                                            outline: transparent;
+                                            padding-bottom: 0px;
+                                            padding-left: 0px;
+                                            padding-right: 0px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="thumbnail"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      //placehold.it/150x150
+                                    </div>
+                                  </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={388}
+                                role="presentation"
+                              >
+                                <div
+                                  aria-rowindex={389}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone23"
+                                  data-is-focusable={true}
+                                  data-item-index={388}
+                                  data-selection-index={388}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 100,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    aria-colindex={1}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 1px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
+                                  >
+                                    <div
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
+                                      className=
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
+
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
+                                            box-sizing: border-box;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
+                                            outline: transparent;
+                                            padding-bottom: 0px;
+                                            padding-left: 0px;
+                                            padding-right: 0px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="thumbnail"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      //placehold.it/150x150
+                                    </div>
+                                  </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={389}
+                                role="presentation"
+                              >
+                                <div
+                                  aria-rowindex={390}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone24"
+                                  data-is-focusable={true}
+                                  data-item-index={389}
+                                  data-selection-index={389}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 100,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    aria-colindex={1}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 1px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
+                                  >
+                                    <div
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
+                                      className=
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
+
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
+                                            box-sizing: border-box;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
+                                            outline: transparent;
+                                            padding-bottom: 0px;
+                                            padding-left: 0px;
+                                            padding-right: 0px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="thumbnail"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      //placehold.it/150x150
+                                    </div>
+                                  </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          className=
+
+                              {
+                                background: #faf9f8;
+                                border-bottom: 1px solid #d2d0ce;
+                                border-top: 1px solid #d2d0ce;
+                                margin-bottom: 8px;
+                                margin-left: 0;
+                                margin-right: 0;
+                                margin-top: 8px;
+                                padding-bottom: 8px;
+                                padding-left: 8px;
+                                padding-right: 8px;
+                                padding-top: 8px;
+                                position: relative;
+                                z-index: 100;
+                              }
+                        >
+                          <em>
+                            Custom footer for group 19
+                          </em>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -1352,7 +1352,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone5"
+                                  data-focuszone-id="FocusZone7"
                                   data-is-focusable={true}
                                   data-item-index={0}
                                   data-selection-index={0}
@@ -1813,7 +1813,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone6"
+                                  data-focuszone-id="FocusZone8"
                                   data-is-focusable={true}
                                   data-item-index={1}
                                   data-selection-index={1}
@@ -2274,7 +2274,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone7"
+                                  data-focuszone-id="FocusZone9"
                                   data-is-focusable={true}
                                   data-item-index={2}
                                   data-selection-index={2}
@@ -2735,7 +2735,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone8"
+                                  data-focuszone-id="FocusZone10"
                                   data-is-focusable={true}
                                   data-item-index={3}
                                   data-selection-index={3}
@@ -3196,7 +3196,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone9"
+                                  data-focuszone-id="FocusZone11"
                                   data-is-focusable={true}
                                   data-item-index={4}
                                   data-selection-index={4}
@@ -3657,7 +3657,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone10"
+                                  data-focuszone-id="FocusZone12"
                                   data-is-focusable={true}
                                   data-item-index={5}
                                   data-selection-index={5}
@@ -4118,7 +4118,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone11"
+                                  data-focuszone-id="FocusZone13"
                                   data-is-focusable={true}
                                   data-item-index={6}
                                   data-selection-index={6}
@@ -4579,7 +4579,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone12"
+                                  data-focuszone-id="FocusZone14"
                                   data-is-focusable={true}
                                   data-item-index={7}
                                   data-selection-index={7}
@@ -5040,7 +5040,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone13"
+                                  data-focuszone-id="FocusZone15"
                                   data-is-focusable={true}
                                   data-item-index={8}
                                   data-selection-index={8}
@@ -5501,7 +5501,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                         opacity: 1;
                                       }
                                   data-automationid="DetailsRow"
-                                  data-focuszone-id="FocusZone14"
+                                  data-focuszone-id="FocusZone16"
                                   data-is-focusable={true}
                                   data-item-index={9}
                                   data-selection-index={9}
@@ -5897,10 +5897,5026 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                     role="presentation"
                     style={
                       Object {
-                        "height": 38178,
+                        "height": 33936,
                       }
                     }
                   />
+                  <div
+                    className="ms-List-page"
+                    role="presentation"
+                    style={Object {}}
+                  >
+                    <div
+                      className="ms-List-cell"
+                      data-automationid="ListCell"
+                      data-list-index={9}
+                      role="presentation"
+                    >
+                      <div
+                        className=
+                            ms-GroupedList-group
+                            {
+                              transition: background-color 0.267s cubic-bezier(0.445, 0.050, 0.550, 0.950);
+                            }
+                        role="presentation"
+                      >
+                        <div
+                          aria-label="9"
+                          className=
+                              ms-GroupHeader
+                              {
+                                -moz-osx-font-smoothing: grayscale;
+                                -webkit-font-smoothing: antialiased;
+                                border-bottom: 1px solid #ffffff;
+                                cursor: default;
+                                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                font-size: 14px;
+                                font-weight: 400;
+                                outline: transparent;
+                                position: relative;
+                                user-select: none;
+                              }
+                              &::-moz-focus-inner {
+                                border: 0;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus:after {
+                                border: 1px solid #ffffff;
+                                bottom: 1px;
+                                content: "";
+                                left: 1px;
+                                outline: 1px solid #605e5c;
+                                position: absolute;
+                                right: 1px;
+                                top: 1px;
+                                z-index: 1;
+                              }
+                              &:hover {
+                                background: #f3f2f1;
+                                color: #201f1e;
+                              }
+                              &:hover .ms-GroupHeader-check {
+                                opacity: 1;
+                              }
+                              .ms-Fabric--isFocusVisible &:focus .ms-GroupHeader-check {
+                                opacity: 1;
+                              }
+                              & > .ms-GroupHeader .ms-GroupHeader-dropIcon {
+                                opacity: 1;
+                                transform: rotate(0.2deg) scale(1);
+                                transition-delay: 0.367s;
+                                transition: transform 0.467s cubic-bezier(0.075, 0.820, 0.165, 1.000) opacity 0.167s cubic-bezier(0.390, 0.575, 0.565, 1.000);
+                              }
+                              .ms-GroupedList-group.is-dropping .ms-GroupHeader-check {
+                                opacity: 0;
+                              }
+                          data-is-focusable={true}
+                          onClick={[Function]}
+                          style={Object {}}
+                        >
+                          <div
+                            className=
+                                ms-FocusZone
+                                &:focus {
+                                  outline: none;
+                                }
+                                {
+                                  align-items: center;
+                                  display: flex;
+                                  height: 48px;
+                                }
+                            data-focuszone-id="FocusZone6"
+                            onFocus={[Function]}
+                            onKeyDown={[Function]}
+                            onMouseDownCapture={[Function]}
+                          >
+                            <button
+                              aria-checked={false}
+                              className=
+                                  ms-GroupHeader-check
+                                  {
+                                    align-items: center;
+                                    background-color: transparent;
+                                    background: none;
+                                    border: none;
+                                    cursor: default;
+                                    display: flex;
+                                    height: 48px;
+                                    justify-content: center;
+                                    margin-top: -1px;
+                                    opacity: 0;
+                                    outline: transparent;
+                                    padding-bottom: 0px;
+                                    padding-left: 0px;
+                                    padding-right: 0px;
+                                    padding-top: 1px;
+                                    position: relative;
+                                    width: 48px;
+                                  }
+                                  &::-moz-focus-inner {
+                                    border: 0;
+                                  }
+                                  .ms-Fabric--isFocusVisible &:focus:after {
+                                    border: 1px solid #ffffff;
+                                    bottom: 1px;
+                                    content: "";
+                                    left: 1px;
+                                    outline: 1px solid #605e5c;
+                                    position: absolute;
+                                    right: 1px;
+                                    top: 1px;
+                                    z-index: 1;
+                                  }
+                                  .ms-Fabric--isFocusVisible &:focus {
+                                    opacity: 1;
+                                  }
+                              data-selection-toggle={true}
+                              onClick={[Function]}
+                              role="checkbox"
+                              type="button"
+                            >
+                              <div
+                                className=
+                                    ms-Check
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                      font-size: 14px;
+                                      font-weight: 400;
+                                      height: 18px;
+                                      line-height: 1;
+                                      position: relative;
+                                      user-select: none;
+                                      vertical-align: top;
+                                      width: 18px;
+                                    }
+                                    &:before {
+                                      background: #ffffff;
+                                      border-radius: 50%;
+                                      bottom: 1px;
+                                      content: "";
+                                      left: 1px;
+                                      opacity: 1;
+                                      position: absolute;
+                                      right: 1px;
+                                      top: 1px;
+                                    }
+                                    .ms-Check-checkHost:hover & {
+                                      opacity: 1;
+                                    }
+                                    .ms-Check-checkHost:focus & {
+                                      opacity: 1;
+                                    }
+                                    &:hover {
+                                      opacity: 1;
+                                    }
+                                    &:focus {
+                                      opacity: 1;
+                                    }
+                              >
+                                <i
+                                  aria-hidden={true}
+                                  className=
+                                      ms-Icon
+                                      ms-Check-circle
+                                      {
+                                        display: inline-block;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        font-family: "FabricMDL2Icons";
+                                        font-style: normal;
+                                        font-weight: normal;
+                                        speak: none;
+                                      }
+                                      {
+                                        color: #605e5c;
+                                        font-size: 18px;
+                                        height: 18px;
+                                        left: 0px;
+                                        position: absolute;
+                                        text-align: center;
+                                        top: 0px;
+                                        vertical-align: middle;
+                                        width: 18px;
+                                      }
+                                      @media screen and (-ms-high-contrast: active){& {
+                                        color: WindowText;
+                                      }
+                                  data-icon-name="CircleRing"
+                                  role="presentation"
+                                >
+                                  
+                                </i>
+                                <i
+                                  aria-hidden={true}
+                                  className=
+                                      ms-Icon
+                                      ms-Check-check
+                                      {
+                                        display: inline-block;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        font-family: "FabricMDL2Icons";
+                                        font-style: normal;
+                                        font-weight: normal;
+                                        speak: none;
+                                      }
+                                      {
+                                        color: #605e5c;
+                                        font-size: 16px;
+                                        height: 18px;
+                                        left: .5px;
+                                        opacity: 0;
+                                        position: absolute;
+                                        text-align: center;
+                                        top: 0px;
+                                        vertical-align: middle;
+                                        width: 18px;
+                                      }
+                                      &:hover {
+                                        opacity: 1;
+                                      }
+                                      @media screen and (-ms-high-contrast: active){& {
+                                        -ms-high-contrast-adjust: none;
+                                      }
+                                  data-icon-name="StatusCircleCheckmark"
+                                  role="presentation"
+                                >
+                                  
+                                </i>
+                              </div>
+                            </button>
+                            <div
+                              className=
+                                  ms-GroupHeader-dropIcon
+                                  {
+                                    color: #605e5c;
+                                    font-size: 20px;
+                                    left: -26px;
+                                    opacity: 0;
+                                    position: absolute;
+                                    transform-origin: 10px 10px;
+                                    transform: rotate(0.2deg) scale(0.65);
+                                    transition: transform 0.267s cubic-bezier(0.600, -0.280, 0.735, 0.045), opacity 0.467s cubic-bezier(0.390, 0.575, 0.565, 1.000);
+                                  }
+                                  .ms-Icon--Tag {
+                                    position: absolute;
+                                  }
+                            >
+                              <i
+                                aria-hidden={true}
+                                className=
+
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      display: inline-block;
+                                      font-family: "FabricMDL2Icons";
+                                      font-style: normal;
+                                      font-weight: normal;
+                                      speak: none;
+                                    }
+                                data-icon-name="Tag"
+                              >
+                                
+                              </i>
+                            </div>
+                            <button
+                              aria-controls="GroupedListSection5"
+                              aria-expanded={true}
+                              aria-label="expand collapse group"
+                              className=
+                                  ms-GroupHeader-expand
+                                  {
+                                    align-items: center;
+                                    background-color: transparent;
+                                    background: none;
+                                    border: none;
+                                    color: #605e5c;
+                                    cursor: default;
+                                    display: flex;
+                                    font-size: 12px;
+                                    height: 48px;
+                                    justify-content: center;
+                                    outline: transparent;
+                                    padding-bottom: 0px;
+                                    padding-left: 0px;
+                                    padding-right: 0px;
+                                    padding-top: 0px;
+                                    position: relative;
+                                    width: 36px;
+                                  }
+                                  &::-moz-focus-inner {
+                                    border: 0;
+                                  }
+                                  .ms-Fabric--isFocusVisible &:focus:after {
+                                    border: 1px solid #ffffff;
+                                    bottom: 1px;
+                                    content: "";
+                                    left: 1px;
+                                    outline: 1px solid #605e5c;
+                                    position: absolute;
+                                    right: 1px;
+                                    top: 1px;
+                                    z-index: 1;
+                                  }
+                                  &:hover {
+                                    background-color: #edebe9;
+                                  }
+                                  &:active {
+                                    background-color: #e1dfdd;
+                                  }
+                              onClick={[Function]}
+                              type="button"
+                            >
+                              <i
+                                aria-hidden={true}
+                                className=
+
+                                    {
+                                      -moz-osx-font-smoothing: grayscale;
+                                      -webkit-font-smoothing: antialiased;
+                                      display: inline-block;
+                                      font-family: "FabricMDL2Icons-3";
+                                      font-style: normal;
+                                      font-weight: normal;
+                                      speak: none;
+                                      transform-origin: 50% 50%;
+                                      transform: rotate(90deg);
+                                      transition: transform .1s linear;
+                                    }
+                                data-icon-name="ChevronRightMed"
+                              >
+                                
+                              </i>
+                            </button>
+                            <div
+                              className=
+                                  ms-GroupHeader-title
+                                  {
+                                    cursor: pointer;
+                                    font-size: 16px;
+                                    font-weight: 600;
+                                    outline: 0px;
+                                    padding-left: 12px;
+                                    text-overflow: ellipsis;
+                                    white-space: nowrap;
+                                  }
+                            >
+                              <span>
+                                9
+                              </span>
+                              <span
+                                className=
+
+                                    {
+                                      padding-bottom: 0px;
+                                      padding-left: 4px;
+                                      padding-right: 4px;
+                                      padding-top: 0px;
+                                    }
+                              >
+                                (
+                                100
+                                )
+                              </span>
+                            </div>
+                          </div>
+                        </div>
+                        <div
+                          className="ms-List"
+                          id="GroupedListSection5"
+                          role="grid"
+                        >
+                          <div
+                            className="ms-List-surface"
+                            role="presentation"
+                          >
+                            <div
+                              className="ms-List-page"
+                              role="presentation"
+                              style={Object {}}
+                            >
+                              <div
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={900}
+                                role="presentation"
+                              >
+                                <div
+                                  aria-rowindex={901}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone17"
+                                  data-is-focusable={true}
+                                  data-item-index={900}
+                                  data-selection-index={900}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 200,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    aria-colindex={1}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 1px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
+                                  >
+                                    <div
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
+                                      className=
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
+
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
+                                            box-sizing: border-box;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
+                                            outline: transparent;
+                                            padding-bottom: 0px;
+                                            padding-left: 0px;
+                                            padding-right: 0px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="name"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      Item 900
+                                    </div>
+                                    <div
+                                      aria-colindex={3}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="value"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      900
+                                    </div>
+                                  </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={901}
+                                role="presentation"
+                              >
+                                <div
+                                  aria-rowindex={902}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone18"
+                                  data-is-focusable={true}
+                                  data-item-index={901}
+                                  data-selection-index={901}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 200,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    aria-colindex={1}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 1px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
+                                  >
+                                    <div
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
+                                      className=
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
+
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
+                                            box-sizing: border-box;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
+                                            outline: transparent;
+                                            padding-bottom: 0px;
+                                            padding-left: 0px;
+                                            padding-right: 0px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="name"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      Item 901
+                                    </div>
+                                    <div
+                                      aria-colindex={3}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="value"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      901
+                                    </div>
+                                  </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={902}
+                                role="presentation"
+                              >
+                                <div
+                                  aria-rowindex={903}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone19"
+                                  data-is-focusable={true}
+                                  data-item-index={902}
+                                  data-selection-index={902}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 200,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    aria-colindex={1}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 1px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
+                                  >
+                                    <div
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
+                                      className=
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
+
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
+                                            box-sizing: border-box;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
+                                            outline: transparent;
+                                            padding-bottom: 0px;
+                                            padding-left: 0px;
+                                            padding-right: 0px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="name"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      Item 902
+                                    </div>
+                                    <div
+                                      aria-colindex={3}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="value"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      902
+                                    </div>
+                                  </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={903}
+                                role="presentation"
+                              >
+                                <div
+                                  aria-rowindex={904}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone20"
+                                  data-is-focusable={true}
+                                  data-item-index={903}
+                                  data-selection-index={903}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 200,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    aria-colindex={1}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 1px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
+                                  >
+                                    <div
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
+                                      className=
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
+
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
+                                            box-sizing: border-box;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
+                                            outline: transparent;
+                                            padding-bottom: 0px;
+                                            padding-left: 0px;
+                                            padding-right: 0px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="name"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      Item 903
+                                    </div>
+                                    <div
+                                      aria-colindex={3}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="value"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      903
+                                    </div>
+                                  </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={904}
+                                role="presentation"
+                              >
+                                <div
+                                  aria-rowindex={905}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone21"
+                                  data-is-focusable={true}
+                                  data-item-index={904}
+                                  data-selection-index={904}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 200,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    aria-colindex={1}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 1px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
+                                  >
+                                    <div
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
+                                      className=
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
+
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
+                                            box-sizing: border-box;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
+                                            outline: transparent;
+                                            padding-bottom: 0px;
+                                            padding-left: 0px;
+                                            padding-right: 0px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="name"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      Item 904
+                                    </div>
+                                    <div
+                                      aria-colindex={3}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="value"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      904
+                                    </div>
+                                  </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={905}
+                                role="presentation"
+                              >
+                                <div
+                                  aria-rowindex={906}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone22"
+                                  data-is-focusable={true}
+                                  data-item-index={905}
+                                  data-selection-index={905}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 200,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    aria-colindex={1}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 1px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
+                                  >
+                                    <div
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
+                                      className=
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
+
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
+                                            box-sizing: border-box;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
+                                            outline: transparent;
+                                            padding-bottom: 0px;
+                                            padding-left: 0px;
+                                            padding-right: 0px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="name"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      Item 905
+                                    </div>
+                                    <div
+                                      aria-colindex={3}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="value"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      905
+                                    </div>
+                                  </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={906}
+                                role="presentation"
+                              >
+                                <div
+                                  aria-rowindex={907}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone23"
+                                  data-is-focusable={true}
+                                  data-item-index={906}
+                                  data-selection-index={906}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 200,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    aria-colindex={1}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 1px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
+                                  >
+                                    <div
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
+                                      className=
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
+
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
+                                            box-sizing: border-box;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
+                                            outline: transparent;
+                                            padding-bottom: 0px;
+                                            padding-left: 0px;
+                                            padding-right: 0px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="name"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      Item 906
+                                    </div>
+                                    <div
+                                      aria-colindex={3}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="value"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      906
+                                    </div>
+                                  </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={907}
+                                role="presentation"
+                              >
+                                <div
+                                  aria-rowindex={908}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone24"
+                                  data-is-focusable={true}
+                                  data-item-index={907}
+                                  data-selection-index={907}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 200,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    aria-colindex={1}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 1px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
+                                  >
+                                    <div
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
+                                      className=
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
+
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
+                                            box-sizing: border-box;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
+                                            outline: transparent;
+                                            padding-bottom: 0px;
+                                            padding-left: 0px;
+                                            padding-right: 0px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="name"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      Item 907
+                                    </div>
+                                    <div
+                                      aria-colindex={3}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="value"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      907
+                                    </div>
+                                  </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={908}
+                                role="presentation"
+                              >
+                                <div
+                                  aria-rowindex={909}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone25"
+                                  data-is-focusable={true}
+                                  data-item-index={908}
+                                  data-selection-index={908}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 200,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    aria-colindex={1}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 1px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
+                                  >
+                                    <div
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
+                                      className=
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
+
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
+                                            box-sizing: border-box;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
+                                            outline: transparent;
+                                            padding-bottom: 0px;
+                                            padding-left: 0px;
+                                            padding-right: 0px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="name"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      Item 908
+                                    </div>
+                                    <div
+                                      aria-colindex={3}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="value"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      908
+                                    </div>
+                                  </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
+                                </div>
+                              </div>
+                              <div
+                                className="ms-List-cell"
+                                data-automationid="ListCell"
+                                data-list-index={909}
+                                role="presentation"
+                              >
+                                <div
+                                  aria-rowindex={910}
+                                  aria-selected={false}
+                                  className=
+                                      ms-FocusZone
+                                      ms-DetailsRow
+                                      is-contentUnselectable
+                                      &:focus {
+                                        outline: none;
+                                      }
+                                      {
+                                        -moz-osx-font-smoothing: grayscale;
+                                        -webkit-font-smoothing: antialiased;
+                                        animation-duration: 0.367s;
+                                        animation-fill-mode: both;
+                                        animation-name: keyframes from{opacity:0;}to{opacity:1;};
+                                        animation-timing-function: cubic-bezier(.1,.25,.75,.9);
+                                        background: #ffffff;
+                                        border-bottom: 1px solid #f3f2f1;
+                                        box-sizing: border-box;
+                                        color: #605e5c;
+                                        cursor: default;
+                                        display: inline-flex;
+                                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                        font-size: 12px;
+                                        font-weight: 400;
+                                        min-height: 42px;
+                                        min-width: 100%;
+                                        outline: transparent;
+                                        padding-bottom: 0px;
+                                        padding-left: 0px;
+                                        padding-right: 0px;
+                                        padding-top: 0px;
+                                        position: relative;
+                                        text-align: left;
+                                        user-select: none;
+                                        vertical-align: top;
+                                        white-space: nowrap;
+                                      }
+                                      &::-moz-focus-inner {
+                                        border: 0;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus:after {
+                                        border: 1px solid #605e5c;
+                                        bottom: 1px;
+                                        content: "";
+                                        left: 1px;
+                                        outline: 1px solid #ffffff;
+                                        position: absolute;
+                                        right: 1px;
+                                        top: 1px;
+                                        z-index: 1;
+                                      }
+                                      .ms-List-cell:first-child &:before {
+                                        display: none;
+                                      }
+                                      &:hover {
+                                        background: #f3f2f1;
+                                        color: #323130;
+                                      }
+                                      &:hover .is-row-header {
+                                        color: #201f1e;
+                                      }
+                                      &:hover .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                      .ms-Fabric--isFocusVisible &:focus .ms-DetailsRow-check {
+                                        opacity: 1;
+                                      }
+                                  data-automationid="DetailsRow"
+                                  data-focuszone-id="FocusZone26"
+                                  data-is-focusable={true}
+                                  data-item-index={909}
+                                  data-selection-index={909}
+                                  onFocus={[Function]}
+                                  onKeyDown={[Function]}
+                                  onMouseDownCapture={[Function]}
+                                  role="row"
+                                  style={
+                                    Object {
+                                      "minWidth": 200,
+                                    }
+                                  }
+                                >
+                                  <div
+                                    aria-colindex={1}
+                                    className=
+                                        ms-DetailsRow-cell
+                                        ms-DetailsRow-cellCheck
+                                        {
+                                          box-sizing: border-box;
+                                          display: inline-block;
+                                          flex-shrink: 0;
+                                          margin-top: -1px;
+                                          min-height: 42px;
+                                          outline: transparent;
+                                          overflow: hidden;
+                                          padding-bottom: 0px;
+                                          padding-left: 0px;
+                                          padding-right: 0px;
+                                          padding-top: 1px;
+                                          position: relative;
+                                          text-overflow: ellipsis;
+                                          vertical-align: top;
+                                          white-space: nowrap;
+                                        }
+                                        &::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                        .ms-Fabric--isFocusVisible &:focus:after {
+                                          border: 1px solid #605e5c;
+                                          bottom: 0px;
+                                          content: "";
+                                          left: 0px;
+                                          outline: 1px solid #ffffff;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: 0px;
+                                          z-index: 1;
+                                        }
+                                        & > button {
+                                          max-width: 100%;
+                                        }
+                                        & [data-is-focusable='true'] {
+                                          outline: transparent;
+                                          position: relative;
+                                        }
+                                        & [data-is-focusable='true']::-moz-focus-inner {
+                                          border: 0;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="gridcell"
+                                  >
+                                    <div
+                                      aria-checked={false}
+                                      aria-label="Row checkbox"
+                                      className=
+                                          ms-DetailsRow-check
+                                          ms-Check-checkHost
+
+                                          {
+                                            -moz-osx-font-smoothing: grayscale;
+                                            -webkit-font-smoothing: antialiased;
+                                            align-items: center;
+                                            background-color: transparent;
+                                            background: none;
+                                            border: none;
+                                            box-sizing: border-box;
+                                            cursor: default;
+                                            display: flex;
+                                            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                            font-size: 12px;
+                                            font-weight: 400;
+                                            height: 42px;
+                                            justify-content: center;
+                                            margin-bottom: 0px;
+                                            margin-left: 0px;
+                                            margin-right: 0px;
+                                            margin-top: 0px;
+                                            opacity: 0;
+                                            outline: transparent;
+                                            padding-bottom: 0px;
+                                            padding-left: 0px;
+                                            padding-right: 0px;
+                                            padding-top: 0px;
+                                            position: relative;
+                                            vertical-align: top;
+                                            width: 48px;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #ffffff;
+                                            bottom: 1px;
+                                            content: "";
+                                            left: 1px;
+                                            outline: 1px solid #605e5c;
+                                            position: absolute;
+                                            right: 1px;
+                                            top: 1px;
+                                            z-index: 1;
+                                          }
+                                      data-automationid="DetailsRowCheck"
+                                      data-selection-toggle={true}
+                                      role="checkbox"
+                                    >
+                                      <div
+                                        className=
+                                            ms-Check
+                                            {
+                                              -moz-osx-font-smoothing: grayscale;
+                                              -webkit-font-smoothing: antialiased;
+                                              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                                              font-size: 14px;
+                                              font-weight: 400;
+                                              height: 18px;
+                                              line-height: 1;
+                                              position: relative;
+                                              user-select: none;
+                                              vertical-align: top;
+                                              width: 18px;
+                                            }
+                                            &:before {
+                                              background: #ffffff;
+                                              border-radius: 50%;
+                                              bottom: 1px;
+                                              content: "";
+                                              left: 1px;
+                                              opacity: 1;
+                                              position: absolute;
+                                              right: 1px;
+                                              top: 1px;
+                                            }
+                                            .ms-Check-checkHost:hover & {
+                                              opacity: 1;
+                                            }
+                                            .ms-Check-checkHost:focus & {
+                                              opacity: 1;
+                                            }
+                                            &:hover {
+                                              opacity: 1;
+                                            }
+                                            &:focus {
+                                              opacity: 1;
+                                            }
+                                      >
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-circle
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 18px;
+                                                height: 18px;
+                                                left: 0px;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                color: WindowText;
+                                              }
+                                          data-icon-name="CircleRing"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                        <i
+                                          aria-hidden={true}
+                                          className=
+                                              ms-Icon
+                                              ms-Check-check
+                                              {
+                                                display: inline-block;
+                                              }
+                                              {
+                                                -moz-osx-font-smoothing: grayscale;
+                                                -webkit-font-smoothing: antialiased;
+                                                font-family: "FabricMDL2Icons";
+                                                font-style: normal;
+                                                font-weight: normal;
+                                                speak: none;
+                                              }
+                                              {
+                                                color: #605e5c;
+                                                font-size: 16px;
+                                                height: 18px;
+                                                left: .5px;
+                                                opacity: 0;
+                                                position: absolute;
+                                                text-align: center;
+                                                top: 0px;
+                                                vertical-align: middle;
+                                                width: 18px;
+                                              }
+                                              &:hover {
+                                                opacity: 1;
+                                              }
+                                              @media screen and (-ms-high-contrast: active){& {
+                                                -ms-high-contrast-adjust: none;
+                                              }
+                                          data-icon-name="StatusCircleCheckmark"
+                                          role="presentation"
+                                        >
+                                          
+                                        </i>
+                                      </div>
+                                    </div>
+                                  </div>
+                                  <span
+                                    className="ms-GroupSpacer"
+                                    style={
+                                      Object {
+                                        "display": "inline-block",
+                                        "width": 36,
+                                      }
+                                    }
+                                  />
+                                  <div
+                                    className=
+                                        ms-DetailsRow-fields
+                                        {
+                                          align-items: stretch;
+                                          display: flex;
+                                        }
+                                    data-automationid="DetailsRowFields"
+                                    role="presentation"
+                                  >
+                                    <div
+                                      aria-colindex={2}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="name"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      Item 909
+                                    </div>
+                                    <div
+                                      aria-colindex={3}
+                                      aria-readonly={true}
+                                      className=
+                                          ms-DetailsRow-cell
+                                          {
+                                            box-sizing: border-box;
+                                            display: inline-block;
+                                            min-height: 42px;
+                                            outline: transparent;
+                                            overflow: hidden;
+                                            padding-bottom: 11px;
+                                            padding-left: 12px;
+                                            padding-top: 11px;
+                                            position: relative;
+                                            text-overflow: ellipsis;
+                                            vertical-align: top;
+                                            white-space: nowrap;
+                                          }
+                                          &::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          .ms-Fabric--isFocusVisible &:focus:after {
+                                            border: 1px solid #605e5c;
+                                            bottom: 0px;
+                                            content: "";
+                                            left: 0px;
+                                            outline: 1px solid #ffffff;
+                                            position: absolute;
+                                            right: 0px;
+                                            top: 0px;
+                                            z-index: 1;
+                                          }
+                                          & > button {
+                                            max-width: 100%;
+                                          }
+                                          & [data-is-focusable='true'] {
+                                            outline: transparent;
+                                            position: relative;
+                                          }
+                                          & [data-is-focusable='true']::-moz-focus-inner {
+                                            border: 0;
+                                          }
+                                          {
+                                            padding-right: 8px;
+                                          }
+                                      data-automation-key="value"
+                                      data-automationid="DetailsRowCell"
+                                      role="gridcell"
+                                      style={
+                                        Object {
+                                          "width": 120,
+                                        }
+                                      }
+                                    >
+                                      909
+                                    </div>
+                                  </div>
+                                  <span
+                                    aria-checked={false}
+                                    className=
+
+                                        {
+                                          bottom: 0px;
+                                          display: none;
+                                          left: 0px;
+                                          position: absolute;
+                                          right: 0px;
+                                          top: -1px;
+                                        }
+                                    data-selection-toggle={true}
+                                    role="checkbox"
+                                  />
+                                </div>
+                              </div>
+                            </div>
+                          </div>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
#### Pull request checklist
- [X] Addresses an existing issue: Fixes #11346
- [X] Include a change request file using `$ yarn change`

#### Description of changes
in case of rendering virtualized list, `End` key doesn't navigate to the __real__ last item in the list because if we didn't render the last item inside the DOM. the fix here is to always render the last page inside `List`.

#### Focus areas to test
- Made sure no unexpected unit test failures
- Manually tested all `DetailList` examples and didn't spot any issues
- Didn't find any assumptions we previously made for not having last item rendered

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11463)