### PR TITLE
Ensure icon font family isn't overridden by Fabric Core

### DIFF
--- a/change/@uifabric-experiments-2019-12-23-14-06-08-icon-family.json
+++ b/change/@uifabric-experiments-2019-12-23-14-06-08-icon-family.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Snapshot updates",
+  "packageName": "@uifabric/experiments",
+  "email": "elcraig@microsoft.com",
+  "commit": "48c4125c20e70512140597cc94447991607237c4",
+  "date": "2019-12-23T19:06:08.430Z"
+}

--- a/change/@uifabric-styling-2019-12-19-16-10-04-icon-family.json
+++ b/change/@uifabric-styling-2019-12-19-16-10-04-icon-family.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Export IIconSubsetRecord",
+  "packageName": "@uifabric/styling",
+  "email": "elcraig@microsoft.com",
+  "commit": "a80d9e640f4655674a2e17a29adc6043d6048dae",
+  "date": "2019-12-20T00:10:04.469Z"
+}

--- a/change/office-ui-fabric-react-2019-12-19-16-10-04-icon-family.json
+++ b/change/office-ui-fabric-react-2019-12-19-16-10-04-icon-family.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Ensure icon font family isn't overridden by Fabric Core",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "commit": "a80d9e640f4655674a2e17a29adc6043d6048dae",
+  "date": "2019-12-20T00:09:54.511Z"
+}

--- a/packages/experiments/src/components/MicroFeedback/__snapshots__/MicroFeedback.test.tsx.snap
+++ b/packages/experiments/src/components/MicroFeedback/__snapshots__/MicroFeedback.test.tsx.snap
@@ -169,6 +169,11 @@ exports[`MicroFeedback renders correctly with inline prop set 1`] = `
                 }
             data-icon-name="Like"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons-2\\"",
+              }
+            }
           >
             
           </i>
@@ -296,6 +301,11 @@ exports[`MicroFeedback renders correctly with inline prop set 1`] = `
                 }
             data-icon-name="Dislike"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons-2\\"",
+              }
+            }
           >
             
           </i>
@@ -475,6 +485,11 @@ exports[`MicroFeedback renders correctly with no props 1`] = `
                 }
             data-icon-name="Like"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons-2\\"",
+              }
+            }
           >
             
           </i>
@@ -602,6 +617,11 @@ exports[`MicroFeedback renders correctly with no props 1`] = `
                 }
             data-icon-name="Dislike"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons-2\\"",
+              }
+            }
           >
             
           </i>

--- a/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -137,6 +137,11 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
               }
           data-icon-name="Previous"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons-1\\"",
+            }
+          }
         >
           
         </i>
@@ -267,6 +272,11 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
               }
           data-icon-name="CaretSolidLeft"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons-8\\"",
+            }
+          }
         >
           
         </i>
@@ -929,6 +939,11 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
               }
           data-icon-name="CaretSolidRight"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons-8\\"",
+            }
+          }
         >
           
         </i>
@@ -1068,6 +1083,11 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
                 }
             data-icon-name="Next"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons-1\\"",
+              }
+            }
           >
             
           </i>
@@ -1219,6 +1239,11 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
             }
         data-icon-name="Previous"
         role="presentation"
+        style={
+          Object {
+            "fontFamily": "\\"FabricMDL2Icons-1\\"",
+          }
+        }
       >
         
       </i>
@@ -1349,6 +1374,11 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
             }
         data-icon-name="CaretSolidLeft"
         role="presentation"
+        style={
+          Object {
+            "fontFamily": "\\"FabricMDL2Icons-8\\"",
+          }
+        }
       >
         
       </i>
@@ -1709,6 +1739,11 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
                 }
             data-icon-name="ChevronDown"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
           >
             
           </i>
@@ -1846,6 +1881,11 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
             }
         data-icon-name="CaretSolidRight"
         role="presentation"
+        style={
+          Object {
+            "fontFamily": "\\"FabricMDL2Icons-8\\"",
+          }
+        }
       >
         
       </i>
@@ -1972,6 +2012,11 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
             }
         data-icon-name="Next"
         role="presentation"
+        style={
+          Object {
+            "fontFamily": "\\"FabricMDL2Icons-1\\"",
+          }
+        }
       >
         
       </i>

--- a/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
+++ b/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
@@ -167,6 +167,7 @@ Array [
             role="presentation"
             style={
               Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
                 "fontSize": "14px",
               }
             }
@@ -503,6 +504,7 @@ Array [
             role="presentation"
             style={
               Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
                 "fontSize": "14px",
               }
             }
@@ -678,6 +680,7 @@ Array [
             role="presentation"
             style={
               Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
                 "fontSize": "14px",
               }
             }
@@ -1014,6 +1017,7 @@ Array [
             role="presentation"
             style={
               Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
                 "fontSize": "14px",
               }
             }

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1316,6 +1316,7 @@ export function getFullColorString(color: IColor): string;
 export const getIconContent: (iconName?: string | undefined) => {
     children: string | undefined;
     iconClassName: string | undefined;
+    fontFamily: string | undefined;
 };
 
 // @public

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -1404,6 +1404,11 @@ exports[`Breadcrumb rendering renders correctly with maxDisplayedItems and overf
                         }
                     data-icon-name="More"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -1635,6 +1640,11 @@ exports[`Breadcrumb rendering renders correctly with maxDisplayedItems and overf
                         }
                     data-icon-name="More"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -1866,6 +1876,11 @@ exports[`Breadcrumb rendering renders correctly with overflow 1`] = `
                         }
                     data-icon-name="More"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -2361,6 +2376,11 @@ exports[`Breadcrumb rendering renders correctly with overflow and overflowIndex 
                         }
                     data-icon-name="More"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>

--- a/packages/office-ui-fabric-react/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -262,6 +262,11 @@ exports[`Button renders CommandBarButton correctly 1`] = `
           }
       data-icon-name="Add"
       role="presentation"
+      style={
+        Object {
+          "fontFamily": "\\"FabricMDL2Icons\\"",
+        }
+      }
     >
       
     </i>
@@ -321,6 +326,11 @@ exports[`Button renders CommandBarButton correctly 1`] = `
           }
       data-icon-name="ChevronDown"
       role="presentation"
+      style={
+        Object {
+          "fontFamily": "\\"FabricMDL2Icons\\"",
+        }
+      }
     >
       
     </i>
@@ -724,6 +734,11 @@ exports[`Button renders IconButton correctly 1`] = `
           }
       data-icon-name="Emoji2"
       role="presentation"
+      style={
+        Object {
+          "fontFamily": "\\"FabricMDL2Icons-0\\"",
+        }
+      }
     >
       
     </i>

--- a/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -350,6 +350,11 @@ exports[`ComboBox Renders correctly 1`] = `
               }
           data-icon-name="ChevronDown"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
         >
           
         </i>
@@ -721,6 +726,11 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
               }
           data-icon-name="ChevronDown"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
         >
           
         </i>

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
@@ -125,6 +125,11 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
           }
       data-icon-name="ChevronDown"
       role="presentation"
