### PR TITLE
Size Auditor: Re-enable

### DIFF
--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -47,13 +47,13 @@ jobs:
           PathtoPublish: 'packages/office-ui-fabric-react/dist/office-ui-fabric-react.js'
           ArtifactName: oufrdrop
 
-  # - job: lightrail
-  #   pool: server
-  #   dependsOn: build
-  #   steps:
-  #     - task: odefun.odsp-lightrail-tasks-partner.odsp-lightrail-tasks-SizeAuditorWorker.SizeAuditorWorker@0
-  #       displayName: 'Size Auditor Check on LightRail'
-  #       inputs:
-  #         connectedServiceName: lowimpact
-  #         sourceVersionMessage: '$(Build.SourceVersionMessage)'
-  #         sourceRepositoryUrl: 'https://github.com/OfficeDev/office-ui-fabric-react'
+  - job: lightrail
+    pool: server
+    dependsOn: build
+    steps:
+      - task: odefun.odsp-lightrail-tasks-partner.odsp-lightrail-tasks-SizeAuditorWorker.SizeAuditorWorker@0
+        displayName: 'Size Auditor Check on LightRail'
+        inputs:
+          connectedServiceName: lowimpact
+          sourceVersionMessage: '$(Build.SourceVersionMessage)'
+          sourceRepositoryUrl: 'https://github.com/OfficeDev/office-ui-fabric-react'


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Size auditor had to be temporarily disabled (#11504) due to [an Azure issue](https://developercommunity.visualstudio.com/content/problem/859511/buildsourceversionmessage-no-longer-works-to-fetch.html
). This PR is being created in draft state to re-enable it as soon as possible, either by waiting for status on the Azure issue or changing size auditor to accommodate changed Azure behavior.

We should also do a sanity check on bundle sizes when it's re-enabled to make sure nothing substantial crept in while size auditor was disabled.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11506)