### PR TITLE
Selection: accept generic item type

### DIFF
--- a/change/@uifabric-utilities-2019-12-20-18-35-16-selection-generic.json
+++ b/change/@uifabric-utilities-2019-12-20-18-35-16-selection-generic.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Selection: accept generic item type",
+  "packageName": "@uifabric/utilities",
+  "email": "elcraig@microsoft.com",
+  "commit": "fd4b72e61ce81ab4dc8ff2e7ffe6d455a8996694",
+  "date": "2019-12-21T02:35:16.898Z"
+}

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -1013,7 +1013,7 @@ export const safeSetTimeout: (component: React.Component<{}, {}, any>) => (cb: F
 
 // @public (undocumented)
 export class Selection<TItem = IObjectWithKey> implements ISelection<TItem> {
-    constructor(...options: TItem extends IObjectWithKey ? [ISelectionOptions<TItem>] | [] : [ISelectionOptionsWithRequiredGetKey<TItem>]);
+    constructor(...options: TItem extends IObjectWithKey ? [] | [ISelectionOptions<TItem>] : [ISelectionOptionsWithRequiredGetKey<TItem>]);
     // (undocumented)
     canSelectItem(item: TItem, index?: number): boolean;
     count: number;

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -1011,7 +1011,7 @@ export const safeSetTimeout: (component: React.Component<{}, {}, any>) => (cb: F
 
 // @public (undocumented)
 export class Selection<TItem = IObjectWithKey> implements ISelection<TItem> {
-    constructor(options?: ISelectionOptions);
+    constructor(options?: ISelectionOptions<TItem>);
     // (undocumented)
     canSelectItem(item: TItem, index?: number): boolean;
     // (undocumented)

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -660,19 +660,19 @@ export function isControlled<P>(props: P, valueProp: keyof P): boolean;
 export function isDirectionalKeyCode(which: number): boolean;
 
 // @public (undocumented)
-export interface ISelection {
+export interface ISelection<TItem = IObjectWithKey> {
     // (undocumented)
-    canSelectItem: (item: IObjectWithKey, index?: number) => boolean;
+    canSelectItem: (item: TItem, index?: number) => boolean;
     // (undocumented)
     count: number;
     // (undocumented)
-    getItems(): IObjectWithKey[];
+    getItems(): TItem[];
     // (undocumented)
     getSelectedCount(): number;
     // (undocumented)
     getSelectedIndices(): number[];
     // (undocumented)
-    getSelection(): IObjectWithKey[];
+    getSelection(): TItem[];
     // (undocumented)
     isAllSelected(): boolean;
     // (undocumented)
@@ -696,7 +696,7 @@ export interface ISelection {
     // (undocumented)
     setIndexSelected(index: number, isSelected: boolean, shouldAnchor: boolean): void;
     // (undocumented)
-    setItems(items: IObjectWithKey[], shouldClear: boolean): void;
+    setItems(items: TItem[], shouldClear: boolean): void;
     // (undocumented)
     setKeySelected(key: string, isSelected: boolean, shouldAnchor: boolean): void;
     // (undocumented)
@@ -712,11 +712,11 @@ export interface ISelection {
 }
 
 // @public (undocumented)
-export interface ISelectionOptions {
+export interface ISelectionOptions<TItem = IObjectWithKey> {
     // (undocumented)
-    canSelectItem?: (item: IObjectWithKey, index?: number) => boolean;
+    canSelectItem?: (item: TItem, index?: number) => boolean;
     // (undocumented)
-    getKey?: (item: IObjectWithKey, index?: number) => string | number;
+    getKey?: (item: TItem, index?: number) => string | number;
     // (undocumented)
     onSelectionChanged?: () => void;
     // (undocumented)
@@ -1010,22 +1010,22 @@ export const safeRequestAnimationFrame: (component: React.Component<{}, {}, any>
 export const safeSetTimeout: (component: React.Component<{}, {}, any>) => (cb: Function, duration: number) => void;
 
 // @public (undocumented)
-export class Selection implements ISelection {
+export class Selection<TItem = IObjectWithKey> implements ISelection<TItem> {
     constructor(options?: ISelectionOptions);
     // (undocumented)
-    canSelectItem(item: IObjectWithKey, index?: number): boolean;
+    canSelectItem(item: TItem, index?: number): boolean;
     // (undocumented)
     count: number;
     // (undocumented)
-    getItems(): IObjectWithKey[];
+    getItems(): TItem[];
     // (undocumented)
-    getKey(item: IObjectWithKey, index?: number): string;
+    getKey(item: TItem, index?: number): string;
     // (undocumented)
     getSelectedCount(): number;
     // (undocumented)
     getSelectedIndices(): number[];
     // (undocumented)
-    getSelection(): IObjectWithKey[];
+    getSelection(): TItem[];
     // (undocumented)
     isAllSelected(): boolean;
     // (undocumented)
@@ -1048,7 +1048,7 @@ export class Selection implements ISelection {
     setChangeEvents(isEnabled: boolean, suppressChange?: boolean): void;
     // (undocumented)
     setIndexSelected(index: number, isSelected: boolean, shouldAnchor: boolean): void;
-    setItems(items: IObjectWithKey[], shouldClear?: boolean): void;
+    setItems(items: TItem[], shouldClear?: boolean): void;
     // (undocumented)
     setKeySelected(key: string, isSelected: boolean, shouldAnchor: boolean): void;
     // (undocumented)

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -715,13 +715,15 @@ export interface ISelection<TItem = IObjectWithKey> {
 export interface ISelectionOptions<TItem = IObjectWithKey> {
     // (undocumented)
     canSelectItem?: (item: TItem, index?: number) => boolean;
-    // (undocumented)
     getKey?: (item: TItem, index?: number) => string | number;
     // (undocumented)
     onSelectionChanged?: () => void;
     // (undocumented)
     selectionMode?: SelectionMode;
 }
+
+// @public
+export type ISelectionOptionsWithRequiredGetKey<TItem> = ISelectionOptions<TItem> & Required<Pick<ISelectionOptions<TItem>, 'getKey'>>;
 
 // @public
 export function isElementFocusSubZone(element?: HTMLElement): boolean;
@@ -1011,10 +1013,9 @@ export const safeSetTimeout: (component: React.Component<{}, {}, any>) => (cb: F
 
 // @public (undocumented)
 export class Selection<TItem = IObjectWithKey> implements ISelection<TItem> {
-    constructor(options?: ISelectionOptions<TItem>);
+    constructor(...options: TItem extends IObjectWithKey ? [ISelectionOptions<TItem>] | [] : [ISelectionOptionsWithRequiredGetKey<TItem>]);
     // (undocumented)
     canSelectItem(item: TItem, index?: number): boolean;
-    // (undocumented)
     count: number;
     // (undocumented)
     getItems(): TItem[];

--- a/packages/utilities/src/selection/Selection.test.ts
+++ b/packages/utilities/src/selection/Selection.test.ts
@@ -1,4 +1,4 @@
-import { Selection } from './Selection';
+import { Selection, ISelectionOptions } from './Selection';
 
 const setA = [{ key: 'a' }, { key: 'b' }, { key: 'c' }];
 const setB = [{ key: 'a' }, { key: 'd' }, { key: 'b' }];
@@ -128,5 +128,20 @@ describe('Selection', () => {
 
     expect(onSelectionChanged).toHaveBeenCalledTimes(2);
     expect(selection.count).toEqual(0);
+  });
+
+  it('allows custom item type', () => {
+    interface ICustomItem {
+      id: string;
+    }
+    const items: ICustomItem[] = [{ id: 'a' }, { id: 'b' }];
+    const selection = new Selection<ICustomItem>({
+      onSelectionChanged: onSelectionChanged,
+      getKey: (item: ICustomItem) => item.id
+    });
+    selection.setItems(items);
+
+    selection.setKeySelected('a', true, true);
+    expect(onSelectionChanged).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/utilities/src/selection/Selection.test.ts
+++ b/packages/utilities/src/selection/Selection.test.ts
@@ -1,4 +1,4 @@
-import { Selection, ISelectionOptions } from './Selection';
+import { Selection } from './Selection';
 
 const setA = [{ key: 'a' }, { key: 'b' }, { key: 'c' }];
 const setB = [{ key: 'a' }, { key: 'd' }, { key: 'b' }];

--- a/packages/utilities/src/selection/Selection.ts
+++ b/packages/utilities/src/selection/Selection.ts
@@ -4,26 +4,26 @@ import { EventGroup } from '../EventGroup';
 /**
  * {@docCategory Selection}
  */
-export interface ISelectionOptions {
+export interface ISelectionOptions<TItem = IObjectWithKey> {
   onSelectionChanged?: () => void;
-  getKey?: (item: IObjectWithKey, index?: number) => string | number;
-  canSelectItem?: (item: IObjectWithKey, index?: number) => boolean;
+  getKey?: (item: TItem, index?: number) => string | number;
+  canSelectItem?: (item: TItem, index?: number) => boolean;
   selectionMode?: SelectionMode;
 }
 
 /**
  * {@docCategory Selection}
  */
-export class Selection implements ISelection {
+export class Selection<TItem = IObjectWithKey> implements ISelection<TItem> {
   public count: number;
   public readonly mode: SelectionMode;
 
-  private _getKey: (item: IObjectWithKey, index?: number) => string | number;
-  private _canSelectItem: (item: IObjectWithKey, index?: number) => boolean;
+  private _getKey: (item: TItem, index?: number) => string | number;
+  private _canSelectItem: (item: TItem, index?: number) => boolean;
 
   private _changeEventSuppressionCount: number;
-  private _items: IObjectWithKey[];
-  private _selectedItems: IObjectWithKey[] | null;
+  private _items: TItem[];
+  private _selectedItems: TItem[] | null;
   private _selectedIndices: number[] | undefined;
   private _isAllSelected: boolean;
   private _exemptedIndices: { [index: string]: boolean };
@@ -37,7 +37,7 @@ export class Selection implements ISelection {
   private _isModal: boolean;
 
   constructor(options: ISelectionOptions = {}) {
-    const { onSelectionChanged, getKey, canSelectItem = (item: IObjectWithKey) => true, selectionMode = SelectionMode.multiple } = options;
+    const { onSelectionChanged, getKey, canSelectItem = () => true, selectionMode = SelectionMode.multiple } = options;
 
     this.mode = selectionMode;
 
@@ -58,7 +58,7 @@ export class Selection implements ISelection {
     this.count = this.getSelectedCount();
   }
 
-  public canSelectItem(item: IObjectWithKey, index?: number): boolean {
+  public canSelectItem(item: TItem, index?: number): boolean {
     if (typeof index === 'number' && index < 0) {
       return false;
     }
@@ -66,7 +66,7 @@ export class Selection implements ISelection {
     return this._canSelectItem(item, index);
   }
 
-  public getKey(item: IObjectWithKey, index?: number): string {
+  public getKey(item: TItem, index?: number): string {
     const key = this._getKey(item, index);
 
     return typeof key === 'number' || key ? `${key}` : '';
@@ -110,7 +110,7 @@ export class Selection implements ISelection {
    * Otherwise, shouldClear should be set to true, so that selection is
    * cleared.
    */
-  public setItems(items: IObjectWithKey[], shouldClear: boolean = true): void {
+  public setItems(items: TItem[], shouldClear: boolean = true): void {
     const newKeyToIndexMap: { [key: string]: number } = {};
     const newUnselectableIndices: { [key: string]: boolean } = {};
     let hasSelectionChanged = false;
@@ -185,11 +185,11 @@ export class Selection implements ISelection {
     this.setChangeEvents(true);
   }
 
-  public getItems(): IObjectWithKey[] {
+  public getItems(): TItem[] {
     return this._items;
   }
 
-  public getSelection(): IObjectWithKey[] {
+  public getSelection(): TItem[] {
     if (!this._selectedItems) {
       this._selectedItems = [];
 
@@ -254,7 +254,7 @@ export class Selection implements ISelection {
     }
 
     return (
-      (this.count > 0 && (this._isAllSelected && this._exemptedCount === 0)) ||
+      (this.count > 0 && this._isAllSelected && this._exemptedCount === 0) ||
       (!this._isAllSelected && this._exemptedCount === selectableCount && selectableCount > 0)
     );
   }
@@ -267,7 +267,7 @@ export class Selection implements ISelection {
 
   public isIndexSelected(index: number): boolean {
     return !!(
-      (this.count > 0 && (this._isAllSelected && !this._exemptedIndices[index] && !this._unselectableIndices[index])) ||
+      (this.count > 0 && this._isAllSelected && !this._exemptedIndices[index] && !this._unselectableIndices[index]) ||
       (!this._isAllSelected && this._exemptedIndices[index])
     );
   }
@@ -465,6 +465,6 @@ export class Selection implements ISelection {
   }
 }
 
-function defaultGetKey(item: IObjectWithKey, index?: number): string | number {
-  return item && item.key ? item.key : `${index}`;
+function defaultGetKey<TItem = IObjectWithKey>(item: TItem, index?: number): string | number {
+  return item && (item as IObjectWithKey).key ? (item as IObjectWithKey).key! : `${index}`;
 }

--- a/packages/utilities/src/selection/Selection.ts
+++ b/packages/utilities/src/selection/Selection.ts
@@ -13,6 +13,12 @@ export interface ISelectionOptions<TItem = IObjectWithKey> {
 }
 
 /**
+ * Selection options with required `getKey` property.
+ * {@docCategory Selection}
+ */
+export type ISelectionOptionsWithRequiredGetKey<TItem> = ISelectionOptions<TItem> & Required<Pick<ISelectionOptions<TItem>, 'getKey'>>;
+
+/**
  * {@docCategory Selection}
  */
 export class Selection<TItem = IObjectWithKey> implements ISelection<TItem> {
@@ -38,8 +44,14 @@ export class Selection<TItem = IObjectWithKey> implements ISelection<TItem> {
   private _unselectableCount: number;
   private _isModal: boolean;
 
-  constructor(options: ISelectionOptions<TItem> = {}) {
-    const { onSelectionChanged, getKey, canSelectItem = () => true, selectionMode = SelectionMode.multiple } = options;
+  /**
+   * Create a new Selection. If `TItem` has a `key` property, the `options` parameter is optional.
+   * Otherwise, you must provide `options` with a `getKey` implementation. (At most one `options`
+   * object is accepted.)
+   */
+  constructor(...options: TItem extends IObjectWithKey ? [ISelectionOptions<TItem>] | [] : [ISelectionOptionsWithRequiredGetKey<TItem>]) {
+    const { onSelectionChanged, getKey, canSelectItem = () => true, selectionMode = SelectionMode.multiple } =
+      options[0] || ({} as ISelectionOptions<TItem>);
 
     this.mode = selectionMode;
 

--- a/packages/utilities/src/selection/Selection.ts
+++ b/packages/utilities/src/selection/Selection.ts
@@ -36,7 +36,7 @@ export class Selection<TItem = IObjectWithKey> implements ISelection<TItem> {
   private _unselectableCount: number;
   private _isModal: boolean;
 
-  constructor(options: ISelectionOptions = {}) {
+  constructor(options: ISelectionOptions<TItem> = {}) {
     const { onSelectionChanged, getKey, canSelectItem = () => true, selectionMode = SelectionMode.multiple } = options;
 
     this.mode = selectionMode;

--- a/packages/utilities/src/selection/Selection.ts
+++ b/packages/utilities/src/selection/Selection.ts
@@ -6,6 +6,7 @@ import { EventGroup } from '../EventGroup';
  */
 export interface ISelectionOptions<TItem = IObjectWithKey> {
   onSelectionChanged?: () => void;
+  /** Custom logic to generate item keys. Required if `TItem` does not have a `key` property. */
   getKey?: (item: TItem, index?: number) => string | number;
   canSelectItem?: (item: TItem, index?: number) => boolean;
   selectionMode?: SelectionMode;
@@ -15,6 +16,7 @@ export interface ISelectionOptions<TItem = IObjectWithKey> {
  * {@docCategory Selection}
  */
 export class Selection<TItem = IObjectWithKey> implements ISelection<TItem> {
+  /** Number of items selected. Do not modify. */
   public count: number;
   public readonly mode: SelectionMode;
 

--- a/packages/utilities/src/selection/Selection.ts
+++ b/packages/utilities/src/selection/Selection.ts
@@ -45,11 +45,15 @@ export class Selection<TItem = IObjectWithKey> implements ISelection<TItem> {
   private _isModal: boolean;
 
   /**
-   * Create a new Selection. If `TItem` has a `key` property, the `options` parameter is optional.
-   * Otherwise, you must provide `options` with a `getKey` implementation. (At most one `options`
-   * object is accepted.)
+   * Create a new Selection. If `TItem` does not have a `key` property, you must provide an options
+   * object with a `getKey` implementation. Providing options is optional otherwise.
+   * (At most one `options` object is accepted.)
    */
-  constructor(...options: TItem extends IObjectWithKey ? [ISelectionOptions<TItem>] | [] : [ISelectionOptionsWithRequiredGetKey<TItem>]) {
+  constructor(
+    ...options: TItem extends IObjectWithKey // If the item type has a built-in key...
+      ? [] | [ISelectionOptions<TItem>] // Then the arguments can be empty or have the options without `getKey`
+      : [ISelectionOptionsWithRequiredGetKey<TItem>] // Otherwise, arguments require options with `getKey`.
+  ) {
     const { onSelectionChanged, getKey, canSelectItem = () => true, selectionMode = SelectionMode.multiple } =
       options[0] || ({} as ISelectionOptions<TItem>);
 

--- a/packages/utilities/src/selection/Selection.types.ts
+++ b/packages/utilities/src/selection/Selection.types.ts
@@ -19,23 +19,23 @@ export enum SelectionMode {
 /**
  * {@docCategory Selection}
  */
-export interface ISelection {
+export interface ISelection<TItem = IObjectWithKey> {
   count: number;
   mode: SelectionMode;
 
-  canSelectItem: (item: IObjectWithKey, index?: number) => boolean;
+  canSelectItem: (item: TItem, index?: number) => boolean;
 
   // Obesrvable methods.
   setChangeEvents(isEnabled: boolean, suppressChange?: boolean): void;
 
   // Initialization methods.
 
-  setItems(items: IObjectWithKey[], shouldClear: boolean): void;
-  getItems(): IObjectWithKey[];
+  setItems(items: TItem[], shouldClear: boolean): void;
+  getItems(): TItem[];
 
   // Read selection methods.
 
-  getSelection(): IObjectWithKey[];
+  getSelection(): TItem[];
   getSelectedIndices(): number[];
   getSelectedCount(): number;
   isRangeSelected(fromIndex: number, count: number): boolean;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11484
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Since Selection supports fully customizing how keys are generated using `getKey`, it makes sense to allow a generic item type instead of just `IObjectWithKey`. I kept `IObjectWithKey` as the default, so this shouldn't be a breaking change.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11538)