### PR TITLE
Remove duplicate ChoiceGroupOption export

### DIFF
--- a/change/office-ui-fabric-react-2019-12-20-18-11-31-remove-reexport.json
+++ b/change/office-ui-fabric-react-2019-12-20-18-11-31-remove-reexport.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove duplicate ChoiceGroupOption export",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "commit": "871ba269748259eed69b43106d8b1a1f5e320408",
+  "date": "2019-12-21T02:11:31.853Z"
+}

--- a/packages/office-ui-fabric-react/src/index.ts
+++ b/packages/office-ui-fabric-react/src/index.ts
@@ -8,7 +8,7 @@ export * from './Callout';
 export * from './Check';
 export * from './Checkbox';
 export * from './ChoiceGroup';
-export * from './ChoiceGroupOption';
+// export * from './ChoiceGroupOption'; // exported by ChoiceGroup
 export * from './Coachmark';
 export * from './Color';
 export * from './ColorPicker';


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11534
- [x]  Include a change request file using `$ yarn change`

#### Description of changes

ChoiceGroupOption should only be exported from the root of the package once (by ChoiceGroup).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11537)