### PR TITLE
Persona: adding alt text to examples.

### DIFF
--- a/change/office-ui-fabric-react-2019-12-13-17-02-35-persona.json
+++ b/change/office-ui-fabric-react-2019-12-13-17-02-35-persona.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Persona: adding alt text to examples",
+  "packageName": "office-ui-fabric-react",
+  "email": "email not defined",
+  "commit": "4f0aaa0a009326081d9e51816fbb701f4b998cf9",
+  "date": "2019-12-14T01:02:35.472Z"
+}

--- a/change/office-ui-fabric-react-2019-12-13-17-02-35-persona.json
+++ b/change/office-ui-fabric-react-2019-12-13-17-02-35-persona.json
@@ -2,7 +2,7 @@
   "type": "minor",
   "comment": "Persona: adding alt text to examples",
   "packageName": "office-ui-fabric-react",
-  "email": "email not defined",
+  "email": "aneeshak@microsoft.com",
   "commit": "4f0aaa0a009326081d9e51816fbb701f4b998cf9",
   "date": "2019-12-14T01:02:35.472Z"
 }

--- a/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.Alternate.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.Alternate.Example.tsx
@@ -5,7 +5,7 @@ import { TestImages } from '@uifabric/example-data';
 
 export const PersonaAlternateExample: React.FunctionComponent = () => {
   const examplePersona: IPersonaSharedProps = {
-    imageUrl: TestImages.personaMale,
+    imageUrl: TestImages.personaFemale,
     imageInitials: 'AR',
     text: 'Annie Reid',
     secondaryText: 'Designer',
@@ -16,9 +16,14 @@ export const PersonaAlternateExample: React.FunctionComponent = () => {
 
   return (
     <Stack tokens={{ childrenGap: 10 }}>
-      <Persona {...examplePersona} size={PersonaSize.size24} presence={PersonaPresence.none} />
-      <Persona {...examplePersona} size={PersonaSize.size28} presence={PersonaPresence.none} />
-      <Persona {...examplePersona} size={PersonaSize.size32} presence={PersonaPresence.online} />
+      <Persona {...examplePersona} size={PersonaSize.size24} presence={PersonaPresence.none} imageAlt="Annie Ried, status is unknown" />
+      <Persona {...examplePersona} size={PersonaSize.size28} presence={PersonaPresence.none} imageAlt="Annie Ried, status is unknown" />
+      <Persona
+        {...examplePersona}
+        size={PersonaSize.size32}
+        presence={PersonaPresence.online}
+        imageAlt="Annie Ried, status is available at 4 PM"
+      />
     </Stack>
   );
 };

--- a/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.Basic.Example.tsx
@@ -25,31 +25,89 @@ export const PersonaBasicExample: React.FunctionComponent = () => {
       <Checkbox label="Include persona details" checked={renderDetails} onChange={onChange} />
 
       <Label>Size 8 Persona, with no presence</Label>
-      <Persona {...examplePersona} size={PersonaSize.size8} hidePersonaDetails={!renderDetails} />
+      <Persona
+        {...examplePersona}
+        size={PersonaSize.size8}
+        hidePersonaDetails={!renderDetails}
+        imageAlt="Annie Lindqvist, no presence detected"
+      />
       <Label>Size 8 Persona, with presence</Label>
-      <Persona {...examplePersona} size={PersonaSize.size8} presence={PersonaPresence.offline} hidePersonaDetails={!renderDetails} />
+      <Persona
+        {...examplePersona}
+        size={PersonaSize.size8}
+        presence={PersonaPresence.offline}
+        hidePersonaDetails={!renderDetails}
+        imageAlt="Annie Lindqvist, status is offline"
+      />
       <Label>Size 24 Persona</Label>
-      <Persona {...examplePersona} size={PersonaSize.size24} presence={PersonaPresence.online} hidePersonaDetails={!renderDetails} />
+      <Persona
+        {...examplePersona}
+        size={PersonaSize.size24}
+        presence={PersonaPresence.online}
+        hidePersonaDetails={!renderDetails}
+        imageAlt="Annie Lindqvist, status is online"
+      />
       <Label>Size 32 Persona</Label>
-      <Persona {...examplePersona} size={PersonaSize.size32} presence={PersonaPresence.online} hidePersonaDetails={!renderDetails} />
+      <Persona
+        {...examplePersona}
+        size={PersonaSize.size32}
+        presence={PersonaPresence.online}
+        hidePersonaDetails={!renderDetails}
+        imageAlt="Annie Lindqvist, status is online"
+      />
 
       <Label>Size 40 Persona</Label>
-      <Persona {...examplePersona} size={PersonaSize.size40} presence={PersonaPresence.away} hidePersonaDetails={!renderDetails} />
+      <Persona
+        {...examplePersona}
+        size={PersonaSize.size40}
+        presence={PersonaPresence.away}
+        hidePersonaDetails={!renderDetails}
+        imageAlt="Annie Lindqvist, status is away"
+      />
 
       <Label>Size 48 Persona (default) </Label>
-      <Persona {...examplePersona} hidePersonaDetails={!renderDetails} presence={PersonaPresence.busy} />
+      <Persona
+        {...examplePersona}
+        hidePersonaDetails={!renderDetails}
+        presence={PersonaPresence.busy}
+        imageAlt="Annie Lindqvist, status is busy"
+      />
 
       <Label>Size 56 Persona (default) </Label>
-      <Persona {...examplePersona} size={PersonaSize.size56} hidePersonaDetails={!renderDetails} presence={PersonaPresence.online} />
+      <Persona
+        {...examplePersona}
+        size={PersonaSize.size56}
+        hidePersonaDetails={!renderDetails}
+        presence={PersonaPresence.online}
+        imageAlt="Annie Lindqvist, status is online"
+      />
 
       <Label>Size 72 Persona</Label>
-      <Persona {...examplePersona} size={PersonaSize.size72} presence={PersonaPresence.dnd} hidePersonaDetails={!renderDetails} />
+      <Persona
+        {...examplePersona}
+        size={PersonaSize.size72}
+        presence={PersonaPresence.dnd}
+        hidePersonaDetails={!renderDetails}
+        imageAlt="Annie Lindqvist, status is dnd"
+      />
 
       <Label>Size 100 Persona</Label>
-      <Persona {...examplePersona} size={PersonaSize.size100} presence={PersonaPresence.blocked} hidePersonaDetails={!renderDetails} />
+      <Persona
+        {...examplePersona}
+        size={PersonaSize.size100}
+        presence={PersonaPresence.blocked}
+        hidePersonaDetails={!renderDetails}
+        imageAlt="Annie Lindqvist, status is blocked"
+      />
 
       <Label>Size 120 Persona</Label>
-      <Persona {...examplePersona} size={PersonaSize.size120} presence={PersonaPresence.away} hidePersonaDetails={!renderDetails} />
+      <Persona
+        {...examplePersona}
+        size={PersonaSize.size120}
+        presence={PersonaPresence.away}
+        hidePersonaDetails={!renderDetails}
+        imageAlt="Annie Lindqvist, status is away"
+      />
     </Stack>
   );
 };

--- a/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.Colors.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.Colors.Example.tsx
@@ -15,26 +15,126 @@ const sharedPersonaProps: IPersonaProps = {
 export const PersonaColorsExample: React.FunctionComponent = () => {
   return (
     <Stack horizontal wrap>
-      <Persona initialsColor={PersonaInitialsColor.green} {...sharedPersonaProps} text="green10" />
-      <Persona initialsColor={PersonaInitialsColor.darkGreen} {...sharedPersonaProps} text="darkGreen20" />
-      <Persona initialsColor={PersonaInitialsColor.teal} {...sharedPersonaProps} text="teal10" />
-      <Persona initialsColor={PersonaInitialsColor.cyan} {...sharedPersonaProps} text="cyan30" />
-      <Persona initialsColor={PersonaInitialsColor.lightBlue} {...sharedPersonaProps} text="lightBlue30" />
-      <Persona initialsColor={PersonaInitialsColor.blue} {...sharedPersonaProps} text="blue20" />
-      <Persona initialsColor={PersonaInitialsColor.darkBlue} {...sharedPersonaProps} text="darkBlue10" />
-      <Persona initialsColor={PersonaInitialsColor.violet} {...sharedPersonaProps} text="violet10" />
-      <Persona initialsColor={PersonaInitialsColor.purple} {...sharedPersonaProps} text="purple10" />
-      <Persona initialsColor={PersonaInitialsColor.magenta} {...sharedPersonaProps} text="magenta10" />
-      <Persona initialsColor={PersonaInitialsColor.lightPink} {...sharedPersonaProps} text="lightPink10" />
-      <Persona initialsColor={PersonaInitialsColor.pink} {...sharedPersonaProps} text="pink10" />
-      <Persona initialsColor={PersonaInitialsColor.burgundy} {...sharedPersonaProps} text="pinkRed10" />
-      <Persona initialsColor={PersonaInitialsColor.lightRed} {...sharedPersonaProps} text="red10" />
-      <Persona initialsColor={PersonaInitialsColor.darkRed} {...sharedPersonaProps} text="darkRed20" />
-      <Persona initialsColor={PersonaInitialsColor.orange} {...sharedPersonaProps} text="orange10" />
-      <Persona initialsColor={PersonaInitialsColor.rust} {...sharedPersonaProps} text="orange30" />
-      <Persona initialsColor={PersonaInitialsColor.gold} {...sharedPersonaProps} text="orangeYellow20" />
-      <Persona initialsColor={PersonaInitialsColor.warmGray} {...sharedPersonaProps} text="gray30" />
-      <Persona initialsColor={PersonaInitialsColor.coolGray} {...sharedPersonaProps} text="gray20" />
+      <Persona
+        initialsColor={PersonaInitialsColor.green}
+        {...sharedPersonaProps}
+        text="green10"
+        imageAlt="Green circle with the letter G in white text at the center"
+      />
+      <Persona
+        initialsColor={PersonaInitialsColor.darkGreen}
+        {...sharedPersonaProps}
+        text="darkGreen20"
+        imageAlt="Dark green circle with the letter D in white text at the center"
+      />
+      <Persona
+        initialsColor={PersonaInitialsColor.teal}
+        {...sharedPersonaProps}
+        text="teal10"
+        imageAlt="Teal circle with the letter T in white text at the center"
+      />
+      <Persona
+        initialsColor={PersonaInitialsColor.cyan}
+        {...sharedPersonaProps}
+        text="cyan30"
+        imageAlt="Cyan circle with the letter C in white text at the center"
+      />
+      <Persona
+        initialsColor={PersonaInitialsColor.lightBlue}
+        {...sharedPersonaProps}
+        text="lightBlue30"
+        imageAlt="Light blue circle with the letter L in white text at the center"
+      />
+      <Persona
+        initialsColor={PersonaInitialsColor.blue}
+        {...sharedPersonaProps}
+        text="blue20"
+        imageAlt="Blue circle with the letter B in white text at the center"
+      />
+      <Persona
+        initialsColor={PersonaInitialsColor.darkBlue}
+        {...sharedPersonaProps}
+        text="darkBlue10"
+        imageAlt="Dark blue circle with the letter D in white text at the center"
+      />
+      <Persona
+        initialsColor={PersonaInitialsColor.violet}
+        {...sharedPersonaProps}
+        text="violet10"
+        imageAlt="Violet circle with the letter V in white text at the center"
+      />
+      <Persona
+        initialsColor={PersonaInitialsColor.purple}
+        {...sharedPersonaProps}
+        text="purple10"
+        imageAlt="Purple circle with the letter P in white text at the center"
+      />
+      <Persona
+        initialsColor={PersonaInitialsColor.magenta}
+        {...sharedPersonaProps}
+        text="magenta10"
+        imageAlt="Magenta circle with the letter M in white text at the center"
+      />
+      <Persona
+        initialsColor={PersonaInitialsColor.lightPink}
+        {...sharedPersonaProps}
+        text="lightPink10"
+        imageAlt="Light pink circle with the letter L in white text at the center"
+      />
+      <Persona
+        initialsColor={PersonaInitialsColor.pink}
+        {...sharedPersonaProps}
+        text="pink10"
+        imageAlt="Pink circle with the letter P in white text at the center"
+      />
+      <Persona
+        initialsColor={PersonaInitialsColor.burgundy}
+        {...sharedPersonaProps}
+        text="pinkRed10"
+        imageAlt="Pink red (burgundy) circle with the letter P in white text at the center"
+      />
+      <Persona
+        initialsColor={PersonaInitialsColor.lightRed}
+        {...sharedPersonaProps}
+        text="red10"
+        imageAlt="Red circle with the letter R in white text at the center"
+      />
+      <Persona
+        initialsColor={PersonaInitialsColor.darkRed}
+        {...sharedPersonaProps}
+        text="darkRed20"
+        imageAlt="Dark red circle with the letter D in white text at the center"
+      />
+      <Persona
+        initialsColor={PersonaInitialsColor.orange}
+        {...sharedPersonaProps}
+        text="orange10"
+        imageAlt="Orange circle with the letter O in white text at the center"
+      />
+      <Persona
+        initialsColor={PersonaInitialsColor.rust}
+        {...sharedPersonaProps}
+        text="orange30"
+        imageAlt="Rusty orange circle with the letter O in white text at the center"
+      />
+      <Persona
+        initialsColor={PersonaInitialsColor.gold}
+        {...sharedPersonaProps}
+        text="orangeYellow20"
+        imageAlt="Orange yellow circle with the letter O in white text at the center"
+      />
+      <Persona
+        initialsColor={PersonaInitialsColor.warmGray}
+        {...sharedPersonaProps}
+        text="gray30"
+        imageAlt="Warm gray circle with the letter G in white text at the center"
+      />
+      <Persona
+        initialsColor={PersonaInitialsColor.coolGray}
+        {...sharedPersonaProps}
+        text="gray20"
+        imageAlt="Cool gray circle with the letter G in white text at the center"
+      />
     </Stack>
   );
 };

--- a/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.CustomCoinRender.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.CustomCoinRender.Example.tsx
@@ -25,7 +25,7 @@ export const PersonaCustomCoinRenderExample: React.FunctionComponent = () => {
         size={PersonaSize.size72}
         presence={PersonaPresence.online}
         onRenderCoin={_onRenderCoin}
-        imageAlt="Custom Coin Image"
+        imageAlt="Ted Randall, status is available at 4 PM"
         imageUrl={TestImages.personaMale}
         coinSize={72}
       />

--- a/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.CustomRender.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.CustomRender.Example.tsx
@@ -23,6 +23,7 @@ export const PersonaCustomRenderExample: React.FunctionComponent = () => {
         presence={PersonaPresence.offline}
         onRenderSecondaryText={_onRenderSecondaryText}
         styles={{ root: { margin: '0 0 10px 0' } }}
+        imageAlt="Annie Lindqvist, status is offline."
       />
     </Stack>
   );

--- a/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.Presence.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.Presence.Example.tsx
@@ -29,20 +29,70 @@ export class PersonaPresenceExample extends React.Component<{}> {
           <Stack>
             <Label>Online</Label>
             <Stack horizontal>
-              <Persona text="" size={PersonaSize.size8} hidePersonaDetails presence={PersonaPresence.online} />
-              <Persona {...examplePersona} size={PersonaSize.size24} hidePersonaDetails presence={PersonaPresence.online} />
-              <Persona {...examplePersona} hidePersonaDetails presence={PersonaPresence.online} />
-              <Persona {...examplePersona} size={PersonaSize.size72} hidePersonaDetails presence={PersonaPresence.online} />
+              <Persona
+                text=""
+                size={PersonaSize.size8}
+                hidePersonaDetails
+                presence={PersonaPresence.online}
+                imageAlt="Annie Lindqvist, status is online."
+              />
+              <Persona
+                {...examplePersona}
+                size={PersonaSize.size24}
+                hidePersonaDetails
+                presence={PersonaPresence.online}
+                imageAlt="Annie Lindqvist, status is online."
+              />
+              <Persona
+                {...examplePersona}
+                hidePersonaDetails
+                presence={PersonaPresence.online}
+                imageAlt="Annie Lindqvist, status is online."
+              />
+              <Persona
+                {...examplePersona}
+                size={PersonaSize.size72}
+                hidePersonaDetails
+                presence={PersonaPresence.online}
+                imageAlt="Annie Lindqvist, status is online."
+              />
             </Stack>
           </Stack>
 
           <Stack>
             <Label>Online + Out of Office</Label>
             <Stack horizontal>
-              <Persona text="" size={PersonaSize.size8} hidePersonaDetails presence={PersonaPresence.online} isOutOfOffice />
-              <Persona {...examplePersona} size={PersonaSize.size24} hidePersonaDetails presence={PersonaPresence.online} isOutOfOffice />
-              <Persona {...examplePersona} hidePersonaDetails presence={PersonaPresence.online} isOutOfOffice />
-              <Persona {...examplePersona} size={PersonaSize.size72} hidePersonaDetails presence={PersonaPresence.online} isOutOfOffice />
+              <Persona
+                text=""
+                size={PersonaSize.size8}
+                hidePersonaDetails
+                presence={PersonaPresence.online}
+                isOutOfOffice
+                imageAlt="Annie Lindqvist, status is online and out of office."
+              />
+              <Persona
+                {...examplePersona}
+                size={PersonaSize.size24}
+                hidePersonaDetails
+                presence={PersonaPresence.online}
+                isOutOfOffice
+                imageAlt="Annie Lindqvist, status is online and out of office."
+              />
+              <Persona
+                {...examplePersona}
+                hidePersonaDetails
+                presence={PersonaPresence.online}
+                isOutOfOffice
+                imageAlt="Annie Lindqvist, status is online and out of office."
+              />
+              <Persona
+                {...examplePersona}
+                size={PersonaSize.size72}
+                hidePersonaDetails
+                presence={PersonaPresence.online}
+                isOutOfOffice
+                imageAlt="Annie Lindqvist, status is online and out of office."
+              />
             </Stack>
           </Stack>
         </Stack>
@@ -51,20 +101,65 @@ export class PersonaPresenceExample extends React.Component<{}> {
           <Stack>
             <Label>Away</Label>
             <Stack horizontal>
-              <Persona text="" size={PersonaSize.size8} hidePersonaDetails presence={PersonaPresence.away} />
-              <Persona {...examplePersona} size={PersonaSize.size24} hidePersonaDetails presence={PersonaPresence.away} />
-              <Persona {...examplePersona} hidePersonaDetails presence={PersonaPresence.away} />
-              <Persona {...examplePersona} size={PersonaSize.size72} hidePersonaDetails presence={PersonaPresence.away} />
+              <Persona
+                text=""
+                size={PersonaSize.size8}
+                hidePersonaDetails
+                presence={PersonaPresence.away}
+                imageAlt="Annie Lindqvist, status is away."
+              />
+              <Persona
+                {...examplePersona}
+                size={PersonaSize.size24}
+                hidePersonaDetails
+                presence={PersonaPresence.away}
+                imageAlt="Annie Lindqvist, status is away."
+              />
+              <Persona {...examplePersona} hidePersonaDetails presence={PersonaPresence.away} imageAlt="Annie Lindqvist, status is away." />
+              <Persona
+                {...examplePersona}
+                size={PersonaSize.size72}
+                hidePersonaDetails
+                presence={PersonaPresence.away}
+                imageAlt="Annie Lindqvist, status is away."
+              />
             </Stack>
           </Stack>
 
           <Stack>
             <Label>Away + Out of Office</Label>
             <Stack horizontal>
-              <Persona text="" size={PersonaSize.size8} hidePersonaDetails presence={PersonaPresence.away} isOutOfOffice />
-              <Persona {...examplePersona} size={PersonaSize.size24} hidePersonaDetails presence={PersonaPresence.away} isOutOfOffice />
-              <Persona {...examplePersona} hidePersonaDetails presence={PersonaPresence.away} isOutOfOffice />
-              <Persona {...examplePersona} size={PersonaSize.size72} hidePersonaDetails presence={PersonaPresence.away} isOutOfOffice />
+              <Persona
+                text=""
+                size={PersonaSize.size8}
+                hidePersonaDetails
+                presence={PersonaPresence.away}
+                isOutOfOffice
+                imageAlt="Annie Lindqvist, status is away and out of office."
+              />
+              <Persona
+                {...examplePersona}
+                size={PersonaSize.size24}
+                hidePersonaDetails
+                presence={PersonaPresence.away}
+                isOutOfOffice
+                imageAlt="Annie Lindqvist, status is away and out of office."
+              />
+              <Persona
+                {...examplePersona}
+                hidePersonaDetails
+                presence={PersonaPresence.away}
+                isOutOfOffice
+                imageAlt="Annie Lindqvist, status is away and out of office."
+              />
+              <Persona
+                {...examplePersona}
+                size={PersonaSize.size72}
+                hidePersonaDetails
+                presence={PersonaPresence.away}
+                isOutOfOffice
+                imageAlt="Annie Lindqvist, status is away and out of office."
+              />
             </Stack>
           </Stack>
         </Stack>
@@ -73,20 +168,65 @@ export class PersonaPresenceExample extends React.Component<{}> {
           <Stack>
             <Label>Busy</Label>
             <Stack horizontal>
-              <Persona text="" size={PersonaSize.size8} hidePersonaDetails presence={PersonaPresence.busy} />
-              <Persona {...examplePersona} size={PersonaSize.size24} hidePersonaDetails presence={PersonaPresence.busy} />
-              <Persona {...examplePersona} hidePersonaDetails presence={PersonaPresence.busy} />
-              <Persona {...examplePersona} size={PersonaSize.size72} hidePersonaDetails presence={PersonaPresence.busy} />
+              <Persona
+                text=""
+                size={PersonaSize.size8}
+                hidePersonaDetails
+                presence={PersonaPresence.busy}
+                imageAlt="Annie Lindqvist, status is busy"
+              />
+              <Persona
+                {...examplePersona}
+                size={PersonaSize.size24}
+                hidePersonaDetails
+                presence={PersonaPresence.busy}
+                imageAlt="Annie Lindqvist, status is busy"
+              />
+              <Persona {...examplePersona} hidePersonaDetails presence={PersonaPresence.busy} imageAlt="Annie Lindqvist, status is busy" />
+              <Persona
+                {...examplePersona}
+                size={PersonaSize.size72}
+                hidePersonaDetails
+                presence={PersonaPresence.busy}
+                imageAlt="Annie Lindqvist, status is busy"
+              />
             </Stack>
           </Stack>
 
           <Stack>
             <Label>Busy + Out of Office</Label>
             <Stack horizontal>
-              <Persona text="" size={PersonaSize.size8} hidePersonaDetails presence={PersonaPresence.busy} isOutOfOffice />
-              <Persona {...examplePersona} size={PersonaSize.size24} hidePersonaDetails presence={PersonaPresence.busy} isOutOfOffice />
-              <Persona {...examplePersona} hidePersonaDetails presence={PersonaPresence.busy} isOutOfOffice />
-              <Persona {...examplePersona} size={PersonaSize.size72} hidePersonaDetails presence={PersonaPresence.busy} isOutOfOffice />
+              <Persona
+                text=""
+                size={PersonaSize.size8}
+                hidePersonaDetails
+                presence={PersonaPresence.busy}
+                isOutOfOffice
+                imageAlt="Annie Lindqvist, status is busy and out of office"
+              />
+              <Persona
+                {...examplePersona}
+                size={PersonaSize.size24}
+                hidePersonaDetails
+                presence={PersonaPresence.busy}
+                isOutOfOffice
+                imageAlt="Annie Lindqvist, status is busy and out of office"
+              />
+              <Persona
+                {...examplePersona}
+                hidePersonaDetails
+                presence={PersonaPresence.busy}
+                isOutOfOffice
+                imageAlt="Annie Lindqvist, status is busy and out of office"
+              />
+              <Persona
+                {...examplePersona}
+                size={PersonaSize.size72}
+                hidePersonaDetails
+                presence={PersonaPresence.busy}
+                isOutOfOffice
+                imageAlt="Annie Lindqvist, status is busy and out of office"
+              />
             </Stack>
           </Stack>
         </Stack>
@@ -95,50 +235,173 @@ export class PersonaPresenceExample extends React.Component<{}> {
           <Stack>
             <Label>Do not Disturb</Label>
             <Stack horizontal>
-              <Persona text="" size={PersonaSize.size8} hidePersonaDetails presence={PersonaPresence.dnd} />
-              <Persona {...examplePersona} size={PersonaSize.size24} hidePersonaDetails presence={PersonaPresence.dnd} />
-              <Persona {...examplePersona} hidePersonaDetails presence={PersonaPresence.dnd} />
-              <Persona {...examplePersona} size={PersonaSize.size72} hidePersonaDetails presence={PersonaPresence.dnd} />
+              <Persona
+                text=""
+                size={PersonaSize.size8}
+                hidePersonaDetails
+                presence={PersonaPresence.dnd}
+                imageAlt="Annie Lindqvist, status is do not disturb"
+              />
+              <Persona
+                {...examplePersona}
+                size={PersonaSize.size24}
+                hidePersonaDetails
+                presence={PersonaPresence.dnd}
+                imageAlt="Annie Lindqvist, status is do not disturb"
+              />
+              <Persona
+                {...examplePersona}
+                hidePersonaDetails
+                presence={PersonaPresence.dnd}
+                imageAlt="Annie Lindqvist, status is do not disturb"
+              />
+              <Persona
+                {...examplePersona}
+                size={PersonaSize.size72}
+                hidePersonaDetails
+                presence={PersonaPresence.dnd}
+                imageAlt="Annie Lindqvist, status is do not disturb"
+              />
             </Stack>
           </Stack>
 
           <Stack>
             <Label>Do not Disturb + Out of Office</Label>
             <Stack horizontal>
-              <Persona text="" size={PersonaSize.size8} hidePersonaDetails presence={PersonaPresence.dnd} isOutOfOffice />
-              <Persona {...examplePersona} size={PersonaSize.size24} hidePersonaDetails presence={PersonaPresence.dnd} isOutOfOffice />
-              <Persona {...examplePersona} hidePersonaDetails presence={PersonaPresence.dnd} isOutOfOffice />
-              <Persona {...examplePersona} size={PersonaSize.size72} hidePersonaDetails presence={PersonaPresence.dnd} isOutOfOffice />
+              <Persona
+                text=""
+                size={PersonaSize.size8}
+                hidePersonaDetails
+                presence={PersonaPresence.dnd}
+                isOutOfOffice
+                imageAlt="Annie Lindqvist, status is do not disturb and out of office"
+              />
+              <Persona
+                {...examplePersona}
+                size={PersonaSize.size24}
+                hidePersonaDetails
+                presence={PersonaPresence.dnd}
+                isOutOfOffice
+                imageAlt="Annie Lindqvist, status is do not disturb and out of office"
+              />
+              <Persona
+                {...examplePersona}
+                hidePersonaDetails
+                presence={PersonaPresence.dnd}
+                isOutOfOffice
+                imageAlt="Annie Lindqvist, status is do not disturb and out of office"
+              />
+              <Persona
+                {...examplePersona}
+                size={PersonaSize.size72}
+                hidePersonaDetails
+                presence={PersonaPresence.dnd}
+                isOutOfOffice
+                imageAlt="Annie Lindqvist, status is do not disturb and out of office"
+              />
             </Stack>
           </Stack>
         </Stack>
 
         <Label>Blocked</Label>
         <Stack horizontal>
-          <Persona text="" size={PersonaSize.size8} hidePersonaDetails presence={PersonaPresence.blocked} />
-          <Persona {...examplePersona} size={PersonaSize.size24} hidePersonaDetails presence={PersonaPresence.blocked} />
-          <Persona {...examplePersona} hidePersonaDetails presence={PersonaPresence.blocked} />
-          <Persona {...examplePersona} size={PersonaSize.size72} hidePersonaDetails presence={PersonaPresence.blocked} />
+          <Persona
+            text=""
+            size={PersonaSize.size8}
+            hidePersonaDetails
+            presence={PersonaPresence.blocked}
+            imageAlt="Annie Lindqvist, status is blocked"
+          />
+          <Persona
+            {...examplePersona}
+            size={PersonaSize.size24}
+            hidePersonaDetails
+            presence={PersonaPresence.blocked}
+            imageAlt="Annie Lindqvist, status is blocked"
+          />
+          <Persona
+            {...examplePersona}
+            hidePersonaDetails
+            presence={PersonaPresence.blocked}
+            imageAlt="Annie Lindqvist, status is blocked"
+          />
+          <Persona
+            {...examplePersona}
+            size={PersonaSize.size72}
+            hidePersonaDetails
+            presence={PersonaPresence.blocked}
+            imageAlt="Annie Lindqvist, status is blocked"
+          />
         </Stack>
 
         <Stack horizontal>
           <Stack>
             <Label>Offline</Label>
             <Stack horizontal>
-              <Persona text="" size={PersonaSize.size8} hidePersonaDetails presence={PersonaPresence.offline} />
-              <Persona {...examplePersona} size={PersonaSize.size24} hidePersonaDetails presence={PersonaPresence.offline} />
-              <Persona {...examplePersona} hidePersonaDetails presence={PersonaPresence.offline} />
-              <Persona {...examplePersona} size={PersonaSize.size72} hidePersonaDetails presence={PersonaPresence.offline} />
+              <Persona
+                text=""
+                size={PersonaSize.size8}
+                hidePersonaDetails
+                presence={PersonaPresence.offline}
+                imageAlt="Annie Lindqvist, status is offline"
+              />
+              <Persona
+                {...examplePersona}
+                size={PersonaSize.size24}
+                hidePersonaDetails
+                presence={PersonaPresence.offline}
+                imageAlt="Annie Lindqvist, status is offline"
+              />
+              <Persona
+                {...examplePersona}
+                hidePersonaDetails
+                presence={PersonaPresence.offline}
+                imageAlt="Annie Lindqvist, status is offline"
+              />
+              <Persona
+                {...examplePersona}
+                size={PersonaSize.size72}
+                hidePersonaDetails
+                presence={PersonaPresence.offline}
+                imageAlt="Annie Lindqvist, status is offline"
+              />
             </Stack>
           </Stack>
 
           <Stack>
             <Label>Offline + Out of Office</Label>
             <Stack horizontal>
-              <Persona text="" size={PersonaSize.size8} hidePersonaDetails presence={PersonaPresence.offline} isOutOfOffice />
-              <Persona {...examplePersona} size={PersonaSize.size24} hidePersonaDetails presence={PersonaPresence.offline} isOutOfOffice />
-              <Persona {...examplePersona} hidePersonaDetails presence={PersonaPresence.offline} isOutOfOffice />
-              <Persona {...examplePersona} size={PersonaSize.size72} hidePersonaDetails presence={PersonaPresence.offline} isOutOfOffice />
+              <Persona
+                text=""
+                size={PersonaSize.size8}
+                hidePersonaDetails
+                presence={PersonaPresence.offline}
+                isOutOfOffice
+                imageAlt="Annie Lindqvist, status is offline and out of office"
+              />
+              <Persona
+                {...examplePersona}
+                size={PersonaSize.size24}
+                hidePersonaDetails
+                presence={PersonaPresence.offline}
+                isOutOfOffice
+                imageAlt="Annie Lindqvist, status is offline and out of office"
+              />
+              <Persona
+                {...examplePersona}
+                hidePersonaDetails
+                presence={PersonaPresence.offline}
+                isOutOfOffice
+                imageAlt="Annie Lindqvist, status is offline and out of office"
+              />
+              <Persona
+                {...examplePersona}
+                size={PersonaSize.size72}
+                hidePersonaDetails
+                presence={PersonaPresence.offline}
+                isOutOfOffice
+                imageAlt="Annie Lindqvist, status is offline and out of office"
+              />
             </Stack>
           </Stack>
         </Stack>

--- a/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.UnknownPersona.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/examples/Persona.UnknownPersona.Example.tsx
@@ -6,7 +6,13 @@ import { TestImages } from '@uifabric/example-data';
 export const UnknownPersonaExample: React.FunctionComponent = () => {
   return (
     <Stack tokens={{ childrenGap: 10 }}>
-      <Persona showUnknownPersonaCoin={true} text="Maor Sharett" secondaryText="Designer" size={PersonaSize.size40} />
+      <Persona
+        showUnknownPersonaCoin={true}
+        text="Maor Sharett"
+        secondaryText="Designer"
+        size={PersonaSize.size40}
+        imageAlt="Maor Sharett, status unknown"
+      />
 
       <Persona
         showUnknownPersonaCoin={true}
@@ -15,6 +21,7 @@ export const UnknownPersonaExample: React.FunctionComponent = () => {
         tertiaryText="Unverified sender"
         size={PersonaSize.size72}
         imageUrl={TestImages.personaFemale}
+        imageAlt="Kat Larrson, status unknown"
       />
     </Stack>
   );

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Alternate.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Alternate.Example.tsx.shot
@@ -105,7 +105,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
           }
         >
           <img
-            alt=""
+            alt="Annie Ried, status is unknown"
             className=
                 ms-Image-image
                 ms-Image-image--cover
@@ -125,7 +125,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
                 }
             onError={[Function]}
             onLoad={[Function]}
-            src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-male.png"
+            src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
           />
         </div>
       </div>
@@ -355,7 +355,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
           }
         >
           <img
-            alt=""
+            alt="Annie Ried, status is unknown"
             className=
                 ms-Image-image
                 ms-Image-image--cover
@@ -375,7 +375,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
                 }
             onError={[Function]}
             onLoad={[Function]}
-            src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-male.png"
+            src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
           />
         </div>
       </div>
@@ -606,7 +606,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
           }
         >
           <img
-            alt=""
+            alt="Annie Ried, status is available at 4 PM"
             className=
                 ms-Image-image
                 ms-Image-image--cover
@@ -626,7 +626,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
                 }
             onError={[Function]}
             onLoad={[Function]}
-            src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-male.png"
+            src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/persona-female.png"
           />
         </div>
         <div

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Basic.Example.tsx.shot
@@ -777,7 +777,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           }
         >
           <img
-            alt=""
+            alt="Annie Lindqvist, status is online"
             className=
                 ms-Image-image
                 ms-Image-image--cover
@@ -1072,7 +1072,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           }
         >
           <img
-            alt=""
+            alt="Annie Lindqvist, status is online"
             className=
                 ms-Image-image
                 ms-Image-image--cover
@@ -1367,7 +1367,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           }
         >
           <img
