### PR TITLE
Size Auditor: Fix auditor failures on PRs

### DIFF
--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -55,5 +55,5 @@ jobs:
         displayName: 'Size Auditor Check on LightRail'
         inputs:
           connectedServiceName: lowimpact
-          sourceVersionMessage: $(Build.SourceVersionMessage)
+          sourceVersionMessage: "$(Build.SourceVersionMessage)"
           sourceRepositoryUrl: 'https://github.com/OfficeDev/office-ui-fabric-react'

--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -47,13 +47,13 @@ jobs:
           PathtoPublish: 'packages/office-ui-fabric-react/dist/office-ui-fabric-react.js'
           ArtifactName: oufrdrop
 
-  - job: lightrail
-    pool: server
-    dependsOn: build
-    steps:
-      - task: odefun.odsp-lightrail-tasks-partner.odsp-lightrail-tasks-SizeAuditorWorker.SizeAuditorWorker@0
-        displayName: 'Size Auditor Check on LightRail'
-        inputs:
-          connectedServiceName: lowimpact
-          sourceVersionMessage: "$(Build.SourceVersionMessage)"
-          sourceRepositoryUrl: 'https://github.com/OfficeDev/office-ui-fabric-react'
+  # - job: lightrail
+  #   pool: server
+  #   dependsOn: build
+  #   steps:
+  #     - task: odefun.odsp-lightrail-tasks-partner.odsp-lightrail-tasks-SizeAuditorWorker.SizeAuditorWorker@0
+  #       displayName: 'Size Auditor Check on LightRail'
+  #       inputs:
+  #         connectedServiceName: lowimpact
+  #         sourceVersionMessage: '$(Build.SourceVersionMessage)'
+  #         sourceRepositoryUrl: 'https://github.com/OfficeDev/office-ui-fabric-react'

--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -55,5 +55,5 @@ jobs:
         displayName: 'Size Auditor Check on LightRail'
         inputs:
           connectedServiceName: lowimpact
-          sourceVersionMessage: '$(Build.SourceVersionMessage)'
+          sourceVersionMessage: $(Build.SourceVersionMessage)
           sourceRepositoryUrl: 'https://github.com/OfficeDev/office-ui-fabric-react'


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Size auditor recently broke on PRs with `$(Build.SourceVersionMessage)` no longer resolving. This PR attempts to fix these issues.

Relevant Info:
* https://developercommunity.visualstudio.com/content/problem/857818/cannot-read-buildsourceversionmessage-when-check-i.html


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11495)