### PR TITLE
ComboBox: support non latin characters

### DIFF
--- a/change/office-ui-fabric-react-2019-12-30-16-09-44-combobox-non-latin.json
+++ b/change/office-ui-fabric-react-2019-12-30-16-09-44-combobox-non-latin.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "ComboBox: Move autoComplete with no freeform key handling to onKeyUp to get access to key value vs key code to support non latin characters",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "88e33cb68a8ae63e40b3cb05ca8233df4eb1a960",
+  "date": "2019-12-31T00:09:44.222Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
@@ -241,7 +241,7 @@ describe('ComboBox', () => {
   it('Can insert non latin text in uncontrolled case with autoComplete on and allowFreeform off', () => {
     wrapper = mount(<ComboBox defaultSelectedKey="0" options={RUSSIAN_OPTIONS} autoComplete="on" allowFreeform={false} />);
 
-    wrapper.find('input').simulate('keyup', { key: 'п' });
+    wrapper.find('input').simulate('input', { target: { value: 'п' } });
     wrapper.update();
     expect(wrapper.find('input').props().value).toEqual('папа');
   });

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.test.tsx
@@ -20,6 +20,13 @@ const DEFAULT_OPTIONS3: IComboBoxOption[] = [
   { key: '3', text: 'Bar' }
 ];
 
+const RUSSIAN_OPTIONS: IComboBoxOption[] = [
+  { key: '0', text: 'сестра' },
+  { key: '1', text: 'брат' },
+  { key: '2', text: 'мама' },
+  { key: '3', text: 'папа' }
+];
+
 const returnUndefined = () => undefined;
 
 type InputElementWrapper = ReactWrapper<React.InputHTMLAttributes<any>, any>;
@@ -229,6 +236,14 @@ describe('ComboBox', () => {
     wrapper.find('input').simulate('input', { target: { value: 'f' } });
     wrapper.update();
     expect(wrapper.find('input').props().value).toEqual('Foo');
+  });
+
+  it('Can insert non latin text in uncontrolled case with autoComplete on and allowFreeform off', () => {
+    wrapper = mount(<ComboBox defaultSelectedKey="0" options={RUSSIAN_OPTIONS} autoComplete="on" allowFreeform={false} />);
+
+    wrapper.find('input').simulate('keyup', { key: 'п' });
+    wrapper.update();
+    expect(wrapper.find('input').props().value).toEqual('папа');
   });
 
   it('Can insert text in uncontrolled case with autoComplete off and allowFreeform on', () => {

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1693,7 +1693,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
    * @param ev - The keyboard event that was fired
    */
   private _onInputKeyDown = (ev: React.KeyboardEvent<HTMLElement | Autofill>): void => {
-    const { disabled, allowFreeform, autoComplete } = this.props;
+    const { disabled, allowFreeform } = this.props;
     const { isOpen, currentOptions, currentPendingValueValidIndexOnHover } = this.state;
 
     // Take note if we are processing an alt (option) or meta (command) keydown.

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1693,7 +1693,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
    * @param ev - The keyboard event that was fired
    */
   private _onInputKeyDown = (ev: React.KeyboardEvent<HTMLElement | Autofill>): void => {
-    const { disabled, allowFreeform } = this.props;
+    const { disabled, allowFreeform, autoComplete } = this.props;
     const { isOpen, currentOptions, currentPendingValueValidIndexOnHover } = this.state;
 
     // Take note if we are processing an alt (option) or meta (command) keydown.
@@ -1833,7 +1833,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
 
       case KeyCodes.space:
         // event handled in _onComboBoxKeyUp
-        if (!allowFreeform) {
+        if (!allowFreeform && autoComplete === 'off') {
           break;
         }
 
@@ -1847,6 +1847,14 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         // or meta key, let the event propagate
         if (ev.keyCode === KeyCodes.alt || ev.key === 'Meta' /* && isOpen */) {
           return;
+        }
+
+        // If we are not allowing freeform and
+        // allowing autoComplete, handle the input here
+        // since we have marked the input as readonly
+        if (!allowFreeform && autoComplete === 'on') {
+          this._onInputChange(ev.key);
+          break;
         }
 
         // allow the key to propagate by default
@@ -1885,15 +1893,6 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
 
     if (disabled) {
       this._handleInputWhenDisabled(ev);
-      return;
-    }
-
-    // If we are not allowing freeform and
-    // allowing autoComplete, handle the input here
-    // since we have marked the input as readonly
-
-    if (!allowFreeform && autoComplete === 'on') {
-      this._onInputChange(ev.key);
       return;
     }
 

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1833,7 +1833,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
 
       case KeyCodes.space:
         // event handled in _onComboBoxKeyUp
-        if (!allowFreeform && autoComplete === 'off') {
+        if (!allowFreeform) {
           break;
         }
 

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1849,14 +1849,6 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
           return;
         }
 
-        // If we are not allowing freeform and
-        // allowing autoComplete, handle the input here
-        // since we have marked the input as readonly
-        if (!allowFreeform && autoComplete === 'on') {
-          this._onInputChange(String.fromCharCode(ev.which));
-          break;
-        }
-
         // allow the key to propagate by default
         return;
     }
@@ -1893,6 +1885,15 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
 
     if (disabled) {
       this._handleInputWhenDisabled(ev);
+      return;
+    }
+
+    // If we are not allowing freeform and
+    // allowing autoComplete, handle the input here
+    // since we have marked the input as readonly
+
+    if (!allowFreeform && autoComplete === 'on') {
+      this._onInputChange(ev.key);
       return;
     }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #5834
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

`String.fromCharCode(ev.which)` returns the latin character mapped to the given keycode, which means even with a Russian keyboard, you are always firing latin characters.

![image](https://user-images.githubusercontent.com/1434956/71632837-7afa5800-2bc5-11ea-9c4f-d8c51cb0546a.png)


#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11582)