### PR TITLE
Combobox: Clicks to headers and scrollbars no longer cause onBlur

### DIFF
--- a/change/office-ui-fabric-react-2019-12-31-11-32-45-combobox-onblur.json
+++ b/change/office-ui-fabric-react-2019-12-31-11-32-45-combobox-onblur.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Combobox: Clicks to headers and scrollbars no longer cause onBlur",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "399896de32fe539ce1bab0bc7b7d0503710e4fa5",
+  "date": "2019-12-31T19:32:45.864Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -1386,6 +1386,9 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       : this._getFirstSelectedIndex();
   }
 
+  /**
+   * Mouse clicks to headers, dividers and scrollbar should not make input lose focus
+   */
   private _onCalloutMouseDown: ICalloutProps['onMouseDown'] = ev => {
     ev.preventDefault();
   };

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -27,6 +27,7 @@ import { KeytipData } from '../../KeytipData';
 import { Label } from '../../Label';
 import { SelectableOptionMenuItemType, getAllSelectedOptions } from '../../utilities/selectableOption/index';
 import { BaseButton, Button } from '../Button/index';
+import { ICalloutProps } from '../Callout';
 
 export interface IComboBoxState {
   /** The open state */
@@ -1173,6 +1174,7 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
         className={css(this._classNames.callout, calloutProps ? calloutProps.className : undefined)}
         target={this._comboBoxWrapper.current}
         onDismiss={this._onDismiss}
+        onMouseDown={this._onCalloutMouseDown}
         onScroll={this._onScroll}
         setInitialFocus={false}
         calloutWidth={useComboBoxAsMenuWidth && this._comboBoxWrapper.current ? comboBoxMenuWidth && comboBoxMenuWidth : dropdownWidth}
@@ -1383,6 +1385,10 @@ export class ComboBox extends BaseComponent<IComboBoxProps, IComboBoxState> {
       ? 0
       : this._getFirstSelectedIndex();
   }
+
+  private _onCalloutMouseDown: ICalloutProps['onMouseDown'] = ev => {
+    ev.preventDefault();
+  };
 
   /**
    * Scroll handler for the callout to make sure the mouse events

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.tsx
@@ -27,7 +27,7 @@ import { KeytipData } from '../../KeytipData';
 import { Label } from '../../Label';
 import { SelectableOptionMenuItemType, getAllSelectedOptions } from '../../utilities/selectableOption/index';
 import { BaseButton, Button } from '../Button/index';
-import { ICalloutProps } from '../Callout';
+import { ICalloutProps } from '../../Callout';
 
 export interface IComboBoxState {
   /** The open state */

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -1872,6 +1872,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                   border: 0px;
                 }
             hidden={true}
+            onMouseDown={[Function]}
             onScroll={[Function]}
             style={
               Object {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #6392
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Clicks outside of the input were causing the input to lose focus and fire 'onblur'. With this change clicks to headers, dividers and scrollbars will have no effect, but clicks to menu items work properly.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11584)