### PR TITLE
SearchBox: Don't duplicate placeholder text in aria-label

### DIFF
--- a/change/office-ui-fabric-react-2019-12-18-12-54-29-searchbox-placeholder-dup.json
+++ b/change/office-ui-fabric-react-2019-12-18-12-54-29-searchbox-placeholder-dup.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "SearchBox: Don't duplicate placeholder text in aria-label",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "fc04a332db8c85e7feacabdbbfb79f36e516381e",
+  "date": "2019-12-18T20:54:29.522Z"
+}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -124,7 +124,7 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
           value={value}
           disabled={disabled}
           role="searchbox"
-          aria-label={ariaLabel ? ariaLabel : placeholder}
+          aria-label={ariaLabel}
           ref={this._inputElement}
         />
         {value!.length > 0 && (

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.types.ts
@@ -85,7 +85,6 @@ export interface ISearchBoxProps extends React.InputHTMLAttributes<HTMLInputElem
 
   /**
    * The aria label of the SearchBox for the benefit of screen readers.
-   * @defaultvalue placeholder
    */
   ariaLabel?: string;
 

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
@@ -92,7 +92,6 @@ exports[`Component Examples renders FloatingPeoplePicker.Basic.Example.tsx corre
         </i>
       </div>
       <input
-        aria-label="Search for person"
         className=
             ms-SearchBox-field
             {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.CustomIcon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.CustomIcon.Example.tsx.shot
@@ -84,7 +84,6 @@ exports[`Component Examples renders SearchBox.CustomIcon.Example.tsx correctly 1
     </i>
   </div>
   <input
-    aria-label="Filter"
     className=
         ms-SearchBox-field
         {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
@@ -110,7 +110,6 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
       </i>
     </div>
     <input
-      aria-label="Search"
       className=
           ms-SearchBox-field
           {
@@ -251,7 +250,6 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
       </i>
     </div>
     <input
-      aria-label="Search"
       className=
           ms-SearchBox-field
           {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
@@ -105,7 +105,6 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
       </i>
     </div>
     <input
-      aria-label="Search"
       className=
           ms-SearchBox-field
           {
@@ -236,7 +235,6 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
       </i>
     </div>
     <input
-      aria-label="Search with no animation"
       className=
           ms-SearchBox-field
           {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
@@ -85,7 +85,6 @@ exports[`Component Examples renders SearchBox.Small.Example.tsx correctly 1`] = 
     </i>
   </div>
   <input
-    aria-label="Search"
     className=
         ms-SearchBox-field
         {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
@@ -86,7 +86,6 @@ exports[`Component Examples renders SearchBox.Underlined.Example.tsx correctly 1
     </i>
   </div>
   <input
-    aria-label="Search"
     className=
         ms-SearchBox-field
         {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #11503
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Placeholder text was being duplicated in the aria-label by default. This is redundant, can cause duplication in narrator (as reported) and isn't consistent with other inputs that take placeholder text.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11509)