### PR TITLE
Removed redundant htmlFor attribute as input already use aria-labelledby

### DIFF
--- a/change/office-ui-fabric-react-2019-12-17-14-27-30-combobox-redundant-for-label.json
+++ b/change/office-ui-fabric-react-2019-12-17-14-27-30-combobox-redundant-for-label.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Combobox: Removed redundant htmlFor attribute as input already use aria-labelledby",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "7728daa71c4b3693cd812f6e67b5906dcb12f1e9",
+  "date": "2019-12-17T22:27:30.436Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -363,7 +363,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     return (
       <div {...divProps} ref={this._root} className={this._classNames.container}>
         {label && (
-          <Label id={id + '-label'} disabled={disabled} required={required} htmlFor={id + '-input'} className={this._classNames.label}>
+          <Label id={id + '-label'} disabled={disabled} required={required} className={this._classNames.label}>
             {label}
           </Label>
         )}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -58,7 +58,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               padding-top: 5px;
               word-wrap: break-word;
             }
-        htmlFor="ComboBox0-input"
         id="ComboBox0-label"
       >
         Single-select ComboBox (uncontrolled, allowFreeform: T, autoComplete: T)
@@ -593,7 +592,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
-      htmlFor="ComboBox7-input"
       id="ComboBox7-label"
     >
       Multi-select ComboBox (uncontrolled)
@@ -988,7 +986,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
-      htmlFor="ComboBox11-input"
       id="ComboBox11-label"
     >
       ComboBox with placeholder text
@@ -1384,7 +1381,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
-      htmlFor="ComboBox15-input"
       id="ComboBox15-label"
     >
       ComboBox with persisted menu
@@ -3573,7 +3569,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
-      htmlFor="ComboBox19-input"
       id="ComboBox19-label"
     >
       ComboBox with static error message
@@ -3907,7 +3902,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
-      htmlFor="ComboBox23-input"
       id="ComboBox23-label"
     >
       ComboBox with dynamic error message
@@ -4306,7 +4300,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active){& {
             color: GrayText;
           }
-      htmlFor="ComboBox27-input"
       id="ComboBox27-label"
     >
       Disabled ComboBox

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
@@ -55,7 +55,6 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
             padding-top: 5px;
             word-wrap: break-word;
           }
-      htmlFor="ComboBox0-input"
       id="ComboBox0-label"
     >
       Controlled single-select ComboBox (allowFreeform: T)
@@ -450,7 +449,6 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
             padding-top: 5px;
             word-wrap: break-word;
           }
-      htmlFor="ComboBox4-input"
       id="ComboBox4-label"
     >
       Controlled multi-select ComboBox (allowFreeform: T)

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
@@ -59,7 +59,6 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
             padding-top: 5px;
             word-wrap: break-word;
           }
-      htmlFor="ComboBox0-input"
       id="ComboBox0-label"
     >
       Custom styled ComboBox
@@ -454,7 +453,6 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
             padding-top: 5px;
             word-wrap: break-word;
           }
-      htmlFor="ComboBox4-input"
       id="ComboBox4-label"
     >
       ComboBox with custom option rendering (type the name of a font and the option will render in that font)

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -56,7 +56,6 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
             padding-top: 5px;
             word-wrap: break-word;
           }
-      htmlFor="ComboBox0-input"
       id="ComboBox0-label"
     >
       ComboBox with toggleable freeform/auto-complete

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
@@ -50,7 +50,6 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
             padding-top: 5px;
             word-wrap: break-word;
           }
-      htmlFor="ComboBox0-input"
       id="ComboBox0-label"
     >
       Scaled/virtualized example with 1000 items


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11205
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Never could repro the 'label gets spoken twice' issue, but this is definitely redundant. I've made this consistent with our dropdown. 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11500)