### PR TITLE
Calendar Example Focus Fix

### DIFF
--- a/change/office-ui-fabric-react-2019-12-26-16-19-00-calendar-edge-focus-example.json
+++ b/change/office-ui-fabric-react-2019-12-26-16-19-00-calendar-edge-focus-example.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add firstFocusableSelector to example FocusTrapZone to resolve Edge issue",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "8cabe7e25ae40ef46dca35f9fc3189c04f370b54",
+  "date": "2019-12-27T00:19:00.563Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Button.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Button.Example.tsx
@@ -79,7 +79,7 @@ export class CalendarButtonExample extends React.Component<ICalendarButtonExampl
             onDismiss={this._onDismiss}
             setInitialFocus={true}
           >
-            <FocusTrapZone isClickableOutsideFocusTrap={true}>
+            <FocusTrapZone firstFocusableSelector="ms-DatePicker-day--today" isClickableOutsideFocusTrap={true}>
               <Calendar
                 onSelectDate={this._onSelectDate}
                 onDismiss={this._onDismiss}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #11551
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

For some reason the FocusTrapZone is messing with focus in the Calendar example, and the problem only occurs in Edge. 

This quick fix will demonstrate how to focus back on the selected day. 

**Before:**

![cal1](https://user-images.githubusercontent.com/1434956/71494420-08bbf900-27fc-11ea-92c3-d39877493e93.gif)

**After:**

![cal2](https://user-images.githubusercontent.com/1434956/71494422-0e194380-27fc-11ea-85d7-ff08b685159a.gif)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11562)