### PR TITLE
SearchBox, Pickers: update focus border styles

### DIFF
--- a/change/@uifabric-experiments-2020-01-06-11-49-47-xgao-fix-border-width.json
+++ b/change/@uifabric-experiments-2020-01-06-11-49-47-xgao-fix-border-width.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update snapshots from combobox style update",
+  "packageName": "@uifabric/experiments",
+  "email": "xgao@microsoft.com",
+  "commit": "3d78a7b98fca4a03ed6116106628722f6c8c262e",
+  "date": "2020-01-06T19:49:47.568Z"
+}

--- a/change/@uifabric-styling-2019-12-17-16-56-38-xgao-fix-border-width.json
+++ b/change/@uifabric-styling-2019-12-17-16-56-38-xgao-fix-border-width.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "add getInputFocusStyle function to build styles for text input on focus",
+  "packageName": "@uifabric/styling",
+  "email": "xgao@microsoft.com",
+  "commit": "7da68efa3439011bcfdb99b5c2fe5d1b40ee16aa",
+  "date": "2019-12-18T00:56:38.321Z"
+}

--- a/change/office-ui-fabric-react-2019-12-16-21-12-19-xgao-fix-border-width.json
+++ b/change/office-ui-fabric-react-2019-12-16-21-12-19-xgao-fix-border-width.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update focus border styles for SearchBox, BasePicker",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "da8b56f6167485f487c59130be4f85fe46728bc6",
+  "date": "2019-12-17T05:12:19.322Z"
+}

--- a/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -1432,6 +1432,9 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           &.is-open {
             border-color: #605e5c;
           }
+          &.is-open:after {
+            content: none;
+          }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;

--- a/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -1429,12 +1429,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
             display: inline-block;
             margin-bottom: 8px;
           }
-          &.is-open {
-            border-color: #605e5c;
-          }
-          &.is-open:after {
-            content: none;
-          }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -13,6 +13,7 @@ import { IComboBoxOptionStyles, IComboBoxStyles } from './ComboBox.types';
 
 import { IButtonStyles } from '../../Button';
 import { memoizeFunction } from '../../Utilities';
+import { getInputFocusBorder } from '../TextField/TextField.styles';
 
 const ComboBoxHeight = 32;
 const ComboBoxLineHeight = 30;
@@ -301,27 +302,7 @@ export const getStyles = memoizeFunction(
       MsHighContrastAdjust: 'none'
     };
 
-    const getFocusBorder = (color: string): IStyle => ({
-      borderColor: color,
-      selectors: {
-        ':after': {
-          pointerEvents: 'none',
-          content: "''",
-          position: 'absolute',
-          left: -1,
-          top: -1,
-          bottom: -1,
-          right: -1,
-          border: '2px solid ' + color,
-          borderRadius: effects.roundedCorner2,
-          selectors: {
-            [HighContrastSelector]: {
-              borderColor: 'Highlight'
-            }
-          }
-        }
-      }
-    });
+    const focusBorderStyles: IStyle = getInputFocusBorder(root.borderPressedColor, effects.roundedCorner2);
 
     const styles: IComboBoxStyles = {
       container: {},
@@ -393,7 +374,7 @@ export const getStyles = memoizeFunction(
             [HighContrastSelector]: ComboBoxRootHighContrastFocused
           }
         },
-        getFocusBorder(root.borderPressedColor)
+        focusBorderStyles
       ],
 
       rootFocused: [
@@ -408,7 +389,7 @@ export const getStyles = memoizeFunction(
             [HighContrastSelector]: ComboBoxRootHighContrastFocused
           }
         },
-        getFocusBorder(root.borderFocusedColor)
+        focusBorderStyles
       ],
 
       rootDisabled: getDisabledStyles(theme),

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -7,13 +7,13 @@ import {
   HighContrastSelector,
   IStyle,
   getPlaceholderStyles,
-  hiddenContentStyle
+  hiddenContentStyle,
+  getInputFocusStyle
 } from '../../Styling';
 import { IComboBoxOptionStyles, IComboBoxStyles } from './ComboBox.types';
 
 import { IButtonStyles } from '../../Button';
 import { memoizeFunction } from '../../Utilities';
-import { getInputFocusBorder } from '../TextField/TextField.styles';
 
 const ComboBoxHeight = 32;
 const ComboBoxLineHeight = 30;
@@ -302,7 +302,7 @@ export const getStyles = memoizeFunction(
       MsHighContrastAdjust: 'none'
     };
 
