### PR TITLE
Combobox: Focus returns to input after item click

### DIFF
--- a/change/office-ui-fabric-react-2019-12-27-13-19-48-combobox-click-close.json
+++ b/change/office-ui-fabric-react-2019-12-27-13-19-48-combobox-click-close.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Combobox: Focus returns to input after item click",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "c45255bca111b40e965ed67540aaf1461f4163d8",
+  "date": "2019-12-27T21:19:48.386Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1463,6 +1463,10 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       this._setSelectedIndex(index as number, ev);
       if (!this.props.multiSelect) {
         // only close the callout when it's in single-select mode
+        if (this._autofill.current) {
+          // ensure that focus returns to the input, not the button
+          this._autofill.current.focus();
+        }
         this.setState({
           isOpen: false
         });

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1461,12 +1461,11 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
     return (ev: any): void => {
       onItemClick && onItemClick(ev, item, index);
       this._setSelectedIndex(index as number, ev);
+
+      // only close the callout when it's in single-select mode
       if (!this.props.multiSelect) {
-        // only close the callout when it's in single-select mode
-        if (this._autofill.current) {
-          // ensure that focus returns to the input, not the button
-          this._autofill.current.focus();
-        }
+        // ensure that focus returns to the input, not the button
+        this._autofill.current && this._autofill.current.focus();
         this.setState({
           isOpen: false
         });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #11567
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Current behavior is not consistent:

![combo](https://user-images.githubusercontent.com/1434956/71594853-5d0df400-2aee-11ea-8e2f-33841137267b.gif)


If user opens combobox via button, and then clicks on an option, focus is returned to the button instead of the input. Any arrow key navigation ensures focus returns to input.

This was causing a bug in IE11 where narrator wouldn't read text if focus was on the button instead of the input. 

This also makes combobox behavior more consistent as per [this comment ](https://github.com/OfficeDev/office-ui-fabric-react/issues/11565#issuecomment-569369587)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11570)