### PR TITLE
ChoiceGroup: update docs and examples

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -86,7 +86,7 @@ Callout/ @joschect
 react-cards/Card/  @khmakoto
 Check/ @KevinTCoughlin
 Checkbox/ @cliffkoh
-ChoiceGroup/ @srideshpande @ecraig12345
+ChoiceGroup/ @ecraig12345
 Coachmark/ @leddie24
 CollapsibleSection/ @JasonGore
 ColorPicker/ @ecraig12345

--- a/change/office-ui-fabric-react-2019-12-20-17-47-03-choicegroup-docs.json
+++ b/change/office-ui-fabric-react-2019-12-20-17-47-03-choicegroup-docs.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "ChoiceGroup: update docs and examples",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "commit": "df9d42f327766a33456b5599eccc4df977a8c06e",
+  "date": "2019-12-21T01:47:03.404Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.doc.tsx
@@ -1,13 +1,15 @@
 import * as React from 'react';
-import { ChoiceGroupBasicExample } from './examples/ChoiceGroup.Basic.Example';
-import { ChoiceGroupLabelExample } from './examples/ChoiceGroup.Label.Example';
-
 import { IDocPageProps } from '../../common/DocPage.types';
+
+import { ChoiceGroupBasicExample } from './examples/ChoiceGroup.Basic.Example';
+import { ChoiceGroupControlledExample } from './examples/ChoiceGroup.Controlled.Example';
+import { ChoiceGroupLabelExample } from './examples/ChoiceGroup.Label.Example';
 import { ChoiceGroupCustomExample } from './examples/ChoiceGroup.Custom.Example';
 import { ChoiceGroupImageExample } from './examples/ChoiceGroup.Image.Example';
 import { ChoiceGroupIconExample } from './examples/ChoiceGroup.Icon.Example';
 
 const ChoiceGroupBasicExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Basic.Example.tsx') as string;
+const ChoiceGroupControlledExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Controlled.Example.tsx') as string;
 const ChoiceGroupLabelExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Label.Example.tsx') as string;
 const ChoiceGroupCustomExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Custom.Example.tsx') as string;
 const ChoiceGroupImageExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Image.Example.tsx') as string;
@@ -20,22 +22,17 @@ export const ChoiceGroupPageProps: IDocPageProps = {
     'https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/office-ui-fabric-react/src/components/ChoiceGroup',
   examples: [
     {
-      title: 'Default ChoiceGroup',
+      title: 'Basic ChoiceGroup',
       code: ChoiceGroupBasicExampleCode,
       view: <ChoiceGroupBasicExample />
     },
     {
-      title: 'ChoiceGroup with a custom label',
-      code: ChoiceGroupLabelExampleCode,
-      view: <ChoiceGroupLabelExample />
+      title: 'Controlled ChoiceGroup',
+      code: ChoiceGroupControlledExampleCode,
+      view: <ChoiceGroupControlledExample />
     },
     {
-      title: 'ChoiceGroup with dropdown',
-      code: ChoiceGroupCustomExampleCode,
-      view: <ChoiceGroupCustomExample />
-    },
-    {
-      title: 'ChoiceGroups with images',
+      title: 'ChoiceGroup with images',
       code: ChoiceGroupImageExampleCode,
       view: <ChoiceGroupImageExample />
     },
@@ -43,6 +40,16 @@ export const ChoiceGroupPageProps: IDocPageProps = {
       title: 'ChoiceGroup with icons',
       code: ChoiceGroupIconExampleCode,
       view: <ChoiceGroupIconExample />
+    },
+    {
+      title: 'ChoiceGroup with a custom label',
+      code: ChoiceGroupLabelExampleCode,
+      view: <ChoiceGroupLabelExample />
+    },
+    {
+      title: 'ChoiceGroup with custom option rendering',
+      code: ChoiceGroupCustomExampleCode,
+      view: <ChoiceGroupCustomExample />
     }
   ],
   overview: require<string>('!raw-loader!office-ui-fabric-react/src/components/ChoiceGroup/docs/ChoiceGroupOverview.md'),

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroup.types.ts
@@ -65,7 +65,7 @@ export interface IChoiceGroupProps extends React.InputHTMLAttributes<HTMLElement
   onChanged?: (option: IChoiceGroupOption, evt?: React.FormEvent<HTMLElement | HTMLInputElement>) => void;
 
   /**
-   * Theme (provided through customization.)
+   * Theme (provided through customization).
    */
   theme?: ITheme;
 
@@ -75,7 +75,7 @@ export interface IChoiceGroupProps extends React.InputHTMLAttributes<HTMLElement
   styles?: IStyleFunctionOrObject<IChoiceGroupStyleProps, IChoiceGroupStyles>;
 
   /**
-   * Aria labelled by prop for the ChoiceGroup itself
+   * ID of an element to use as the aria label for this ChoiceGroup.
    */
   ariaLabelledBy?: string;
 }
@@ -95,27 +95,28 @@ export interface IChoiceGroupOption extends React.InputHTMLAttributes<HTMLElemen
   text: string;
 
   /**
-   * Optional override of option render
+   * Used to customize option rendering.
    */
   onRenderField?: IRenderFunction<IChoiceGroupOption>;
 
   /**
-   * Optional override of label render
+   * Used to customize label rendering.
    */
   onRenderLabel?: (option: IChoiceGroupOption) => JSX.Element;
 
   /**
-   * The Icon component props for choice field
+   * Props for an icon to display with this option.
    */
   iconProps?: IIconProps;
 
   /**
-   * The src of image for choice field.
+   * Image to display with this option.
    */
   imageSrc?: string;
 
   /**
-   * The alt of image for choice field. Defaults to '' if not set.
+   * Alt text if the option is an image.
+   * @default '' (empty string)
    */
   imageAlt?: string;
 
@@ -126,7 +127,7 @@ export interface IChoiceGroupOption extends React.InputHTMLAttributes<HTMLElemen
 
   /**
    * The width and height of the image in px for choice field.
-   * @defaultvalue \{ width: 32, height: 32 \}
+   * @defaultvalue `{ width: 32, height: 32 }`
    */
   imageSize?: { width: number; height: number };
 