-            alt=""
+            alt="Annie Lindqvist, status is away"
             className=
                 ms-Image-image
                 ms-Image-image--cover
@@ -1688,7 +1688,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           }
         >
           <img
-            alt=""
+            alt="Annie Lindqvist, status is busy"
             className=
                 ms-Image-image
                 ms-Image-image--cover
@@ -2001,7 +2001,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           }
         >
           <img
-            alt=""
+            alt="Annie Lindqvist, status is online"
             className=
                 ms-Image-image
                 ms-Image-image--cover
@@ -2320,7 +2320,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           }
         >
           <img
-            alt=""
+            alt="Annie Lindqvist, status is dnd"
             className=
                 ms-Image-image
                 ms-Image-image--cover
@@ -2639,7 +2639,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           }
         >
           <img
-            alt=""
+            alt="Annie Lindqvist, status is blocked"
             className=
                 ms-Image-image
                 ms-Image-image--cover
@@ -2985,7 +2985,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           }
         >
           <img
-            alt=""
+            alt="Annie Lindqvist, status is away"
             className=
                 ms-Image-image
                 ms-Image-image--cover

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.CustomCoinRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.CustomCoinRender.Example.tsx.shot
@@ -93,7 +93,7 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
         }
       >
         <img
-          alt="Custom Coin Image"
+          alt="Ted Randall, status is available at 4 PM"
           className=
 
               {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.CustomRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.CustomRender.Example.tsx.shot
@@ -109,7 +109,7 @@ exports[`Component Examples renders Persona.CustomRender.Example.tsx correctly 1
           }
         >
           <img
-            alt=""
+            alt="Annie Lindqvist, status is offline."
             className=
                 ms-Image-image
                 ms-Image-image--cover

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Presence.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Presence.Example.tsx.shot
@@ -333,7 +333,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is online."
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -466,7 +466,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is online."
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -624,7 +624,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is online."
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -1019,7 +1019,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is online and out of office."
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -1170,7 +1170,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is online and out of office."
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -1347,7 +1347,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is online and out of office."
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -1765,7 +1765,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is away."
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -1898,7 +1898,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is away."
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -2058,7 +2058,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is away."
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -2455,7 +2455,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is away and out of office."
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -2606,7 +2606,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is away and out of office."
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -2784,7 +2784,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is away and out of office."
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -3203,7 +3203,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is busy"
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -3336,7 +3336,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is busy"
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -3488,7 +3488,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is busy"
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -3877,7 +3877,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is busy and out of office"
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -4028,7 +4028,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is busy and out of office"
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -4199,7 +4199,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is busy and out of office"
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -4611,7 +4611,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is do not disturb"
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -4744,7 +4744,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is do not disturb"
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -4902,7 +4902,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is do not disturb"
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -5297,7 +5297,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is do not disturb and out of office"
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -5448,7 +5448,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is do not disturb and out of office"
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -5625,7 +5625,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is do not disturb and out of office"
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -6024,7 +6024,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
             }
           >
             <img
-              alt=""
+              alt="Annie Lindqvist, status is blocked"
               className=
                   ms-Image-image
                   ms-Image-image--cover
@@ -6180,7 +6180,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
             }
           >
             <img
-              alt=""
+              alt="Annie Lindqvist, status is blocked"
               className=
                   ms-Image-image
                   ms-Image-image--cover
@@ -6365,7 +6365,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
             }
           >
             <img
-              alt=""
+              alt="Annie Lindqvist, status is blocked"
               className=
                   ms-Image-image
                   ms-Image-image--cover
@@ -6807,7 +6807,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is offline"
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -6958,7 +6958,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is offline"
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -7129,7 +7129,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is offline"
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -7537,7 +7537,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is offline and out of office"
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -7688,7 +7688,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is offline and out of office"
                   className=
                       ms-Image-image
                       ms-Image-image--cover
@@ -7865,7 +7865,7 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
                 }
               >
                 <img
-                  alt=""
+                  alt="Annie Lindqvist, status is offline and out of office"
                   className=
                       ms-Image-image
                       ms-Image-image--cover


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10853 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Persona examples didn't have alt text before but now they do!
![image](https://user-images.githubusercontent.com/4161791/70840856-449d9a00-1dca-11ea-93a0-790c58abf585.png)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11472)