+      style={
+        Object {
+          "fontFamily": "\\"FabricMDL2Icons\\"",
+        }
+      }
     >
       
     </i>

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.test.tsx
@@ -522,7 +522,7 @@ describe('DetailsHeader', () => {
     expect(header._currentDropHintIndex).toBe(1);
     let dropHintElement = component.find('#columnDropHint_1').getDOMNode();
     let dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toEqual('display: inline-block;');
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toContain('display: inline-block;');
     expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual('display: inline-block;');
 
     // dragover b/w b&c and c&d -> dead zone b/w 370 and 810
@@ -537,13 +537,13 @@ describe('DetailsHeader', () => {
     // dead zone : idx 2 and 3 -> no hint shown
     dropHintElement = component.find('#columnDropHint_2').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toEqual(null);
-    expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual(null);
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).not.toContain('display:');
+    expect(dropHintElementChildren.item(1)!.getAttribute('style')).toBe(null);
 
     dropHintElement = component.find('#columnDropHint_3').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toEqual(null);
-    expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual(null);
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).not.toContain('display:');
+    expect(dropHintElementChildren.item(1)!.getAttribute('style')).toBe(null);
 
     // dragover e
     _RaiseEvent(detailsColTargetE, _DRAGOVER, 811);
@@ -551,7 +551,7 @@ describe('DetailsHeader', () => {
     expect(header._currentDropHintIndex).toBe(4);
     dropHintElement = component.find('#columnDropHint_4').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toEqual('display: inline-block;');
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toContain('display: inline-block;');
     expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual('display: inline-block;');
 
     // raise dragend on column c
@@ -560,7 +560,7 @@ describe('DetailsHeader', () => {
     // drop hint should be hidden on doing a dragend
     dropHintElement = component.find('#columnDropHint_4').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toEqual('display: none;');
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toContain('display: none;');
     expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual('display: none;');
 
     // do a mousedown and dragstart on source column c
@@ -574,7 +574,7 @@ describe('DetailsHeader', () => {
     dropHintElement = component.find('#columnDropHint_5').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
 
-    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toEqual('display: inline-block;');
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toContain('display: inline-block;');
     expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual('display: inline-block;');
 
     // dragover outside f's zone (frozen) -> should get last valid drop hint
@@ -583,7 +583,7 @@ describe('DetailsHeader', () => {
     expect(header._currentDropHintIndex).toBe(5);
     dropHintElement = component.find('#columnDropHint_5').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toEqual('display: inline-block;');
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toContain('display: inline-block;');
     expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual('display: inline-block;');
   });
 
@@ -636,7 +636,7 @@ describe('DetailsHeader', () => {
 
     let dropHintElement = component.find('#columnDropHint_1').getDOMNode();
     let dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toEqual('display: inline-block;');
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toContain('display: inline-block;');
     expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual('display: inline-block;');
 
     _RaiseEvent(detailsColTarget, _DROP, 160);
@@ -645,7 +645,7 @@ describe('DetailsHeader', () => {
 
     dropHintElement = component.find('#columnDropHint_1').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toEqual('display: none;');
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toContain('display: none;');
     expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual('display: none;');
 
     // try moving column c after frozen column f (abcdef -> abdecf)
@@ -663,7 +663,7 @@ describe('DetailsHeader', () => {
 
     dropHintElement = component.find('#columnDropHint_5').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toEqual('display: inline-block;');
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toContain('display: inline-block;');
     expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual('display: inline-block;');
 
     _RaiseEvent(detailsColTarget, _DROP, 1169);
@@ -672,7 +672,7 @@ describe('DetailsHeader', () => {
 
     dropHintElement = component.find('#columnDropHint_5').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toEqual('display: none;');
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toContain('display: none;');
     expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual('display: none;');
 
     // source and target column are the same
@@ -688,8 +688,8 @@ describe('DetailsHeader', () => {
 
     dropHintElement = component.find('#columnDropHint_2').getDOMNode();
     dropHintElementChildren = dropHintElement.children;
-    expect(dropHintElementChildren.item(0)!.getAttribute('style')).toEqual(null);
-    expect(dropHintElementChildren.item(1)!.getAttribute('style')).toEqual(null);
+    expect(dropHintElementChildren.item(0)!.getAttribute('style')).not.toContain('display');
+    expect(dropHintElementChildren.item(1)!.getAttribute('style')).toBe(null);
 
     // drop on source column itself -> drophintindex should not be set and hence target index not updated
     _RaiseEvent(detailsColTarget, _DROP, 500);

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsHeader.test.tsx.snap
@@ -233,6 +233,11 @@ exports[`DetailsHeader can render 1`] = `
                 }
             data-icon-name="CircleRing"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
           >
             
           </i>
@@ -272,6 +277,11 @@ exports[`DetailsHeader can render 1`] = `
                 }
             data-icon-name="StatusCircleCheckmark"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
           >
             
           </i>
@@ -625,6 +635,11 @@ exports[`DetailsHeader can render 1`] = `
               }
           data-icon-name="SortUp"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
         >
           
         </i>
@@ -843,6 +858,11 @@ exports[`DetailsHeader can render 1`] = `
               }
           data-icon-name="ChevronDown"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
         >
           
         </i>
@@ -1412,6 +1432,11 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
               }
           data-icon-name="SortUp"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
         >
           
         </i>
@@ -1630,6 +1655,11 @@ exports[`DetailsHeader can render a hidden select all checkbox in single selecti
               }
           data-icon-name="ChevronDown"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
         >
           
         </i>
@@ -1928,6 +1958,11 @@ exports[`DetailsHeader renders accessible labels 1`] = `
                 }
             data-icon-name="CircleRing"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
           >
             
           </i>
@@ -1967,6 +2002,11 @@ exports[`DetailsHeader renders accessible labels 1`] = `
                 }
             data-icon-name="StatusCircleCheckmark"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
           >
             
           </i>
@@ -2321,6 +2361,11 @@ exports[`DetailsHeader renders accessible labels 1`] = `
               }
           data-icon-name="SortUp"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
         >
           
         </i>
@@ -2563,6 +2608,11 @@ exports[`DetailsHeader renders accessible labels 1`] = `
               }
           data-icon-name="Filter"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
         >
           
         </i>
@@ -2589,6 +2639,11 @@ exports[`DetailsHeader renders accessible labels 1`] = `
               }
           data-icon-name="GroupedDescending"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons-7\\"",
+            }
+          }
         >
           
         </i>
@@ -2616,6 +2671,11 @@ exports[`DetailsHeader renders accessible labels 1`] = `
               }
           data-icon-name="ChevronDown"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
         >
           
         </i>

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -279,6 +279,11 @@ exports[`DetailsList renders List correctly 1`] = `
                         }
                     data-icon-name="CircleRing"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -318,6 +323,11 @@ exports[`DetailsList renders List correctly 1`] = `
                         }
                     data-icon-name="StatusCircleCheckmark"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -886,6 +896,11 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                         }
                     data-icon-name="CircleRing"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -925,6 +940,11 @@ exports[`DetailsList renders List correctly with onRenderDivider props 1`] = `
                         }
                     data-icon-name="StatusCircleCheckmark"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -2089,6 +2109,11 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
                         }
                     data-icon-name="CircleRing"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -2128,6 +2153,11 @@ exports[`DetailsList renders List in compact mode correctly 1`] = `
                         }
                     data-icon-name="StatusCircleCheckmark"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -2697,6 +2727,11 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                         }
                     data-icon-name="CircleRing"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -2736,6 +2771,11 @@ exports[`DetailsList renders List in fixed constrained layout correctly 1`] = `
                         }
                     data-icon-name="StatusCircleCheckmark"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -3684,6 +3724,11 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                         }
                     data-icon-name="CircleRing"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -3723,6 +3768,11 @@ exports[`DetailsList renders List with custom icon as column divider 1`] = `
                         }
                     data-icon-name="StatusCircleCheckmark"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -4792,6 +4842,11 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                   }
               data-icon-name="ChevronRightMed"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons-3\\"",
+                }
+              }
             >
               
             </i>

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsRow.test.tsx.snap
@@ -279,6 +279,11 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                         }
                     data-icon-name="CircleRing"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -318,6 +323,11 @@ exports[`DetailsRow renders details list row correctly 1`] = `
                         }
                     data-icon-name="StatusCircleCheckmark"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -1118,6 +1128,11 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                         }
                     data-icon-name="CircleRing"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -1157,6 +1172,11 @@ exports[`DetailsRow renders details list row with all rows selected correctly 1`
                         }
                     data-icon-name="StatusCircleCheckmark"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -1934,6 +1954,11 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
               }
           data-icon-name="CircleRing"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
         >
           
         </i>
@@ -1973,6 +1998,11 @@ exports[`DetailsRow renders details list row with checkbox visible always correc
               }
           data-icon-name="StatusCircleCheckmark"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
         >
           
         </i>
@@ -2458,6 +2488,11 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
                         }
                     data-icon-name="CircleRing"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -2497,6 +2532,11 @@ exports[`DetailsRow renders details list row with multiple selections correctly 
                         }
                     data-icon-name="StatusCircleCheckmark"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -3297,6 +3337,11 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
                         }
                     data-icon-name="CircleRing"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -3336,6 +3381,11 @@ exports[`DetailsRow renders details list row with one row selected correctly 1`]
                         }
                     data-icon-name="StatusCircleCheckmark"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
@@ -279,6 +279,11 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                         }
                     data-icon-name="CircleRing"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -318,6 +323,11 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                         }
                     data-icon-name="StatusCircleCheckmark"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>

--- a/packages/office-ui-fabric-react/src/components/Icon/FontIcon.tsx
+++ b/packages/office-ui-fabric-react/src/components/Icon/FontIcon.tsx
@@ -3,19 +3,18 @@ import * as React from 'react';
 import { IFontIconProps } from './Icon.types';
 import { classNames, MS_ICON } from './Icon.styles';
 import { css, getNativeProps, htmlElementProperties, memoizeFunction } from '../../Utilities';
-import { getIcon } from '../../Styling';
+import { getIcon, IIconRecord, IIconSubsetRecord } from '../../Styling';
 
 export const getIconContent = memoizeFunction((iconName?: string) => {
-  const iconDefinition = getIcon(iconName) || {
-    subset: {
-      className: undefined
-    },
+  const { code, subset }: Pick<IIconRecord, 'code'> & { subset: Partial<IIconSubsetRecord> } = getIcon(iconName) || {
+    subset: {},
     code: undefined
   };
 
   return {
-    children: iconDefinition.code,
-    iconClassName: iconDefinition.subset.className
+    children: code,
+    iconClassName: subset.className,
+    fontFamily: subset.fontFace && subset.fontFace.fontFamily
   };
 });
 
@@ -25,8 +24,8 @@ export const getIconContent = memoizeFunction((iconName?: string) => {
  * {@docCategory Icon}
  */
 export const FontIcon: React.FunctionComponent<IFontIconProps> = props => {
-  const { iconName, className } = props;
-  const { iconClassName, children } = getIconContent(iconName);
+  const { iconName, className, style = {} } = props;
+  const { iconClassName, children, fontFamily } = getIconContent(iconName);
 
   const nativeProps = getNativeProps<React.HTMLAttributes<HTMLElement>>(props, htmlElementProperties);
   const containerProps = props['aria-label']
@@ -42,6 +41,9 @@ export const FontIcon: React.FunctionComponent<IFontIconProps> = props => {
       {...containerProps}
       {...nativeProps}
       className={css(MS_ICON, classNames.root, iconClassName, !iconName && classNames.placeholder, className)}
+      // Apply the font family this way to ensure it doesn't get overridden by Fabric Core ms-Icon styles
+      // https://github.com/OfficeDev/office-ui-fabric-react/issues/10449
+      style={{ fontFamily, ...style }}
     >
       {children}
     </i>

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -303,6 +303,11 @@ exports[`Panel renders Panel correctly 1`] = `
                         }
                     data-icon-name="Cancel"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>

--- a/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
@@ -272,6 +272,11 @@ exports[`SpinButton renders SpinButton correctly 1`] = `
                 }
             data-icon-name="ChevronUpSmall"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons-2\\"",
+              }
+            }
           >
             
           </i>
@@ -410,6 +415,11 @@ exports[`SpinButton renders SpinButton correctly 1`] = `
                 }
             data-icon-name="ChevronDownSmall"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons-3\\"",
+              }
+            }
           >
             
           </i>
@@ -694,6 +704,11 @@ exports[`SpinButton renders SpinButton correctly with values that the user passe
                 }
             data-icon-name="ChevronUpSmall"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons-2\\"",
+              }
+            }
           >
             
           </i>
