### PR TITLE
FocusZone: Adding tab handle for DomOrder direction

### DIFF
--- a/change/office-ui-fabric-react-2019-12-13-14-37-26-focusZoneDomOrderTabHandling.json
+++ b/change/office-ui-fabric-react-2019-12-13-14-37-26-focusZoneDomOrderTabHandling.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "FocusZone: Adding tab handle for DomOrder direction.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "15fc4fbae5bb62a79129c26cd30799b35fe15336",
+  "date": "2019-12-13T22:37:26.232Z"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -581,7 +581,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
               !this._shouldWrapFocus(this._activeElement as HTMLElement, NO_HORIZONTAL_WRAP)
             ) {
               focusChanged = ev.shiftKey ? this._moveFocusUp() : this._moveFocusDown();
-            } else if (direction === FocusZoneDirection.horizontal || direction === FocusZoneDirection.bidirectional) {
+            } else {
               const tabWithDirection = getRTL() ? !ev.shiftKey : ev.shiftKey;
               focusChanged = tabWithDirection ? this._moveFocusLeft() : this._moveFocusRight();
             }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11336
- [x] Include a change request file using `$ yarn change`

#### Description of changes

An issue recently came that specified that the `handleTabKey` prop was not working when `FocusZoneDirection.domOrder` was specified. This PR fixes this issue and adds a test so it doesn't regress in the future.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11469)