### PR TITLE
DetailsList: Update examples to work in strictFunctionTypes

### DIFF
--- a/change/office-ui-fabric-react-2019-12-26-17-00-28-details-list-exmaples.json
+++ b/change/office-ui-fabric-react-2019-12-26-17-00-28-details-list-exmaples.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "DetailsList: Update examples to work in strictFunctionTypes",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "4b7738397411b203ef516b28f9c8f00c569dcc2e",
+  "date": "2019-12-27T01:00:28.650Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomFooter.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomFooter.Example.tsx
@@ -6,9 +6,9 @@ import {
   IDetailsFooterProps,
   DetailsRow,
   SelectionMode,
-  IDetailsRowCheckProps,
   DetailsRowCheck
 } from 'office-ui-fabric-react/lib/DetailsList';
+import { IDetailsRowBaseProps } from '../DetailsRow';
 
 export interface IDetailsListCustomFooterExampleItem {
   key: number;
@@ -71,14 +71,17 @@ export class DetailsListCustomFooterExample extends React.Component<{}, {}> {
   }
 }
 
-function _renderDetailsFooterItemColumn(item: IDetailsListCustomFooterExampleItem, index: number, column: IColumn) {
-  return (
-    <div>
-      <b>{column.name}</b>
-    </div>
-  );
-}
+const _renderDetailsFooterItemColumn: IDetailsRowBaseProps['onRenderItemColumn'] = (item, index, column) => {
+  if (column) {
+    return (
+      <div>
+        <b>{column.name}</b>
+      </div>
+    );
+  }
+  return undefined;
+};
 
-function _onRenderCheckForFooterRow(props: IDetailsRowCheckProps): JSX.Element {
+const _onRenderCheckForFooterRow: IDetailsRowBaseProps['onRenderCheck'] = (props): JSX.Element => {
   return <DetailsRowCheck {...props} styles={{ root: { visibility: 'hidden' } }} selected={true} />;
-}
+};

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomFooter.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomFooter.Example.tsx
@@ -6,9 +6,9 @@ import {
   IDetailsFooterProps,
   DetailsRow,
   SelectionMode,
-  DetailsRowCheck
+  DetailsRowCheck,
+  IDetailsRowBaseProps
 } from 'office-ui-fabric-react/lib/DetailsList';
-import { IDetailsRowBaseProps } from '../DetailsRow';
 
 export interface IDetailsListCustomFooterExampleItem {
   key: number;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomGroupHeaders.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomGroupHeaders.Example.tsx
@@ -82,7 +82,7 @@ export class DetailsListCustomGroupHeadersExample extends React.Component<{}, {}
     return null;
   };
 
