### PR TITLE
OverflowSet: add menuitem role to child

### DIFF
--- a/change/office-ui-fabric-react-2019-12-24-12-39-09-user-v-satgar-addedRoleAsMenuItem.json
+++ b/change/office-ui-fabric-react-2019-12-24-12-39-09-user-v-satgar-addedRoleAsMenuItem.json
@@ -2,7 +2,7 @@
   "type": "patch",
   "comment": "Added role as menuitem to the child div",
   "packageName": "office-ui-fabric-react",
-  "email": "email not defined",
+  "email": "gantaravishankar@gmail.com",
   "commit": "8295ecd9f838cd45fa9432a21d0c24edfc116551",
   "date": "2019-12-24T07:09:09.120Z"
 }

--- a/change/office-ui-fabric-react-2019-12-24-12-39-09-user-v-satgar-addedRoleAsMenuItem.json
+++ b/change/office-ui-fabric-react-2019-12-24-12-39-09-user-v-satgar-addedRoleAsMenuItem.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Added role as menuitem to the child div",
+  "packageName": "office-ui-fabric-react",
+  "email": "email not defined",
+  "commit": "8295ecd9f838cd45fa9432a21d0c24edfc116551",
+  "date": "2019-12-24T07:09:09.120Z"
+}

--- a/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/OverflowSet/OverflowSet.base.tsx
@@ -143,7 +143,8 @@ export class OverflowSetBase extends BaseComponent<IOverflowSetProps, {}> implem
   private _onRenderItems = (items: IOverflowSetItemProps[]): JSX.Element[] => {
     return items.map((item, i) => {
       const wrapperDivProps: React.HTMLProps<HTMLDivElement> = {
-        className: this._classNames.item
+        className: this._classNames.item,
+        role: item.role ? item.role : 'menuitem'
       };
       return (
         <div key={item.key} {...wrapperDivProps}>


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Added role as 'menuitem' to the child div which already has role as 'menubar' in 'OverflowSet'

#### Focus areas to test

OverflowSet

#### Before Fix

![image](https://user-images.githubusercontent.com/53299259/71400333-74f7fa80-264c-11ea-8199-7a395edb0ce8.png)

#### After Fix

![image](https://user-images.githubusercontent.com/53299259/71400354-7f19f900-264c-11ea-959d-3cca67dabd56.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11548)