### PR TITLE
Removed circular import (cherry-pick to 5.0)

### DIFF
--- a/common/changes/office-ui-fabric-react/2019-12-31-02-43.json
+++ b/common/changes/office-ui-fabric-react/2019-12-31-02-43.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "office-ui-fabric-react",
+      "comment": "Removed the circular import in positioning.types.ts",
+      "type": "patch"
+    }
+  ],
+  "packageName": "office-ui-fabric-react",
+  "email": "not specified"
+}

--- a/packages/office-ui-fabric-react/src/utilities/positioning/positioning.types.ts
+++ b/packages/office-ui-fabric-react/src/utilities/positioning/positioning.types.ts
@@ -1,6 +1,5 @@
 
 import { DirectionalHint } from '../../common/DirectionalHint';
-import { IPoint } from './positioning.types';
 import { IRectangle } from '../../Utilities';
 
 export enum RectangleEdge {


### PR DESCRIPTION
#### Pull request checklist

Cherry-pick of #10972 

#### Description of changes

Removed the circular import in positioning.types.ts in Utilities. Did import from itself, which crashed with Typescript 3.7 (does not allow importing names that are locally defined)

However, in order to to a npm install I had to remove the dev-dependency 

"office-ui-fabric-react-tslint": ">=5.0.0 <6.0.0",

which seems to be not available in npm registry any more. This is not checked in, as I did not want to. If it is necessary, pls have someone a look at it if there are alternatives or if it can be removed safely.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11527)