### PR TITLE
Modal ignoreExternalFocusing prop should also affect Popup

### DIFF
--- a/change/office-ui-fabric-react-2019-12-20-13-17-02-modal-focus.json
+++ b/change/office-ui-fabric-react-2019-12-20-13-17-02-modal-focus.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Modal ignoreExternalFocusing should also affect Popup",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "commit": "30f3293eb58cb16866a2005a6ef54fceef24dd5d",
+  "date": "2019-12-20T21:17:02.143Z"
+}

--- a/change/office-ui-fabric-react-2019-12-20-13-17-02-modal-focus.json
+++ b/change/office-ui-fabric-react-2019-12-20-13-17-02-modal-focus.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Modal ignoreExternalFocusing should also affect Popup",
+  "comment": "Modal ignoreExternalFocusing prop should also affect Popup",
   "packageName": "office-ui-fabric-react",
   "email": "elcraig@microsoft.com",
   "commit": "30f3293eb58cb16866a2005a6ef54fceef24dd5d",

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1453,6 +1453,16 @@ export function hsv2hsl(h: number, s: number, v: number): IHSL;
 export function hsv2rgb(h: number, s: number, v: number): IRGB;
 
 // @public (undocumented)
+export interface IAccessiblePopupProps {
+    closeButtonAriaLabel?: string;
+    elementToFocusOnDismiss?: HTMLElement;
+    firstFocusableSelector?: string | (() => string);
+    forceFocusInsideTrap?: boolean;
+    ignoreExternalFocusing?: boolean;
+    isClickableOutsideFocusTrap?: boolean;
+}
+
+// @public (undocumented)
 export interface IActivityItemProps extends React.AllHTMLAttributes<HTMLElement> {
     activityDescription?: React.ReactNode[] | React.ReactNode;
     // @deprecated
@@ -3807,8 +3817,6 @@ export interface IDialogFooterStyles {
     actionsRight: IStyle;
 }
 
-// Warning: (ae-forgotten-export) The symbol "IAccessiblePopupProps" needs to be exported by the entry point index.d.ts
-// 
 // @public (undocumented)
 export interface IDialogProps extends React.ClassAttributes<DialogBase>, IWithResponsiveModeState, IAccessiblePopupProps {
     // @deprecated

--- a/packages/office-ui-fabric-react/src/common/IAccessiblePopupProps.ts
+++ b/packages/office-ui-fabric-react/src/common/IAccessiblePopupProps.ts
@@ -1,5 +1,5 @@
 /**
- * {@docCategory Modal}
+ * {@docCategory IAccessiblePopupProps}
  */
 export interface IAccessiblePopupProps {
   /**

--- a/packages/office-ui-fabric-react/src/common/IAccessiblePopupProps.ts
+++ b/packages/office-ui-fabric-react/src/common/IAccessiblePopupProps.ts
@@ -1,3 +1,6 @@
+/**
+ * {@docCategory Modal}
+ */
 export interface IAccessiblePopupProps {
   /**
    * Sets the HTMLElement to focus on when exiting the FocusTrapZone.

--- a/packages/office-ui-fabric-react/src/common/IAccessiblePopupProps.ts
+++ b/packages/office-ui-fabric-react/src/common/IAccessiblePopupProps.ts
@@ -3,35 +3,36 @@
  */
 export interface IAccessiblePopupProps {
   /**
-   * Sets the HTMLElement to focus on when exiting the FocusTrapZone.
-   * @defaultvalue The element.target that triggered the Panel.
+   * Sets the element to focus on when exiting the control's FocusTrapZone.
+   * @defaultvalue The `element.target` that triggered the control opening.
    */
   elementToFocusOnDismiss?: HTMLElement;
 
   /**
-   * Indicates if this dialog will ignore keeping track of HTMLElement that activated the Zone.
+   * If false (the default), the control's FocusTrapZone will restore focus to the element which
+   * activated it once the trap zone is unmounted or disabled. Set to true to disable this behavior.
    * @defaultvalue false
    */
   ignoreExternalFocusing?: boolean;
 
   /**
-   * Indicates whether dialog should force focus inside the focus trap zone
+   * Whether control should force focus inside its focus trap zone.
    * @defaultvalue true
    */
   forceFocusInsideTrap?: boolean;
 
   /**
-   * Indicates the selector for first focusable item
+   * Class name (not actual selector) for first focusable item. Do not append a dot.
    */
   firstFocusableSelector?: string | (() => string);
 
   /**
-   * Aria label on close button
+   * Aria label on close button.
    */
   closeButtonAriaLabel?: string;
 
   /**
-   * Indicates if this dialog will allow clicks outside the FocusTrapZone
+   * Whether this control will allow clicks outside its FocusTrapZone.
    * @defaultvalue false
    */
   isClickableOutsideFocusTrap?: boolean;

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.test.tsx
@@ -592,10 +592,18 @@ describe('FocusTrapZone', () => {
       expect(document.activeElement).toBe(activeElement);
     });
 
-    it('Focuses on firstFocusableSelector on mount', async () => {
+    it('Focuses on firstFocusableSelector class name on mount', async () => {
       expect.assertions(1);
 
       const { buttonC } = setupTest({ firstFocusableSelector: 'c' });
+
+      expect(document.activeElement).toBe(buttonC);
+    });
+
+    it('Focuses on firstFocusableSelector actual selector on mount', async () => {
+      expect.assertions(1);
+
+      const { buttonC } = setupTest({ firstFocusableSelector: '.c' });
 
       expect(document.activeElement).toBe(buttonC);
     });

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.test.tsx
@@ -592,18 +592,10 @@ describe('FocusTrapZone', () => {
       expect(document.activeElement).toBe(activeElement);
     });
 
-    it('Focuses on firstFocusableSelector class name on mount', async () => {
+    it('Focuses on firstFocusableSelector on mount', async () => {
       expect.assertions(1);
 
       const { buttonC } = setupTest({ firstFocusableSelector: 'c' });
-
-      expect(document.activeElement).toBe(buttonC);
-    });
-
-    it('Focuses on firstFocusableSelector actual selector on mount', async () => {
-      expect.assertions(1);
-
-      const { buttonC } = setupTest({ firstFocusableSelector: '.c' });
 
       expect(document.activeElement).toBe(buttonC);
     });

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.types.ts
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.types.ts
@@ -23,14 +23,14 @@ export interface IFocusTrapZoneProps extends React.HTMLAttributes<HTMLDivElement
   componentRef?: IRefObject<IFocusTrapZone>;
 
   /**
-   * Disables the FocusTrapZone's focus trapping behavior when set.
+   * Whether to disable the FocusTrapZone's focus trapping behavior.
    * @defaultvalue false
    */
   disabled?: boolean;
 
   /**
-   * Sets the HTMLElement to focus on when exiting the FocusTrapZone.
-   * @defaultvalue element.target The element.target that triggered the FTZ.
+   * Sets the element to focus on when exiting the FocusTrapZone.
+   * @defaultvalue The `element.target` that triggered the FTZ.
    */
   elementToFocusOnDismiss?: HTMLElement;
 
@@ -40,40 +40,41 @@ export interface IFocusTrapZoneProps extends React.HTMLAttributes<HTMLDivElement
   ariaLabelledBy?: string;
 
   /**
-   * Indicates if this Trap Zone will allow clicks outside the FocusTrapZone
+   * Whether clicks are allowed outside this FocusTrapZone.
    * @defaultvalue false
    */
   isClickableOutsideFocusTrap?: boolean;
 
   /**
-   * Indicates if this Trap Zone will ignore keeping track of HTMLElement that activated the Zone.
+   * If false (the default), the trap zone will restore focus to the element which activated it
+   * once the trap zone is unmounted or disabled. Set to true to disable this behavior.
    * @defaultvalue false
    */
   ignoreExternalFocusing?: boolean;
 
   /**
-   * Indicates whether focus trap zone should force focus inside the focus trap zone
+   * Whether the focus trap zone should force focus to stay inside of it.
    * @defaultvalue true
    */
   forceFocusInsideTrap?: boolean;
 
   /**
-   * Class name for first focusable item (do not append a dot).
+   * Class name (not actual selector) for first focusable item. Do not append a dot.
    * Only applies if `focusPreviouslyFocusedInnerElement` is false.
    */
   firstFocusableSelector?: string | (() => string);
 
   /**
-   * Do not put focus onto first element when render focus trap zone
+   * Do not put focus onto the first element inside the focus trap zone.
    * @defaultvalue false
    */
   disableFirstFocus?: boolean;
 
   /**
-   * Specifies the algorithm used to determine which descendant element to focus when focus() is called.
-   * If false, the first focusable descendant, filtered by the firstFocusableSelector property if present, is chosen.
-   * If true, the element that was focused when the Trap Zone last had a focused descendant is chosen.
-   * If it has never had a focused descendant before, behavior falls back to the first focused descendant.
+   * Specifies which descendant element to focus when `focus()` is called.
+   * If false, use the first focusable descendant, filtered by the `firstFocusableSelector` property if present.
+   * If true, use the element that was focused when the trap zone last had a focused descendant
+   * (or fall back to the first focusable descendant if the trap zone has never been focused).
    * @defaultvalue false
    */
   focusPreviouslyFocusedInnerElement?: boolean;

--- a/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Modal/Modal.base.tsx
@@ -236,6 +236,7 @@ export class ModalBase extends BaseComponent<IModalProps, IDialogState> implemen
             ariaLabelledBy={titleAriaId}
             ariaDescribedBy={subtitleAriaId}
             onDismiss={onDismiss}
+            shouldRestoreFocus={!ignoreExternalFocusing}
           >
             <div className={classNames.root}>
               {!isModeless && <Overlay isDarkThemed={isDarkOverlay} onClick={isBlocking ? undefined : (onDismiss as any)} {...overlay} />}

--- a/packages/office-ui-fabric-react/src/components/Modal/index.ts
+++ b/packages/office-ui-fabric-react/src/components/Modal/index.ts
@@ -1,3 +1,4 @@
 export * from './Modal';
 export * from './Modal.base';
 export * from './Modal.types';
+export { IAccessiblePopupProps } from '../../common/IAccessiblePopupProps';


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11514
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Modal/Dialog have a (misleadingly named) `ignoreExternalFocusing` prop which if true means that when the modal closes, it shouldn't re-focus the element which opened the modal. Popup (underlying component) *also* has the capability to re-focus elements, controlled by its `shouldRestoreFocus` prop. #11514 pointed out that even if re-focusing the opening element was disabled at the Modal level, that wasn't being passed through to the Popup--now fixed.

I also updated the docs for various `IAccessiblePopupProps` (Modal/Dialog shared) and `IFocusTrapZoneProps` members to be clearer/more accurate, and gave `IAccessiblePopupProps` a `docCategory` to make it actually show up on the website.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11535)