@@ -832,6 +847,11 @@ exports[`SpinButton renders SpinButton correctly with values that the user passe
                 }
             data-icon-name="ChevronDownSmall"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons-3\\"",
+              }
+            }
           >
             
           </i>

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
@@ -575,6 +575,11 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                 }
             data-icon-name="Cancel"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
           >
             
           </i>

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -843,6 +843,11 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                 }
             data-icon-name="Cancel"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
           >
             
           </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.BulkOperations.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.BulkOperations.Example.tsx.shot
@@ -344,6 +344,11 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                             }
                         data-icon-name="CircleRing"
                         role="presentation"
+                        style={
+                          Object {
+                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                          }
+                        }
                       >
                         
                       </i>
@@ -383,6 +388,11 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                             }
                         data-icon-name="StatusCircleCheckmark"
                         role="presentation"
+                        style={
+                          Object {
+                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                          }
+                        }
                       >
                         
                       </i>
@@ -1490,6 +1500,11 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -1529,6 +1544,11 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -2122,6 +2142,11 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -2161,6 +2186,11 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -2754,6 +2784,11 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -2793,6 +2828,11 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -3386,6 +3426,11 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -3425,6 +3470,11 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -4018,6 +4068,11 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -4057,6 +4112,11 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -4650,6 +4710,11 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -4689,6 +4754,11 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -5282,6 +5352,11 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -5321,6 +5396,11 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -5914,6 +5994,11 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -5953,6 +6038,11 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -6546,6 +6636,11 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -6585,6 +6680,11 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -7178,6 +7278,11 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -7217,6 +7322,11 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.QuickActions.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.QuickActions.Example.tsx.shot
@@ -290,6 +290,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           }
                       data-icon-name="CircleRing"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
                     >
                       
                     </i>
@@ -329,6 +334,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                           }
                       data-icon-name="StatusCircleCheckmark"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
                     >
                       
                     </i>
@@ -1434,6 +1444,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -1473,6 +1488,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -1673,6 +1693,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                         }
                                     data-icon-name="MoreVertical"
                                     role="presentation"
+                                    style={
+                                      Object {
+                                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                                      }
+                                    }
                                   >
                                     
                                   </i>
@@ -2139,6 +2164,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2178,6 +2208,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2378,6 +2413,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                         }
                                     data-icon-name="MoreVertical"
                                     role="presentation"
+                                    style={
+                                      Object {
+                                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                                      }
+                                    }
                                   >
                                     
                                   </i>
@@ -2844,6 +2884,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2883,6 +2928,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3083,6 +3133,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                         }
                                     data-icon-name="MoreVertical"
                                     role="presentation"
+                                    style={
+                                      Object {
+                                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                                      }
+                                    }
                                   >
                                     
                                   </i>
@@ -3549,6 +3604,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3588,6 +3648,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3788,6 +3853,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                         }
                                     data-icon-name="MoreVertical"
                                     role="presentation"
+                                    style={
+                                      Object {
+                                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                                      }
+                                    }
                                   >
                                     
                                   </i>
@@ -4254,6 +4324,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -4293,6 +4368,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -4493,6 +4573,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                         }
                                     data-icon-name="MoreVertical"
                                     role="presentation"
+                                    style={
+                                      Object {
+                                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                                      }
+                                    }
                                   >
                                     
                                   </i>
@@ -4959,6 +5044,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -4998,6 +5088,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -5198,6 +5293,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                         }
                                     data-icon-name="MoreVertical"
                                     role="presentation"
+                                    style={
+                                      Object {
+                                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                                      }
+                                    }
                                   >
                                     
                                   </i>
@@ -5664,6 +5764,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -5703,6 +5808,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -5903,6 +6013,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                         }
                                     data-icon-name="MoreVertical"
                                     role="presentation"
+                                    style={
+                                      Object {
+                                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                                      }
+                                    }
                                   >
                                     
                                   </i>
@@ -6369,6 +6484,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -6408,6 +6528,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -6608,6 +6733,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                         }
                                     data-icon-name="MoreVertical"
                                     role="presentation"
+                                    style={
+                                      Object {
+                                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                                      }
+                                    }
                                   >
                                     
                                   </i>
@@ -7074,6 +7204,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -7113,6 +7248,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -7313,6 +7453,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                         }
                                     data-icon-name="MoreVertical"
                                     role="presentation"
+                                    style={
+                                      Object {
+                                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                                      }
+                                    }
                                   >
                                     
                                   </i>
@@ -7779,6 +7924,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -7818,6 +7968,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -8018,6 +8173,11 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                         }
                                     data-icon-name="MoreVertical"
                                     role="presentation"
+                                    style={
+                                      Object {
+                                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                                      }
+                                    }
                                   >
                                     
                                   </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -250,6 +250,11 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                           }
                       data-icon-name="More"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
                     >
                       
                     </i>
@@ -919,6 +924,11 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                           }
                       data-icon-name="More"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
                     >
                       
                     </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Collapsing.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Collapsing.Example.tsx.shot
@@ -1208,6 +1208,11 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                           }
                       data-icon-name="More"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
                     >
                       
                     </i>
@@ -2037,6 +2042,11 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                           }
                       data-icon-name="More"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
                     >
                       
                     </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
@@ -226,6 +226,11 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                           }
                       data-icon-name="More"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
                     >
                       
                     </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Action.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Action.Example.tsx.shot
@@ -126,6 +126,11 @@ exports[`Component Examples renders Button.Action.Example.tsx correctly 1`] = `
           }
       data-icon-name="AddFriend"
       role="presentation"
+      style={
+        Object {
+          "fontFamily": "\\"FabricMDL2Icons\\"",
+        }
+      }
     >
       
     </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Command.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Command.Example.tsx.shot
@@ -130,6 +130,11 @@ exports[`Component Examples renders Button.Command.Example.tsx correctly 1`] = `
           }
       data-icon-name="Add"
       role="presentation"
+      style={
+        Object {
+          "fontFamily": "\\"FabricMDL2Icons\\"",
+        }
+      }
     >
       
     </i>
@@ -188,6 +193,11 @@ exports[`Component Examples renders Button.Command.Example.tsx correctly 1`] = `
           }
       data-icon-name="ChevronDown"
       role="presentation"
+      style={
+        Object {
+          "fontFamily": "\\"FabricMDL2Icons\\"",
+        }
+      }
     >
       
     </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CommandBar.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CommandBar.Example.tsx.shot
@@ -160,6 +160,11 @@ exports[`Component Examples renders Button.CommandBar.Example.tsx correctly 1`] 
             }
         data-icon-name="Add"
         role="presentation"
+        style={
+          Object {
+            "fontFamily": "\\"FabricMDL2Icons\\"",
+          }
+        }
       >
         
       </i>
@@ -219,6 +224,11 @@ exports[`Component Examples renders Button.CommandBar.Example.tsx correctly 1`] 
             }
         data-icon-name="ChevronDown"
         role="presentation"
+        style={
+          Object {
+            "fontFamily": "\\"FabricMDL2Icons\\"",
+          }
+        }
       >
         
       </i>
@@ -358,6 +368,11 @@ exports[`Component Examples renders Button.CommandBar.Example.tsx correctly 1`] 
             }
         data-icon-name="Mail"
         role="presentation"
+        style={
+          Object {
+            "fontFamily": "\\"FabricMDL2Icons\\"",
+          }
+        }
       >
         
       </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.ContextualMenu.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.ContextualMenu.Example.tsx.shot
@@ -125,6 +125,11 @@ exports[`Component Examples renders Button.ContextualMenu.Example.tsx correctly 
           }
       data-icon-name="Add"
       role="presentation"
+      style={
+        Object {
+          "fontFamily": "\\"FabricMDL2Icons\\"",
+        }
+      }
     >
       
     </i>
@@ -183,6 +188,11 @@ exports[`Component Examples renders Button.ContextualMenu.Example.tsx correctly 
           }
       data-icon-name="ChevronDown"
       role="presentation"
+      style={
+        Object {
+          "fontFamily": "\\"FabricMDL2Icons\\"",
+        }
+      }
     >
       
     </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CustomSplit.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CustomSplit.Example.tsx.shot
@@ -233,6 +233,11 @@ exports[`Component Examples renders Button.CustomSplit.Example.tsx correctly 1`]
                 }
             data-icon-name="Add"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
           >
             
           </i>
@@ -336,6 +341,11 @@ exports[`Component Examples renders Button.CustomSplit.Example.tsx correctly 1`]
                 }
             data-icon-name="ChevronDown"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
           >
             
           </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Icon.Example.tsx.shot
@@ -145,6 +145,11 @@ exports[`Component Examples renders Button.Icon.Example.tsx correctly 1`] = `
               }
           data-icon-name="Emoji2"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons-0\\"",
+            }
+          }
         >
           
         </i>
@@ -276,6 +281,11 @@ exports[`Component Examples renders Button.Icon.Example.tsx correctly 1`] = `
               }
           data-icon-name="Emoji2"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons-0\\"",
+            }
+          }
         >
           
         </i>
@@ -309,6 +319,11 @@ exports[`Component Examples renders Button.Icon.Example.tsx correctly 1`] = `
               }
           data-icon-name="ChevronDown"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
         >
           
         </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Split.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Split.Example.tsx.shot
@@ -346,6 +346,11 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                   }
               data-icon-name="ChevronDown"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
             >
               
             </i>
@@ -693,6 +698,11 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                   }
               data-icon-name="ChevronDown"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
             >
               
             </i>
@@ -1024,6 +1034,11 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                   }
               data-icon-name="ChevronDown"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
             >
               
             </i>
@@ -1363,6 +1378,11 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                   }
               data-icon-name="ChevronDown"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
             >
               
             </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Toggle.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Toggle.Example.tsx.shot
@@ -122,6 +122,11 @@ exports[`Component Examples renders Button.Toggle.Example.tsx correctly 1`] = `
           }
       data-icon-name="Volume3"
       role="presentation"
