### PR TITLE
 Pivot: Move ARIA role to align with props assignment

### DIFF
--- a/change/office-ui-fabric-react-2019-12-13-13-35-32-11072-fix-pivot.json
+++ b/change/office-ui-fabric-react-2019-12-13-13-35-32-11072-fix-pivot.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Move ARIA role to outer div where native props are assigned to allow for ARIA attributes such as aria-label.",
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com",
+  "commit": "b39f8d8589a174e424508eb79180a2455da0872f",
+  "date": "2019-12-13T21:35:32.144Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
@@ -87,7 +87,7 @@ export class PivotBase extends BaseComponent<IPivotProps, IPivotState> {
     this._classNames = this._getClassNames(this.props);
 
     return (
-      <div {...divProps}>
+      <div role="tablist" {...divProps}>
         {this._renderPivotLinks(linkCollection, selectedKey)}
         {selectedKey && this._renderPivotItem(linkCollection, selectedKey)}
       </div>
@@ -121,9 +121,7 @@ export class PivotBase extends BaseComponent<IPivotProps, IPivotState> {
 
     return (
       <FocusZone componentRef={this._focusZone} direction={FocusZoneDirection.horizontal}>
-        <div className={this._classNames.root} role="tablist">
-          {items}
-        </div>
+        <div className={this._classNames.root}>{items}</div>
       </FocusZone>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.deprecated.test.tsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Pivot renders link Pivot correctly 1`] = `
-<div>
+<div
+  role="tablist"
+>
   <div
     className=
         ms-FocusZone
@@ -36,7 +38,6 @@ exports[`Pivot renders link Pivot correctly 1`] = `
             position: relative;
             white-space: nowrap;
           }
-      role="tablist"
     >
       <button
         aria-selected={true}

--- a/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
-<div>
+<div
+  role="tablist"
+>
   <div
     className=
         ms-FocusZone
@@ -36,7 +38,6 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
             position: relative;
             white-space: nowrap;
           }
-      role="tablist"
     >
       <button
         aria-selected={true}
@@ -391,6 +392,7 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
 exports[`Pivot renders Pivot correctly with custom className 1`] = `
 <div
   className="specialClassName"
+  role="tablist"
 >
   <div
     className=
@@ -426,7 +428,6 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
             position: relative;
             white-space: nowrap;
           }
-      role="tablist"
     >
       <button
         aria-selected={true}
@@ -769,7 +770,9 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
 `;
 
 exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
-<div>
+<div
+  role="tablist"
+>
   <div
     className=
         ms-FocusZone
@@ -804,7 +807,6 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
             position: relative;
             white-space: nowrap;
           }
-      role="tablist"
     >
       <button
         aria-selected={true}
@@ -1338,7 +1340,9 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
 `;
 
 exports[`Pivot renders large link Pivot correctly 1`] = `
-<div>
+<div
+  role="tablist"
+>
   <div
     className=
         ms-FocusZone
@@ -1374,7 +1378,6 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
             position: relative;
             white-space: nowrap;
           }
-      role="tablist"
     >
       <button
         aria-selected={true}
@@ -1715,7 +1718,9 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
 `;
 
 exports[`Pivot renders large tabbed Pivot correctly 1`] = `
-<div>
+<div
+  role="tablist"
+>
   <div
     className=
         ms-FocusZone
@@ -1752,7 +1757,6 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
             position: relative;
             white-space: nowrap;
           }
-      role="tablist"
     >
       <button
         aria-selected={true}
@@ -2109,7 +2113,9 @@ exports[`Pivot renders large tabbed Pivot correctly 1`] = `
 `;
 
 exports[`Pivot renders link Pivot correctly 1`] = `
-<div>
+<div
+  role="tablist"
+>
   <div
     className=
         ms-FocusZone
@@ -2144,7 +2150,6 @@ exports[`Pivot renders link Pivot correctly 1`] = `
             position: relative;
             white-space: nowrap;
           }
-      role="tablist"
     >
       <button
         aria-selected={true}
@@ -2485,7 +2490,9 @@ exports[`Pivot renders link Pivot correctly 1`] = `
 `;
 
 exports[`Pivot renders tabbed Pivot correctly 1`] = `
-<div>
+<div
+  role="tablist"
+>
   <div
     className=
         ms-FocusZone
@@ -2521,7 +2528,6 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
             position: relative;
             white-space: nowrap;
           }
-      role="tablist"
     >
       <button
         aria-selected={true}
@@ -2878,7 +2884,9 @@ exports[`Pivot renders tabbed Pivot correctly 1`] = `
 `;
 
 exports[`Pivot supports JSX expressions 1`] = `
-<div>
+<div
+  role="tablist"
+>
   <div
     className=
         ms-FocusZone
@@ -2913,7 +2921,6 @@ exports[`Pivot supports JSX expressions 1`] = `
             position: relative;
             white-space: nowrap;
           }
-      role="tablist"
     >
       <button
         aria-selected={false}

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Basic.Example.tsx
@@ -9,7 +9,7 @@ const labelStyles: Partial<IStyleSet<ILabelStyles>> = {
 
 export const PivotBasicExample: React.FunctionComponent = () => {
   return (
-    <Pivot>
+    <Pivot aria-label="Basic Pivot Example">
       <PivotItem
         headerText="My Files"
         headerButtonProps={{

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.IconCount.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.IconCount.Example.tsx
@@ -11,7 +11,7 @@ const labelStyles: Partial<IStyleSet<ILabelStyles>> = {
 export const PivotIconCountExample: React.FunctionComponent = () => {
   return (
     <div>
-      <Pivot>
+      <Pivot aria-label="Count and Icon Pivot Example">
         <PivotItem headerText="My Files" itemCount={42} itemIcon="Emoji2">
           <Label styles={labelStyles}>Pivot #1</Label>
         </PivotItem>

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Large.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Large.Example.tsx
@@ -6,7 +6,7 @@ export class PivotLargeExample extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
       <div>
-        <Pivot linkSize={PivotLinkSize.large}>
+        <Pivot aria-label="Large Link Size Pivot Example" linkSize={PivotLinkSize.large}>
           <PivotItem headerText="My Files">
             <Label>Pivot #1</Label>
           </PivotItem>

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.OnChange.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.OnChange.Example.tsx
@@ -6,7 +6,12 @@ export class PivotOnChangeExample extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
       <div>
-        <Pivot linkSize={PivotLinkSize.large} linkFormat={PivotLinkFormat.tabs} onLinkClick={this.onLinkClick}>
+        <Pivot
+          aria-label="OnChange Pivot Example"
+          linkSize={PivotLinkSize.large}
+          linkFormat={PivotLinkFormat.tabs}
+          onLinkClick={this.onLinkClick}
+        >
           <PivotItem headerText="Foo">
             <Label>Pivot #1</Label>
           </PivotItem>

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Override.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Override.Example.tsx
@@ -17,7 +17,7 @@ export class PivotOverrideExample extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
       <div>
-        <Pivot selectedKey={`${this.state.selectedKey}`}>
+        <Pivot aria-label="Override Selected Item Pivot Example" selectedKey={`${this.state.selectedKey}`}>
           <PivotItem headerText="My Files" itemKey="0">
             <Label>Pivot #1</Label>
           </PivotItem>

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Remove.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Remove.Example.tsx
@@ -47,7 +47,7 @@ export class PivotRemoveExample extends React.Component<any, IPivotOnChangeExamp
 
     return (
       <div>
-        <Pivot linkSize={PivotLinkSize.large} linkFormat={PivotLinkFormat.tabs}>
+        <Pivot aria-label="Remove Pivot Example" linkSize={PivotLinkSize.large} linkFormat={PivotLinkFormat.tabs}>
           {pivotArray}
         </Pivot>
         <div>

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Separate.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Separate.Example.tsx
@@ -17,7 +17,13 @@ export class PivotSeparateExample extends React.Component<any, any> {
             background: this.state.selectedKey === 'rectangleGreen' ? 'green' : 'red'
           }}
         />
-        <Pivot selectedKey={this.state.selectedKey} onLinkClick={this._handleLinkClick} headersOnly={true} getTabId={this._getTabId}>
+        <Pivot
+          aria-label="Separately Rendered Content Pivot Example"
+          selectedKey={this.state.selectedKey}
+          onLinkClick={this._handleLinkClick}
+          headersOnly={true}
+          getTabId={this._getTabId}
+        >
           <PivotItem headerText="Rectangle red" itemKey="rectangleRed" />
           <PivotItem headerText="Square red" itemKey="squareRed" />
           <PivotItem headerText="Rectangle green" itemKey="rectangleGreen" />

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.SeparateNoSelectedKey.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.SeparateNoSelectedKey.Example.tsx
@@ -22,6 +22,7 @@ export class PivotSeparateNoSelectedKeyExample extends React.Component<any, any>
           }}
         >
           <Pivot
+            aria-label="No Selected Pivot Example"
             style={{ flexGrow: 1 }}
             selectedKey={Object.keys(pivotItems).indexOf(this.state.selectedKey) >= 0 ? this.state.selectedKey : null}
             onLinkClick={this._handleLinkClick}

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Tabs.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.Tabs.Example.tsx
@@ -6,7 +6,7 @@ export class PivotTabsExample extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
       <div>
-        <Pivot linkFormat={PivotLinkFormat.tabs}>
+        <Pivot aria-label="Links of Tab Style Pivot Example" linkFormat={PivotLinkFormat.tabs}>
           <PivotItem headerText="Foo">
             <Label>Pivot #1</Label>
           </PivotItem>

--- a/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.TabsLarge.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/examples/Pivot.TabsLarge.Example.tsx
@@ -6,7 +6,7 @@ export class PivotTabsLargeExample extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
       <div>
-        <Pivot linkFormat={PivotLinkFormat.tabs} linkSize={PivotLinkSize.large}>
+        <Pivot aria-label="Links of Large Tabs Pivot Example" linkFormat={PivotLinkFormat.tabs} linkSize={PivotLinkSize.large}>
           <PivotItem headerText="Foo">
             <Label>Pivot #1</Label>
           </PivotItem>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -5,7 +5,9 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
   <p>
     For Pivots, keytips will first show for each of the pivots. After selecting a pivot, the Keytips for its content are shown.
   </p>
-  <div>
+  <div
+    role="tablist"
+  >
     <div
       className=
           ms-FocusZone
@@ -40,7 +42,6 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
               position: relative;
               white-space: nowrap;
             }
-        role="tablist"
       >
         <button
           aria-describedby="ktp-layer-id ktp-a"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Basic.Example.tsx.shot
@@ -1,7 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
-<div>
+<div
+  aria-label="Basic Pivot Example"
+  role="tablist"
+>
   <div
     className=
         ms-FocusZone
@@ -36,7 +39,6 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
             position: relative;
             white-space: nowrap;
           }
-      role="tablist"
     >
       <button
         aria-selected={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.IconCount.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.IconCount.Example.tsx.shot
@@ -2,7 +2,10 @@
 
 exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = `
 <div>
-  <div>
+  <div
+    aria-label="Count and Icon Pivot Example"
+    role="tablist"
+  >
     <div
       className=
           ms-FocusZone
@@ -37,7 +40,6 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
               position: relative;
               white-space: nowrap;
             }
-        role="tablist"
       >
         <button
           aria-selected={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Large.Example.tsx.shot
@@ -2,7 +2,10 @@
 
 exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
 <div>
-  <div>
+  <div
+    aria-label="Large Link Size Pivot Example"
+    role="tablist"
+  >
     <div
       className=
           ms-FocusZone
@@ -38,7 +41,6 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
               position: relative;
               white-space: nowrap;
             }
-        role="tablist"
       >
         <button
           aria-selected={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.OnChange.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.OnChange.Example.tsx.shot
@@ -2,7 +2,10 @@
 
 exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
 <div>
-  <div>
+  <div
+    aria-label="OnChange Pivot Example"
+    role="tablist"
+  >
     <div
       className=
           ms-FocusZone
@@ -39,7 +42,6 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
               position: relative;
               white-space: nowrap;
             }
-        role="tablist"
       >
         <button
           aria-selected={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Override.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Override.Example.tsx.shot
@@ -2,7 +2,10 @@
 
 exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
 <div>
-  <div>
+  <div
+    aria-label="Override Selected Item Pivot Example"
+    role="tablist"
+  >
     <div
       className=
           ms-FocusZone
@@ -37,7 +40,6 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
               position: relative;
               white-space: nowrap;
             }
-        role="tablist"
       >
         <button
           aria-selected={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Remove.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Remove.Example.tsx.shot
@@ -2,7 +2,10 @@
 
 exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
 <div>
-  <div>
+  <div
+    aria-label="Remove Pivot Example"
+    role="tablist"
+  >
     <div
       className=
           ms-FocusZone
@@ -39,7 +42,6 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
               position: relative;
               white-space: nowrap;
             }
-        role="tablist"
       >
         <button
           aria-selected={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Separate.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Separate.Example.tsx.shot
@@ -14,7 +14,10 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
       }
     }
   />
-  <div>
+  <div
+    aria-label="Separately Rendered Content Pivot Example"
+    role="tablist"
+  >
     <div
       className=
           ms-FocusZone
@@ -49,7 +52,6 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
               position: relative;
               white-space: nowrap;
             }
-        role="tablist"
       >
         <button
           aria-selected={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.SeparateNoSelectedKey.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.SeparateNoSelectedKey.Example.tsx.shot
@@ -20,6 +20,8 @@ exports[`Component Examples renders Pivot.SeparateNoSelectedKey.Example.tsx corr
     }
   >
     <div
+      aria-label="No Selected Pivot Example"
+      role="tablist"
       style={
         Object {
           "flexGrow": 1,
@@ -60,7 +62,6 @@ exports[`Component Examples renders Pivot.SeparateNoSelectedKey.Example.tsx corr
                 position: relative;
                 white-space: nowrap;
               }
-          role="tablist"
         >
           <button
             aria-selected={false}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Tabs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Tabs.Example.tsx.shot
@@ -2,7 +2,10 @@
 
 exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
 <div>
-  <div>
+  <div
+    aria-label="Links of Tab Style Pivot Example"
+    role="tablist"
+  >
     <div
       className=
           ms-FocusZone
@@ -38,7 +41,6 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
               position: relative;
               white-space: nowrap;
             }
-        role="tablist"
       >
         <button
           aria-selected={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.TabsLarge.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.TabsLarge.Example.tsx.shot
@@ -2,7 +2,10 @@
 
 exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = `
 <div>
-  <div>
+  <div
+    aria-label="Links of Large Tabs Pivot Example"
+    role="tablist"
+  >
     <div
       className=
           ms-FocusZone
@@ -39,7 +42,6 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
               position: relative;
               white-space: nowrap;
             }
-        role="tablist"
       >
         <button
           aria-selected={true}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11072
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Move ARIA `role` to outer `div` where native props are assigned to allow for ARIA attributes such as `aria-label` to be properly applied on same element as default `role`. Also update examples to assign accessible names to all `Pivots`.

The root classname is still on the inner `div` which seems inconsistent with our standards. I had considered changing it as part of this PR, but that's a much riskier change in terms of possible regression and think it should be changed separately.

#### Focus areas to test

Example snapshots updated.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11465)