### PR TITLE
Add custom Icon renderers to Calendar component

### DIFF
--- a/change/office-ui-fabric-react-2019-12-27-15-14-05-master.json
+++ b/change/office-ui-fabric-react-2019-12-27-15-14-05-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Add custom renderers to Calendar Icons",
+  "packageName": "office-ui-fabric-react",
+  "email": "madomi@microsoft.com",
+  "commit": "dfb2dc019f02b1108fda68d867484495c1df6d45",
+  "date": "2019-12-27T23:14:05.203Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -836,6 +836,9 @@ export class DefaultButton extends BaseComponent<IButtonProps, {}> {
 }
 
 // @public (undocumented)
+export const defaultIconRenderers: ICalendarIconRenderer;
+
+// @public (undocumented)
 export type DefaultProps = Required<Pick<ISpinButtonProps, 'step' | 'min' | 'max' | 'disabled' | 'labelPosition' | 'label' | 'incrementButtonIcon' | 'decrementButtonIcon'>>;
 
 // @public
@@ -1996,6 +1999,13 @@ export interface ICalendarFormatDateCallbacks {
 }
 
 // @public (undocumented)
+export interface ICalendarIconRenderer {
+    closeIcon?: JSX.Element;
+    leftNavigation?: JSX.Element;
+    rightNavigation?: JSX.Element;
+}
+
+// @public (undocumented)
 export interface ICalendarIconStrings {
     closeIcon?: string;
     leftNavigation?: string;
@@ -2019,6 +2029,7 @@ export interface ICalendarProps extends IBaseProps<ICalendar>, React.HTMLAttribu
     maxDate?: Date;
     minDate?: Date;
     navigationIcons?: ICalendarIconStrings;
+    navigationIconsRenderer?: ICalendarIconRenderer;
     onDismiss?: () => void;
     onSelectDate?: (date: Date, selectedDateRangeArray?: Date[]) => void;
     restrictedDates?: Date[];

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.doc.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.doc.tsx
@@ -4,6 +4,7 @@ import { IDocPageProps } from 'office-ui-fabric-react/lib/common/DocPage.types';
 import { CalendarButtonExample } from './examples/Calendar.Button.Example';
 import { CalendarInlineExample } from './examples/Calendar.Inline.Example';
 import { addMonths, addYears, addWeeks, addDays } from 'office-ui-fabric-react/lib/utilities/dateMath/DateMath';
+import { Icon } from 'office-ui-fabric-react/lib/Icon';
 
 const CalendarButtonExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Calendar/examples/Calendar.Button.Example.tsx') as string;
 const CalendarInlineExampleCode = require('!raw-loader!office-ui-fabric-react/src/components/Calendar/examples/Calendar.Inline.Example.tsx') as string;
@@ -164,6 +165,24 @@ export const CalendarPageProps: IDocPageProps = {
           minDate={addMonths(today, -1)}
           maxDate={addYears(today, 1)}
           restrictedDates={[addDays(today, -2), addDays(today, -8), addDays(today, 2), addDays(today, 8)]}
+        />
+      )
+    },
+    {
+      title: 'Inline Calendar with custom rendered icons',
+      code: CalendarInlineExampleCode,
+
+      view: (
+        <CalendarInlineExample
+          isMonthPickerVisible={false}
+          dateRangeType={DateRangeType.Day}
+          autoNavigateOnSelection={false}
+          showGoToToday={true}
+          iconRenderer={{
+            leftNavigation: <Icon iconName={'chevronLeft'} />,
+            rightNavigation: <Icon iconName={'chevronRight'} />,
+            closeIcon: <Icon iconName={'CalculatorMultiply'} />
+          }}
         />
       )
     },

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.types.ts
@@ -122,6 +122,11 @@ export interface ICalendarProps extends IBaseProps<ICalendar>, React.HTMLAttribu
   navigationIcons?: ICalendarIconStrings;
 
   /**
+   * Customize navigation icons using ICalendarIconRenderer
+   */
+  navigationIconsRenderer?: ICalendarIconRenderer;
+
+  /**
    * Whether the calendar should show the week number (weeks 1 to 53) before each week row
    * @defaultvalue false
    */