+      style={
+        Object {
+          "fontFamily": "\\"FabricMDL2Icons-3\\"",
+        }
+      }
     >
       
     </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -409,6 +409,11 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                   }
               data-icon-name="ChevronDown"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
             >
               
             </i>
@@ -943,6 +948,11 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                 }
             data-icon-name="ChevronDown"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
           >
             
           </i>
@@ -1338,6 +1348,11 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                 }
             data-icon-name="ChevronDown"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
           >
             
           </i>
@@ -1732,6 +1747,11 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                 }
             data-icon-name="ChevronDown"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
           >
             
           </i>
@@ -3849,6 +3869,11 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                 }
             data-icon-name="ChevronDown"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
           >
             
           </i>
@@ -4254,6 +4279,11 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                 }
             data-icon-name="ChevronDown"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
           >
             
           </i>
@@ -4561,6 +4591,11 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                 }
             data-icon-name="ChevronDown"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
           >
             
           </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
@@ -406,6 +406,11 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
                 }
             data-icon-name="ChevronDown"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
           >
             
           </i>
@@ -800,6 +805,11 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
                 }
             data-icon-name="ChevronDown"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
           >
             
           </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
@@ -410,6 +410,11 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
                 }
             data-icon-name="ChevronDown"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
           >
             
           </i>
@@ -804,6 +809,11 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
                 }
             data-icon-name="ChevronDown"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
           >
             
           </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -407,6 +407,11 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
                 }
             data-icon-name="ChevronDown"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
           >
             
           </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
@@ -402,6 +402,11 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
                 }
             data-icon-name="ChevronDown"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
           >
             
           </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.Basic.Example.tsx.shot
@@ -210,6 +210,11 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                         }
                     data-icon-name="Add"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -270,6 +275,11 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                         }
                     data-icon-name="ChevronDown"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -421,6 +431,11 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                         }
                     data-icon-name="Upload"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -598,6 +613,11 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                         }
                     data-icon-name="Share"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -775,6 +795,11 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                         }
                     data-icon-name="Download"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -955,6 +980,11 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                         }
                     data-icon-name="More"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -1134,6 +1164,11 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                           }
                       data-icon-name="Tiles"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
                     >
                       
                     </i>
@@ -1299,6 +1334,11 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                           }
                       data-icon-name="Info"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
                     >
                       
                     </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
@@ -209,6 +209,11 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                       }
                   data-icon-name="Add"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -269,6 +274,11 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                       }
                   data-icon-name="ChevronDown"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -420,6 +430,11 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                       }
                   data-icon-name="Upload"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -597,6 +612,11 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                       }
                   data-icon-name="Share"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -774,6 +794,11 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                       }
                   data-icon-name="Download"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -954,6 +979,11 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                       }
                   data-icon-name="More"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -1133,6 +1163,11 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                         }
                     data-icon-name="Tiles"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -1298,6 +1333,11 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                         }
                     data-icon-name="Info"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
@@ -205,6 +205,11 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                       }
                   data-icon-name="Add"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -382,6 +387,11 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                       }
                   data-icon-name="Upload"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -560,6 +570,11 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                         }
                     data-icon-name="Share"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -1079,6 +1094,11 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                                                     }
                                                 data-icon-name="Cancel"
                                                 role="presentation"
+                                                style={
+                                                  Object {
+                                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                                  }
+                                                }
                                               >
                                                 
                                               </i>
@@ -1267,6 +1287,11 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                       }
                   data-icon-name="Download"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
@@ -289,6 +289,11 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                             }
                         data-icon-name="Add"
                         role="presentation"
+                        style={
+                          Object {
+                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                          }
+                        }
                       >
                         
                       </i>
@@ -436,6 +441,11 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                             }
                         data-icon-name="ChevronDown"
                         role="presentation"
+                        style={
+                          Object {
+                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                          }
+                        }
                       >
                         
                       </i>
@@ -671,6 +681,11 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                             }
                         data-icon-name="Upload"
                         role="presentation"
+                        style={
+                          Object {
+                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                          }
+                        }
                       >
                         
                       </i>
@@ -833,6 +848,11 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                             }
                         data-icon-name="ChevronDown"
                         role="presentation"
+                        style={
+                          Object {
+                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                          }
+                        }
                       >
                         
                       </i>
@@ -995,6 +1015,11 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                         }
                     data-icon-name="Share"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -1178,6 +1203,11 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                           }
                       data-icon-name="Download"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
                     >
                       
                     </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Checkmarks.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Checkmarks.Example.tsx.shot
@@ -150,6 +150,11 @@ exports[`Component Examples renders ContextualMenu.Checkmarks.Example.tsx correc
           }
       data-icon-name="ChevronDown"
       role="presentation"
+      style={
+        Object {
+          "fontFamily": "\\"FabricMDL2Icons\\"",
+        }
+      }
     >
       
     </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.CustomMenuItem.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.CustomMenuItem.Example.tsx.shot
@@ -151,6 +151,11 @@ exports[`Component Examples renders ContextualMenu.CustomMenuItem.Example.tsx co
             }
         data-icon-name="ChevronDown"
         role="presentation"
+        style={
+          Object {
+            "fontFamily": "\\"FabricMDL2Icons\\"",
+          }
+        }
       >
         
       </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.CustomMenuList.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.CustomMenuList.Example.tsx.shot
@@ -151,6 +151,11 @@ exports[`Component Examples renders ContextualMenu.CustomMenuList.Example.tsx co
             }
         data-icon-name="ChevronDown"
         role="presentation"
+        style={
+          Object {
+            "fontFamily": "\\"FabricMDL2Icons\\"",
+          }
+        }
       >
         
       </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Customization.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Customization.Example.tsx.shot
@@ -151,6 +151,11 @@ exports[`Component Examples renders ContextualMenu.Customization.Example.tsx cor
           }
       data-icon-name="ChevronDown"
       role="presentation"
+      style={
+        Object {
+          "fontFamily": "\\"FabricMDL2Icons\\"",
+        }
+      }
     >
       
     </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.CustomizationWithNoWrap.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.CustomizationWithNoWrap.Example.tsx.shot
@@ -151,6 +151,11 @@ exports[`Component Examples renders ContextualMenu.CustomizationWithNoWrap.Examp
           }
       data-icon-name="ChevronDown"
       role="presentation"
+      style={
+        Object {
+          "fontFamily": "\\"FabricMDL2Icons\\"",
+        }
+      }
     >
       
     </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Default.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Default.Example.tsx.shot
@@ -151,6 +151,11 @@ exports[`Component Examples renders ContextualMenu.Default.Example.tsx correctly
             }
         data-icon-name="ChevronDown"
         role="presentation"
+        style={
+          Object {
+            "fontFamily": "\\"FabricMDL2Icons\\"",
+          }
+        }
       >
         
       </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
@@ -521,6 +521,11 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
               }
           data-icon-name="ChevronDown"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
         >
           
         </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Header.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Header.Example.tsx.shot
@@ -150,6 +150,11 @@ exports[`Component Examples renders ContextualMenu.Header.Example.tsx correctly 
           }
       data-icon-name="ChevronDown"
       role="presentation"
+      style={
+        Object {
+          "fontFamily": "\\"FabricMDL2Icons\\"",
+        }
+      }
     >
       
     </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Icon.Example.tsx.shot
@@ -151,6 +151,11 @@ exports[`Component Examples renders ContextualMenu.Icon.Example.tsx correctly 1`
             }
         data-icon-name="ChevronDown"
         role="presentation"
+        style={
+          Object {
+            "fontFamily": "\\"FabricMDL2Icons\\"",
+          }
+        }
       >
         
       </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Icon.SecondaryText.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Icon.SecondaryText.Example.tsx.shot
@@ -151,6 +151,11 @@ exports[`Component Examples renders ContextualMenu.Icon.SecondaryText.Example.ts
             }
         data-icon-name="ChevronDown"
         role="presentation"
+        style={
+          Object {
+            "fontFamily": "\\"FabricMDL2Icons\\"",
+          }
+        }
       >
         
       </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Persisted.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Persisted.Example.tsx.shot
@@ -151,6 +151,11 @@ exports[`Component Examples renders ContextualMenu.Persisted.Example.tsx correct
             }
         data-icon-name="ChevronDown"
         role="presentation"
+        style={
+          Object {
+            "fontFamily": "\\"FabricMDL2Icons\\"",
+          }
+        }
       >
         
       </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.ScrollBar.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.ScrollBar.Example.tsx.shot
@@ -151,6 +151,11 @@ exports[`Component Examples renders ContextualMenu.ScrollBar.Example.tsx correct
             }
         data-icon-name="ChevronDown"
         role="presentation"
+        style={
+          Object {
+            "fontFamily": "\\"FabricMDL2Icons\\"",
+          }
+        }
       >
         
       </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Section.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Section.Example.tsx.shot