@@ -147,19 +148,17 @@ export interface IChoiceGroupOption extends React.InputHTMLAttributes<HTMLElemen
   checked?: boolean;
 
   /**
-   * DOM id to tag the ChoiceGroup input with, for reference.
-   * Should be used for 'aria-owns' and other such uses, rather than direct reference for programmatic purposes.
+   * ID used on the option's input element.
    */
   id?: string;
 
   /**
-   * DOM id to tag the ChoiceGroup label with, for reference.
-   * Should be used for 'aria-owns' and other such uses, rather than direct reference for programmatic purposes.
+   * ID used on the option's label.
    */
   labelId?: string;
 
   /**
-   * The aria label of the ChoiceGroupOption for the benefit of screen readers.
+   * Aria label of the option for the benefit of screen reader users.
    */
   ariaLabel?: string;
 

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Basic.Example.tsx
@@ -1,35 +1,15 @@
 import * as React from 'react';
 import { ChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react/lib/ChoiceGroup';
 
+const options: IChoiceGroupOption[] = [
+  { key: 'A', text: 'Option A' },
+  { key: 'B', text: 'Option B' },
+  { key: 'C', text: 'Option C', disabled: true },
+  { key: 'D', text: 'Option D' }
+];
+
 export const ChoiceGroupBasicExample: React.FunctionComponent = () => {
-  return (
-    <ChoiceGroup
-      className="defaultChoiceGroup"
-      defaultSelectedKey="B"
-      options={[
-        {
-          key: 'A',
-          text: 'Option A'
-        },
-        {
-          key: 'B',
-          text: 'Option B'
-        },
-        {
-          key: 'C',
-          text: 'Option C',
-          disabled: true
-        },
-        {
-          key: 'D',
-          text: 'Option D'
-        }
-      ]}
-      onChange={_onChange}
-      label="Pick one"
-      required={true}
-    />
-  );
+  return <ChoiceGroup defaultSelectedKey="B" options={options} onChange={_onChange} label="Pick one" required={true} />;
 };
 
 function _onChange(ev: React.FormEvent<HTMLInputElement>, option: IChoiceGroupOption): void {

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Controlled.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Controlled.Example.tsx
@@ -1,0 +1,19 @@
+import * as React from 'react';
+import { ChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react/lib/ChoiceGroup';
+
+const options: IChoiceGroupOption[] = [
+  { key: 'A', text: 'Option A' },
+  { key: 'B', text: 'Option B' },
+  { key: 'C', text: 'Option C', disabled: true },
+  { key: 'D', text: 'Option D' }
+];
+
+export const ChoiceGroupControlledExample: React.FunctionComponent = () => {
+  const [selectedKey, setSelectedKey] = React.useState<string>('B');
+
+  const onChange = React.useCallback((ev: React.SyntheticEvent<HTMLElement>, option: IChoiceGroupOption) => {
+    setSelectedKey(option.key);
+  }, []);
+
+  return <ChoiceGroup selectedKey={selectedKey} options={options} onChange={onChange} label="Pick one" />;
+};

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Custom.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Custom.Example.tsx
@@ -1,68 +1,43 @@
 import * as React from 'react';
 import { ChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react/lib/ChoiceGroup';
-import { Dropdown, IDropdownStyles } from 'office-ui-fabric-react/lib/Dropdown';
+import { Dropdown, IDropdownStyles, IDropdownOption } from 'office-ui-fabric-react/lib/Dropdown';
 import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
 
-const optionRootClass = mergeStyles({
-  display: 'flex',
-  alignItems: 'baseline'
-});
-const dropdownStyles: Partial<IDropdownStyles> = {
-  root: {
-    marginBottom: 0,
-    marginLeft: 5
-  }
-};
-
 export const ChoiceGroupCustomExample: React.FunctionComponent = () => {
-  return (
-    <ChoiceGroup
-      defaultSelectedKey="B"
-      options={[
-        {
-          key: 'A',
-          text: 'Mark displayed items as read after',
-          ariaLabel: 'Mark displayed items as read after - Press tab for further action',
-          onRenderField: (props, render) => {
-            return (
-              <div className={optionRootClass}>
-                {render!(props)}
-                <Dropdown
-                  defaultSelectedKey="A"
-                  styles={dropdownStyles}
-                  options={[{ key: 'A', text: '5 seconds' }, { key: 'B', text: '10 seconds' }, { key: 'C', text: '20 seconds' }]}
-                  disabled={props ? !props.checked : false}
-                  ariaLabel="Select a time span"
-                />
-              </div>
-            );
-          }
-        },
-        {
-          key: 'B',
-          text: 'Option B',
-          styles: {
-            root: {
-              border: '1px solid green'
-            }
-          }
-        },
-        {
-          key: 'C',
-          text: 'Option C',
-          disabled: true
-        },
-        {
-          key: 'D',
-          text: 'Option D'
-        }
-      ]}
-      onChange={_onChange}
-      label="Pick one"
-    />
-  );
+  return <ChoiceGroup defaultSelectedKey="B" options={options} label="Pick one" />;
 };
 
-function _onChange(ev: React.FormEvent<HTMLInputElement>, option: IChoiceGroupOption): void {
-  console.dir(option);
-}
+const optionRootClass = mergeStyles({ display: 'flex', alignItems: 'baseline' });
+const dropdownStyles: Partial<IDropdownStyles> = {
+  root: { marginBottom: 0, marginLeft: 5 }
+};
+const dropdownOptions: IDropdownOption[] = [
+  { key: 'A', text: '5 seconds' },
+  { key: 'B', text: '10 seconds' },
+  { key: 'C', text: '20 seconds' }
+];
+
+const options: IChoiceGroupOption[] = [
+  {
+    key: 'A',
+    text: 'Mark displayed items as read after',
+    ariaLabel: 'Mark displayed items as read after - Press tab for further action',
+    onRenderField: (props, render) => {
+      return (
+        <div className={optionRootClass}>
+          {render!(props)}
+          <Dropdown
+            defaultSelectedKey="A"
+            styles={dropdownStyles}
+            options={dropdownOptions}
+            disabled={props ? !props.checked : false}
+            ariaLabel="Select a time span"
+          />
+        </div>
+      );
+    }
+  },
+  { key: 'B', text: 'Option B', styles: { root: { border: '1px solid green' } } },
+  { key: 'C', text: 'Option C', disabled: true },
+  { key: 'D', text: 'Option D' }
+];

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Icon.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Icon.Example.tsx
@@ -1,29 +1,12 @@
 import * as React from 'react';
-import { ChoiceGroup } from 'office-ui-fabric-react/lib/ChoiceGroup';
+import { ChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react/lib/ChoiceGroup';
+
+const options: IChoiceGroupOption[] = [
+  { key: 'day', text: 'Day', iconProps: { iconName: 'CalendarDay' } },
+  { key: 'week', text: 'Week', iconProps: { iconName: 'CalendarWeek' } },
+  { key: 'month', text: 'Month', iconProps: { iconName: 'Calendar' }, disabled: true }
+];
 
 export const ChoiceGroupIconExample: React.FunctionComponent = () => {
-  return (
-    <ChoiceGroup
-      label="Pick one icon"
-      defaultSelectedKey="day"
-      options={[
-        {
-          key: 'day',
-          iconProps: { iconName: 'CalendarDay' },
-          text: 'Day'
-        },
-        {
-          key: 'week',
-          iconProps: { iconName: 'CalendarWeek' },
-          text: 'Week'
-        },
-        {
-          key: 'month',
-          iconProps: { iconName: 'Calendar' },
-          text: 'Month',
-          disabled: true
-        }
-      ]}
-    />
-  );
+  return <ChoiceGroup label="Pick one icon" defaultSelectedKey="day" options={options} />;
 };

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Image.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Image.Example.tsx
@@ -2,37 +2,24 @@ import * as React from 'react';
 import { ChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react/lib/ChoiceGroup';
 import { TestImages } from '@uifabric/example-data';
 
+const options: IChoiceGroupOption[] = [
+  {
+    key: 'bar',
+    imageSrc: TestImages.choiceGroupBarUnselected,
+    imageAlt: 'Bar chart icon',
+    selectedImageSrc: TestImages.choiceGroupBarSelected,
+    imageSize: { width: 32, height: 32 },
+    text: 'Clustered bar chart' // This text is long to show text wrapping.
+  },
+  {
+    key: 'pie',
+    imageSrc: TestImages.choiceGroupBarUnselected,
+    selectedImageSrc: TestImages.choiceGroupBarSelected,
+    imageSize: { width: 32, height: 32 },
+    text: 'Pie chart'
+  }
+];
+
 export const ChoiceGroupImageExample: React.FunctionComponent = () => {
-  const [selectedKey, setSelectedKey] = React.useState<string>('bar');
-
-  const onChange = (ev: React.SyntheticEvent<HTMLElement>, option: IChoiceGroupOption) => {
-    setSelectedKey(option.key);
-  };
-
-  return (
-    <div>
-      <ChoiceGroup
-        label="Pick one image"
-        selectedKey={selectedKey}
-        options={[
-          {
-            key: 'bar',
-            imageSrc: TestImages.choiceGroupBarUnselected,
-            imageAlt: 'Bar chart icon',
-            selectedImageSrc: TestImages.choiceGroupBarSelected,
-            imageSize: { width: 32, height: 32 },
-            text: 'Clustered bar chart' // This text is long to show text wrapping.
-          },
-          {
-            key: 'pie',
-            imageSrc: TestImages.choiceGroupBarUnselected,
-            selectedImageSrc: TestImages.choiceGroupBarSelected,
-            imageSize: { width: 32, height: 32 },
-            text: 'Pie chart'
-          }
-        ]}
-        onChange={onChange}
-      />
-    </div>
-  );
+  return <ChoiceGroup label="Pick one image" defaultSelectedKey="bar" options={options} />;
 };

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Label.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/examples/ChoiceGroup.Label.Example.tsx
@@ -1,7 +1,16 @@
 import * as React from 'react';
 import { ChoiceGroup, IChoiceGroupOption } from 'office-ui-fabric-react/lib/ChoiceGroup';
 import { Label } from 'office-ui-fabric-react/lib/Label';
+import { Icon } from 'office-ui-fabric-react/lib/Icon';
+import { Stack } from 'office-ui-fabric-react/lib/Stack';
 import { useId } from '@uifabric/react-hooks';
+
+const options: IChoiceGroupOption[] = [
+  { key: 'A', text: 'Option A' },
+  { key: 'B', text: 'Option B' },
+  { key: 'C', text: 'Option C', disabled: true },
+  { key: 'D', text: 'Option D' }
+];
 
 export const ChoiceGroupLabelExample: React.FunctionComponent = () => {
   // Use the useId() hook to ensure that the label ID is unique on the page. Notes:
@@ -12,30 +21,19 @@ export const ChoiceGroupLabelExample: React.FunctionComponent = () => {
 
   return (
     <div>
-      <Label id={labelId} required={true}>
-        Custom label
+      {/* ONLY do this if you need to customize the label.
+      In most cases you should use ChoiceGroup's built-in `label` prop instead. */}
+      <Label id={labelId}>
+        <Stack horizontal verticalAlign="center">
+          <span>Custom label&nbsp;&nbsp;</span>
+          <Icon iconName="Filter" />
+        </Stack>
       </Label>
       <ChoiceGroup
+        // This is usually what you should do
+        // label="Normal label"
         defaultSelectedKey="B"
-        options={[
-          {
-            key: 'A',
-            text: 'Option A'
-          },
-          {
-            key: 'B',
-            text: 'Option B'
-          },
-          {
-            key: 'C',
-            text: 'Option C',
-            disabled: true
-          },
-          {
-            key: 'D',
-            text: 'Option D'
-          }
-        ]}
+        options={options}
         onChange={_onChange}
         ariaLabelledBy={labelId}
       />

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Controlled.Example.tsx.shot
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] = `
+exports[`Component Examples renders ChoiceGroup.Controlled.Example.tsx correctly 1`] = `
 <div
   className=
 
@@ -43,11 +43,6 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
             padding-right: 0;
             padding-top: 5px;
             word-wrap: break-word;
-          }
-          &::after {
-            color: #a4262c;
-            content: ' *';
-            padding-right: 12px;
           }
       id="ChoiceGroup0-label"
     >
@@ -107,7 +102,6 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
-            required={true}
             type="radio"
           />
           <label
@@ -244,7 +238,6 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
-            required={true}
             type="radio"
           />
           <label
@@ -383,7 +376,6 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
-            required={true}
             type="radio"
           />
           <label
@@ -499,7 +491,6 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
             onBlur={[Function]}
             onChange={[Function]}
             onFocus={[Function]}
-            required={true}
             type="radio"
           />
           <label

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
@@ -1,670 +1,668 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] = `
-<div>
+<div
+  className=
+
+
+>
   <div
+    aria-labelledby="ChoiceGroup0-label"
     className=
-
-
+        ms-ChoiceFieldGroup
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          display: block;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+        }
+    role="radiogroup"
   >
-    <div
-      aria-labelledby="ChoiceGroup0-label"
+    <label
       className=
-          ms-ChoiceFieldGroup
+          ms-Label
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            box-shadow: none;
+            box-sizing: border-box;
+            color: #323130;
             display: block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
-            font-weight: 400;
+            font-weight: 600;
+            margin-bottom: 0px;
+            margin-left: 0px;
+            margin-right: 0px;
+            margin-top: 0px;
+            overflow-wrap: break-word;
+            padding-bottom: 5px;
+            padding-left: 0;
+            padding-right: 0;
+            padding-top: 5px;
+            word-wrap: break-word;
           }
-      role="radiogroup"
+      id="ChoiceGroup0-label"
     >
-      <label
+      Pick one image
+    </label>
+    <div
+      className=
+          ms-ChoiceFieldGroup-flexContainer
+          {
+            display: flex;
+            flex-direction: row;
+            flex-wrap: wrap;
+          }
+    >
+      <div
         className=
-            ms-Label
+            ms-ChoiceField
+            ms-ChoiceField--image
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              box-shadow: none;
+              align-items: center;
+              background-color: #f3f2f1;
+              border: none;
               box-sizing: border-box;
               color: #323130;
-              display: block;
+              display: inline-flex;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-              font-size: 14px;
-              font-weight: 600;
-              margin-bottom: 0px;
-              margin-left: 0px;
-              margin-right: 0px;
-              margin-top: 0px;
-              overflow-wrap: break-word;
-              padding-bottom: 5px;
-              padding-left: 0;
-              padding-right: 0;
-              padding-top: 5px;
-              word-wrap: break-word;
+              font-size: 0px;
+              font-weight: 400;
+              height: 100%;
+              margin-bottom: 4px;
+              margin-left: 0;
+              margin-right: 4px;
+              margin-top: 0;
+              min-height: 26px;
+              padding-left: 0px;
+              position: relative;
             }
-        id="ChoiceGroup0-label"
+            & .ms-ChoiceFieldLabel {
+              display: inline-block;
+            }
       >
-        Pick one image
-      </label>
+        <div
+          className=
+              ms-ChoiceField-wrapper
+
+        >
+          <input
+            checked={true}
+            className=
+                ms-ChoiceField-input
+                {
+                  height: 100%;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  opacity: 0;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  width: 100%;
+                }
+            id="ChoiceGroup0-bar"
+            name="ChoiceGroup0"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="radio"
+          />
+          <label
+            className=
+                ms-ChoiceField-field
+                is-checked
+                ms-ChoiceField-field--image
+                {
+                  align-items: center;
+                  border-color: #0078d4;
+                  border: 1px solid transparent;
+                  box-sizing: content-box;
+                  cursor: pointer;
+                  display: flex;
+                  flex-direction: column;
+                  justify-content: center;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  min-height: 20px;
+                  padding-top: 22px;
+                  position: relative;
+                  text-align: center;
+                  transition-duration: 200ms;
+                  transition-property: all;
+                  transition-timing-function: ease;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &:hover {
+                  border-color: #005a9e;
+                }
+                &:hover .ms-ChoiceFieldLabel {
+                  color: #201f1e;
+                }
+                &:hover:before {
+                  border-color: #005a9e;
+                  opacity: 1;
+                }
+                &:hover:after {
+                  border-color: #005a9e;
+                }
+                &:focus {
+                  border-color: #005a9e;
+                }
+                &:focus .ms-ChoiceFieldLabel {
+                  color: #201f1e;
+                }
+                &:focus:before {
+                  border-color: #005a9e;
+                  opacity: 1;
+                }
+                &:focus:after {
+                  border-color: #005a9e;
+                }
+                &:before {
+                  background-color: #ffffff;
+                  border-color: #0078d4;
+                  border-radius: 50%;
+                  border-style: solid;
+                  border-width: 1px;
+                  box-sizing: border-box;
+                  content: "";
+                  display: inline-block;
+                  font-weight: normal;
+                  height: 20px;
+                  left: auto;
+                  opacity: 1;
+                  position: absolute;
+                  right: 3px;
+                  top: 3px;
+                  transition-duration: 200ms;
+                  transition-property: border-color;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 20px;
+                }
+                @media screen and (-ms-high-contrast: active){&:before {
+                  border-color: Highlight;
+                }
+                &:after {
+                  border-color: #0078d4;
+                  border-radius: 50%;
+                  border-style: solid;
+                  border-width: 5px;
+                  box-sizing: border-box;
+                  content: "";
+                  height: 10px;
+                  left: auto;
+                  position: absolute;
+                  right: 8px;
+                  top: 8px;
+                  transition-duration: 200ms;
+                  transition-property: border-width;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 10px;
+                }
+                @media screen and (-ms-high-contrast: active){&:after {
+                  border-color: Highlight;
+                }
+            htmlFor="ChoiceGroup0-bar"
+          >
+            <div
+              className=
+                  ms-ChoiceField-innerField
+                  {
+                    display: inline-block;
+                    height: 32px;
+                    padding-left: 30px;
+                    padding-right: 30px;
+                    position: relative;
+                    width: 32px;
+                  }
+            >
+              <div
+                className=
+                    ms-ChoiceField-imageWrapper
+                    is-hidden
+                    {
+                      height: 100%;
+                      left: 0px;
+                      opacity: 0;
+                      overflow: hidden;
+                      padding-bottom: 2px;
+                      position: absolute;
+                      top: 0px;
+                      transition-duration: 200ms;
+                      transition-property: opacity;
+                      transition-timing-function: ease;
+                      width: 100%;
+                    }
+                    & .ms-Image {
+                      border-style: none;
+                      display: inline-block;
+                    }
+              >
+                <div
+                  className=
+                      ms-Image
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        overflow: hidden;
+                      }
+                  style={
+                    Object {
+                      "height": 32,
+                      "width": 32,
+                    }
+                  }
+                >
+                  <img
+                    alt="Bar chart icon"
+                    className=
+                        ms-Image-image
+                        ms-Image-image--portrait
+                        is-notLoaded
+                        is-fadeIn
+                        {
+                          display: block;
+                          height: 100%;
+                          opacity: 0;
+                          width: 100%;
+                        }
+                    onError={[Function]}
+                    onLoad={[Function]}
+                    src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/choicegroup-bar-unselected.png"
+                  />
+                </div>
+              </div>
+              <div
+                className=
+                    ms-ChoiceField-imageWrapper
+                    {
+                      padding-bottom: 2px;
+                      transition-duration: 200ms;
+                      transition-property: opacity;
+                      transition-timing-function: ease;
+                    }
+                    & .ms-Image {
+                      border-style: none;
+                      display: inline-block;
+                    }
+              >
+                <div
+                  className=
+                      ms-Image
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        overflow: hidden;
+                      }
+                  style={
+                    Object {
+                      "height": 32,
+                      "width": 32,
+                    }
+                  }
+                >
+                  <img
+                    alt="Bar chart icon"
+                    className=
+                        ms-Image-image
+                        ms-Image-image--portrait
+                        is-notLoaded
+                        is-fadeIn
+                        {
+                          display: block;
+                          height: 100%;
+                          opacity: 0;
+                          width: 100%;
+                        }
+                    onError={[Function]}
+                    onLoad={[Function]}
+                    src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/choicegroup-bar-selected.png"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
+              className=
+                  ms-ChoiceField-labelWrapper
+                  {
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 30px;
+                    line-height: 15px;
+                    margin-bottom: 4px;
+                    margin-left: 8px;
+                    margin-right: 8px;
+                    margin-top: 4px;
+                    max-width: 64px;
+                    overflow: hidden;
+                    position: relative;
+                    text-overflow: ellipsis;
+                    white-space: pre-wrap;
+                  }
+            >
+              <span
+                className="ms-ChoiceFieldLabel"
+                id="ChoiceGroupLabel1-bar"
+              >
+                Clustered bar chart
+              </span>
+            </div>
+          </label>
+        </div>
+      </div>
       <div
         className=
-            ms-ChoiceFieldGroup-flexContainer
+            ms-ChoiceField
+            ms-ChoiceField--image
             {
-              display: flex;
-              flex-direction: row;
-              flex-wrap: wrap;
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              align-items: center;
+              background-color: #f3f2f1;
+              border: none;
+              box-sizing: border-box;
+              color: #323130;
+              display: inline-flex;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 0px;
+              font-weight: 400;
+              height: 100%;
+              margin-bottom: 4px;
+              margin-left: 0;
+              margin-right: 4px;
+              margin-top: 0;
+              min-height: 26px;
+              padding-left: 0px;
+              position: relative;
+            }
+            & .ms-ChoiceFieldLabel {
+              display: inline-block;
             }
       >
         <div
           className=
-              ms-ChoiceField
-              ms-ChoiceField--image
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                align-items: center;
-                background-color: #f3f2f1;
-                border: none;
-                box-sizing: border-box;
-                color: #323130;
-                display: inline-flex;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 0px;
-                font-weight: 400;
-                height: 100%;
-                margin-bottom: 4px;
-                margin-left: 0;
-                margin-right: 4px;
-                margin-top: 0;
-                min-height: 26px;
-                padding-left: 0px;
-                position: relative;
-              }
-              & .ms-ChoiceFieldLabel {
-                display: inline-block;
-              }
-        >
-          <div
-            className=
-                ms-ChoiceField-wrapper
+              ms-ChoiceField-wrapper
 
+        >
+          <input
+            checked={false}
+            className=
+                ms-ChoiceField-input
+                {
+                  height: 100%;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  opacity: 0;
+                  position: absolute;
+                  right: 0px;
+                  top: 0px;
+                  width: 100%;
+                }
+            id="ChoiceGroup0-pie"
+            name="ChoiceGroup0"
+            onBlur={[Function]}
+            onChange={[Function]}
+            onFocus={[Function]}
+            type="radio"
+          />
+          <label
+            className=
+                ms-ChoiceField-field
+                ms-ChoiceField-field--image
+                {
+                  align-items: center;
+                  border: 1px solid transparent;
+                  box-sizing: content-box;
+                  cursor: pointer;
+                  display: flex;
+                  flex-direction: column;
+                  justify-content: center;
+                  margin-bottom: 0px;
+                  margin-left: 0px;
+                  margin-right: 0px;
+                  margin-top: 0px;
+                  min-height: 20px;
+                  padding-top: 22px;
+                  position: relative;
+                  text-align: center;
+                  transition-duration: 200ms;
+                  transition-property: all;
+                  transition-timing-function: ease;
+                  user-select: none;
+                  vertical-align: top;
+                }
+                &:hover {
+                  border-color: #323130;
+                }
+                &:hover .ms-ChoiceFieldLabel {
+                  color: #201f1e;
+                }
+                &:hover:before {
+                  border-color: #323130;
+                  opacity: 1;
+                }
+                &:focus {
+                  border-color: #323130;
+                }
+                &:focus .ms-ChoiceFieldLabel {
+                  color: #201f1e;
+                }
+                &:focus:before {
+                  border-color: #323130;
+                  opacity: 1;
+                }
+                &:before {
+                  background-color: #ffffff;
+                  border-color: #323130;
+                  border-radius: 50%;
+                  border-style: solid;
+                  border-width: 1px;
+                  box-sizing: border-box;
+                  content: "";
+                  display: inline-block;
+                  font-weight: normal;
+                  height: 20px;
+                  left: auto;
+                  opacity: 0;
+                  position: absolute;
+                  right: 3px;
+                  top: 3px;
+                  transition-duration: 200ms;
+                  transition-property: border-color;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 20px;
+                }
+                &:after {
+                  border-radius: 50%;
+                  box-sizing: border-box;
+                  content: "";
+                  height: 0px;
+                  left: 10px;
+                  position: absolute;
+                  right: 0px;
+                  transition-duration: 200ms;
+                  transition-property: border-width;
+                  transition-timing-function: cubic-bezier(.4, 0, .23, 1);
+                  width: 0px;
+                }
+            htmlFor="ChoiceGroup0-pie"
           >
-            <input
-              checked={true}
+            <div
               className=
-                  ms-ChoiceField-input
+                  ms-ChoiceField-innerField
                   {
-                    height: 100%;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    opacity: 0;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                    width: 100%;
-                  }
-              id="ChoiceGroup0-bar"
-              name="ChoiceGroup0"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              type="radio"
-            />
-            <label
-              className=
-                  ms-ChoiceField-field
-                  is-checked
-                  ms-ChoiceField-field--image
-                  {
-                    align-items: center;
-                    border-color: #0078d4;
-                    border: 1px solid transparent;
-                    box-sizing: content-box;
-                    cursor: pointer;
-                    display: flex;
-                    flex-direction: column;
-                    justify-content: center;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    min-height: 20px;
-                    padding-top: 22px;
-                    position: relative;
-                    text-align: center;
-                    transition-duration: 200ms;
-                    transition-property: all;
-                    transition-timing-function: ease;
-                    user-select: none;
-                    vertical-align: top;
-                  }
-                  &:hover {
-                    border-color: #005a9e;
-                  }
-                  &:hover .ms-ChoiceFieldLabel {
-                    color: #201f1e;
-                  }
-                  &:hover:before {
-                    border-color: #005a9e;
-                    opacity: 1;
-                  }
-                  &:hover:after {
-                    border-color: #005a9e;
-                  }
-                  &:focus {
-                    border-color: #005a9e;
-                  }
-                  &:focus .ms-ChoiceFieldLabel {
-                    color: #201f1e;
-                  }
-                  &:focus:before {
-                    border-color: #005a9e;
-                    opacity: 1;
-                  }
-                  &:focus:after {
-                    border-color: #005a9e;
-                  }
-                  &:before {
-                    background-color: #ffffff;
-                    border-color: #0078d4;
-                    border-radius: 50%;
-                    border-style: solid;
-                    border-width: 1px;
-                    box-sizing: border-box;
-                    content: "";
                     display: inline-block;
-                    font-weight: normal;
-                    height: 20px;
-                    left: auto;
-                    opacity: 1;
-                    position: absolute;
-                    right: 3px;
-                    top: 3px;
-                    transition-duration: 200ms;
-                    transition-property: border-color;
-                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
-                    width: 20px;
+                    height: 32px;
+                    padding-left: 30px;
+                    padding-right: 30px;
+                    position: relative;
+                    width: 32px;
                   }
-                  @media screen and (-ms-high-contrast: active){&:before {
-                    border-color: Highlight;
-                  }
-                  &:after {
-                    border-color: #0078d4;
-                    border-radius: 50%;
-                    border-style: solid;
-                    border-width: 5px;
-                    box-sizing: border-box;
-                    content: "";
-                    height: 10px;
-                    left: auto;
-                    position: absolute;
-                    right: 8px;
-                    top: 8px;
-                    transition-duration: 200ms;
-                    transition-property: border-width;
-                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
-                    width: 10px;
-                  }
-                  @media screen and (-ms-high-contrast: active){&:after {
-                    border-color: Highlight;
-                  }
-              htmlFor="ChoiceGroup0-bar"
             >
               <div
                 className=
-                    ms-ChoiceField-innerField
+                    ms-ChoiceField-imageWrapper
                     {
+                      padding-bottom: 2px;
+                      transition-duration: 200ms;
+                      transition-property: opacity;
+                      transition-timing-function: ease;
+                    }
+                    & .ms-Image {
+                      border-style: none;
                       display: inline-block;
-                      height: 32px;
-                      padding-left: 30px;
-                      padding-right: 30px;
-                      position: relative;
-                      width: 32px;
                     }
               >
                 <div
                   className=
-                      ms-ChoiceField-imageWrapper
-                      is-hidden
+                      ms-Image
                       {
-                        height: 100%;
-                        left: 0px;
-                        opacity: 0;
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
                         overflow: hidden;
-                        padding-bottom: 2px;
-                        position: absolute;
-                        top: 0px;
-                        transition-duration: 200ms;
-                        transition-property: opacity;
-                        transition-timing-function: ease;
-                        width: 100%;
                       }
-                      & .ms-Image {
-                        border-style: none;
-                        display: inline-block;
-                      }
-                >
-                  <div
-                    className=
-                        ms-Image
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                          overflow: hidden;
-                        }
-                    style={
-                      Object {
-                        "height": 32,
-                        "width": 32,
-                      }
+                  style={
+                    Object {
+                      "height": 32,
+                      "width": 32,
                     }
-                  >
-                    <img
-                      alt="Bar chart icon"
-                      className=
-                          ms-Image-image
-                          ms-Image-image--portrait
-                          is-notLoaded
-                          is-fadeIn
-                          {
-                            display: block;
-                            height: 100%;
-                            opacity: 0;
-                            width: 100%;
-                          }
-                      onError={[Function]}
-                      onLoad={[Function]}
-                      src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/choicegroup-bar-unselected.png"
-                    />
-                  </div>
-                </div>
-                <div
-                  className=
-                      ms-ChoiceField-imageWrapper
-                      {
-                        padding-bottom: 2px;
-                        transition-duration: 200ms;
-                        transition-property: opacity;
-                        transition-timing-function: ease;
-                      }
-                      & .ms-Image {
-                        border-style: none;
-                        display: inline-block;
-                      }
+                  }
                 >
-                  <div
+                  <img
+                    alt=""
                     className=
-                        ms-Image
+                        ms-Image-image
+                        ms-Image-image--portrait
+                        is-notLoaded
+                        is-fadeIn
                         {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                          overflow: hidden;
+                          display: block;
+                          height: 100%;
+                          opacity: 0;
+                          width: 100%;
                         }
-                    style={
-                      Object {
-                        "height": 32,
-                        "width": 32,
-                      }
-                    }
-                  >
-                    <img
-                      alt="Bar chart icon"
-                      className=
-                          ms-Image-image
-                          ms-Image-image--portrait
-                          is-notLoaded
-                          is-fadeIn
-                          {
-                            display: block;
-                            height: 100%;
-                            opacity: 0;
-                            width: 100%;
-                          }
-                      onError={[Function]}
-                      onLoad={[Function]}
-                      src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/choicegroup-bar-selected.png"
-                    />
-                  </div>
+                    onError={[Function]}
+                    onLoad={[Function]}
+                    src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/choicegroup-bar-unselected.png"
+                  />
                 </div>
               </div>
               <div
                 className=
-                    ms-ChoiceField-labelWrapper
+                    ms-ChoiceField-imageWrapper
+                    is-hidden
                     {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      display: block;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 30px;
-                      line-height: 15px;
-                      margin-bottom: 4px;
-                      margin-left: 8px;
-                      margin-right: 8px;
-                      margin-top: 4px;
-                      max-width: 64px;
+                      height: 100%;
+                      left: 0px;
+                      opacity: 0;
                       overflow: hidden;
-                      position: relative;
-                      text-overflow: ellipsis;
-                      white-space: pre-wrap;
+                      padding-bottom: 2px;
+                      position: absolute;
+                      top: 0px;
+                      transition-duration: 200ms;
+                      transition-property: opacity;
+                      transition-timing-function: ease;
+                      width: 100%;
+                    }
+                    & .ms-Image {
+                      border-style: none;
+                      display: inline-block;
                     }
               >
-                <span
-                  className="ms-ChoiceFieldLabel"
-                  id="ChoiceGroupLabel1-bar"
-                >
-                  Clustered bar chart
-                </span>
-              </div>
-            </label>
-          </div>
-        </div>
-        <div
-          className=
-              ms-ChoiceField
-              ms-ChoiceField--image
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                align-items: center;
-                background-color: #f3f2f1;
-                border: none;
-                box-sizing: border-box;
-                color: #323130;
-                display: inline-flex;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 0px;
-                font-weight: 400;
-                height: 100%;
-                margin-bottom: 4px;
-                margin-left: 0;
-                margin-right: 4px;
-                margin-top: 0;
-                min-height: 26px;
-                padding-left: 0px;
-                position: relative;
-              }
-              & .ms-ChoiceFieldLabel {
-                display: inline-block;
-              }
-        >
-          <div
-            className=
-                ms-ChoiceField-wrapper
-
-          >
-            <input
-              checked={false}
-              className=
-                  ms-ChoiceField-input
-                  {
-                    height: 100%;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    opacity: 0;
-                    position: absolute;
-                    right: 0px;
-                    top: 0px;
-                    width: 100%;
+                <div
+                  className=
+                      ms-Image
+                      {
+                        -moz-osx-font-smoothing: grayscale;
+                        -webkit-font-smoothing: antialiased;
+                        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                        font-size: 14px;
+                        font-weight: 400;
+                        overflow: hidden;
+                      }
+                  style={
+                    Object {
+                      "height": 32,
+                      "width": 32,
+                    }
                   }
-              id="ChoiceGroup0-pie"
-              name="ChoiceGroup0"
-              onBlur={[Function]}
-              onChange={[Function]}
-              onFocus={[Function]}
-              type="radio"
-            />
-            <label
+                >
+                  <img
+                    alt=""
+                    className=
+                        ms-Image-image
+                        ms-Image-image--portrait
+                        is-notLoaded
+                        is-fadeIn
+                        {
+                          display: block;
+                          height: 100%;
+                          opacity: 0;
+                          width: 100%;
+                        }
+                    onError={[Function]}
+                    onLoad={[Function]}
+                    src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/choicegroup-bar-selected.png"
+                  />
+                </div>
+              </div>
+            </div>
+            <div
               className=
-                  ms-ChoiceField-field
-                  ms-ChoiceField-field--image
+                  ms-ChoiceField-labelWrapper
                   {
-                    align-items: center;
-                    border: 1px solid transparent;
-                    box-sizing: content-box;
-                    cursor: pointer;
-                    display: flex;
-                    flex-direction: column;
-                    justify-content: center;
-                    margin-bottom: 0px;
-                    margin-left: 0px;
-                    margin-right: 0px;
-                    margin-top: 0px;
-                    min-height: 20px;
-                    padding-top: 22px;
+                    -moz-osx-font-smoothing: grayscale;
+                    -webkit-font-smoothing: antialiased;
+                    display: block;
+                    font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                    font-size: 14px;
+                    font-weight: 400;
+                    height: 30px;
+                    line-height: 15px;
+                    margin-bottom: 4px;
+                    margin-left: 8px;
+                    margin-right: 8px;
+                    margin-top: 4px;
+                    max-width: 64px;
+                    overflow: hidden;
                     position: relative;
-                    text-align: center;
-                    transition-duration: 200ms;
-                    transition-property: all;
-                    transition-timing-function: ease;
-                    user-select: none;
-                    vertical-align: top;
+                    text-overflow: ellipsis;
+                    white-space: pre-wrap;
                   }
-                  &:hover {
-                    border-color: #323130;
-                  }
-                  &:hover .ms-ChoiceFieldLabel {
-                    color: #201f1e;
-                  }
-                  &:hover:before {
-                    border-color: #323130;
-                    opacity: 1;
-                  }
-                  &:focus {
-                    border-color: #323130;
-                  }
-                  &:focus .ms-ChoiceFieldLabel {
-                    color: #201f1e;
-                  }
-                  &:focus:before {
-                    border-color: #323130;
-                    opacity: 1;
-                  }
-                  &:before {
-                    background-color: #ffffff;
-                    border-color: #323130;
-                    border-radius: 50%;
-                    border-style: solid;
-                    border-width: 1px;
-                    box-sizing: border-box;
-                    content: "";
-                    display: inline-block;
-                    font-weight: normal;
-                    height: 20px;
-                    left: auto;
-                    opacity: 0;
-                    position: absolute;
-                    right: 3px;
-                    top: 3px;
-                    transition-duration: 200ms;
-                    transition-property: border-color;
-                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
-                    width: 20px;
-                  }
-                  &:after {
-                    border-radius: 50%;
-                    box-sizing: border-box;
-                    content: "";
-                    height: 0px;
-                    left: 10px;
-                    position: absolute;
-                    right: 0px;
-                    transition-duration: 200ms;
-                    transition-property: border-width;
-                    transition-timing-function: cubic-bezier(.4, 0, .23, 1);
-                    width: 0px;
-                  }
-              htmlFor="ChoiceGroup0-pie"
             >
-              <div
-                className=
-                    ms-ChoiceField-innerField
-                    {
-                      display: inline-block;
-                      height: 32px;
-                      padding-left: 30px;
-                      padding-right: 30px;
-                      position: relative;
-                      width: 32px;
-                    }
+              <span
+                className="ms-ChoiceFieldLabel"
+                id="ChoiceGroupLabel1-pie"
               >
-                <div
-                  className=
-                      ms-ChoiceField-imageWrapper
-                      {
-                        padding-bottom: 2px;
-                        transition-duration: 200ms;
-                        transition-property: opacity;
-                        transition-timing-function: ease;
-                      }
-                      & .ms-Image {
-                        border-style: none;
-                        display: inline-block;
-                      }
-                >
-                  <div
-                    className=
-                        ms-Image
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                          overflow: hidden;
-                        }
-                    style={
-                      Object {
-                        "height": 32,
-                        "width": 32,
-                      }
-                    }
-                  >
-                    <img
-                      alt=""
-                      className=
-                          ms-Image-image
-                          ms-Image-image--portrait
-                          is-notLoaded
-                          is-fadeIn
-                          {
-                            display: block;
-                            height: 100%;
-                            opacity: 0;
-                            width: 100%;
-                          }
-                      onError={[Function]}
-                      onLoad={[Function]}
-                      src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/choicegroup-bar-unselected.png"
-                    />
-                  </div>
-                </div>
-                <div
-                  className=
-                      ms-ChoiceField-imageWrapper
-                      is-hidden
-                      {
-                        height: 100%;
-                        left: 0px;
-                        opacity: 0;
-                        overflow: hidden;
-                        padding-bottom: 2px;
-                        position: absolute;
-                        top: 0px;
-                        transition-duration: 200ms;
-                        transition-property: opacity;
-                        transition-timing-function: ease;
-                        width: 100%;
-                      }
-                      & .ms-Image {
-                        border-style: none;
-                        display: inline-block;
-                      }
-                >
-                  <div
-                    className=
-                        ms-Image
-                        {
-                          -moz-osx-font-smoothing: grayscale;
-                          -webkit-font-smoothing: antialiased;
-                          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                          font-size: 14px;
-                          font-weight: 400;
-                          overflow: hidden;
-                        }
-                    style={
-                      Object {
-                        "height": 32,
-                        "width": 32,
-                      }
-                    }
-                  >
-                    <img
-                      alt=""
-                      className=
-                          ms-Image-image
-                          ms-Image-image--portrait
-                          is-notLoaded
-                          is-fadeIn
-                          {
-                            display: block;
-                            height: 100%;
-                            opacity: 0;
-                            width: 100%;
-                          }
-                      onError={[Function]}
-                      onLoad={[Function]}
-                      src="https://static2.sharepointonline.com/files/fabric/office-ui-fabric-react-assets/choicegroup-bar-selected.png"
-                    />
-                  </div>
-                </div>
-              </div>
-              <div
-                className=
-                    ms-ChoiceField-labelWrapper
-                    {
-                      -moz-osx-font-smoothing: grayscale;
-                      -webkit-font-smoothing: antialiased;
-                      display: block;
-                      font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                      font-size: 14px;
-                      font-weight: 400;
-                      height: 30px;
-                      line-height: 15px;
-                      margin-bottom: 4px;
-                      margin-left: 8px;
-                      margin-right: 8px;
-                      margin-top: 4px;
-                      max-width: 64px;
-                      overflow: hidden;
-                      position: relative;
-                      text-overflow: ellipsis;
-                      white-space: pre-wrap;
-                    }
-              >
-                <span
-                  className="ms-ChoiceFieldLabel"
-                  id="ChoiceGroupLabel1-pie"
-                >
-                  Pie chart
-                </span>
-              </div>
-            </label>
-          </div>
+                Pie chart
+              </span>
+            </div>
+          </label>
         </div>
       </div>
     </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
@@ -26,14 +26,51 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
           padding-top: 5px;
           word-wrap: break-word;
         }
-        &::after {
-          color: #a4262c;
-          content: ' *';
-          padding-right: 12px;
-        }
     id="labelElement0"
   >
-    Custom label
+    <div
+      className=
+          ms-Stack
+          {
+            align-items: center;
+            box-sizing: border-box;
+            display: flex;
+            flex-direction: row;
+            flex-wrap: nowrap;
+            height: auto;
+            width: auto;
+          }
+          & > * {
+            text-overflow: ellipsis;
+          }
+          & > *:not(:first-child) {
+            margin-left: 0px;
+          }
+          & > *:not(.ms-StackItem) {
+            flex-shrink: 1;
+          }
+    >
+      <span>
+        Custom label  
+      </span>
+      <i
+        aria-hidden={true}
+        className=
+
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              font-family: "FabricMDL2Icons";
+              font-style: normal;
+              font-weight: normal;
+              speak: none;
+            }
+        data-icon-name="Filter"
+      >
+        
+      </i>
+    </div>
   </label>
   <div
     className=


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Related to #11479
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Update ChoiceGroupOption `labelId` docs to remove potential for confusion around `aria-owns`. Nothing in ChoiceGroup automatically applies `aria-owns`, and it's more potentially-misleading than helpful to be that specific in our docs about potential uses for an ID.

Also update examples: best practices, add a controlled example, and change ordering (to discourage people from unnecessarily doing more complex things like using custom labels). And remove @srideshpande from codeowners moving forward due to team changes.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11536)