### PR TITLE
DetailsList: Adding Announced section for # of filtered items in examples

### DIFF
--- a/change/office-ui-fabric-react-2019-12-18-14-39-37-detailsListFilterByName.json
+++ b/change/office-ui-fabric-react-2019-12-18-14-39-37-detailsListFilterByName.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "DetailsList: Adding Announced section for # of filtered items in examples.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "00a61a5d34d3c557742809ac3fbe06095f742627",
+  "date": "2019-12-18T22:39:37.781Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Basic.Example.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Announced } from 'office-ui-fabric-react/lib/Announced';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { DetailsList, DetailsListLayoutMode, Selection, IColumn } from 'office-ui-fabric-react/lib/DetailsList';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
@@ -66,6 +67,7 @@ export class DetailsListBasicExample extends React.Component<{}, IDetailsListBas
           onChange={this._onFilter}
           styles={{ root: { maxWidth: '300px' } }}
         />
+        <Announced message={`Number of items after filter applied: ${items.length}.`} />
         <MarqueeSelection selection={this._selection}>
           <DetailsList
             items={items}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Compact.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Compact.Example.tsx
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { Announced } from 'office-ui-fabric-react/lib/Announced';
 import { TextField } from 'office-ui-fabric-react/lib/TextField';
 import { DetailsList, DetailsListLayoutMode, Selection, IColumn } from 'office-ui-fabric-react/lib/DetailsList';
 import { MarqueeSelection } from 'office-ui-fabric-react/lib/MarqueeSelection';
@@ -65,6 +66,7 @@ export class DetailsListCompactExample extends React.Component<{}, IDetailsListC
           onChange={this._onFilter}
           styles={{ root: { maxWidth: '300px' } }}
         />
+        <Announced message={`Number of items after filter applied: ${items.length}.`} />
         <MarqueeSelection selection={this._selection}>
           <DetailsList
             compact={true}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Documents.Example.tsx
@@ -200,6 +200,7 @@ export class DetailsListDocumentsExample extends React.Component<{}, IDetailsLis
             styles={controlStyles}
           />
           <TextField label="Filter by name:" onChange={this._onChangeText} styles={controlStyles} />
+          <Announced message={`Number of items after filter applied: ${items.length}.`} />
         </div>
         <div className={classNames.selectionDetails}>{selectionDetails}</div>
         {announcedMessage ? <Announced message={announcedMessage} /> : undefined}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -203,6 +203,13 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
     </div>
   </div>
   <div
+    aria-live="polite"
+    className=
+
+
+    role="status"
+  />
+  <div
     className=
 
         {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -203,6 +203,13 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
     </div>
   </div>
   <div
+    aria-live="polite"
+    className=
+
+
+    role="status"
+  />
+  <div
     className=
 
         {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -547,6 +547,13 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
         </div>
       </div>
     </div>
+    <div
+      aria-live="polite"
+      className=
+
+
+      role="status"
+    />
   </div>
   <div
     className=


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes bug 4 in #6646
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR adds the `Announced` component with its message focusing on the number of items in the `DetailsList` so that when this number changes because of a change in the name filter `TextField` this information is announced by screen readers.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11512)