@@ -151,6 +151,11 @@ exports[`Component Examples renders ContextualMenu.Section.Example.tsx correctly
             }
         data-icon-name="ChevronDown"
         role="presentation"
+        style={
+          Object {
+            "fontFamily": "\\"FabricMDL2Icons\\"",
+          }
+        }
       >
         
       </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
@@ -323,6 +323,11 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
             }
         data-icon-name="ChevronDown"
         role="presentation"
+        style={
+          Object {
+            "fontFamily": "\\"FabricMDL2Icons\\"",
+          }
+        }
       >
         
       </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -212,6 +212,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         }
                     data-icon-name="Add"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -389,6 +394,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         }
                     data-icon-name="Delete"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -570,6 +580,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         }
                     data-icon-name="Settings"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -630,6 +645,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                         }
                     data-icon-name="ChevronDown"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -1080,6 +1100,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           }
                       data-icon-name="CircleRing"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
                     >
                       
                     </i>
@@ -1119,6 +1144,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           }
                       data-icon-name="StatusCircleCheckmark"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
                     >
                       
                     </i>
@@ -1307,6 +1337,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           }
                       data-icon-name="Picture"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                        }
+                      }
                     >
                       
                     </i>
@@ -1751,6 +1786,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -1790,6 +1830,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2146,6 +2191,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2185,6 +2235,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2541,6 +2596,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2580,6 +2640,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2936,6 +3001,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2975,6 +3045,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3331,6 +3406,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3370,6 +3450,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3726,6 +3811,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3765,6 +3855,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -4121,6 +4216,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -4160,6 +4260,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -4516,6 +4621,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -4555,6 +4665,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -4911,6 +5026,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -4950,6 +5070,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -5306,6 +5431,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -5345,6 +5475,11 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Animation.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Animation.Example.tsx.shot
@@ -303,6 +303,11 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           }
                       data-icon-name="CircleRing"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
                     >
                       
                     </i>
@@ -342,6 +347,11 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                           }
                       data-icon-name="StatusCircleCheckmark"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
                     >
                       
                     </i>
@@ -1068,6 +1078,11 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -1107,6 +1122,11 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -1520,6 +1540,11 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -1559,6 +1584,11 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -1972,6 +2002,11 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2011,6 +2046,11 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2424,6 +2464,11 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2463,6 +2508,11 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2876,6 +2926,11 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2915,6 +2970,11 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3328,6 +3388,11 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3367,6 +3432,11 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3780,6 +3850,11 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3819,6 +3894,11 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -4232,6 +4312,11 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -4271,6 +4356,11 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -4684,6 +4774,11 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -4723,6 +4818,11 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -5136,6 +5236,11 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -5175,6 +5280,11 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -490,6 +490,11 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             }
                         data-icon-name="CircleRing"
                         role="presentation"
+                        style={
+                          Object {
+                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                          }
+                        }
                       >
                         
                       </i>
@@ -529,6 +534,11 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                             }
                         data-icon-name="StatusCircleCheckmark"
                         role="presentation"
+                        style={
+                          Object {
+                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                          }
+                        }
                       >
                         
                       </i>
@@ -1255,6 +1265,11 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -1294,6 +1309,11 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -1707,6 +1727,11 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -1746,6 +1771,11 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -2159,6 +2189,11 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -2198,6 +2233,11 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -2611,6 +2651,11 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -2650,6 +2695,11 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -3063,6 +3113,11 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -3102,6 +3157,11 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -3515,6 +3575,11 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -3554,6 +3619,11 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -3967,6 +4037,11 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -4006,6 +4081,11 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -4419,6 +4499,11 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -4458,6 +4543,11 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -4871,6 +4961,11 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -4910,6 +5005,11 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -5323,6 +5423,11 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -5362,6 +5467,11 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -491,6 +491,11 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             }
                         data-icon-name="CircleRing"
                         role="presentation"
+                        style={
+                          Object {
+                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                          }
+                        }
                       >
                         
                       </i>
@@ -530,6 +535,11 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                             }
                         data-icon-name="StatusCircleCheckmark"
                         role="presentation"
+                        style={
+                          Object {
+                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                          }
+                        }
                       >
                         
                       </i>
@@ -1257,6 +1267,11 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -1296,6 +1311,11 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -1710,6 +1730,11 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -1749,6 +1774,11 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -2163,6 +2193,11 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -2202,6 +2237,11 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -2616,6 +2656,11 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -2655,6 +2700,11 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -3069,6 +3119,11 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -3108,6 +3163,11 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -3522,6 +3582,11 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -3561,6 +3626,11 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -3975,6 +4045,11 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -4014,6 +4089,11 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -4428,6 +4508,11 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -4467,6 +4552,11 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -4881,6 +4971,11 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -4920,6 +5015,11 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -5334,6 +5434,11 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -5373,6 +5478,11 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomColumns.Example.tsx.shot
@@ -281,6 +281,11 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                         }
                     data-icon-name="CircleRing"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -320,6 +325,11 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                         }
                     data-icon-name="StatusCircleCheckmark"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -802,6 +812,11 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -841,6 +856,11 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -1238,6 +1258,11 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -1277,6 +1302,11 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -1674,6 +1704,11 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -1713,6 +1748,11 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -2110,6 +2150,11 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -2149,6 +2194,11 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -2546,6 +2596,11 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -2585,6 +2640,11 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -2982,6 +3042,11 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -3021,6 +3086,11 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -3418,6 +3488,11 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -3457,6 +3532,11 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -3854,6 +3934,11 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -3893,6 +3978,11 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -4290,6 +4380,11 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -4329,6 +4424,11 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -4726,6 +4826,11 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -4765,6 +4870,11 @@ exports[`Component Examples renders DetailsList.CustomColumns.Example.tsx correc
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomFooter.Example.tsx.shot
@@ -281,6 +281,11 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                         }
                     data-icon-name="CircleRing"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -320,6 +325,11 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                         }
                     data-icon-name="StatusCircleCheckmark"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -1046,6 +1056,11 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -1085,6 +1100,11 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -1498,6 +1518,11 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -1537,6 +1562,11 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -1950,6 +1980,11 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -1989,6 +2024,11 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -2402,6 +2442,11 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -2441,6 +2486,11 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -2854,6 +2904,11 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -2893,6 +2948,11 @@ exports[`Component Examples renders DetailsList.CustomFooter.Example.tsx correct
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -281,6 +281,11 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                         }
                     data-icon-name="CircleRing"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -320,6 +325,11 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                         }
                     data-icon-name="StatusCircleCheckmark"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -428,6 +438,11 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                   }
               data-icon-name="ChevronRightMed"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons-3\\"",
+                }
+              }
             >
               
             </i>
@@ -1162,6 +1177,11 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                               }
                                           data-icon-name="CircleRing"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -1201,6 +1221,11 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                               }
                                           data-icon-name="StatusCircleCheckmark"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -1566,6 +1591,11 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                               }
                                           data-icon-name="CircleRing"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -1605,6 +1635,11 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                               }
                                           data-icon-name="StatusCircleCheckmark"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -1970,6 +2005,11 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                               }
                                           data-icon-name="CircleRing"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -2009,6 +2049,11 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                               }
                                           data-icon-name="StatusCircleCheckmark"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -2374,6 +2419,11 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                               }
                                           data-icon-name="CircleRing"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -2413,6 +2463,11 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                               }
                                           data-icon-name="StatusCircleCheckmark"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -2778,6 +2833,11 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                               }
                                           data-icon-name="CircleRing"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -2817,6 +2877,11 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                               }
                                           data-icon-name="StatusCircleCheckmark"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -3182,6 +3247,11 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                               }
                                           data-icon-name="CircleRing"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -3221,6 +3291,11 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                               }
                                           data-icon-name="StatusCircleCheckmark"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -3586,6 +3661,11 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                               }
                                           data-icon-name="CircleRing"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -3625,6 +3705,11 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                               }
                                           data-icon-name="StatusCircleCheckmark"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -3990,6 +4075,11 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                               }
                                           data-icon-name="CircleRing"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -4029,6 +4119,11 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                               }
                                           data-icon-name="StatusCircleCheckmark"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -4394,6 +4489,11 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                               }
                                           data-icon-name="CircleRing"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -4433,6 +4533,11 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                               }
                                           data-icon-name="StatusCircleCheckmark"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -4798,6 +4903,11 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                               }
                                           data-icon-name="CircleRing"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -4837,6 +4947,11 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                               }
                                           data-icon-name="StatusCircleCheckmark"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomRows.Example.tsx.shot
@@ -279,6 +279,11 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                         }
                     data-icon-name="CircleRing"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -318,6 +323,11 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                         }
                     data-icon-name="StatusCircleCheckmark"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -832,6 +842,11 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -871,6 +886,11 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -1227,6 +1247,11 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -1266,6 +1291,11 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -1623,6 +1653,11 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -1662,6 +1697,11 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -2018,6 +2058,11 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -2057,6 +2102,11 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -2414,6 +2464,11 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -2453,6 +2508,11 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -2809,6 +2869,11 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -2848,6 +2913,11 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -3205,6 +3275,11 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -3244,6 +3319,11 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -3600,6 +3680,11 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -3639,6 +3724,11 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -3996,6 +4086,11 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -4035,6 +4130,11 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -4391,6 +4491,11 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -4430,6 +4535,11 @@ exports[`Component Examples renders DetailsList.CustomRows.Example.tsx correctly
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -813,6 +813,11 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                           }
                       data-icon-name="Page"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
                     >
                       
                     </i>
@@ -1021,6 +1026,11 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                         }
                     data-icon-name="SortUp"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -816,6 +816,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                             }
                         data-icon-name="CircleRing"
                         role="presentation"
+                        style={
+                          Object {
+                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                          }
+                        }
                       >
                         
                       </i>
@@ -855,6 +860,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                             }
                         data-icon-name="StatusCircleCheckmark"
                         role="presentation"
+                        style={
+                          Object {
+                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                          }
+                        }
                       >
                         
                       </i>
@@ -1114,6 +1124,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                   data-is-focusable={false}
                   data-sizer-index={1}
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons-15\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -1454,6 +1469,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -1493,6 +1513,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -1851,6 +1876,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -1890,6 +1920,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -2248,6 +2283,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -2287,6 +2327,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -2645,6 +2690,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -2684,6 +2734,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -3042,6 +3097,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -3081,6 +3141,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -3439,6 +3504,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -3478,6 +3548,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -3836,6 +3911,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -3875,6 +3955,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -4233,6 +4318,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -4272,6 +4362,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -4630,6 +4725,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -4669,6 +4769,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -5027,6 +5132,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -5066,6 +5176,11 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -682,6 +682,11 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                           }
                       data-icon-name="CircleRing"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
                     >
                       
                     </i>
@@ -721,6 +726,11 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                           }
                       data-icon-name="StatusCircleCheckmark"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
                     >
                       
                     </i>
@@ -829,6 +839,11 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                     }
                 data-icon-name="ChevronRightMed"
                 role="presentation"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons-3\\"",
+                  }
+                }
               >
                 
               </i>
