### PR TITLE
Layer: add touch events to filtering to stop those that are bubbling up.

### DIFF
--- a/change/office-ui-fabric-react-2019-12-27-13-39-03-reactdnd.json
+++ b/change/office-ui-fabric-react-2019-12-27-13-39-03-reactdnd.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Layer: add touch events to filtering to stop those that are bubbling up",
+  "packageName": "office-ui-fabric-react",
+  "email": "email not defined",
+  "commit": "992537473a22e8d7f7ef217e17ab4da31ceef3db",
+  "date": "2019-12-27T21:39:03.474Z"
+}

--- a/change/office-ui-fabric-react-2019-12-27-13-39-03-reactdnd.json
+++ b/change/office-ui-fabric-react-2019-12-27-13-39-03-reactdnd.json
@@ -2,7 +2,7 @@
   "type": "patch",
   "comment": "Layer: add touch events to filtering to stop those that are bubbling up",
   "packageName": "office-ui-fabric-react",
-  "email": "email not defined",
+  "email": "aneeshak@microsoft.com",
   "commit": "992537473a22e8d7f7ef217e17ab4da31ceef3db",
   "date": "2019-12-27T21:39:03.474Z"
 }

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
@@ -184,6 +184,10 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
         onMouseOver={[Function]}
         onMouseUp={[Function]}
         onSubmit={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
       >
         <div
           className=

--- a/packages/office-ui-fabric-react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
@@ -52,6 +52,10 @@ exports[`HoverCard renders ExpandingCard correctly 1`] = `
     onMouseOver={[Function]}
     onMouseUp={[Function]}
     onSubmit={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
   >
     <div
       className=
@@ -215,6 +219,10 @@ exports[`HoverCard renders PlainCard correctly 1`] = `
     onMouseOver={[Function]}
     onMouseUp={[Function]}
     onSubmit={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
   >
     <div
       className=

--- a/packages/office-ui-fabric-react/src/components/Layer/Layer.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Layer/Layer.base.tsx
@@ -163,7 +163,13 @@ export class LayerBase extends React.Component<ILayerProps, ILayerBaseState> {
 const _onFilterEvent = (ev: React.SyntheticEvent<HTMLElement>): void => {
   // We should just be able to check ev.bubble here and only stop events that are bubbling up. However, even though mouseenter and
   //    mouseleave do NOT bubble up, they are showing up as bubbling. Therefore we stop events based on event name rather than ev.bubble.
-  if (ev.eventPhase === Event.BUBBLING_PHASE && ev.type !== 'mouseenter' && ev.type !== 'mouseleave') {
+  if (
+    ev.eventPhase === Event.BUBBLING_PHASE &&
+    ev.type !== 'mouseenter' &&
+    ev.type !== 'mouseleave' &&
+    ev.type !== 'touchstart' &&
+    ev.type !== 'touchend'
+  ) {
     ev.stopPropagation();
   }
 };
@@ -193,6 +199,10 @@ function _getFilteredEvents() {
       'onMouseOver',
       'onMouseOut',
       'onMouseUp',
+      'onTouchMove',
+      'onTouchStart',
+      'onTouchCancel',
+      'onTouchEnd',
       'onKeyDown',
       'onKeyPress',
       'onKeyUp',

--- a/packages/office-ui-fabric-react/src/components/Layer/__snapshots__/Layer.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Layer/__snapshots__/Layer.test.tsx.snap
@@ -52,6 +52,10 @@ exports[`Layer renders Layer correctly 1`] = `
     onMouseOver={[Function]}
     onMouseUp={[Function]}
     onSubmit={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
   >
     Content
   </div>

--- a/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -52,6 +52,10 @@ exports[`Modal renders Draggable Modal correctly 1`] = `
     onMouseOver={[Function]}
     onMouseUp={[Function]}
     onSubmit={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
   >
     <div
       aria-modal={false}
@@ -216,6 +220,10 @@ exports[`Modal renders Modal correctly 1`] = `
     onMouseOver={[Function]}
     onMouseUp={[Function]}
     onSubmit={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
   >
     <div
       aria-modal={true}
@@ -391,6 +399,10 @@ exports[`Modal renders Modeless Modal correctly 1`] = `
     onMouseOver={[Function]}
     onMouseUp={[Function]}
     onSubmit={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
   >
     <div
       aria-modal={false}

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -52,6 +52,10 @@ exports[`Panel renders Panel correctly 1`] = `
     onMouseOver={[Function]}
     onMouseUp={[Function]}
     onSubmit={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
   >
     <div
       aria-labelledby="Panel0-headerText"

--- a/packages/office-ui-fabric-react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -52,6 +52,10 @@ exports[`Tooltip renders default Tooltip correctly 1`] = `
     onMouseOver={[Function]}
     onMouseUp={[Function]}
     onSubmit={[Function]}
+    onTouchCancel={[Function]}
+    onTouchEnd={[Function]}
+    onTouchMove={[Function]}
+    onTouchStart={[Function]}
   >
     <div
       className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -1830,6 +1830,10 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
         onMouseOver={[Function]}
         onMouseUp={[Function]}
         onSubmit={[Function]}
+        onTouchCancel={[Function]}
+        onTouchEnd={[Function]}
+        onTouchMove={[Function]}
+        onTouchStart={[Function]}
       >
         <div
           className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
@@ -658,6 +658,10 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                 onMouseOver={[Function]}
                 onMouseUp={[Function]}
                 onSubmit={[Function]}
+                onTouchCancel={[Function]}
+                onTouchEnd={[Function]}
+                onTouchMove={[Function]}
+                onTouchStart={[Function]}
               >
                 <div
                   className=

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Basic.Example.tsx.shot
@@ -63,6 +63,10 @@ exports[`Component Examples renders ContextualMenu.Basic.Example.tsx correctly 1
       onMouseOver={[Function]}
       onMouseUp={[Function]}
       onSubmit={[Function]}
+      onTouchCancel={[Function]}
+      onTouchEnd={[Function]}
+      onTouchMove={[Function]}
+      onTouchStart={[Function]}
     >
       <div
         className=


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11264 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Drag and Drop stopped working inside Dialog and Modal components because Layer which both of these are built on doesn't catch touch events that are bubbling up and stop them.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11571)