### PR TITLE
Fix Link colors inside MessageBar

### DIFF
--- a/change/@uifabric-example-app-base-2019-12-19-17-16-23-messagebar-website.json
+++ b/change/@uifabric-example-app-base-2019-12-19-17-16-23-messagebar-website.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix Link colors inside MessageBar",
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com",
+  "commit": "30b8026fbfad792779bf9a895b35475e59656f5f",
+  "date": "2019-12-20T01:16:23.246Z"
+}

--- a/packages/example-app-base/src/components/Page/Page.module.scss
+++ b/packages/example-app-base/src/components/Page/Page.module.scss
@@ -24,6 +24,19 @@ $usageListPadding: 24px;
       color: $linkHoveredColor;
     }
   }
+
+  :global(.ms-MessageBar) a:global(.ms-Link) {
+    // Link colors need to be darker inside MessageBar
+    color: $ms-color-themeDark;
+    &:link {
+      color: $ms-color-themeDark;
+    }
+    &:active,
+    &:hover,
+    &:active:hover {
+      color: $linkHoveredColor;
+    }
+  }
 }
 
 .section {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10647
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Link colors need to be darker inside MessageBar on the website.

Before:

![image](https://user-images.githubusercontent.com/1434956/71298282-402e2f80-233c-11ea-8e81-1acee7b55f1a.png)

After:

![image](https://user-images.githubusercontent.com/1434956/71298286-47553d80-233c-11ea-9cb5-7db5d266637d.png)



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11525)