@@ -1426,6 +1441,11 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         }
                                     data-icon-name="CircleRing"
                                     role="presentation"
+                                    style={
+                                      Object {
+                                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                                      }
+                                    }
                                   >
                                     
                                   </i>
@@ -1465,6 +1485,11 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         }
                                     data-icon-name="StatusCircleCheckmark"
                                     role="presentation"
+                                    style={
+                                      Object {
+                                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                                      }
+                                    }
                                   >
                                     
                                   </i>
@@ -1886,6 +1911,11 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                                 }
                                             data-icon-name="CircleRing"
                                             role="presentation"
+                                            style={
+                                              Object {
+                                                "fontFamily": "\\"FabricMDL2Icons\\"",
+                                              }
+                                            }
                                           >
                                             
                                           </i>
@@ -1925,6 +1955,11 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                                 }
                                             data-icon-name="StatusCircleCheckmark"
                                             role="presentation"
+                                            style={
+                                              Object {
+                                                "fontFamily": "\\"FabricMDL2Icons\\"",
+                                              }
+                                            }
                                           >
                                             
                                           </i>
@@ -2355,6 +2390,11 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                                 }
                                             data-icon-name="CircleRing"
                                             role="presentation"
+                                            style={
+                                              Object {
+                                                "fontFamily": "\\"FabricMDL2Icons\\"",
+                                              }
+                                            }
                                           >
                                             
                                           </i>
@@ -2394,6 +2434,11 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                                 }
                                             data-icon-name="StatusCircleCheckmark"
                                             role="presentation"
+                                            style={
+                                              Object {
+                                                "fontFamily": "\\"FabricMDL2Icons\\"",
+                                              }
+                                            }
                                           >
                                             
                                           </i>
@@ -2770,6 +2815,11 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         }
                                     data-icon-name="CircleRing"
                                     role="presentation"
+                                    style={
+                                      Object {
+                                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                                      }
+                                    }
                                   >
                                     
                                   </i>
@@ -2809,6 +2859,11 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         }
                                     data-icon-name="StatusCircleCheckmark"
                                     role="presentation"
+                                    style={
+                                      Object {
+                                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                                      }
+                                    }
                                   >
                                     
                                   </i>
@@ -3168,6 +3223,11 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         }
                                     data-icon-name="CircleRing"
                                     role="presentation"
+                                    style={
+                                      Object {
+                                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                                      }
+                                    }
                                   >
                                     
                                   </i>
@@ -3207,6 +3267,11 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                         }
                                     data-icon-name="StatusCircleCheckmark"
                                     role="presentation"
+                                    style={
+                                      Object {
+                                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                                      }
+                                    }
                                   >
                                     
                                   </i>
@@ -3628,6 +3693,11 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                                 }
                                             data-icon-name="CircleRing"
                                             role="presentation"
+                                            style={
+                                              Object {
+                                                "fontFamily": "\\"FabricMDL2Icons\\"",
+                                              }
+                                            }
                                           >
                                             
                                           </i>
@@ -3667,6 +3737,11 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                                 }
                                             data-icon-name="StatusCircleCheckmark"
                                             role="presentation"
+                                            style={
+                                              Object {
+                                                "fontFamily": "\\"FabricMDL2Icons\\"",
+                                              }
+                                            }
                                           >
                                             
                                           </i>
@@ -4097,6 +4172,11 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                                 }
                                             data-icon-name="CircleRing"
                                             role="presentation"
+                                            style={
+                                              Object {
+                                                "fontFamily": "\\"FabricMDL2Icons\\"",
+                                              }
+                                            }
                                           >
                                             
                                           </i>
@@ -4136,6 +4216,11 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                                 }
                                             data-icon-name="StatusCircleCheckmark"
                                             role="presentation"
+                                            style={
+                                              Object {
+                                                "fontFamily": "\\"FabricMDL2Icons\\"",
+                                              }
+                                            }
                                           >
                                             
                                           </i>
@@ -4566,6 +4651,11 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                                 }
                                             data-icon-name="CircleRing"
                                             role="presentation"
+                                            style={
+                                              Object {
+                                                "fontFamily": "\\"FabricMDL2Icons\\"",
+                                              }
+                                            }
                                           >
                                             
                                           </i>
@@ -4605,6 +4695,11 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                                                 }
                                             data-icon-name="StatusCircleCheckmark"
                                             role="presentation"
+                                            style={
+                                              Object {
+                                                "fontFamily": "\\"FabricMDL2Icons\\"",
+                                              }
+                                            }
                                           >
                                             
                                           </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -281,6 +281,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                         }
                     data-icon-name="CircleRing"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -320,6 +325,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                         }
                     data-icon-name="StatusCircleCheckmark"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -428,6 +438,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                   }
               data-icon-name="ChevronRightMed"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons-3\\"",
+                }
+              }
             >
               
             </i>
@@ -1081,6 +1096,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       }
                                   data-icon-name="CircleRing"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -1120,6 +1140,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                       }
                                   data-icon-name="StatusCircleCheckmark"
                                   role="presentation"
+                                  style={
+                                    Object {
+                                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                                    }
+                                  }
                                 >
                                   
                                 </i>
@@ -1541,6 +1566,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                               }
                                           data-icon-name="CircleRing"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -1580,6 +1610,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                               }
                                           data-icon-name="StatusCircleCheckmark"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -2002,6 +2037,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                               }
                                           data-icon-name="CircleRing"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -2041,6 +2081,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                               }
                                           data-icon-name="StatusCircleCheckmark"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -2463,6 +2508,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                               }
                                           data-icon-name="CircleRing"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -2502,6 +2552,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                               }
                                           data-icon-name="StatusCircleCheckmark"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -2924,6 +2979,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                               }
                                           data-icon-name="CircleRing"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -2963,6 +3023,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                               }
                                           data-icon-name="StatusCircleCheckmark"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -3385,6 +3450,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                               }
                                           data-icon-name="CircleRing"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -3424,6 +3494,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                               }
                                           data-icon-name="StatusCircleCheckmark"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -3846,6 +3921,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                               }
                                           data-icon-name="CircleRing"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -3885,6 +3965,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                               }
                                           data-icon-name="StatusCircleCheckmark"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -4307,6 +4392,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                               }
                                           data-icon-name="CircleRing"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -4346,6 +4436,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                               }
                                           data-icon-name="StatusCircleCheckmark"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -4768,6 +4863,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                               }
                                           data-icon-name="CircleRing"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -4807,6 +4907,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                               }
                                           data-icon-name="StatusCircleCheckmark"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -5229,6 +5334,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                               }
                                           data-icon-name="CircleRing"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -5268,6 +5378,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                               }
                                           data-icon-name="StatusCircleCheckmark"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -5690,6 +5805,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                               }
                                           data-icon-name="CircleRing"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>
@@ -5729,6 +5849,11 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                                               }
                                           data-icon-name="StatusCircleCheckmark"
                                           role="presentation"
+                                          style={
+                                            Object {
+                                              "fontFamily": "\\"FabricMDL2Icons\\"",
+                                            }
+                                          }
                                         >
                                           
                                         </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -281,6 +281,11 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                         }
                     data-icon-name="CircleRing"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -320,6 +325,11 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                         }
                     data-icon-name="StatusCircleCheckmark"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -934,6 +944,11 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -973,6 +988,11 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -1450,6 +1470,11 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -1489,6 +1514,11 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -1966,6 +1996,11 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -2005,6 +2040,11 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -2482,6 +2522,11 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -2521,6 +2566,11 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -2998,6 +3048,11 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -3037,6 +3092,11 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -3514,6 +3574,11 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -3553,6 +3618,11 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -4030,6 +4100,11 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -4069,6 +4144,11 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -4546,6 +4626,11 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -4585,6 +4670,11 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -5062,6 +5152,11 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   }
                               data-icon-name="CircleRing"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>
@@ -5101,6 +5196,11 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   }
                               data-icon-name="StatusCircleCheckmark"
                               role="presentation"
+                              style={
+                                Object {
+                                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                                }
+                              }
                             >
                               
                             </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
@@ -745,6 +745,11 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
                 }
             data-icon-name="Share"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
           >
             
           </i>
@@ -891,6 +896,11 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
                 }
             data-icon-name="Pin"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons-0\\"",
+              }
+            }
           >
             
           </i>
@@ -1037,6 +1047,11 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
                 }
             data-icon-name="Ringer"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons-4\\"",
+              }
+            }
           >
             
           </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
@@ -421,6 +421,11 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
                 }
             data-icon-name="Info"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
           >
             
           </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
@@ -854,6 +854,11 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                     }
                 data-icon-name="ChevronDown"
                 role="presentation"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
               >
                 
               </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Basic.Example.tsx.shot
@@ -310,6 +310,11 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                           }
                       data-icon-name="CircleRing"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
                     >
                       
                     </i>
@@ -349,6 +354,11 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                           }
                       data-icon-name="StatusCircleCheckmark"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
                     >
                       
                     </i>
