### PR TITLE
Allow RTL to be passed into createTheme and picked up by Fabric and Layer

### DIFF
--- a/change/@uifabric-styling-2019-12-26-12-57-09-rtl-theme-fix.json
+++ b/change/@uifabric-styling-2019-12-26-12-57-09-rtl-theme-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "createTheme: Pass through RTL if specified",
+  "packageName": "@uifabric/styling",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "75306dc096b49d26b0e3f3310343fbe267b7f1f9",
+  "date": "2019-12-26T20:57:09.095Z"
+}

--- a/change/office-ui-fabric-react-2019-12-26-12-57-09-rtl-theme-fix.json
+++ b/change/office-ui-fabric-react-2019-12-26-12-57-09-rtl-theme-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Layer and Fabric controls: listen for rtl in theme",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "75306dc096b49d26b0e3f3310343fbe267b7f1f9",
+  "date": "2019-12-26T20:56:42.440Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Fabric/Fabric.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Fabric/Fabric.styles.ts
@@ -22,6 +22,7 @@ export const getStyles = (props: IFabricStyleProps): IFabricStyles => {
       isFocusVisible && 'is-focusVisible ms-Fabric--isFocusVisible',
       theme.fonts.medium,
       {
+        direction: theme.rtl ? 'rtl' : undefined,
         color: theme.palette.neutralPrimary,
         selectors: {
           '& button': inheritFont,

--- a/packages/office-ui-fabric-react/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
@@ -505,6 +505,7 @@ exports[`Fabric renders a Fabric component in RTL 1`] = `
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
               color: #323130;
+              direction: rtl;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 400;

--- a/packages/office-ui-fabric-react/src/components/Layer/Layer.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Layer/Layer.styles.ts
@@ -16,10 +16,12 @@ export const getStyles = (props: ILayerStyleProps): ILayerStyles => {
     root: [
       classNames.root,
       theme.fonts.medium,
+      {
+        direction: theme.rtl ? 'rtl' : undefined
+      },
       isNotHost && [
         classNames.rootNoHost,
         {
-          direction: theme.rtl ? 'rtl' : undefined,
           position: 'fixed',
           zIndex: ZIndexes.Layer,
           top: 0,

--- a/packages/office-ui-fabric-react/src/components/Layer/Layer.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Layer/Layer.styles.ts
@@ -16,9 +16,6 @@ export const getStyles = (props: ILayerStyleProps): ILayerStyles => {
     root: [
       classNames.root,
       theme.fonts.medium,
-      {
-        direction: theme.rtl ? 'rtl' : undefined
-      },
       isNotHost && [
         classNames.rootNoHost,
         {

--- a/packages/office-ui-fabric-react/src/components/Layer/Layer.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Layer/Layer.styles.ts
@@ -19,6 +19,7 @@ export const getStyles = (props: ILayerStyleProps): ILayerStyles => {
       isNotHost && [
         classNames.rootNoHost,
         {
+          direction: theme.rtl ? 'rtl' : undefined,
           position: 'fixed',
           zIndex: ZIndexes.Layer,
           top: 0,

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -148,6 +148,7 @@ export function createTheme(theme: IPartialTheme, depComments: boolean = false):
     fonts: {
       ...defaultFontStyles
     },
+    rtl: !!theme.rtl,
     semanticColors: newSemanticColors,
     isInverted: !!theme.isInverted,
     disableGlobalClassNames: !!theme.disableGlobalClassNames,

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -148,7 +148,7 @@ export function createTheme(theme: IPartialTheme, depComments: boolean = false):
     fonts: {
       ...defaultFontStyles
     },
-    rtl: !!theme.rtl,
+    rtl: theme.rtl,
     semanticColors: newSemanticColors,
     isInverted: !!theme.isInverted,
     disableGlobalClassNames: !!theme.disableGlobalClassNames,


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #11543
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Here's an example of how to use contextual RTL once this is released.

```tsx
       const rtlTheme = createTheme({
         rtl: true
       });

      // Customizer creates an RTL theme that is passed
      // to all child components style functions, 
      // even those rendered outside of the rtl div
      <Customizer settings={{ theme: rtlTheme }}>
        {/* 
            RTL is still required because Customizer does modify the DOM
            You can also use `Fabric` component instead of RTL div, 
            as Fabric will pick up RTL from theme 
        */}
        <div dir="rtl">
          <Dropdown
            placeholder="Select an option"
            label="Basic uncontrolled example"
            options={options}
            styles={dropdownStyles}
          />
        </div>
      </Customizer>

```

https://codepen.io/micahgodbolt/pen/NWPaGoB?editors=0010

#### Focus areas to test




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11560)