-    const focusBorderStyles: IStyle = getInputFocusBorder(root.borderPressedColor, effects.roundedCorner2);
+    const focusBorderStyles: IStyle = getInputFocusStyle(root.borderPressedColor, effects.roundedCorner2);
 
     const styles: IComboBoxStyles = {
       container: {},

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -339,11 +339,7 @@ export const getStyles = memoizeFunction(
               marginBottom: '8px'
             },
             '&.is-open': {
-              borderColor: root.borderColor,
               selectors: {
-                ':after': {
-                  content: 'none'
-                },
                 [HighContrastSelector]: ComboBoxRootHighContrastFocused
               }
             }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -341,6 +341,9 @@ export const getStyles = memoizeFunction(
             '&.is-open': {
               borderColor: root.borderColor,
               selectors: {
+                ':after': {
+                  content: 'none'
+                },
                 [HighContrastSelector]: ComboBoxRootHighContrastFocused
               }
             }

--- a/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -43,6 +43,9 @@ exports[`ComboBox Renders correctly 1`] = `
         &.is-open {
           border-color: #605e5c;
         }
+        &.is-open:after {
+          content: none;
+        }
         @media screen and (-ms-high-contrast: active){&.is-open {
           -ms-high-contrast-adjust: none;
           background-color: Window;
@@ -415,6 +418,9 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
         }
         &.is-open {
           border-color: #605e5c;
+        }
+        &.is-open:after {
+          content: none;
         }
         @media screen and (-ms-high-contrast: active){&.is-open {
           -ms-high-contrast-adjust: none;

--- a/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -40,12 +40,6 @@ exports[`ComboBox Renders correctly 1`] = `
           display: inline-block;
           margin-bottom: 8px;
         }
-        &.is-open {
-          border-color: #605e5c;
-        }
-        &.is-open:after {
-          content: none;
-        }
         @media screen and (-ms-high-contrast: active){&.is-open {
           -ms-high-contrast-adjust: none;
           background-color: Window;
@@ -415,12 +409,6 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
         & .ms-Label {
           display: inline-block;
           margin-bottom: 8px;
-        }
-        &.is-open {
-          border-color: #605e5c;
-        }
-        &.is-open:after {
-          content: none;
         }
         @media screen and (-ms-high-contrast: active){&.is-open {
           -ms-high-contrast-adjust: none;

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.styles.ts
@@ -1,11 +1,10 @@
-import { getGlobalClassNames, HighContrastSelector, IStyle } from '../../Styling';
+import { getGlobalClassNames, getInputFocusStyle } from '../../Styling';
 import { IsFocusVisibleClassName } from '../../Utilities';
 import { IDocumentCardStyleProps, IDocumentCardStyles } from './DocumentCard.types';
 import { DocumentCardPreviewGlobalClassNames as previewClassNames } from './DocumentCardPreview.styles';
 import { DocumentCardActivityGlobalClassNames as activityClassNames } from './DocumentCardActivity.styles';
 import { DocumentCardTitleGlobalClassNames as titleClassNames } from './DocumentCardTitle.styles';
 import { DocumentCardLocationGlobalClassNames as locationClassNames } from './DocumentCardLocation.styles';
-import { getInputFocusBorder } from '../TextField/TextField.styles';
 
 const GlobalClassNames = {
   root: 'ms-DocumentCard',
@@ -34,7 +33,7 @@ export const getStyles = (props: IDocumentCardStyleProps): IDocumentCardStyles =
           ':focus': {
             outline: '0px solid'
           },
-          [`.${IsFocusVisibleClassName} &:focus`]: getInputFocusBorder(palette.neutralSecondary, effects.roundedCorner2),
+          [`.${IsFocusVisibleClassName} &:focus`]: getInputFocusStyle(palette.neutralSecondary, effects.roundedCorner2),
           [`.${locationClassNames.root} + .${titleClassNames.root}`]: {
             paddingTop: '4px'
           }

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCard.styles.ts
@@ -5,6 +5,7 @@ import { DocumentCardPreviewGlobalClassNames as previewClassNames } from './Docu
 import { DocumentCardActivityGlobalClassNames as activityClassNames } from './DocumentCardActivity.styles';
 import { DocumentCardTitleGlobalClassNames as titleClassNames } from './DocumentCardTitle.styles';
 import { DocumentCardLocationGlobalClassNames as locationClassNames } from './DocumentCardLocation.styles';
+import { getInputFocusBorder } from '../TextField/TextField.styles';
 
 const GlobalClassNames = {
   root: 'ms-DocumentCard',
@@ -14,29 +15,9 @@ const GlobalClassNames = {
 
 export const getStyles = (props: IDocumentCardStyleProps): IDocumentCardStyles => {
   const { className, theme, actionable, compact } = props;
-  const { palette, fonts } = theme;
+  const { palette, fonts, effects } = theme;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
-
-  const getFocusBorder: IStyle = {
-    selectors: {
-      ':after': {
-        pointerEvents: 'none',
-        content: "''",
-        position: 'absolute',
-        left: -1,
-        top: -1,
-        bottom: -1,
-        right: -1,
-        border: '2px solid ' + palette.neutralSecondary,
-        selectors: {
-          [HighContrastSelector]: {
-            borderColor: 'Highlight'
-          }
-        }
-      }
-    }
-  };
 
   return {
     root: [
@@ -53,9 +34,7 @@ export const getStyles = (props: IDocumentCardStyleProps): IDocumentCardStyles =
           ':focus': {
             outline: '0px solid'
           },
-          [`.${IsFocusVisibleClassName} &:focus`]: {
-            ...getFocusBorder
-          },
+          [`.${IsFocusVisibleClassName} &:focus`]: getInputFocusBorder(palette.neutralSecondary, effects.roundedCorner2),
           [`.${locationClassNames.root} + .${titleClassNames.root}`]: {
             paddingTop: '4px'
           }

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
@@ -16,7 +16,11 @@ exports[`DocumentCard renders DocumentCard correctly 1`] = `
       &:focus {
         outline: 0px solid;
       }
+      .ms-Fabric--isFocusVisible &:focus {
+        border-color: #605e5c;
+      }
       .ms-Fabric--isFocusVisible &:focus:after {
+        border-radius: 2px;
         border: 2px solid #605e5c;
         bottom: -1px;
         content: '';

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -197,7 +197,7 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
         selectors: {
           ['&:hover .' + globalClassnames.title]: [
             !disabled && rootHoverFocusActiveSelectorNeutralDarkMixin,
-            { borderColor: !isOpen ? palette.neutralPrimary : palette.themePrimary },
+            { borderColor: isOpen ? palette.neutralSecondary : palette.neutralPrimary },
             highContrastBorderState
           ],
           ['&:focus .' + globalClassnames.title]: [!disabled && rootHoverFocusActiveSelectorNeutralDarkMixin],

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
@@ -1,7 +1,14 @@
-import { HighContrastSelector, AnimationVariables, normalize, IStyle, getPlaceholderStyles, getGlobalClassNames } from '../../Styling';
+import {
+  HighContrastSelector,
+  AnimationVariables,
+  normalize,
+  IStyle,
+  getPlaceholderStyles,
+  getGlobalClassNames,
+  getInputFocusStyle
+} from '../../Styling';
 import { ISearchBoxStyleProps, ISearchBoxStyles } from './SearchBox.types';
 import { getRTL } from '../../Utilities';
-import { getInputFocusBorder } from '../TextField/TextField.styles';
 
 const GlobalClassNames = {
   root: 'ms-SearchBox',
@@ -78,7 +85,7 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
         {
           position: 'relative'
         },
-        getInputFocusBorder(
+        getInputFocusStyle(
           semanticColors.inputFocusBorderAlt,
           underlined ? 0 : effects.roundedCorner2,
           underlined ? 'borderBottom' : 'border'

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
@@ -96,12 +96,7 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
       hasFocus && [
         'is-active',
         {
-          position: 'relative',
-          selectors: {
-            [HighContrastSelector]: {
-              borderColor: 'Highlight'
-            }
-          }
+          position: 'relative'
         },
         getFocusBorder(semanticColors.inputFocusBorderAlt)
       ],

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
@@ -14,6 +14,27 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
   const { theme, underlined, disabled, hasFocus, className, hasInput, disableAnimation } = props;
   const { palette, fonts, semanticColors, effects } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
+  const getFocusBorder = (color: string): IStyle => ({
+    borderColor: color,
+    selectors: {
+      ':after': {
+        pointerEvents: 'none',
+        content: "''",
+        position: 'absolute',
+        left: -1,
+        top: -1,
+        bottom: -1,
+        right: -1,
+        border: '2px solid ' + color,
+        borderRadius: effects.roundedCorner2,
+        selectors: {
+          [HighContrastSelector]: {
+            borderColor: 'Highlight'
+          }
+        }
+      }
+    }
+  });
 
   // placeholder style constants
   const placeholderStyles: IStyle = {
@@ -75,16 +96,14 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
       hasFocus && [
         'is-active',
         {
-          borderColor: semanticColors.inputFocusBorderAlt,
+          position: 'relative',
           selectors: {
-            ':hover': {
-              borderColor: semanticColors.inputFocusBorderAlt
-            },
             [HighContrastSelector]: {
               borderColor: 'Highlight'
             }
           }
-        }
+        },
+        getFocusBorder(semanticColors.inputFocusBorderAlt)
       ],
       disabled && [
         'is-disabled',

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
@@ -1,6 +1,7 @@
 import { HighContrastSelector, AnimationVariables, normalize, IStyle, getPlaceholderStyles, getGlobalClassNames } from '../../Styling';
 import { ISearchBoxStyleProps, ISearchBoxStyles } from './SearchBox.types';
 import { getRTL } from '../../Utilities';
+import { getFocusBorder } from '../TextField/TextField.styles';
 
 const GlobalClassNames = {
   root: 'ms-SearchBox',
@@ -14,27 +15,6 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
   const { theme, underlined, disabled, hasFocus, className, hasInput, disableAnimation } = props;
   const { palette, fonts, semanticColors, effects } = theme;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
-  const getFocusBorder = (color: string): IStyle => ({
-    borderColor: color,
-    selectors: {
-      ':after': {
-        pointerEvents: 'none',
-        content: "''",
-        position: 'absolute',
-        left: -1,
-        top: -1,
-        bottom: -1,
-        right: -1,
-        border: '2px solid ' + color,
-        borderRadius: effects.roundedCorner2,
-        selectors: {
-          [HighContrastSelector]: {
-            borderColor: 'Highlight'
-          }
-        }
-      }
-    }
-  });
 
   // placeholder style constants
   const placeholderStyles: IStyle = {
@@ -98,7 +78,7 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
         {
           position: 'relative'
         },
-        getFocusBorder(semanticColors.inputFocusBorderAlt)
+        getFocusBorder(semanticColors.inputFocusBorderAlt, underlined ? 0 : effects.roundedCorner2, underlined ? 'borderBottom' : 'border')
       ],
       disabled && [
         'is-disabled',

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
@@ -1,7 +1,7 @@
 import { HighContrastSelector, AnimationVariables, normalize, IStyle, getPlaceholderStyles, getGlobalClassNames } from '../../Styling';
 import { ISearchBoxStyleProps, ISearchBoxStyles } from './SearchBox.types';
 import { getRTL } from '../../Utilities';
-import { getFocusBorder } from '../TextField/TextField.styles';
+import { getInputFocusBorder } from '../TextField/TextField.styles';
 
 const GlobalClassNames = {
   root: 'ms-SearchBox',
@@ -78,7 +78,11 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
         {
           position: 'relative'
         },
-        getFocusBorder(semanticColors.inputFocusBorderAlt, underlined ? 0 : effects.roundedCorner2, underlined ? 'borderBottom' : 'border')
+        getInputFocusBorder(
+          semanticColors.inputFocusBorderAlt,
+          underlined ? 0 : effects.roundedCorner2,
+          underlined ? 'borderBottom' : 'border'
+        )
       ],
       disabled && [
         'is-disabled',

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.styles.tsx
@@ -47,7 +47,7 @@ export function getStyles(props: ISearchBoxStyleProps): ISearchBoxStyles {
         height: 32,
         selectors: {
           [HighContrastSelector]: {
-            border: '1px solid WindowText'
+            borderColor: 'WindowText'
           },
           ':hover': {
             borderColor: semanticColors.inputBorderHovered,

--- a/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
@@ -31,7 +31,7 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
         padding-top: 1px;
       }
       @media screen and (-ms-high-contrast: active){& {
-        border: 1px solid WindowText;
+        border-color: WindowText;
       }
       &:hover {
         border-color: #323130;
@@ -165,7 +165,7 @@ exports[`SearchBox renders SearchBox without animation correctly 1`] = `
         padding-top: 1px;
       }
       @media screen and (-ms-high-contrast: active){& {
-        border: 1px solid WindowText;
+        border-color: WindowText;
       }
       &:hover {
         border-color: #323130;

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -1,6 +1,7 @@
 import {
   AnimationClassNames,
   getGlobalClassNames,
+  getInputFocusStyle,
   HighContrastSelector,
   IStyle,
   normalize,
@@ -60,33 +61,6 @@ function getLabelStyles(props: ITextFieldStyleProps): IStyleFunctionOrObject<ILa
     ]
   });
 }
-
-export const getInputFocusBorder = (
-  color: string,
-  borderRadius: string | number,
-  borderType: 'border' | 'borderBottom' = 'border'
-): IStyle => ({
-  borderColor: color,
-  selectors: {
-    ':after': {
-      pointerEvents: 'none',
-      content: "''",
-      position: 'absolute',
-      left: -1,
-      top: -1,
-      bottom: -1,
-      right: -1,
-      [borderType]: `2px solid ${color}`,
-      borderRadius,
-      width: borderType === 'borderBottom' ? '100%' : undefined,
-      selectors: {
-        [HighContrastSelector]: {
-          [borderType === 'border' ? 'borderColor' : 'borderBottomColor']: 'Highlight'
-        }
-      }
-    }
-  }
-});
 
 export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
   const {
@@ -179,7 +153,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
             }
           }
         },
-        focused && getInputFocusBorder(!hasErrorMessage ? semanticColors.inputFocusBorderAlt : semanticColors.errorText, 'borderBottom')
+        focused && getInputFocusStyle(!hasErrorMessage ? semanticColors.inputFocusBorderAlt : semanticColors.errorText, 'borderBottom')
       ]
     ],
     fieldGroup: [
@@ -218,7 +192,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
 
       focused &&
         !underlined &&
-        getInputFocusBorder(!hasErrorMessage ? semanticColors.inputFocusBorderAlt : semanticColors.errorText, effects.roundedCorner2),
+        getInputFocusStyle(!hasErrorMessage ? semanticColors.inputFocusBorderAlt : semanticColors.errorText, effects.roundedCorner2),
       disabled && {
         borderColor: semanticColors.disabledBackground,
         selectors: {

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -61,6 +61,29 @@ function getLabelStyles(props: ITextFieldStyleProps): IStyleFunctionOrObject<ILa
   });
 }
 
+export const getFocusBorder = (color: string, borderRadius: string | number, borderType: 'border' | 'borderBottom' = 'border'): IStyle => ({
+  borderColor: color,
+  selectors: {
+    ':after': {
+      pointerEvents: 'none',
+      content: "''",
+      position: 'absolute',
+      left: -1,
+      top: -1,
+      bottom: -1,
+      right: -1,
+      [borderType]: '2px solid ' + color,
+      borderRadius,
+      width: borderType === 'borderBottom' ? '100%' : undefined,
+      selectors: {
+        [HighContrastSelector]: {
+          [borderType === 'border' ? 'borderColor' : 'borderBottomColor']: 'Highlight'
+        }
+      }
+    }
+  }
+});
+
 export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
   const {
     theme,
@@ -106,29 +129,6 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
   const disabledPlaceholderStyles: IStyle = {
     color: semanticColors.disabledText
   };
-
-  const getFocusBorder = (color: string, borderType: 'border' | 'borderBottom' = 'border'): IStyle => ({
-    borderColor: color,
-    selectors: {
-      ':after': {
-        pointerEvents: 'none',
-        content: "''",
-        position: 'absolute',
-        left: -1,
-        top: -1,
-        bottom: -1,
-        right: -1,
-        [borderType]: '2px solid ' + color,
-        borderRadius: effects.roundedCorner2,
-        width: borderType === 'borderBottom' ? '100%' : undefined,
-        selectors: {
-          [HighContrastSelector]: {
-            [borderType === 'border' ? 'borderColor' : 'borderBottomColor']: 'Highlight'
-          }
-        }
-      }
-    }
-  });
 
   return {
     root: [
@@ -212,7 +212,9 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
           }
         },
 
-      focused && !underlined && getFocusBorder(!hasErrorMessage ? semanticColors.inputFocusBorderAlt : semanticColors.errorText),
+      focused &&
+        !underlined &&
+        getFocusBorder(!hasErrorMessage ? semanticColors.inputFocusBorderAlt : semanticColors.errorText, effects.roundedCorner2),
       disabled && {
         borderColor: semanticColors.disabledBackground,
         selectors: {

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -153,7 +153,12 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
             }
           }
         },
-        focused && getInputFocusStyle(!hasErrorMessage ? semanticColors.inputFocusBorderAlt : semanticColors.errorText, 'borderBottom')
+        focused &&
+          getInputFocusStyle(
+            !hasErrorMessage ? semanticColors.inputFocusBorderAlt : semanticColors.errorText,
+            effects.roundedCorner2,
+            'borderBottom'
+          )
       ]
     ],
     fieldGroup: [

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -61,7 +61,11 @@ function getLabelStyles(props: ITextFieldStyleProps): IStyleFunctionOrObject<ILa
   });
 }
 
-export const getFocusBorder = (color: string, borderRadius: string | number, borderType: 'border' | 'borderBottom' = 'border'): IStyle => ({
+export const getInputFocusBorder = (
+  color: string,
+  borderRadius: string | number,
+  borderType: 'border' | 'borderBottom' = 'border'
+): IStyle => ({
   borderColor: color,
   selectors: {
     ':after': {
@@ -72,7 +76,7 @@ export const getFocusBorder = (color: string, borderRadius: string | number, bor
       top: -1,
       bottom: -1,
       right: -1,
-      [borderType]: '2px solid ' + color,
+      [borderType]: `2px solid ${color}`,
       borderRadius,
       width: borderType === 'borderBottom' ? '100%' : undefined,
       selectors: {
@@ -175,7 +179,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
             }
           }
         },
-        focused && getFocusBorder(!hasErrorMessage ? semanticColors.inputFocusBorderAlt : semanticColors.errorText, 'borderBottom')
+        focused && getInputFocusBorder(!hasErrorMessage ? semanticColors.inputFocusBorderAlt : semanticColors.errorText, 'borderBottom')
       ]
     ],
     fieldGroup: [
@@ -214,7 +218,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
 
       focused &&
         !underlined &&
-        getFocusBorder(!hasErrorMessage ? semanticColors.inputFocusBorderAlt : semanticColors.errorText, effects.roundedCorner2),
+        getInputFocusBorder(!hasErrorMessage ? semanticColors.inputFocusBorderAlt : semanticColors.errorText, effects.roundedCorner2),
       disabled && {
         borderColor: semanticColors.disabledBackground,
         selectors: {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -98,12 +98,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               display: inline-block;
               margin-bottom: 8px;
             }
-            &.is-open {
-              border-color: #605e5c;
-            }
-            &.is-open:after {
-              content: none;
-            }
             @media screen and (-ms-high-contrast: active){&.is-open {
               -ms-high-contrast-adjust: none;
               background-color: Window;
@@ -661,12 +655,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             display: inline-block;
             margin-bottom: 8px;
           }
-          &.is-open {
-            border-color: #605e5c;
-          }
-          &.is-open:after {
-            content: none;
-          }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -1062,12 +1050,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           & .ms-Label {
             display: inline-block;
             margin-bottom: 8px;
-          }
-          &.is-open {
-            border-color: #605e5c;
-          }
-          &.is-open:after {
-            content: none;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
@@ -1465,12 +1447,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           & .ms-Label {
             display: inline-block;
             margin-bottom: 8px;
-          }
-          &.is-open {
-            border-color: #605e5c;
-          }
-          &.is-open:after {
-            content: none;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
@@ -3670,12 +3646,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             display: inline-block;
             margin-bottom: 8px;
           }
-          &.is-open {
-            border-color: #605e5c;
-          }
-          &.is-open:after {
-            content: none;
-          }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -4007,12 +3977,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           & .ms-Label {
             display: inline-block;
             margin-bottom: 8px;
-          }
-          &.is-open {
-            border-color: #605e5c;
-          }
-          &.is-open:after {
-            content: none;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
@@ -4414,12 +4378,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           & .ms-Label {
             display: inline-block;
             margin-bottom: 8px;
-          }
-          &.is-open {
-            border-color: #605e5c;
-          }
-          &.is-open:after {
-            content: none;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -101,6 +101,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             &.is-open {
               border-color: #605e5c;
             }
+            &.is-open:after {
+              content: none;
+            }
             @media screen and (-ms-high-contrast: active){&.is-open {
               -ms-high-contrast-adjust: none;
               background-color: Window;
@@ -661,6 +664,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           &.is-open {
             border-color: #605e5c;
           }
+          &.is-open:after {
+            content: none;
+          }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -1059,6 +1065,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           }
           &.is-open {
             border-color: #605e5c;
+          }
+          &.is-open:after {
+            content: none;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
@@ -1459,6 +1468,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           }
           &.is-open {
             border-color: #605e5c;
+          }
+          &.is-open:after {
+            content: none;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
@@ -3661,6 +3673,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           &.is-open {
             border-color: #605e5c;
           }
+          &.is-open:after {
+            content: none;
+          }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -3995,6 +4010,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           }
           &.is-open {
             border-color: #605e5c;
+          }
+          &.is-open:after {
+            content: none;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
@@ -4399,6 +4417,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           }
           &.is-open {
             border-color: #605e5c;
+          }
+          &.is-open:after {
+            content: none;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
@@ -98,6 +98,9 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
           &.is-open {
             border-color: #605e5c;
           }
+          &.is-open:after {
+            content: none;
+          }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -497,6 +500,9 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
           }
           &.is-open {
             border-color: #605e5c;
+          }
+          &.is-open:after {
+            content: none;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
@@ -95,12 +95,6 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
             display: inline-block;
             margin-bottom: 8px;
           }
-          &.is-open {
-            border-color: #605e5c;
-          }
-          &.is-open:after {
-            content: none;
-          }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -497,12 +491,6 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
           & .ms-Label {
             display: inline-block;
             margin-bottom: 8px;
-          }
-          &.is-open {
-            border-color: #605e5c;
-          }
-          &.is-open:after {
-            content: none;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
@@ -99,12 +99,6 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
             display: inline-block;
             margin-bottom: 8px;
           }
-          &.is-open {
-            border-color: #605e5c;
-          }
-          &.is-open:after {
-            content: none;
-          }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -500,12 +494,6 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
           & .ms-Label {
             display: inline-block;
             margin-bottom: 8px;
-          }
-          &.is-open {
-            border-color: #605e5c;
-          }
-          &.is-open:after {
-            content: none;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
@@ -102,6 +102,9 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
           &.is-open {
             border-color: #605e5c;
           }
+          &.is-open:after {
+            content: none;
+          }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
@@ -500,6 +503,9 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
           }
           &.is-open {
             border-color: #605e5c;
+          }
+          &.is-open:after {
+            content: none;
           }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -99,6 +99,9 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
           &.is-open {
             border-color: #605e5c;
           }
+          &.is-open:after {
+            content: none;
+          }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -96,12 +96,6 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
             display: inline-block;
             margin-bottom: 8px;
           }
-          &.is-open {
-            border-color: #605e5c;
-          }
-          &.is-open:after {
-            content: none;
-          }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
@@ -91,12 +91,6 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
             display: inline-block;
             margin-bottom: 8px;
           }
-          &.is-open {
-            border-color: #605e5c;
-          }
-          &.is-open:after {
-            content: none;
-          }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
@@ -94,6 +94,9 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
           &.is-open {
             border-color: #605e5c;
           }
+          &.is-open:after {
+            content: none;
+          }
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Basic.Example.tsx.shot
@@ -18,7 +18,11 @@ exports[`Component Examples renders DocumentCard.Basic.Example.tsx correctly 1`]
       &:focus {
         outline: 0px solid;
       }
+      .ms-Fabric--isFocusVisible &:focus {
+        border-color: #605e5c;
+      }
       .ms-Fabric--isFocusVisible &:focus:after {
+        border-radius: 2px;
         border: 2px solid #605e5c;
         bottom: -1px;
         content: '';

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
@@ -43,7 +43,11 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
         &:focus {
           outline: 0px solid;
         }
+        .ms-Fabric--isFocusVisible &:focus {
+          border-color: #605e5c;
+        }
         .ms-Fabric--isFocusVisible &:focus:after {
+          border-radius: 2px;
           border: 2px solid #605e5c;
           bottom: -1px;
           content: '';
@@ -397,7 +401,11 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
         &:focus {
           outline: 0px solid;
         }
+        .ms-Fabric--isFocusVisible &:focus {
+          border-color: #605e5c;
+        }
         .ms-Fabric--isFocusVisible &:focus:after {
+          border-radius: 2px;
           border: 2px solid #605e5c;
           bottom: -1px;
           content: '';
@@ -1058,7 +1066,11 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
         &:focus {
           outline: 0px solid;
         }
+        .ms-Fabric--isFocusVisible &:focus {
+          border-color: #605e5c;
+        }
         .ms-Fabric--isFocusVisible &:focus:after {
+          border-radius: 2px;
           border: 2px solid #605e5c;
           bottom: -1px;
           content: '';
@@ -1396,7 +1408,11 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
         &:focus {
           outline: 0px solid;
         }
+        .ms-Fabric--isFocusVisible &:focus {
+          border-color: #605e5c;
+        }
         .ms-Fabric--isFocusVisible &:focus:after {
+          border-radius: 2px;
           border: 2px solid #605e5c;
           bottom: -1px;
           content: '';

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
@@ -19,7 +19,11 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
       &:focus {
         outline: 0px solid;
       }
+      .ms-Fabric--isFocusVisible &:focus {
+        border-color: #605e5c;
+      }
       .ms-Fabric--isFocusVisible &:focus:after {
+        border-radius: 2px;
         border: 2px solid #605e5c;
         bottom: -1px;
         content: '';

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Conversation.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Conversation.Example.tsx.shot
@@ -23,7 +23,11 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
         &:focus {
           outline: 0px solid;
         }
+        .ms-Fabric--isFocusVisible &:focus {
+          border-color: #605e5c;
+        }
         .ms-Fabric--isFocusVisible &:focus:after {
+          border-radius: 2px;
           border: 2px solid #605e5c;
           bottom: -1px;
           content: '';
@@ -472,7 +476,11 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
         &:focus {
           outline: 0px solid;
         }
+        .ms-Fabric--isFocusVisible &:focus {
+          border-color: #605e5c;
+        }
         .ms-Fabric--isFocusVisible &:focus:after {
+          border-radius: 2px;
           border: 2px solid #605e5c;
           bottom: -1px;
           content: '';
@@ -911,7 +919,11 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
         &:focus {
           outline: 0px solid;
         }
+        .ms-Fabric--isFocusVisible &:focus {
+          border-color: #605e5c;
+        }
         .ms-Fabric--isFocusVisible &:focus:after {
+          border-radius: 2px;
           border: 2px solid #605e5c;
           bottom: -1px;
           content: '';

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Image.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Image.Example.tsx.shot
@@ -23,7 +23,11 @@ exports[`Component Examples renders DocumentCard.Image.Example.tsx correctly 1`]
         &:focus {
           outline: 0px solid;
         }
+        .ms-Fabric--isFocusVisible &:focus {
+          border-color: #605e5c;
+        }
         .ms-Fabric--isFocusVisible &:focus:after {
+          border-radius: 2px;
           border: 2px solid #605e5c;
           bottom: -1px;
           content: '';
@@ -457,7 +461,11 @@ exports[`Component Examples renders DocumentCard.Image.Example.tsx correctly 1`]
         &:focus {
           outline: 0px solid;
         }
+        .ms-Fabric--isFocusVisible &:focus {
+          border-color: #605e5c;
+        }
         .ms-Fabric--isFocusVisible &:focus:after {
+          border-radius: 2px;
           border: 2px solid #605e5c;
           bottom: -1px;
           content: '';

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
@@ -39,7 +39,7 @@ exports[`Component Examples renders FloatingPeoplePicker.Basic.Example.tsx corre
             padding-top: 1px;
           }
           @media screen and (-ms-high-contrast: active){& {
-            border: 1px solid WindowText;
+            border-color: WindowText;
           }
           &:hover {
             border-color: #323130;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.CustomIcon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.CustomIcon.Example.tsx.shot
@@ -31,7 +31,7 @@ exports[`Component Examples renders SearchBox.CustomIcon.Example.tsx correctly 1
         padding-top: 1px;
       }
       @media screen and (-ms-high-contrast: active){& {
-        border: 1px solid WindowText;
+        border-color: WindowText;
       }
       &:hover {
         border-color: #323130;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
@@ -57,7 +57,6 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
         }
         @media screen and (-ms-high-contrast: active){& {
           border-color: GrayText;
-          border: 1px solid WindowText;
         }
         &:hover {
           border-color: #323130;
@@ -197,7 +196,6 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
         }
         @media screen and (-ms-high-contrast: active){& {
           border-color: GrayText;
-          border: 1px solid WindowText;
         }
         &:hover {
           border-color: #323130;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
@@ -52,7 +52,7 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
           padding-top: 1px;
         }
         @media screen and (-ms-high-contrast: active){& {
-          border: 1px solid WindowText;
+          border-color: WindowText;
         }
         &:hover {
           border-color: #323130;
@@ -184,7 +184,7 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
           padding-top: 1px;
         }
         @media screen and (-ms-high-contrast: active){& {
-          border: 1px solid WindowText;
+          border-color: WindowText;
         }
         &:hover {
           border-color: #323130;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
@@ -32,7 +32,7 @@ exports[`Component Examples renders SearchBox.Small.Example.tsx correctly 1`] = 
         width: 200px;
       }
       @media screen and (-ms-high-contrast: active){& {
-        border: 1px solid WindowText;
+        border-color: WindowText;
       }
       &:hover {
         border-color: #323130;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
@@ -33,7 +33,7 @@ exports[`Component Examples renders SearchBox.Underlined.Example.tsx correctly 1
         padding-top: 1px;
       }
       @media screen and (-ms-high-contrast: active){& {
-        border: 1px solid WindowText;
+        border-color: WindowText;
       }
       &:hover {
         border-color: #323130;

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.scss
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.scss
@@ -14,7 +14,18 @@
   }
 
   &.inputFocused {
+    position: relative;
     border-color: $inputFocusBorderAltColor;
+    &:after {
+      pointer-events: none;
+      content: '';
+      position: absolute;
+      left: -1px;
+      top: -1px;
+      bottom: -1px;
+      right: -1px;
+      border: 2px solid $inputFocusBorderAltColor;
+    }
   }
 }
 

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.styles.ts
@@ -1,4 +1,4 @@
-import { getGlobalClassNames, hiddenContentStyle, HighContrastSelector } from '../../Styling';
+import { getGlobalClassNames, hiddenContentStyle, HighContrastSelector, IStyle } from '../../Styling';
 import { IBasePickerStyleProps, IBasePickerStyles } from './BasePicker.types';
 
 const GlobalClassNames = {
@@ -18,6 +18,27 @@ export function getStyles(props: IBasePickerStyleProps): IBasePickerStyles {
   const { inputBorder, inputBorderHovered, inputFocusBorderAlt } = semanticColors;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
+  const getFocusBorder = (color: string): IStyle => ({
+    borderColor: color,
+    selectors: {
+      ':after': {
+        pointerEvents: 'none',
+        content: "''",
+        position: 'absolute',
+        left: -1,
+        top: -1,
+        bottom: -1,
+        right: -1,
+        border: '2px solid ' + color,
+        borderRadius: effects.roundedCorner2,
+        selectors: {
+          [HighContrastSelector]: {
+            borderColor: 'Highlight'
+          }
+        }
+      }
+    }
+  });
 
   // The following lines are to create a semi-transparent color overlay for the disabled state with designer's approval.
   // @todo: investigate the performance cost of the calculation below and apply if negligible. Replacing with a static color for now.
@@ -48,10 +69,7 @@ export function getStyles(props: IBasePickerStyleProps): IBasePickerStyles {
             }
           }
         },
-      isFocused &&
-        !disabled && {
-          borderColor: inputFocusBorderAlt
-        },
+      isFocused && !disabled && getFocusBorder(inputFocusBorderAlt),
       disabled && {
         borderColor: disabledOverlayColor,
         selectors: {

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.styles.ts
@@ -1,6 +1,5 @@
-import { getGlobalClassNames, hiddenContentStyle, HighContrastSelector } from '../../Styling';
+import { getGlobalClassNames, getInputFocusStyle, hiddenContentStyle, HighContrastSelector } from '../../Styling';
 import { IBasePickerStyleProps, IBasePickerStyles } from './BasePicker.types';
-import { getInputFocusBorder } from '../TextField/TextField.styles';
 
 const GlobalClassNames = {
   root: 'ms-BasePicker',
@@ -49,7 +48,7 @@ export function getStyles(props: IBasePickerStyleProps): IBasePickerStyles {
             }
           }
         },
-      isFocused && !disabled && getInputFocusBorder(inputFocusBorderAlt, effects.roundedCorner2),
+      isFocused && !disabled && getInputFocusStyle(inputFocusBorderAlt, effects.roundedCorner2),
       disabled && {
         borderColor: disabledOverlayColor,
         selectors: {

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.styles.ts
@@ -1,5 +1,6 @@
-import { getGlobalClassNames, hiddenContentStyle, HighContrastSelector, IStyle } from '../../Styling';
+import { getGlobalClassNames, hiddenContentStyle, HighContrastSelector } from '../../Styling';
 import { IBasePickerStyleProps, IBasePickerStyles } from './BasePicker.types';
+import { getFocusBorder } from '../TextField/TextField.styles';
 
 const GlobalClassNames = {
   root: 'ms-BasePicker',
@@ -18,27 +19,6 @@ export function getStyles(props: IBasePickerStyleProps): IBasePickerStyles {
   const { inputBorder, inputBorderHovered, inputFocusBorderAlt } = semanticColors;
 
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
-  const getFocusBorder = (color: string): IStyle => ({
-    borderColor: color,
-    selectors: {
-      ':after': {
-        pointerEvents: 'none',
-        content: "''",
-        position: 'absolute',
-        left: -1,
-        top: -1,
-        bottom: -1,
-        right: -1,
-        border: '2px solid ' + color,
-        borderRadius: effects.roundedCorner2,
-        selectors: {
-          [HighContrastSelector]: {
-            borderColor: 'Highlight'
-          }
-        }
-      }
-    }
-  });
 
   // The following lines are to create a semi-transparent color overlay for the disabled state with designer's approval.
   // @todo: investigate the performance cost of the calculation below and apply if negligible. Replacing with a static color for now.
@@ -69,7 +49,7 @@ export function getStyles(props: IBasePickerStyleProps): IBasePickerStyles {
             }
           }
         },
-      isFocused && !disabled && getFocusBorder(inputFocusBorderAlt),
+      isFocused && !disabled && getFocusBorder(inputFocusBorderAlt, effects.roundedCorner2),
       disabled && {
         borderColor: disabledOverlayColor,
         selectors: {

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.styles.ts
@@ -1,6 +1,6 @@
 import { getGlobalClassNames, hiddenContentStyle, HighContrastSelector } from '../../Styling';
 import { IBasePickerStyleProps, IBasePickerStyles } from './BasePicker.types';
-import { getFocusBorder } from '../TextField/TextField.styles';
+import { getInputFocusBorder } from '../TextField/TextField.styles';
 
 const GlobalClassNames = {
   root: 'ms-BasePicker',
@@ -49,7 +49,7 @@ export function getStyles(props: IBasePickerStyleProps): IBasePickerStyles {
             }
           }
         },
-      isFocused && !disabled && getFocusBorder(inputFocusBorderAlt, effects.roundedCorner2),
+      isFocused && !disabled && getInputFocusBorder(inputFocusBorderAlt, effects.roundedCorner2),
       disabled && {
         borderColor: disabledOverlayColor,
         selectors: {

--- a/packages/styling/etc/styling.api.md
+++ b/packages/styling/etc/styling.api.md
@@ -39,7 +39,7 @@ export function buildClassMap<T extends Object>(styles: T): {
 };
 
 // Warning: (ae-forgotten-export) The symbol "IColorClassNames" needs to be exported by the entry point index.d.ts
-//
+// 
 // @public (undocumented)
 export const ColorClassNames: IColorClassNames;
 
@@ -152,7 +152,7 @@ export function getScreenSelector(min: number, max: number): string;
 export function getTheme(depComments?: boolean): ITheme;
 
 // Warning: (ae-internal-missing-underscore) The name "getThemedContext" should be prefixed with an underscore because the declaration is marked as @internal
-//
+// 
 // @internal
 export function getThemedContext(context: ICustomizerContext, scheme?: ISchemeNames, theme?: ITheme): ICustomizerContext;
 
@@ -347,7 +347,7 @@ export interface IIconRecord {
     // (undocumented)
     code: string | undefined;
     // Warning: (ae-forgotten-export) The symbol "IIconSubsetRecord" needs to be exported by the entry point index.d.ts
-    //
+    // 
     // (undocumented)
     subset: IIconSubsetRecord;
 }
@@ -468,7 +468,7 @@ export interface IScheme {
 }
 
 // Warning: (ae-internal-missing-underscore) The name "ISchemeNames" should be prefixed with an underscore because the declaration is marked as @internal
-//
+// 
 // @internal
 export type ISchemeNames = 'default' | 'neutral' | 'soft' | 'strong';
 
@@ -573,7 +573,7 @@ export interface ISemanticTextColors {
 }
 
 // Warning: (ae-internal-missing-underscore) The name "ISpacing" should be prefixed with an underscore because the declaration is marked as @internal
-//
+// 
 // @internal
 export interface ISpacing {
     // (undocumented)
@@ -704,7 +704,7 @@ export namespace ZIndexes {
 
 
 // Warnings were encountered during analysis:
-//
+// 
 // lib/interfaces/ITheme.d.ts:70:5 - (ae-incompatible-release-tags) The symbol "spacing" is marked as @public, but its signature references "ISpacing" which is marked as @internal
 // lib/interfaces/ITheme.d.ts:72:5 - (ae-incompatible-release-tags) The symbol "schemes" is marked as @public, but its signature references "ISchemeNames" which is marked as @internal
 // lib/styles/PulsingBeaconAnimationStyles.d.ts:6:5 - (ae-forgotten-export) The symbol "_continuousPulseAnimationDouble" needs to be exported by the entry point index.d.ts

--- a/packages/styling/etc/styling.api.md
+++ b/packages/styling/etc/styling.api.md
@@ -346,8 +346,6 @@ export interface IIconOptions {
 export interface IIconRecord {
     // (undocumented)
     code: string | undefined;
-    // Warning: (ae-forgotten-export) The symbol "IIconSubsetRecord" needs to be exported by the entry point index.d.ts
-    // 
     // (undocumented)
     subset: IIconSubsetRecord;
 }

--- a/packages/styling/etc/styling.api.md
+++ b/packages/styling/etc/styling.api.md
@@ -39,7 +39,7 @@ export function buildClassMap<T extends Object>(styles: T): {
 };
 
 // Warning: (ae-forgotten-export) The symbol "IColorClassNames" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export const ColorClassNames: IColorClassNames;
 
@@ -140,6 +140,9 @@ export function getIcon(name?: string): IIconRecord | undefined;
 export function getIconClassName(name: string): string;
 
 // @public
+export const getInputFocusStyle: (borderColor: string, borderRadius: string | number, borderType?: "border" | "borderBottom") => IRawStyle;
+
+// @public
 export function getPlaceholderStyles(styles: IStyle): IStyle;
 
 // @public (undocumented)
@@ -149,7 +152,7 @@ export function getScreenSelector(min: number, max: number): string;
 export function getTheme(depComments?: boolean): ITheme;
 
 // Warning: (ae-internal-missing-underscore) The name "getThemedContext" should be prefixed with an underscore because the declaration is marked as @internal
-// 
+//
 // @internal
 export function getThemedContext(context: ICustomizerContext, scheme?: ISchemeNames, theme?: ITheme): ICustomizerContext;
 
@@ -343,6 +346,8 @@ export interface IIconOptions {
 export interface IIconRecord {
     // (undocumented)
     code: string | undefined;
+    // Warning: (ae-forgotten-export) The symbol "IIconSubsetRecord" needs to be exported by the entry point index.d.ts
+    //
     // (undocumented)
     subset: IIconSubsetRecord;
 }
@@ -463,7 +468,7 @@ export interface IScheme {
 }
 
 // Warning: (ae-internal-missing-underscore) The name "ISchemeNames" should be prefixed with an underscore because the declaration is marked as @internal
-// 
+//
 // @internal
 export type ISchemeNames = 'default' | 'neutral' | 'soft' | 'strong';
 
@@ -568,7 +573,7 @@ export interface ISemanticTextColors {
 }
 
 // Warning: (ae-internal-missing-underscore) The name "ISpacing" should be prefixed with an underscore because the declaration is marked as @internal
-// 
+//
 // @internal
 export interface ISpacing {
     // (undocumented)
@@ -699,7 +704,7 @@ export namespace ZIndexes {
 
 
 // Warnings were encountered during analysis:
-// 
+//
 // lib/interfaces/ITheme.d.ts:70:5 - (ae-incompatible-release-tags) The symbol "spacing" is marked as @public, but its signature references "ISpacing" which is marked as @internal
 // lib/interfaces/ITheme.d.ts:72:5 - (ae-incompatible-release-tags) The symbol "schemes" is marked as @public, but its signature references "ISchemeNames" which is marked as @internal
 // lib/styles/PulsingBeaconAnimationStyles.d.ts:6:5 - (ae-forgotten-export) The symbol "_continuousPulseAnimationDouble" needs to be exported by the entry point index.d.ts

--- a/packages/styling/src/styles/getFocusStyle.ts
+++ b/packages/styling/src/styles/getFocusStyle.ts
@@ -132,3 +132,38 @@ export function getFocusOutlineStyle(theme: ITheme, inset: number = 0, width: nu
     }
   };
 }
+
+/**
+ * Generates text input border styles on focus.
+ *
+ * @param borderColor - Color of the border.
+ * @param borderRadius - Radius of the border.
+ * @param borderType - Type of the border.
+ * @returns The style object.
+ */
+export const getInputFocusStyle = (
+  borderColor: string,
+  borderRadius: string | number,
+  borderType: 'border' | 'borderBottom' = 'border'
+): IRawStyle => ({
+  borderColor,
+  selectors: {
+    ':after': {
+      pointerEvents: 'none',
+      content: "''",
+      position: 'absolute',
+      left: -1,
+      top: -1,
+      bottom: -1,
+      right: -1,
+      [borderType]: `2px solid ${borderColor}`,
+      borderRadius,
+      width: borderType === 'borderBottom' ? '100%' : undefined,
+      selectors: {
+        [HighContrastSelector]: {
+          [borderType === 'border' ? 'borderColor' : 'borderBottomColor']: 'Highlight'
+        }
+      }
+    }
+  }
+});


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #11147
- [X] Include a change request file using `$ yarn change`

#### Description of changes
- Apply border style update to SearchBox, TagPicker, PeoplePicker similar to [this fix](https://github.com/OfficeDev/office-ui-fabric-react/pull/10885) by Ben
- Noticed and fixed a bug with underlined `SearchBox` in HC, that it was showing border in all directions rather than just the bottom border
- Minor refactor to use 1 `getInputFocusBorder` everywhere

#### Screenshots
SearchBox:
![image](https://user-images.githubusercontent.com/1207059/71044547-bc2f3a00-20e6-11ea-9496-b123203d9cd4.png)
![image](https://user-images.githubusercontent.com/1207059/71044557-c6e9cf00-20e6-11ea-848d-8c6a46583cbe.png)

Picker:
![image](https://user-images.githubusercontent.com/1207059/71044572-d8cb7200-20e6-11ea-9267-e9020cbfb08d.png)
![image](https://user-images.githubusercontent.com/1207059/71044586-e5e86100-20e6-11ea-8a0c-5d766f1912d7.png)
![image](https://user-images.githubusercontent.com/1207059/71044618-fef11200-20e6-11ea-804c-b8f33a52e794.png)
![image](https://user-images.githubusercontent.com/1207059/71044627-07e1e380-20e7-11ea-9bf1-16ba99929db3.png)

#### Focus areas to test
- Components: TextField, DocumentCard, Dropdown, Combobox, Searchbox, Pickers
- Modes: High contrast, focused 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11497)