@@ -805,6 +815,11 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -844,6 +859,11 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -1199,6 +1219,11 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -1238,6 +1263,11 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -1593,6 +1623,11 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -1632,6 +1667,11 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -1987,6 +2027,11 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2026,6 +2071,11 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2381,6 +2431,11 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2420,6 +2475,11 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2775,6 +2835,11 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2814,6 +2879,11 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3169,6 +3239,11 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3208,6 +3283,11 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3563,6 +3643,11 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3602,6 +3687,11 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3957,6 +4047,11 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3996,6 +4091,11 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -4351,6 +4451,11 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -4390,6 +4495,11 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.EventListenerTarget.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.EventListenerTarget.Example.tsx.shot
@@ -156,6 +156,11 @@ exports[`Component Examples renders HoverCard.EventListenerTarget.Example.tsx co
               }
           data-icon-name="Emoji2"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons-0\\"",
+            }
+          }
         >
           
         </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.PlainCard.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.PlainCard.Example.tsx.shot
@@ -307,6 +307,11 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                           }
                       data-icon-name="CircleRing"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
                     >
                       
                     </i>
@@ -346,6 +351,11 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                           }
                       data-icon-name="StatusCircleCheckmark"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
                     >
                       
                     </i>
@@ -802,6 +812,11 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -841,6 +856,11 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -1217,6 +1237,11 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -1256,6 +1281,11 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -1632,6 +1662,11 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -1671,6 +1706,11 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2047,6 +2087,11 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2086,6 +2131,11 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2462,6 +2512,11 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2501,6 +2556,11 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2877,6 +2937,11 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2916,6 +2981,11 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3292,6 +3362,11 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3331,6 +3406,11 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3707,6 +3787,11 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3746,6 +3831,11 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -4122,6 +4212,11 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -4161,6 +4256,11 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -4537,6 +4637,11 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -4576,6 +4681,11 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Target.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Target.Example.tsx.shot
@@ -311,6 +311,11 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                           }
                       data-icon-name="CircleRing"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
                     >
                       
                     </i>
@@ -350,6 +355,11 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                           }
                       data-icon-name="StatusCircleCheckmark"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons\\"",
+                        }
+                      }
                     >
                       
                     </i>
@@ -806,6 +816,11 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -845,6 +860,11 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -1219,6 +1239,11 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -1258,6 +1283,11 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -1632,6 +1662,11 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -1671,6 +1706,11 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2045,6 +2085,11 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2084,6 +2129,11 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2458,6 +2508,11 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2497,6 +2552,11 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2871,6 +2931,11 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -2910,6 +2975,11 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3284,6 +3354,11 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3323,6 +3398,11 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3697,6 +3777,11 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -3736,6 +3821,11 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -4110,6 +4200,11 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -4149,6 +4244,11 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -4523,6 +4623,11 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                     }
                                 data-icon-name="CircleRing"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>
@@ -4562,6 +4667,11 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
                                     }
                                 data-icon-name="StatusCircleCheckmark"
                                 role="presentation"
+                                style={
+                                  Object {
+                                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                                  }
+                                }
                               >
                                 
                               </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Icon.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Icon.Basic.Example.tsx.shot
@@ -28,6 +28,11 @@ exports[`Component Examples renders Icon.Basic.Example.tsx correctly 1`] = `
         }
     data-icon-name="CompassNW"
     role="presentation"
+    style={
+      Object {
+        "fontFamily": "\\"FabricMDL2Icons-2\\"",
+      }
+    }
   >
     
   </i>
@@ -57,6 +62,11 @@ exports[`Component Examples renders Icon.Basic.Example.tsx correctly 1`] = `
         }
     data-icon-name="Dictionary"
     role="presentation"
+    style={
+      Object {
+        "fontFamily": "\\"FabricMDL2Icons-1\\"",
+      }
+    }
   >
     
   </i>
@@ -86,6 +96,11 @@ exports[`Component Examples renders Icon.Basic.Example.tsx correctly 1`] = `
         }
     data-icon-name="TrainSolid"
     role="presentation"
+    style={
+      Object {
+        "fontFamily": "\\"FabricMDL2Icons-4\\"",
+      }
+    }
   >
     
   </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Icon.Color.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Icon.Color.Example.tsx.shot
@@ -29,6 +29,11 @@ exports[`Component Examples renders Icon.Color.Example.tsx correctly 1`] = `
         }
     data-icon-name="CompassNW"
     role="presentation"
+    style={
+      Object {
+        "fontFamily": "\\"FabricMDL2Icons-2\\"",
+      }
+    }
   >
     
   </i>
@@ -59,6 +64,11 @@ exports[`Component Examples renders Icon.Color.Example.tsx correctly 1`] = `
         }
     data-icon-name="Dictionary"
     role="presentation"
+    style={
+      Object {
+        "fontFamily": "\\"FabricMDL2Icons-1\\"",
+      }
+    }
   >
     
   </i>
@@ -89,6 +99,11 @@ exports[`Component Examples renders Icon.Color.Example.tsx correctly 1`] = `
         }
     data-icon-name="TrainSolid"
     role="presentation"
+    style={
+      Object {
+        "fontFamily": "\\"FabricMDL2Icons-4\\"",
+      }
+    }
   >
     
   </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Icon.Svg.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Icon.Svg.Example.tsx.shot
@@ -20,6 +20,11 @@ exports[`Component Examples renders Icon.Svg.Example.tsx correctly 1`] = `
         }
     data-icon-name="onedrive-svg"
     role="presentation"
+    style={
+      Object {
+        "fontFamily": undefined,
+      }
+    }
   >
     <svg
       viewBox="0,0,2048,2048"
@@ -66,6 +71,11 @@ exports[`Component Examples renders Icon.Svg.Example.tsx correctly 1`] = `
         }
     data-icon-name="yammer-svg"
     role="presentation"
+    style={
+      Object {
+        "fontFamily": undefined,
+      }
+    }
   >
     <svg
       viewBox="0,0,2048,2048"
@@ -118,6 +128,11 @@ exports[`Component Examples renders Icon.Svg.Example.tsx correctly 1`] = `
         }
     data-icon-name="borderblinds-svg"
     role="presentation"
+    style={
+      Object {
+        "fontFamily": undefined,
+      }
+    }
   >
     <svg
       style={

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -847,6 +847,11 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                           }
                       data-icon-name="ChevronUpSmall"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                        }
+                      }
                     >
                       
                     </i>
@@ -985,6 +990,11 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                           }
                       data-icon-name="ChevronDownSmall"
                       role="presentation"
+                      style={
+                        Object {
+                          "fontFamily": "\\"FabricMDL2Icons-3\\"",
+                        }
+                      }
                     >
                       
                     </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
@@ -451,6 +451,11 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
               }
           data-icon-name="ChevronDown"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
         >
           
         </i>
@@ -762,6 +767,11 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
                   }
               data-icon-name="ChevronDown"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
             >
               
             </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.CommandBar.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.CommandBar.Example.tsx.shot
@@ -214,6 +214,11 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
                         }
                     data-icon-name="Add"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -394,6 +399,11 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
                         }
                     data-icon-name="Upload"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -593,6 +603,11 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
                         }
                     data-icon-name="SortLines"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>
@@ -653,6 +668,11 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
                         }
                     data-icon-name="ChevronDown"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons\\"",
+                      }
+                    }
                   >
                     
                   </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Overflow.Example.tsx.shot
@@ -603,6 +603,11 @@ exports[`Component Examples renders Keytips.Overflow.Example.tsx correctly 1`] =
                 }
             data-icon-name="More"
             role="presentation"
+            style={
+              Object {
+                "fontFamily": "\\"FabricMDL2Icons\\"",
+              }
+            }
           >
             
           </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
@@ -1391,6 +1391,11 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                         }
                     data-icon-name="News"
                     role="presentation"
+                    style={
+                      Object {
+                        "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                      }
+                    }
                   >
                     
                   </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Basic.Example.tsx.shot
@@ -382,6 +382,11 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
               }
           data-icon-name="More"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
         >
           
         </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
@@ -320,6 +320,11 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
               }
           data-icon-name="Add"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
         >
           
         </i>
@@ -379,6 +384,11 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
               }
           data-icon-name="ChevronDown"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
         >
           
         </i>
@@ -528,6 +538,11 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
               }
           data-icon-name="Upload"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
         >
           
         </i>
@@ -702,6 +717,11 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
               }
           data-icon-name="Share"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
         >
           
         </i>
@@ -883,6 +903,11 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
               }
           data-icon-name="More"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
         >
           
         </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Vertical.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Vertical.Example.tsx.shot
@@ -166,6 +166,11 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
               }
           data-icon-name="Add"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
         >
           
         </i>
@@ -316,6 +321,11 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
               }
           data-icon-name="Upload"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
         >
           
         </i>
@@ -466,6 +476,11 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
               }
           data-icon-name="Share"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
         >
           
         </i>
@@ -620,6 +635,11 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
               }
           data-icon-name="More"
           role="presentation"
+          style={
+            Object {
+              "fontFamily": "\\"FabricMDL2Icons\\"",
+            }
+          }
         >
           
         </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.SeparateNoSelectedKey.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.SeparateNoSelectedKey.Example.tsx.shot
