### PR TITLE
SwatchColorPicker: properly apply ID; naming and doc updates

### DIFF
--- a/change/office-ui-fabric-react-2019-12-19-18-19-03-swatch-id.json
+++ b/change/office-ui-fabric-react-2019-12-19-18-19-03-swatch-id.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "SwatchColorPicker: properly apply ID; doc updates",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "commit": "7be84c9391cdbc832cca9f4325b2814b2c92bcdf",
+  "date": "2019-12-20T02:19:03.368Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -612,7 +612,7 @@ export const ColorPickerGridCell: React.StatelessComponent<IColorPickerGridCellP
 // @public (undocumented)
 export class ColorPickerGridCellBase extends React.PureComponent<IColorPickerGridCellProps, {}> {
     // (undocumented)
-    static defaultProps: IColorPickerGridCellProps;
+    static defaultProps: Partial<IColorPickerGridCellProps>;
     // (undocumented)
     render(): JSX.Element;
 }
@@ -2485,17 +2485,24 @@ export interface IColorPickerGridCellProps {
     color?: string;
     disabled?: boolean;
     height?: number;
-    id: string;
+    // @deprecated
+    id?: string;
+    idPrefix?: string;
     index?: number;
     item: IColorCellProps;
     label?: string;
     onClick?: (item: IColorCellProps) => void;
+    // (undocumented)
     onFocus?: (item: IColorCellProps) => void;
+    // (undocumented)
     onHover?: (item?: IColorCellProps) => void;
+    // (undocumented)
     onKeyDown?: (ev: React.KeyboardEvent<HTMLButtonElement>) => void;
     onMouseEnter?: (ev: React.MouseEvent<HTMLButtonElement>) => boolean;
+    // (undocumented)
     onMouseLeave?: (ev: React.MouseEvent<HTMLButtonElement>) => void;
     onMouseMove?: (ev: React.MouseEvent<HTMLButtonElement>) => boolean;
+    // (undocumented)
     onWheel?: (ev: React.MouseEvent<HTMLButtonElement>) => void;
     selected: boolean;
     styles?: IStyleFunctionOrObject<IColorPickerGridCellStyleProps, IColorPickerGridCellStyles>;
@@ -2503,7 +2510,7 @@ export interface IColorPickerGridCellProps {
     width?: number;
 }
 
-// @public
+// @public (undocumented)
 export interface IColorPickerGridCellStyleProps {
     borderWidth?: number;
     circle?: boolean;
@@ -2515,7 +2522,7 @@ export interface IColorPickerGridCellStyleProps {
     width?: number;
 }
 
-// @public
+// @public (undocumented)
 export interface IColorPickerGridCellStyles {
     colorCell: IStyle;
     svg: IStyle;
@@ -4695,7 +4702,9 @@ export interface IGridCellProps<T> {
 }
 
 // @public (undocumented)
-export interface IGridProps {
+export interface IGridProps extends React.TableHTMLAttributes<HTMLTableElement> {
+    ariaPosInSet?: number;
+    ariaSetSize?: number;
     columnCount: number;
     componentRef?: IRefObject<IGrid>;
     // @deprecated
@@ -4704,7 +4713,9 @@ export interface IGridProps {
     items: any[];
     onBlur?: () => void;
     onRenderItem: (item: any, index: number) => JSX.Element;
+    // @deprecated (undocumented)
     positionInSet?: number;
+    // @deprecated (undocumented)
     setSize?: number;
     shouldFocusCircularNavigate?: boolean;
     styles?: IStyleFunctionOrObject<IGridStyleProps, IGridStyles>;
@@ -7379,6 +7390,8 @@ export function isValidShade(shade?: Shade): boolean;
 
 // @public (undocumented)
 export interface ISwatchColorPickerProps {
+    ariaPosInSet?: number;
+    ariaSetSize?: number;
     cellBorderWidth?: number;
     cellHeight?: number;
     cellMargin?: number;
@@ -7397,8 +7410,10 @@ export interface ISwatchColorPickerProps {
     onCellFocused?: (id?: string, color?: string) => void;
     onCellHovered?: (id?: string, color?: string) => void;
     onColorChanged?: (id?: string, color?: string) => void;
+    // @deprecated (undocumented)
     positionInSet?: number;
     selectedId?: string;
+    // @deprecated (undocumented)
     setSize?: number;
     shouldFocusCircularNavigate?: boolean;
     styles?: IStyleFunctionOrObject<ISwatchColorPickerStyleProps, ISwatchColorPickerStyles>;

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.base.tsx
@@ -61,18 +61,18 @@ const getClassNames = classNamesFunction<IColorPickerGridCellStyleProps, IColorP
 class ColorCell extends GridCell<IColorCellProps, IGridCellProps<IColorCellProps>> {}
 
 export class ColorPickerGridCellBase extends React.PureComponent<IColorPickerGridCellProps, {}> {
-  public static defaultProps = {
+  public static defaultProps: Partial<IColorPickerGridCellProps> = {
     circle: true,
     disabled: false,
     selected: false
-  } as IColorPickerGridCellProps;
+  };
 
   private _classNames: { [key in keyof IColorPickerGridCellStyles]: string };
 
   public render(): JSX.Element {
     const {
       item,
-      id,
+      idPrefix = this.props.id,
       selected,
       disabled,
       styles,
@@ -106,7 +106,7 @@ export class ColorPickerGridCellBase extends React.PureComponent<IColorPickerGri
     return (
       <ColorCell
         item={item}
-        id={`${id}-${item.id}-${item.index}`}
+        id={`${idPrefix}-${item.id}-${item.index}`}
         key={item.id}
         disabled={disabled}
         role={'gridcell'}

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/ColorPickerGridCell.types.ts
@@ -12,14 +12,18 @@ export interface IColorPickerGridCellProps {
   item: IColorCellProps;
 
   /**
-   * Arbitrary unique string associated with this option
+   * Used as a PREFIX for the cell's ID (the cell will not have this literal string as its ID).
+   * @deprecated Deprecated due to misleading name. Use `idPrefix` instead.
    */
-  id: string;
+  id?: string;
 
   /**
-   * The label for this item.
-   * Visible text if this item is a header,
-   * tooltip if is this item is normal
+   * Prefix for this cell's ID. Will be required in a future version once `id` is removed.
+   */
+  idPrefix?: string;
+
+  /**
+   * Tooltip and aria label for this item
    */
   label?: string;
 
@@ -39,17 +43,19 @@ export interface IColorPickerGridCellProps {
   theme?: ITheme;
 
   /**
-   * Wheter or not colorOption should be rendered as a circle or square.
+   * True if this cell should be rendered as a circle, false if it should be a square.
+   * @default `true` (render as circle)
    */
   circle?: boolean;
 
   /**
-   * Optional, if the this option should be disabled
+   * Whether this cell should be disabled
+   * @default false
    */
   disabled?: boolean;
 
   /**
-   * Optional, if the cell is currently selected
+   * Whether this cell is currently selected
    */
   selected: boolean;
 
@@ -67,56 +73,38 @@ export interface IColorPickerGridCellProps {
 
   /**
    * Width of the border that indicates a selected/hovered cell, in pixels.
-   * If `cellWidth` is less than 24px, then default value is 2px. Otherwise it defaults to 4px.
-   * @defaultvalue 2
+   * @defaultvalue 2 if `cellWidth` is less than 24; otherwise 4
    */
   borderWidth?: number;
 
   /**
-   * The on click handler
+   * Handler for when a color cell is clicked.
    */
   onClick?: (item: IColorCellProps) => void;
 
-  /**
-   * Optional, the onHover handler
-   */
   onHover?: (item?: IColorCellProps) => void;
 
-  /**
-   * Optional, the onFocus handler
-   */
   onFocus?: (item: IColorCellProps) => void;
 
   /**
-   * Optional styles for the component.
+   * Custom styles for the component.
    */
   styles?: IStyleFunctionOrObject<IColorPickerGridCellStyleProps, IColorPickerGridCellStyles>;
 
   /**
-   * Optional, mouseEnter handler.
-   * @returns true if the event should be processed, false otherwise
+   * Mouse enter handler. Returns true if the event should be processed, false otherwise.
    */
   onMouseEnter?: (ev: React.MouseEvent<HTMLButtonElement>) => boolean;
 
   /**
-   * Optional, mouseMove handler
-   * @returns true if the event should be processed, false otherwise
+   * Mouse move handler. Returns true if the event should be processed, false otherwise.
    */
   onMouseMove?: (ev: React.MouseEvent<HTMLButtonElement>) => boolean;
 
-  /**
-   * Optional, mouseLeave handler
-   */
   onMouseLeave?: (ev: React.MouseEvent<HTMLButtonElement>) => void;
 
-  /**
-   * Optional, onWheel handler
-   */
   onWheel?: (ev: React.MouseEvent<HTMLButtonElement>) => void;
 
-  /**
-   * Optional, onkeydown handler
-   */
   onKeyDown?: (ev: React.KeyboardEvent<HTMLButtonElement>) => void;
 }
 
@@ -130,9 +118,7 @@ export interface IColorCellProps {
   id: string;
 
   /**
-   * The label for this item.
-   * Visible text if this item is a header,
-   * tooltip if is this item is normal
+   * Tooltip and aria label for this item
    */
   label?: string;
 
@@ -148,7 +134,6 @@ export interface IColorCellProps {
 }
 
 /**
- * Properties required to build the styles for the color picker component.
  * {@docCategory SwatchColorPicker}
  */
 export interface IColorPickerGridCellStyleProps {
@@ -194,7 +179,6 @@ export interface IColorPickerGridCellStyleProps {
 }
 
 /**
- * Styles for the Color Picker Component.
  * {@docCategory SwatchColorPicker}
  */
 export interface IColorPickerGridCellStyles {

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
@@ -12,13 +12,15 @@ import { ISwatchColorPickerProps, ISwatchColorPickerStyleProps, ISwatchColorPick
 import { Grid } from '../../utilities/grid/Grid';
 import { IColorCellProps } from './ColorPickerGridCell.types';
 import { ColorPickerGridCell } from './ColorPickerGridCell';
-import { memoizeFunction } from '@uifabric/utilities';
+import { memoizeFunction, warnDeprecations } from '@uifabric/utilities';
 
 export interface ISwatchColorPickerState {
   selectedIndex?: number;
 }
 
 const getClassNames = classNamesFunction<ISwatchColorPickerStyleProps, ISwatchColorPickerStyles>();
+
+const COMPONENT_NAME = 'SwatchColorPicker';
 
 export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerProps, ISwatchColorPickerState> {
   public static defaultProps = {
@@ -49,17 +51,16 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
     this._id = props.id || getId('swatchColorPicker');
 
     if (process.env.NODE_ENV !== 'production') {
-      warnMutuallyExclusive('SwatchColorPicker', this.props, {
+      warnMutuallyExclusive(COMPONENT_NAME, props, {
         focusOnHover: 'onHover'
       });
 
-      warnConditionallyRequiredProps(
-        'SwatchColorPicker',
-        this.props,
-        ['focusOnHover'],
-        'mouseLeaveParentSelector',
-        !!this.props.mouseLeaveParentSelector
-      );
+      warnConditionallyRequiredProps(COMPONENT_NAME, props, ['focusOnHover'], 'mouseLeaveParentSelector', !!props.mouseLeaveParentSelector);
+
+      warnDeprecations(COMPONENT_NAME, props, {
+        positionInSet: 'ariaPosInSet',
+        setSize: 'ariaSetSize'
+      });
     }
 
     this.isNavigationIdle = true;
@@ -89,6 +90,7 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
       this._cellFocused = false;
       this.props.onCellFocused();
     }
+    this.async.dispose();
   }
 
   public render(): JSX.Element | null {
@@ -119,18 +121,17 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
         items={this._getItemsWithIndex(colorCells)}
         columnCount={columnCount}
         onRenderItem={this._renderOption}
-        positionInSet={positionInSet && positionInSet}
-        setSize={setSize && setSize}
+        ariaPosInSet={positionInSet}
+        ariaSetSize={setSize}
         shouldFocusCircularNavigate={shouldFocusCircularNavigate}
         doNotContainWithinFocusZone={doNotContainWithinFocusZone}
         onBlur={this._onSwatchColorPickerBlur}
         theme={this.props.theme!}
-        // tslint:disable-next-line:jsx-no-lambda
-        styles={props => ({
+        styles={{
           root: classNames.root,
           tableCell: classNames.tableCell,
           focusedContainer: classNames.focusedContainer
-        })}
+        }}
       />
     );
   }
@@ -163,29 +164,30 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
    * @returns - Element representing the item
    */
   private _renderOption = (item: IColorCellProps): JSX.Element => {
+    const props = this.props;
     const id = this._id;
 
     return (
       <ColorPickerGridCell
         item={item}
-        id={id}
+        idPrefix={id}
         color={item.color}
-        styles={this.props.getColorGridCellStyles}
-        disabled={this.props.disabled}
+        styles={props.getColorGridCellStyles}
+        disabled={props.disabled}
         onClick={this._onCellClick}
         onHover={this._onGridCellHovered}
         onFocus={this._onGridCellFocused}
         selected={this.state.selectedIndex !== undefined && this.state.selectedIndex === item.index}
-        circle={this.props.cellShape === 'circle'}
+        circle={props.cellShape === 'circle'}
         label={item.label}
         onMouseEnter={this._onMouseEnter}
         onMouseMove={this._onMouseMove}
         onMouseLeave={this._onMouseLeave}
         onWheel={this._onWheel}
         onKeyDown={this._onKeyDown}
-        height={this.props.cellHeight}
-        width={this.props.cellWidth}
-        borderWidth={this.props.cellBorderWidth}
+        height={props.cellHeight}
+        width={props.cellWidth}
+        borderWidth={props.cellBorderWidth}
       />
     );
   };
@@ -195,11 +197,7 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
    */
   private _onMouseEnter = (ev: React.MouseEvent<HTMLButtonElement>): boolean => {
     if (!this.props.focusOnHover) {
-      if (!this.isNavigationIdle || this.props.disabled) {
-        return true;
-      }
-
-      return false;
+      return !this.isNavigationIdle || !!this.props.disabled;
     }
 
     if (this.isNavigationIdle && !this.props.disabled) {
@@ -214,11 +212,7 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
    */
   private _onMouseMove = (ev: React.MouseEvent<HTMLButtonElement>): boolean => {
     if (!this.props.focusOnHover) {
-      if (!this.isNavigationIdle || this.props.disabled) {
-        return true;
-      }
-
-      return false;
+      return !this.isNavigationIdle || !!this.props.disabled;
     }
 
     const targetElement = ev.currentTarget as HTMLElement;

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.base.tsx
@@ -118,6 +118,7 @@ export class SwatchColorPickerBase extends React.Component<ISwatchColorPickerPro
     return (
       <Grid
         {...this.props}
+        id={this._id}
         items={this._getItemsWithIndex(colorCells)}
         columnCount={columnCount}
         onRenderItem={this._renderOption}

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.test.tsx
@@ -51,15 +51,8 @@ describe('SwatchColorPicker', () => {
   });
 
   it('Can execute a cell in non-collapsable swatch color picker ', () => {
-    let eventFireCounter = 0;
-    const wrapper = mount(
-      <SwatchColorPicker
-        colorCells={[{ id: 'a', label: 'green', color: '#00ff00' }]}
-        // tslint:disable-next-line:jsx-no-lambda
-        onColorChanged={color => eventFireCounter++}
-        columnCount={4}
-      />
-    );
+    const onChange = jest.fn();
+    const wrapper = mount(<SwatchColorPicker colorCells={[DEFAULT_OPTIONS[0]]} onColorChanged={onChange} columnCount={4} />);
 
     expectNodes(wrapper, '.ms-swatchColorPickerBodyContainer', 1);
     expectNodes(wrapper, '.ms-swatchColorPickerBodyContainer [role="gridcell"]', 1);
@@ -68,42 +61,28 @@ describe('SwatchColorPicker', () => {
       .find('.ms-swatchColorPickerBodyContainer [role="gridcell"]')
       .at(1)
       .simulate('click');
-    expect(eventFireCounter).toEqual(1);
+    expect(onChange).toHaveBeenCalledTimes(1);
   });
 
   it('Can fire the hover event on a cell in non-collapsable swatch color picker ', () => {
-    let eventFireCounter = 0;
-    const wrapper = mount(
-      <SwatchColorPicker
-        colorCells={[{ id: 'a', label: 'green', color: '#00ff00' }]}
-        // tslint:disable-next-line:jsx-no-lambda
-        onCellHovered={color => eventFireCounter++}
-        columnCount={4}
-      />
-    );
+    const onHover = jest.fn();
+    const wrapper = mount(<SwatchColorPicker colorCells={[DEFAULT_OPTIONS[0]]} onCellHovered={onHover} columnCount={4} />);
 
     wrapper
       .find('.ms-swatchColorPickerBodyContainer [role="gridcell"]')
       .at(0)
       .simulate('mouseenter');
-    expect(eventFireCounter).toEqual(1);
+    expect(onHover).toHaveBeenCalledTimes(1);
   });
 
   it('Can fire the focus event on a cell in non-collapsable swatch color picker ', () => {
-    let eventFireCounter = 0;
-    const wrapper = mount(
-      <SwatchColorPicker
-        colorCells={[{ id: 'a', label: 'green', color: '#00ff00' }]}
-        // tslint:disable-next-line:jsx-no-lambda
-        onCellFocused={color => eventFireCounter++}
-        columnCount={4}
-      />
-    );
+    const onFocus = jest.fn();
+    const wrapper = mount(<SwatchColorPicker colorCells={[DEFAULT_OPTIONS[0]]} onCellFocused={onFocus} columnCount={4} />);
 
     wrapper
       .find('.ms-swatchColorPickerBodyContainer [role="gridcell"]')
       .at(0)
       .simulate('focus');
-    expect(eventFireCounter).toEqual(1);
+    expect(onFocus).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/SwatchColorPicker.types.ts
@@ -7,12 +7,12 @@ import { IColorCellProps, IColorPickerGridCellStyleProps, IColorPickerGridCellSt
  */
 export interface ISwatchColorPickerProps {
   /**
-   * the number of columns for the swatch color picker
+   * Number of columns for the swatch color picker
    */
   columnCount: number;
 
   /**
-   * The id for the swatch color picker
+   * ID for the swatch color picker's root element. Also used as a prefix for the IDs of color cells.
    */
   id?: string;
 
@@ -22,21 +22,21 @@ export interface ISwatchColorPickerProps {
   className?: string;
 
   /**
-   * The shape of the color cells, defaults to circle
+   * The shape of the color cells.
+   * @default 'circle'
    */
   cellShape?: 'circle' | 'square';
 
   /**
-   * The id of color cell that is currently selected
+   * The ID of color cell that is currently selected
    */
   selectedId?: string;
 
   /**
    * The color cells that will be made available to the user.
    *
-   * Note: When the reference to this prop changes,
-   * regardless of how many color cells change, all of the color cells
-   * will be re-rendered (potentially bad perf.) because we memoize
+   * Note: When the reference to this prop changes, regardless of how many color cells change,
+   * all of the color cells will be re-rendered (potentially bad perf) because we memoize
    * based on this prop's reference.
    */
   colorCells: IColorCellProps[];
@@ -45,7 +45,7 @@ export interface ISwatchColorPickerProps {
    * Indicates whether the SwatchColorPicker is fully controlled.
    * When true, the component will not set its internal state to track the selected color.
    * Instead, the parent component will be responsible for handling state in the callbacks like
-   * onColorChanged.
+   * `onColorChanged`.
    *
    * NOTE: This property is a temporary workaround to force the component to be fully controllable
    * without breaking existing behavior
@@ -53,49 +53,60 @@ export interface ISwatchColorPickerProps {
   isControlled?: boolean;
 
   /**
-   * Callback issued when the user changes the color.
-   * Note, if no id or color is given, there is no selected cell
+   * Callback for when the user changes the color.
+   * If `id` and `color` are unspecified, there is no selected cell.
    * (e.g. the user executed the currently selected cell to unselect it)
    */
   onColorChanged?: (id?: string, color?: string) => void;
 
   /**
-   * Callback issued when the user hovers over a color cell.
-   * Note, if no id or color is given, cells are not longer being hovered
+   * Callback for when the user hovers over a color cell.
+   * If `id` and `color` are unspecified, cells are no longer being hovered.
    */
   onCellHovered?: (id?: string, color?: string) => void;
 
   /**
-   * Callback issued when the user focuses a color cell.
-   * Note, if no id or color is given, cells are not longer being focused
+   * Callback for when the user focuses a color cell.
+   * If `id` and `color` are unspecified, cells are no longer being focused.
    */
   onCellFocused?: (id?: string, color?: string) => void;
 
   /**
-   * Is this swatch color picker disabled?
+   * Whether the control is disabled.
    */
   disabled?: boolean;
 
   /**
-   * The optional position this grid is in the parent set (index in a parent menu, for example)
+   * Position this grid is in the parent set (index in a parent menu, for example)
+   */
+  ariaPosInSet?: number;
+
+  /**
+   * @deprecated Use `ariaPosInSet`
    */
   positionInSet?: number;
 
   /**
-   * The optional size of the parent set (size of parent menu, for example)
+   * Size of the parent set (size of parent menu, for example)
+   */
+  ariaSetSize?: number;
+
+  /**
+   * @deprecated Use `ariaSetSize`
    */
   setSize?: number;
 
   /**
-   * Should focus cycle to the beginning of once the user navigates past the end (and vice versa).
-   * This prop is only relevant if doNotcontainWithinFocusZone is not true
+   * Whether focus should cycle back to the beginning once the user navigates past the end (and vice versa).
+   * Only relevant if `doNotContainWithinFocusZone` is not true.
    * @defaultvalue true
    */
   shouldFocusCircularNavigate?: boolean;
 
   /**
-   * If true do not contain the grid inside of a FocusZone.
-   * If false contain the grid inside of a FocusZone.
+   * If false (the default), the grid is contained inside a FocusZone.
+   * If true, a FocusZone is not used.
+   * @default false
    */
   doNotContainWithinFocusZone?: boolean;
 
@@ -119,8 +130,7 @@ export interface ISwatchColorPickerProps {
 
   /**
    * Width of the border indicating a hovered/selected cell, in pixels
-   * If `cellWidth` is less than 24px, then default value is 2px. Otherwise it defaults to 4px.
-   * @defaultvalue 2
+   * @defaultvalue If `cellWidth` is less than 24px, then default value is 2px. Otherwise it defaults to 4px.
    */
   cellBorderWidth?: number;
 
@@ -130,24 +140,23 @@ export interface ISwatchColorPickerProps {
   theme?: ITheme;
 
   /**
-   * Optional styles for the component.
+   * Styles for the component.
    */
   styles?: IStyleFunctionOrObject<ISwatchColorPickerStyleProps, ISwatchColorPickerStyles>;
 
   /**
-   * Optional styles for the component.
+   * Styles for the grid cells.
    */
   getColorGridCellStyles?: IStyleFunctionOrObject<IColorPickerGridCellStyleProps, IColorPickerGridCellStyles>;
 
   /**
-   * Optional, whether to update focus when a cell is hovered.
+   * Whether to update focus when a cell is hovered.
    * @defaultvalue false
    */
   focusOnHover?: boolean;
 
   /**
-   * Selector to focus on mouseLeave
-   * SHOULD ONLY BE USED IN CONJUNCTION WITH focusOnHover
+   * Selector to focus on mouse leave. Should only be used in conjunction with `focusOnHover`.
    */
   mouseLeaveParentSelector?: string | undefined;
 }
@@ -179,7 +188,7 @@ export interface ISwatchColorPickerStyleProps {
  */
 export interface ISwatchColorPickerStyles {
   /**
-   * Style applied to the container grid of the swatchColorPicker
+   * Style applied to the container grid.
    */
   root: IStyle;
 
@@ -189,7 +198,7 @@ export interface ISwatchColorPickerStyles {
   tableCell: IStyle;
 
   /**
-   * Optional, style for the FocusZone container for the grid
+   * Style for the FocusZone container for the grid.
    */
   focusedContainer?: IStyle;
 }

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
@@ -13,7 +13,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
         display: block;
         min-width: 180px;
       }
-  data-focuszone-id="FocusZone3"
+  data-focuszone-id="FocusZone2"
   onBlur={[Function]}
   onFocus={[Function]}
   onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
@@ -34,8 +34,7 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
           padding-right: 2px;
           padding-top: 2px;
         }
-    id="id__2"
-    onBlur={[Function]}
+    id="swatchColorPicker1"
     role="grid"
   >
     <tbody>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SwatchColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SwatchColorPicker.Basic.Example.tsx.shot
@@ -17,7 +17,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
           display: block;
           min-width: 180px;
         }
-    data-focuszone-id="FocusZone2"
+    data-focuszone-id="FocusZone1"
     onBlur={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -914,7 +914,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
           display: block;
           min-width: 180px;
         }
-    data-focuszone-id="FocusZone20"
+    data-focuszone-id="FocusZone18"
     onBlur={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -935,7 +935,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             padding-right: 2px;
             padding-top: 2px;
           }
-      id="swatchColorPicker18"
+      id="swatchColorPicker17"
       role="grid"
     >
       <tbody>
@@ -1056,7 +1056,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
               data-index={0}
               data-is-focusable={true}
-              id="swatchColorPicker18-a-0"
+              id="swatchColorPicker17-a-0"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -1215,7 +1215,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
               data-index={1}
               data-is-focusable={true}
-              id="swatchColorPicker18-b-1"
+              id="swatchColorPicker17-b-1"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -1374,7 +1374,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
               data-index={2}
               data-is-focusable={true}
-              id="swatchColorPicker18-c-2"
+              id="swatchColorPicker17-c-2"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -1533,7 +1533,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
               data-index={3}
               data-is-focusable={true}
-              id="swatchColorPicker18-d-3"
+              id="swatchColorPicker17-d-3"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -1692,7 +1692,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
               data-index={4}
               data-is-focusable={true}
-              id="swatchColorPicker18-e-4"
+              id="swatchColorPicker17-e-4"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -1756,7 +1756,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
           display: block;
           min-width: 180px;
         }
-    data-focuszone-id="FocusZone38"
+    data-focuszone-id="FocusZone35"
     onBlur={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -1777,7 +1777,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             padding-right: 2px;
             padding-top: 2px;
           }
-      id="swatchColorPicker36"
+      id="swatchColorPicker34"
       role="grid"
     >
       <tbody>
@@ -1898,7 +1898,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
               data-index={0}
               data-is-focusable={true}
-              id="swatchColorPicker36-a-0"
+              id="swatchColorPicker34-a-0"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -2057,7 +2057,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
               data-index={1}
               data-is-focusable={true}
-              id="swatchColorPicker36-b-1"
+              id="swatchColorPicker34-b-1"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -2216,7 +2216,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
               data-index={2}
               data-is-focusable={true}
-              id="swatchColorPicker36-c-2"
+              id="swatchColorPicker34-c-2"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -2375,7 +2375,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
               data-index={3}
               data-is-focusable={true}
-              id="swatchColorPicker36-d-3"
+              id="swatchColorPicker34-d-3"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -2534,7 +2534,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
               data-index={4}
               data-is-focusable={true}
-              id="swatchColorPicker36-e-4"
+              id="swatchColorPicker34-e-4"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -2608,7 +2608,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
           display: block;
           min-width: 180px;
         }
-    data-focuszone-id="FocusZone56"
+    data-focuszone-id="FocusZone52"
     onBlur={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -2629,7 +2629,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             padding-right: 2px;
             padding-top: 2px;
           }
-      id="swatchColorPicker54"
+      id="swatchColorPicker51"
       role="grid"
     >
       <tbody>
@@ -2759,7 +2759,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
               data-index={0}
               data-is-focusable={true}
-              id="swatchColorPicker54-a-0"
+              id="swatchColorPicker51-a-0"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -2929,7 +2929,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
               data-index={1}
               data-is-focusable={true}
-              id="swatchColorPicker54-b-1"
+              id="swatchColorPicker51-b-1"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -3099,7 +3099,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
               data-index={2}
               data-is-focusable={true}
-              id="swatchColorPicker54-c-2"
+              id="swatchColorPicker51-c-2"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -3269,7 +3269,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
               data-index={3}
               data-is-focusable={true}
-              id="swatchColorPicker54-d-3"
+              id="swatchColorPicker51-d-3"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -3443,7 +3443,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
               data-index={4}
               data-is-focusable={true}
-              id="swatchColorPicker54-e-4"
+              id="swatchColorPicker51-e-4"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -3613,7 +3613,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
               data-index={5}
               data-is-focusable={true}
-              id="swatchColorPicker54-f-5"
+              id="swatchColorPicker51-f-5"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -3783,7 +3783,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
               data-index={6}
               data-is-focusable={true}
-              id="swatchColorPicker54-g-6"
+              id="swatchColorPicker51-g-6"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -3953,7 +3953,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
               data-index={7}
               data-is-focusable={true}
-              id="swatchColorPicker54-h-7"
+              id="swatchColorPicker51-h-7"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -4127,7 +4127,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
               data-index={8}
               data-is-focusable={true}
-              id="swatchColorPicker54-i-8"
+              id="swatchColorPicker51-i-8"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -4297,7 +4297,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
               data-index={9}
               data-is-focusable={true}
-              id="swatchColorPicker54-j-9"
+              id="swatchColorPicker51-j-9"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -4467,7 +4467,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
               data-index={10}
               data-is-focusable={true}
-              id="swatchColorPicker54-k-10"
+              id="swatchColorPicker51-k-10"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -4637,7 +4637,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                   }
               data-index={11}
               data-is-focusable={true}
-              id="swatchColorPicker54-l-11"
+              id="swatchColorPicker51-l-11"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -4703,7 +4703,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
           display: block;
           min-width: 180px;
         }
-    data-focuszone-id="FocusZone95"
+    data-focuszone-id="FocusZone90"
     onBlur={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
@@ -4724,7 +4724,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             padding-right: 2px;
             padding-top: 2px;
           }
-      id="swatchColorPicker93"
+      id="swatchColorPicker89"
       role="grid"
     >
       <tbody>
@@ -4861,7 +4861,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               data-index={0}
               data-is-focusable={false}
               disabled={true}
-              id="swatchColorPicker93-a-0"
+              id="swatchColorPicker89-a-0"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -5038,7 +5038,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               data-index={1}
               data-is-focusable={false}
               disabled={true}
-              id="swatchColorPicker93-b-1"
+              id="swatchColorPicker89-b-1"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -5215,7 +5215,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               data-index={2}
               data-is-focusable={false}
               disabled={true}
-              id="swatchColorPicker93-c-2"
+              id="swatchColorPicker89-c-2"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -5392,7 +5392,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               data-index={3}
               data-is-focusable={false}
               disabled={true}
-              id="swatchColorPicker93-d-3"
+              id="swatchColorPicker89-d-3"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}
@@ -5569,7 +5569,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
               data-index={4}
               data-is-focusable={false}
               disabled={true}
-              id="swatchColorPicker93-e-4"
+              id="swatchColorPicker89-e-4"
               onClick={[Function]}
               onFocus={[Function]}
               onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SwatchColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SwatchColorPicker.Basic.Example.tsx.shot
@@ -38,8 +38,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             padding-right: 2px;
             padding-top: 2px;
           }
-      id="id__1"
-      onBlur={[Function]}
+      id="swatchColorPicker0"
       role="grid"
     >
       <tbody>
@@ -936,8 +935,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             padding-right: 2px;
             padding-top: 2px;
           }
-      id="id__19"
-      onBlur={[Function]}
+      id="swatchColorPicker18"
       role="grid"
     >
       <tbody>
@@ -1779,8 +1777,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             padding-right: 2px;
             padding-top: 2px;
           }
-      id="id__37"
-      onBlur={[Function]}
+      id="swatchColorPicker36"
       role="grid"
     >
       <tbody>
@@ -2632,8 +2629,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             padding-right: 2px;
             padding-top: 2px;
           }
-      id="id__55"
-      onBlur={[Function]}
+      id="swatchColorPicker54"
       role="grid"
     >
       <tbody>
@@ -4728,8 +4724,7 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
             padding-right: 2px;
             padding-top: 2px;
           }
-      id="id__94"
-      onBlur={[Function]}
+      id="swatchColorPicker93"
       role="grid"
     >
       <tbody>

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.base.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.base.tsx
@@ -10,7 +10,7 @@ export class GridBase extends BaseComponent<IGridProps, {}> implements IGrid {
 
   constructor(props: IGridProps) {
     super(props);
-    this._id = getId() || (props as any).id;
+    this._id = props.id || getId();
   }
 
   public render(): JSX.Element {

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.base.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.base.tsx
@@ -10,15 +10,14 @@ export class GridBase extends BaseComponent<IGridProps, {}> implements IGrid {
 
   constructor(props: IGridProps) {
     super(props);
-    this._id = getId();
+    this._id = getId() || (props as any).id;
   }
 
   public render(): JSX.Element {
-    const { items, columnCount, onRenderItem, positionInSet, setSize, styles } = this.props;
+    const props = this.props;
+    const { items, columnCount, onRenderItem, ariaPosInSet = props.positionInSet, ariaSetSize = props.setSize, styles } = props;
 
-    const htmlProps = getNativeProps<React.HTMLAttributes<HTMLTableElement>>(this.props, htmlElementProperties, [
-      'onBlur, aria-posinset, aria-setsize'
-    ]);
+    const htmlProps = getNativeProps<React.HTMLAttributes<HTMLTableElement>>(this.props, htmlElementProperties, ['onBlur']);
 
     const classNames = getClassNames(styles!, { theme: this.props.theme! });
 
@@ -26,7 +25,7 @@ export class GridBase extends BaseComponent<IGridProps, {}> implements IGrid {
     const rowsOfItems: any[][] = toMatrix(items, columnCount);
 
     const content = (
-      <table {...htmlProps} aria-posinset={positionInSet} aria-setsize={setSize} id={this._id} role={'grid'} className={classNames.root}>
+      <table aria-posinset={ariaPosInSet} aria-setsize={ariaSetSize} id={this._id} role="grid" {...htmlProps} className={classNames.root}>
         <tbody>
           {rowsOfItems.map((rows: any[], rowIndex: number) => {
             return (

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.types.ts
@@ -1,16 +1,17 @@
+import * as React from 'react';
 import { IStyle, ITheme } from '../../Styling';
 import { IRefObject, IStyleFunctionOrObject } from '../../Utilities';
 
 export interface IGrid {}
 
-export interface IGridProps {
+export interface IGridProps extends React.TableHTMLAttributes<HTMLTableElement> {
   /**
    * Gets the component ref.
    */
   componentRef?: IRefObject<IGrid>;
 
   /**
-   * The items to turn into a grid
+   * Items to display in a grid with the specified number of columns
    */
   items: any[];
 
@@ -25,36 +26,46 @@ export interface IGridProps {
   onRenderItem: (item: any, index: number) => JSX.Element;
 
   /**
-   * Boolean indicating if the focus should support circular navigation.
-   * This prop is only relevant if doNotcontainWithinFocusZone is not true
+   * Whether focus should cycle back to the beginning once the user navigates past the end (and vice versa).
+   * Only relevant if `doNotContainWithinFocusZone` is not true.
    */
   shouldFocusCircularNavigate?: boolean;
 
   /**
-   * If true do not contain the grid inside of a FocusZone.
-   * If false contain the grid inside of a FocusZone.
+   * If false (the default), the grid is contained inside a FocusZone.
+   * If true, a FocusZone is not used.
+   * @default false
    */
   doNotContainWithinFocusZone?: boolean;
 
   /**
-   * Optional, class name for the FocusZone container for the grid
-   * @deprecated Use `styles` and `IGridStyles` to define a styling for the focus zone container with
-   * focusedContainer property.
+   * Class name for the FocusZone container for the grid.
+   * @deprecated Use `styles.focusedContainer` to define styling for the focus zone container
    */
   containerClassName?: string;
 
   /**
-   * Optional, handler for when the grid should blur
+   * Handler for when focus leaves the grid.
    */
   onBlur?: () => void;
 
   /**
-   * The optional position this grid is in the parent set (index in a parent menu, for example)
+   * Position this grid is in the parent set (index in a parent menu, for example)
+   */
+  ariaPosInSet?: number;
+
+  /**
+   * @deprecated Use `ariaPosInSet`
    */
   positionInSet?: number;
 
   /**
-   * The optional size of the parent set (size of parent menu, for example)
+   * Size of the parent set (size of parent menu, for example)
+   */
+  ariaSetSize?: number;
+
+  /**
+   * @deprecated Use `ariaSetSize`
    */
   setSize?: number;
 
@@ -94,7 +105,7 @@ export interface IGridStyles {
   tableCell: IStyle;
 
   /**
-   * Optional, style for the FocusZone container for the grid
+   * Style for the FocusZone container for the grid.
    */
   focusedContainer?: IStyle;
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11520
- [x] Include a change request file using `$ yarn change`

#### Description of changes

SwatchColorPicker's `id` prop should be applied to the root of the grid.

Also "renamed" some SwatchColorPicker-related props (add new prop, deprecate old one) which were badly named:
- `IColorPickerGridCellProps`:
  - `id` to `idPrefix`, because it's actually just used as a prefix for a generated ID
- `ISwatchColorPickerProps` and `IGridProps`:
  - `positionInSet` to `ariaPosInSet` to match standard naming
  - `setSize` to `ariaSetSize` to match standard naming

And assorted doc updates in SwatchColorPicker and related components.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11526)