@@ -286,6 +291,26 @@ export interface ICalendarIconStrings {
    * @defaultvalue 'CalculatorMultiply'
    */
   closeIcon?: string;
+}
+
+export interface ICalendarIconRenderer {
+  /**
+   * FabricMDL2Icons name for the left navigation icon.  Previous default: ChevronLeft.
+   * @defaultvalue  'Up'
+   */
+  leftNavigation?: JSX.Element;
+
+  /**
+   * FabricMDL2Icons name for the right navigation icon.  Previous default: ChevronRight.
+   * @defaultvalue  'Down'
+   */
+  rightNavigation?: JSX.Element;
+
+  /**
+   * Close icon
+   * @defaultvalue  'CalculatorMultiply'
+   */
+  closeIcon?: JSX.Element;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.types.ts
@@ -293,21 +293,22 @@ export interface ICalendarIconStrings {
   closeIcon?: string;
 }
 
+/**
+ * {@docCategory Calendar}
+ */
 export interface ICalendarIconRenderer {
   /**
-   * FabricMDL2Icons name for the left navigation icon.  Previous default: ChevronLeft.
-   * @defaultvalue  'Up'
+   * Left navigation icon renderer
    */
   leftNavigation?: JSX.Element;
 
   /**
-   * FabricMDL2Icons name for the right navigation icon.  Previous default: ChevronRight.
-   * @defaultvalue  'Down'
+   * Right navigation icon renderer
    */
   rightNavigation?: JSX.Element;
 
   /**
-   * Close icon
+   * Close icon renderer
    * @defaultvalue  'CalculatorMultiply'
    */
   closeIcon?: JSX.Element;

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
 import { BaseComponent, KeyCodes, css, getId, getRTL, getRTLSafeKeyCode, format, IRefObject, findIndex, find } from '../../Utilities';
-import { ICalendarStrings, ICalendarIconStrings, ICalendarFormatDateCallbacks } from './Calendar.types';
+import { ICalendarStrings, ICalendarFormatDateCallbacks, ICalendarIconRenderer } from './Calendar.types';
 import { DayOfWeek, FirstWeekOfYear, DateRangeType } from '../../utilities/dateValues/DateValues';
 import { FocusZone } from '../../FocusZone';
-import { Icon } from '../../Icon';
 import {
   addDays,
   addWeeks,
@@ -49,7 +48,7 @@ export interface ICalendarDayProps extends React.ClassAttributes<CalendarDay> {
   firstDayOfWeek: DayOfWeek;
   dateRangeType: DateRangeType;
   autoNavigateOnSelection: boolean;
-  navigationIcons: ICalendarIconStrings;
+  navigationIconsRenderer: ICalendarIconRenderer;
   today?: Date;
   onHeaderSelect?: (focus: boolean) => void;
   showWeekNumbers?: boolean;
@@ -105,7 +104,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
       navigatedDate,
       selectedDate,
       dateRangeType,
-      navigationIcons,
+      navigationIconsRenderer,
       showWeekNumbers,
       firstWeekOfYear,
       dateTimeFormatter,
@@ -116,9 +115,9 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
     } = this.props;
     const dayPickerId = getId('DatePickerDay-dayPicker');
     const monthAndYearId = getId('DatePickerDay-monthAndYear');
-    const leftNavigationIcon = navigationIcons.leftNavigation;
-    const rightNavigationIcon = navigationIcons.rightNavigation;
-    const closeNavigationIcon = navigationIcons.closeIcon;
+    const leftNavigationIcon = navigationIconsRenderer.leftNavigation;
+    const rightNavigationIcon = navigationIconsRenderer.rightNavigation;
+    const closeNavigationIcon = navigationIconsRenderer.closeIcon;
     const weekNumbers = showWeekNumbers ? getWeekNumbersInMonth(weeks!.length, firstDayOfWeek, firstWeekOfYear, navigatedDate) : null;
     const selectedDateWeekNumber = showWeekNumbers ? getWeekNumber(selectedDate, firstDayOfWeek, firstWeekOfYear) : undefined;
 
@@ -176,7 +175,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
                 role="button"
                 type="button"
               >
-                <Icon iconName={leftNavigationIcon} />
+                {leftNavigationIcon}
               </button>
               <button
                 className={css('ms-DatePicker-nextMonth js-nextMonth', styles.nextMonth, {
@@ -195,7 +194,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
                 role="button"
                 type="button"
               >
-                <Icon iconName={rightNavigationIcon} />
+                {rightNavigationIcon}
               </button>
               {showCloseButton && (
                 <button
@@ -206,7 +205,7 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
                   role="button"
                   type="button"
                 >
-                  <Icon iconName={closeNavigationIcon} />
+                  {closeNavigationIcon}
                 </button>
               )}
             </div>

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarMonth.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarMonth.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
-import { BaseComponent, KeyCodes, css, getRTL, IRefObject } from '../../Utilities';
-import { ICalendarStrings, ICalendarIconStrings, ICalendarFormatDateCallbacks } from './Calendar.types';
+import { BaseComponent, KeyCodes, css, IRefObject } from '../../Utilities';
+import { ICalendarStrings, ICalendarFormatDateCallbacks, ICalendarIconRenderer } from './Calendar.types';
 import { FocusZone } from '../../FocusZone';
 import {
   addYears,
@@ -11,7 +11,6 @@ import {
   getMonthEnd,
   compareDatePart
 } from '../../utilities/dateMath/DateMath';
-import { Icon } from '../../Icon';
 import * as stylesImport from './Calendar.scss';
 import { CalendarYear, ICalendarYearRange } from './CalendarYear';
 const styles: any = stylesImport;
@@ -31,7 +30,7 @@ export interface ICalendarMonthProps extends React.ClassAttributes<CalendarMonth
   highlightCurrentMonth: boolean;
   highlightSelectedMonth: boolean;
   onHeaderSelect?: (focus: boolean) => void;
-  navigationIcons: ICalendarIconStrings;
+  navigationIconsRenderer: ICalendarIconRenderer;
   dateTimeFormatter: ICalendarFormatDateCallbacks;
   minDate?: Date;
   maxDate?: Date;
@@ -88,7 +87,7 @@ export class CalendarMonth extends BaseComponent<ICalendarMonthProps, ICalendarM
       today,
       highlightCurrentMonth,
       highlightSelectedMonth,
-      navigationIcons,
+      navigationIconsRenderer,
       dateTimeFormatter,
       minDate,
       maxDate,
@@ -104,7 +103,7 @@ export class CalendarMonth extends BaseComponent<ICalendarMonthProps, ICalendarM
           minYear={minDate ? minDate.getFullYear() : undefined}
           maxYear={maxDate ? maxDate.getFullYear() : undefined}
           onSelectYear={this._onSelectYear}
-          navigationIcons={navigationIcons}
+          navigationIconsRenderer={navigationIconsRenderer}
           onHeaderSelect={this._onYearPickerHeaderSelect}
           selectedYear={currentSelectedDate}
           onRenderYear={this._onRenderYear}
@@ -123,8 +122,8 @@ export class CalendarMonth extends BaseComponent<ICalendarMonthProps, ICalendarM
       rowIndexes.push(i);
     }
 
-    const leftNavigationIcon = navigationIcons.leftNavigation;
-    const rightNavigationIcon = navigationIcons.rightNavigation;
+    const leftNavigationIcon = navigationIconsRenderer.leftNavigation;
+    const rightNavigationIcon = navigationIconsRenderer.rightNavigation;
 
     // determine if previous/next years are in bounds
     const isPrevYearInBounds = minDate ? compareDatePart(minDate, getYearStart(navigatedDate)) < 0 : true;
@@ -168,7 +167,7 @@ export class CalendarMonth extends BaseComponent<ICalendarMonthProps, ICalendarM
                 role="button"
                 type="button"
               >
-                <Icon iconName={getRTL() ? rightNavigationIcon : leftNavigationIcon} />
+                {leftNavigationIcon}
               </button>
               <button
                 className={css('ms-DatePicker-nextYear js-nextYear', styles.nextYear, {
@@ -185,7 +184,7 @@ export class CalendarMonth extends BaseComponent<ICalendarMonthProps, ICalendarM
                 role="button"
                 type="button"
               >
-                <Icon iconName={getRTL() ? leftNavigationIcon : rightNavigationIcon} />
+                {rightNavigationIcon}
               </button>
             </div>
           </div>

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarYear.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarYear.tsx
@@ -1,9 +1,9 @@
 import * as React from 'react';
-import { KeyCodes, css, getRTL } from '../../Utilities';
-import { ICalendarIconStrings } from './Calendar.types';
+import { KeyCodes, css } from '../../Utilities';
+import { ICalendarIconRenderer } from './Calendar.types';
 import { FocusZone } from '../../FocusZone';
 import * as stylesImport from './Calendar.scss';
-import { Icon } from '../../Icon';
+import { defaultIconRenderers } from './Calendar';
 
 const styles: any = stylesImport;
 
@@ -29,7 +29,7 @@ export interface ICalendarYear {
 }
 
 export interface ICalendarYearProps {
-  navigationIcons?: ICalendarIconStrings;
+  navigationIconsRenderer: ICalendarIconRenderer;
   navigatedYear?: number;
   selectedYear?: number;
   minYear?: number;
@@ -45,12 +45,6 @@ export interface ICalendarYearProps {
 const DefaultCalendarYearStrings: ICalendarYearStrings = {
   prevRangeAriaLabel: undefined,
   nextRangeAriaLabel: undefined
-};
-
-const DefaultNavigationIcons: ICalendarIconStrings = {
-  leftNavigation: 'Up',
-  rightNavigation: 'Down',
-  closeIcon: 'CalculatorMultiply'
 };
 
 interface ICalendarYearGridCell {
@@ -181,7 +175,7 @@ export interface ICalendarYearHeaderProps extends ICalendarYearProps, ICalendarY
 
 class CalendarYearNavPrev extends React.Component<ICalendarYearHeaderProps, any> {
   public render() {
-    const iconStrings = this.props.navigationIcons || DefaultNavigationIcons;
+    const iconRenderers = this.props.navigationIconsRenderer || defaultIconRenderers;
     const strings = this.props.strings || DefaultCalendarYearStrings;
     const prevRangeAriaLabel = strings.prevRangeAriaLabel;
     const prevRange = { fromYear: this.props.fromYear - CELL_COUNT, toYear: this.props.toYear - CELL_COUNT };
@@ -204,7 +198,7 @@ class CalendarYearNavPrev extends React.Component<ICalendarYearHeaderProps, any>
         title={prevAriaLabel}
         disabled={disabled}
       >
-        <Icon iconName={getRTL() ? iconStrings.rightNavigation : iconStrings.leftNavigation} />
+        {iconRenderers.leftNavigation}
       </button>
     );
   }
@@ -229,7 +223,7 @@ class CalendarYearNavPrev extends React.Component<ICalendarYearHeaderProps, any>
 
 class CalendarYearNavNext extends React.Component<ICalendarYearHeaderProps, any> {
   public render() {
-    const iconStrings = this.props.navigationIcons || DefaultNavigationIcons;
+    const iconRenderers = this.props.navigationIconsRenderer || defaultIconRenderers;
     const strings = this.props.strings || DefaultCalendarYearStrings;
     const nextRangeAriaLabel = strings.nextRangeAriaLabel;
     const nextRange = { fromYear: this.props.fromYear + CELL_COUNT, toYear: this.props.toYear + CELL_COUNT };
@@ -252,7 +246,7 @@ class CalendarYearNavNext extends React.Component<ICalendarYearHeaderProps, any>
         title={nextAriaLabel}
         disabled={this.isDisabled}
       >
-        <Icon iconName={getRTL() ? iconStrings.leftNavigation : iconStrings.rightNavigation} />
+        {iconRenderers.rightNavigation}
       </button>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Inline.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/examples/Calendar.Inline.Example.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
 import { addDays, getDateRangeArray } from 'office-ui-fabric-react/lib/utilities/dateMath/DateMath';
-import { Calendar, DayOfWeek, DateRangeType } from 'office-ui-fabric-react/lib/Calendar';
+import { Calendar, DayOfWeek, DateRangeType, ICalendarIconRenderer } from 'office-ui-fabric-react/lib/Calendar';
 
 const DayPickerStrings = {
   months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
@@ -41,6 +41,7 @@ export interface ICalendarInlineExampleProps {
   showSixWeeksByDefault?: boolean;
   workWeekDays?: DayOfWeek[];
   firstDayOfWeek?: DayOfWeek;
+  iconRenderer?: ICalendarIconRenderer;
 }
 
 export class CalendarInlineExample extends React.Component<ICalendarInlineExampleProps, ICalendarInlineExampleState> {
@@ -124,6 +125,7 @@ export class CalendarInlineExample extends React.Component<ICalendarInlineExampl
           restrictedDates={this.props.restrictedDates}
           showSixWeeksByDefault={this.props.showSixWeeksByDefault}
           workWeekDays={this.props.workWeekDays}
+          navigationIconsRenderer={this.props.iconRenderer}
         />
         {this.props.showNavigateButtons && (
           <div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11572
- [x] Include a change request file using `$ yarn change`

#### Description of changes

- Added an Icon renderer prop for the Calendar component while maintaining the old Icon name string property due for backwards compatibility.
- Fixed a small bug where Icons where not being rotated for RTL in CalendarDay component

#### Focus areas to test

Calendar component


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11573)