-  private _onRenderGroupHeader: IDetailsGroupRenderProps['onRenderHeader'] = (props): JSX.Element => {
+  private _onRenderGroupHeader: IDetailsGroupRenderProps['onRenderHeader'] = props => {
     if (props) {
       return (
         <div className={classNames.headerAndFooter}>
@@ -98,9 +98,11 @@ export class DetailsListCustomGroupHeadersExample extends React.Component<{}, {}
         </div>
       );
     }
+
+    return null;
   };
 
-  private _onRenderGroupFooter: IDetailsGroupRenderProps['onRenderFooter'] = (props): JSX.Element => {
+  private _onRenderGroupFooter: IDetailsGroupRenderProps['onRenderFooter'] = props => {
     if (props) {
       return (
         <div className={classNames.headerAndFooter}>
@@ -108,6 +110,8 @@ export class DetailsListCustomGroupHeadersExample extends React.Component<{}, {}
         </div>
       );
     }
+
+    return null;
   };
 
   private _getGroupTotalRowHeight = (group: IGroup): number => {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomGroupHeaders.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomGroupHeaders.Example.tsx
@@ -1,10 +1,15 @@
 import * as React from 'react';
 import { Link } from 'office-ui-fabric-react/lib/Link';
-import { DetailsHeader, DetailsList, IGroup, IGroupDividerProps } from 'office-ui-fabric-react/lib/DetailsList';
+import {
+  DetailsHeader,
+  DetailsList,
+  IGroup,
+  IGroupDividerProps,
+  IDetailsListProps,
+  IDetailsGroupRenderProps
+} from 'office-ui-fabric-react/lib/DetailsList';
 import { createListItems, createGroups, IExampleItem } from '@uifabric/example-data';
 import { getTheme, mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
-import { IDetailsListProps } from '../DetailsList';
-import { IDetailsGroupRenderProps } from '../DetailsList.types';
 
 const ROW_HEIGHT: number = 42; // from DEFAULT_ROW_HEIGHTS in DetailsRow.styles.ts
 const GROUP_HEADER_AND_FOOTER_SPACING: number = 8;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomGroupHeaders.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomGroupHeaders.Example.tsx
@@ -1,8 +1,10 @@
 import * as React from 'react';
 import { Link } from 'office-ui-fabric-react/lib/Link';
-import { DetailsHeader, DetailsList, IDetailsHeaderProps, IGroup, IGroupDividerProps } from 'office-ui-fabric-react/lib/DetailsList';
+import { DetailsHeader, DetailsList, IGroup, IGroupDividerProps } from 'office-ui-fabric-react/lib/DetailsList';
 import { createListItems, createGroups, IExampleItem } from '@uifabric/example-data';
 import { getTheme, mergeStyleSets } from 'office-ui-fabric-react/lib/Styling';
+import { IDetailsListProps } from '../DetailsList';
+import { IDetailsGroupRenderProps } from '../DetailsList.types';
 
 const ROW_HEIGHT: number = 42; // from DEFAULT_ROW_HEIGHTS in DetailsRow.styles.ts
 const GROUP_HEADER_AND_FOOTER_SPACING: number = 8;
@@ -68,32 +70,39 @@ export class DetailsListCustomGroupHeadersExample extends React.Component<{}, {}
     );
   }
 
-  private _onRenderDetailsHeader(props: IDetailsHeaderProps) {
-    return <DetailsHeader {...props} ariaLabelForToggleAllGroupsButton={'Toggle selection'} />;
-  }
-
-  private _onRenderGroupHeader = (props: IGroupDividerProps): JSX.Element => {
-    return (
-      <div className={classNames.headerAndFooter}>
-        <div className={classNames.headerTitle}>{`Custom header for ${props.group!.name}`}</div>
-        <div className={classNames.headerLinkSet}>
-          <Link className={classNames.headerLink} onClick={this._onToggleSelectGroup(props)}>
-            {props.isSelected ? 'Remove selection' : 'Select group'}
-          </Link>
-          <Link className={classNames.headerLink} onClick={this._onToggleCollapse(props)}>
-            {props.group!.isCollapsed ? 'Expand group' : 'Collapse group'}
-          </Link>
-        </div>
-      </div>
-    );
+  private _onRenderDetailsHeader: IDetailsListProps['onRenderDetailsHeader'] = props => {
+    if (props) {
+      return <DetailsHeader {...props} ariaLabelForToggleAllGroupsButton={'Toggle selection'} />;
+    }
+    return null;
   };
 
-  private _onRenderGroupFooter = (props: IGroupDividerProps): JSX.Element => {
-    return (
-      <div className={classNames.headerAndFooter}>
-        <em>{`Custom footer for ${props.group!.name}`}</em>
-      </div>
-    );
+  private _onRenderGroupHeader: IDetailsGroupRenderProps['onRenderHeader'] = (props): JSX.Element => {
+    if (props) {
+      return (
+        <div className={classNames.headerAndFooter}>
+          <div className={classNames.headerTitle}>{`Custom header for ${props.group!.name}`}</div>
+          <div className={classNames.headerLinkSet}>
+            <Link className={classNames.headerLink} onClick={this._onToggleSelectGroup(props)}>
+              {props.isSelected ? 'Remove selection' : 'Select group'}
+            </Link>
+            <Link className={classNames.headerLink} onClick={this._onToggleCollapse(props)}>
+              {props.group!.isCollapsed ? 'Expand group' : 'Collapse group'}
+            </Link>
+          </div>
+        </div>
+      );
+    }
+  };
+
+  private _onRenderGroupFooter: IDetailsGroupRenderProps['onRenderFooter'] = (props): JSX.Element => {
+    if (props) {
+      return (
+        <div className={classNames.headerAndFooter}>
+          <em>{`Custom footer for ${props.group!.name}`}</em>
+        </div>
+      );
+    }
   };
 
   private _getGroupTotalRowHeight = (group: IGroup): number => {

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomRows.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomRows.Example.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
-import { DetailsList, DetailsRow, IDetailsRowProps, IDetailsRowStyles } from 'office-ui-fabric-react/lib/DetailsList';
+import { DetailsList, DetailsRow, IDetailsRowStyles } from 'office-ui-fabric-react/lib/DetailsList';
 import { createListItems, IExampleItem } from '@uifabric/example-data';
 import { getTheme } from 'office-ui-fabric-react/lib/Styling';
+import { IDetailsListProps } from '../DetailsList';
 
 const theme = getTheme();
 
@@ -17,13 +18,15 @@ export class DetailsListCustomRowsExample extends React.Component<{}, {}> {
     return <DetailsList items={this._items} setKey="set" onRenderRow={this._onRenderRow} checkButtonAriaLabel="Row checkbox" />;
   }
 
-  private _onRenderRow = (props: IDetailsRowProps): JSX.Element => {
+  private _onRenderRow: IDetailsListProps['onRenderRow'] = (props): JSX.Element => {
     const customStyles: Partial<IDetailsRowStyles> = {};
-    if (props.itemIndex % 2 === 0) {
-      // Every other row renders with a different background color
-      customStyles.root = { backgroundColor: theme.palette.themeLighterAlt };
-    }
+    if (props) {
+      if (props.itemIndex % 2 === 0) {
+        // Every other row renders with a different background color
+        customStyles.root = { backgroundColor: theme.palette.themeLighterAlt };
+      }
 
-    return <DetailsRow {...props} styles={customStyles} />;
+      return <DetailsRow {...props} styles={customStyles} />;
+    }
   };
 }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomRows.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomRows.Example.tsx
@@ -1,8 +1,7 @@
 import * as React from 'react';
-import { DetailsList, DetailsRow, IDetailsRowStyles } from 'office-ui-fabric-react/lib/DetailsList';
+import { DetailsList, DetailsRow, IDetailsRowStyles, IDetailsListProps } from 'office-ui-fabric-react/lib/DetailsList';
 import { createListItems, IExampleItem } from '@uifabric/example-data';
 import { getTheme } from 'office-ui-fabric-react/lib/Styling';
-import { IDetailsListProps } from '../DetailsList';
 
 const theme = getTheme();
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomRows.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.CustomRows.Example.tsx
@@ -17,7 +17,7 @@ export class DetailsListCustomRowsExample extends React.Component<{}, {}> {
     return <DetailsList items={this._items} setKey="set" onRenderRow={this._onRenderRow} checkButtonAriaLabel="Row checkbox" />;
   }
 
-  private _onRenderRow: IDetailsListProps['onRenderRow'] = (props): JSX.Element => {
+  private _onRenderRow: IDetailsListProps['onRenderRow'] = props => {
     const customStyles: Partial<IDetailsRowStyles> = {};
     if (props) {
       if (props.itemIndex % 2 === 0) {
@@ -27,5 +27,6 @@ export class DetailsListCustomRowsExample extends React.Component<{}, {}> {
 
       return <DetailsRow {...props} styles={customStyles} />;
     }
+    return null;
   };
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #11546
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Previous examples listed onRenderFunctions too loosely, stating that props would always be defined, when in fact the function only passes them optionally.

Without strictFunctionTypes typescript has no problem with this because the defined function is a [supertype of the original.](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-2-6.html) 



#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11563)