@@ -663,6 +663,7 @@ exports[`Component Examples renders Pivot.SeparateNoSelectedKey.Example.tsx corr
           style={
             Object {
               "color": "blue",
+              "fontFamily": "\\"FabricMDL2Icons\\"",
             }
           }
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -186,6 +186,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       }
                   data-icon-name="Add"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -359,6 +364,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       }
                   data-icon-name="Share"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -532,6 +542,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       }
                   data-icon-name="Upload"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -705,6 +720,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       }
                   data-icon-name="Add"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -878,6 +898,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       }
                   data-icon-name="Share"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -1051,6 +1076,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       }
                   data-icon-name="Upload"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -1224,6 +1254,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       }
                   data-icon-name="Add"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -1397,6 +1432,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       }
                   data-icon-name="Share"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -1570,6 +1610,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       }
                   data-icon-name="Upload"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -1743,6 +1788,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       }
                   data-icon-name="Add"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -1916,6 +1966,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       }
                   data-icon-name="Share"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -2089,6 +2144,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       }
                   data-icon-name="Upload"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -2262,6 +2322,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       }
                   data-icon-name="Add"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -2435,6 +2500,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       }
                   data-icon-name="Share"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -2608,6 +2678,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       }
                   data-icon-name="Upload"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -2781,6 +2856,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       }
                   data-icon-name="Add"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -2954,6 +3034,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       }
                   data-icon-name="Share"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -3127,6 +3212,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       }
                   data-icon-name="Upload"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -3300,6 +3390,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       }
                   data-icon-name="Add"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>
@@ -3473,6 +3568,11 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                       }
                   data-icon-name="Share"
                   role="presentation"
+                  style={
+                    Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
+                    }
+                  }
                 >
                   
                 </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.VerticalOverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.VerticalOverflowSet.Example.tsx.shot
@@ -189,6 +189,11 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                     }
                 data-icon-name="Add"
                 role="presentation"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
               >
                 
               </i>
@@ -363,6 +368,11 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                     }
                 data-icon-name="Share"
                 role="presentation"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
               >
                 
               </i>
@@ -537,6 +547,11 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                     }
                 data-icon-name="Upload"
                 role="presentation"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
               >
                 
               </i>
@@ -711,6 +726,11 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                     }
                 data-icon-name="Add"
                 role="presentation"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
               >
                 
               </i>
@@ -885,6 +905,11 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                     }
                 data-icon-name="Share"
                 role="presentation"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
               >
                 
               </i>
@@ -1059,6 +1084,11 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                     }
                 data-icon-name="Upload"
                 role="presentation"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
               >
                 
               </i>
@@ -1233,6 +1263,11 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                     }
                 data-icon-name="Add"
                 role="presentation"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
               >
                 
               </i>
@@ -1407,6 +1442,11 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                     }
                 data-icon-name="Share"
                 role="presentation"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
               >
                 
               </i>
@@ -1581,6 +1621,11 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                     }
                 data-icon-name="Upload"
                 role="presentation"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
               >
                 
               </i>
@@ -1755,6 +1800,11 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                     }
                 data-icon-name="Add"
                 role="presentation"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
               >
                 
               </i>
@@ -1929,6 +1979,11 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                     }
                 data-icon-name="Share"
                 role="presentation"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
               >
                 
               </i>
@@ -2103,6 +2158,11 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                     }
                 data-icon-name="Upload"
                 role="presentation"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
               >
                 
               </i>
@@ -2277,6 +2337,11 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                     }
                 data-icon-name="Add"
                 role="presentation"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
               >
                 
               </i>
@@ -2451,6 +2516,11 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                     }
                 data-icon-name="Share"
                 role="presentation"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
               >
                 
               </i>
@@ -2625,6 +2695,11 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                     }
                 data-icon-name="Upload"
                 role="presentation"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
               >
                 
               </i>
@@ -2799,6 +2874,11 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                     }
                 data-icon-name="Add"
                 role="presentation"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
               >
                 
               </i>
@@ -2973,6 +3053,11 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                     }
                 data-icon-name="Share"
                 role="presentation"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
               >
                 
               </i>
@@ -3147,6 +3232,11 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                     }
                 data-icon-name="Upload"
                 role="presentation"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
               >
                 
               </i>
@@ -3321,6 +3411,11 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                     }
                 data-icon-name="Add"
                 role="presentation"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
               >
                 
               </i>
@@ -3495,6 +3590,11 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                     }
                 data-icon-name="Share"
                 role="presentation"
+                style={
+                  Object {
+                    "fontFamily": "\\"FabricMDL2Icons\\"",
+                  }
+                }
               >
                 
               </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SelectedPeopleList.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SelectedPeopleList.Controlled.Example.tsx.shot
@@ -315,6 +315,7 @@ exports[`Component Examples renders SelectedPeopleList.Controlled.Example.tsx co
                   role="presentation"
                   style={
                     Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
                       "fontSize": "14px",
                     }
                   }
@@ -633,6 +634,7 @@ exports[`Component Examples renders SelectedPeopleList.Controlled.Example.tsx co
                   role="presentation"
                   style={
                     Object {
+                      "fontFamily": "\\"FabricMDL2Icons\\"",
                       "fontSize": "14px",
                     }
                   }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
@@ -429,6 +429,11 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                             }
                         data-icon-name="Page"
                         role="presentation"
+                        style={
+                          Object {
+                            "fontFamily": "\\"FabricMDL2Icons\\"",
+                          }
+                        }
                       >
                         
                       </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Basic.Example.tsx.shot
@@ -302,6 +302,11 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
                   }
               data-icon-name="ChevronUpSmall"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                }
+              }
             >
               
             </i>
@@ -441,6 +446,11 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
                   }
               data-icon-name="ChevronDownSmall"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons-3\\"",
+                }
+              }
             >
               
             </i>
@@ -721,6 +731,11 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
                   }
               data-icon-name="ChevronUpSmall"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                }
+              }
             >
               
             </i>
@@ -860,6 +875,11 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
                   }
               data-icon-name="ChevronDownSmall"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons-3\\"",
+                }
+              }
             >
               
             </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
@@ -291,6 +291,11 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
                   }
               data-icon-name="ChevronUpSmall"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                }
+              }
             >
               
             </i>
@@ -432,6 +437,11 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
                   }
               data-icon-name="ChevronDownSmall"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons-3\\"",
+                }
+              }
             >
               
             </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithEndPosition.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithEndPosition.Example.tsx.shot
@@ -302,6 +302,11 @@ exports[`Component Examples renders SpinButton.BasicWithEndPosition.Example.tsx 
                   }
               data-icon-name="ChevronUpSmall"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                }
+              }
             >
               
             </i>
@@ -441,6 +446,11 @@ exports[`Component Examples renders SpinButton.BasicWithEndPosition.Example.tsx 
                   }
               data-icon-name="ChevronDownSmall"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons-3\\"",
+                }
+              }
             >
               
             </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIcon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIcon.Example.tsx.shot
@@ -302,6 +302,11 @@ exports[`Component Examples renders SpinButton.BasicWithIcon.Example.tsx correct
                   }
               data-icon-name="ChevronUpSmall"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                }
+              }
             >
               
             </i>
@@ -441,6 +446,11 @@ exports[`Component Examples renders SpinButton.BasicWithIcon.Example.tsx correct
                   }
               data-icon-name="ChevronDownSmall"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons-3\\"",
+                }
+              }
             >
               
             </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
@@ -314,6 +314,11 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
                   }
               data-icon-name="ChevronUpSmall"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                }
+              }
             >
               
             </i>
@@ -455,6 +460,11 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
                   }
               data-icon-name="ChevronDownSmall"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons-3\\"",
+                }
+              }
             >
               
             </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.CustomStyled.Example.tsx.shot
@@ -274,6 +274,11 @@ exports[`Component Examples renders SpinButton.CustomStyled.Example.tsx correctl
                   }
               data-icon-name="ChevronUpSmall"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                }
+              }
             >
               
             </i>
@@ -413,6 +418,11 @@ exports[`Component Examples renders SpinButton.CustomStyled.Example.tsx correctl
                   }
               data-icon-name="ChevronDownSmall"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons-3\\"",
+                }
+              }
             >
               
             </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Stateful.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Stateful.Example.tsx.shot
@@ -280,6 +280,11 @@ exports[`Component Examples renders SpinButton.Stateful.Example.tsx correctly 1`
                   }
               data-icon-name="ChevronUpSmall"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons-2\\"",
+                }
+              }
             >
               
             </i>
@@ -419,6 +424,11 @@ exports[`Component Examples renders SpinButton.Stateful.Example.tsx correctly 1`
                   }
               data-icon-name="ChevronDownSmall"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons-3\\"",
+                }
+              }
             >
               
             </i>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
@@ -201,6 +201,11 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                   }
               data-icon-name="Info"
               role="presentation"
+              style={
+                Object {
+                  "fontFamily": "\\"FabricMDL2Icons\\"",
+                }
+              }
             >
               
             </i>

--- a/packages/styling/etc/styling.api.md
+++ b/packages/styling/etc/styling.api.md
@@ -343,8 +343,6 @@ export interface IIconOptions {
 export interface IIconRecord {
     // (undocumented)
     code: string | undefined;
-    // Warning: (ae-forgotten-export) The symbol "IIconSubsetRecord" needs to be exported by the entry point index.d.ts
-    // 
     // (undocumented)
     subset: IIconSubsetRecord;
 }
@@ -359,6 +357,14 @@ export interface IIconSubset {
     };
     // (undocumented)
     style?: IRawStyle;
+}
+
+// @public (undocumented)
+export interface IIconSubsetRecord extends IIconSubset {
+    // (undocumented)
+    className?: string;
+    // (undocumented)
+    isRegistered?: boolean;
 }
 
 export { InjectionMode }

--- a/packages/styling/src/utilities/index.ts
+++ b/packages/styling/src/utilities/index.ts
@@ -3,6 +3,7 @@ export { buildClassMap } from './buildClassMap';
 export {
   IIconRecord,
   IIconSubset,
+  IIconSubsetRecord,
   IIconOptions,
   getIcon,
   registerIcons,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10449
- [x] Include a change request file using `$ yarn change`

#### Description of changes

In `FontIcon`, apply the proper Fabric React icon `fontFamily` using the element's `style` prop (rather than a className) to ensure that the correct font always takes precedence. This means that even if a mismatched Fabric Core version is present on the page, its `ms-Icon` font family won't override the one defined for Fabric React icons.

#### Background

When I added the optimized `FontIcon` and `ImageIcon`, I gave them the className `ms-Icon` to provide a way to target them for customization (as an optimization, the new icons can't be targeted the standard way through `scopedSettings`). 

This unexpectedly created problems because while Fabric React doesn't directly apply any styling using the `ms-Icon` class, Fabric Core does, creating potential `font-family` conflicts. If an icon was available in Fabric React's icon font, but some version of Fabric Core which did **not** have that icon yet was loaded on the page first, the outdated `font-family` defined for `ms-Icon` in Fabric Core would be applied to the Fabric React icon and prevent the icon character from displaying.

Potential downside of applying the proper `font-family` using `style` is that it can't be overridden using normal CSS styles. But I don't think that's a big concern in this case because if someone wants to change the font family for Fabric React icons, they should be doing that through `registerIcons`/`initializeIcons`.

This workaround is only necessary in `FontIcon`. Traditional `Icon` doesn't have the issue because it doesn't use `ms-Icon`, and `ImageIcon` doesn't practically have the issue because it doesn't depend on fonts.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11524)