### PR TITLE
Tile: Fix text over image color

### DIFF
--- a/change/@uifabric-experiments-2020-01-02-09-47-28-pratik-chhajer-text-over-image-color-fix.json
+++ b/change/@uifabric-experiments-2020-01-02-09-47-28-pratik-chhajer-text-over-image-color-fix.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix color of text over image in dark mode",
+  "comment": "Tile: fix color of text over image in dark mode",
   "packageName": "@uifabric/experiments",
   "email": "prchhaje@microsoft.com",
   "commit": "964a018662ecadc2db4f6ee9cb049bc9543b1ec3",

--- a/change/@uifabric-experiments-2020-01-02-09-47-28-pratik-chhajer-text-over-image-color-fix.json
+++ b/change/@uifabric-experiments-2020-01-02-09-47-28-pratik-chhajer-text-over-image-color-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix color of text over image in dark mode",
+  "packageName": "@uifabric/experiments",
+  "email": "prchhaje@microsoft.com",
+  "commit": "964a018662ecadc2db4f6ee9cb049bc9543b1ec3",
+  "date": "2020-01-02T04:17:28.546Z"
+}

--- a/packages/experiments/src/components/Tile/Tile.scss
+++ b/packages/experiments/src/components/Tile/Tile.scss
@@ -474,11 +474,13 @@
     }
 
     .name {
+      // text appearing on tile must be white irrespective of theme
       color: #fff;
       text-shadow: 0.5px 0.5px 2px rgba(#000, 0.55);
     }
 
     .activity {
+      // text appearing on tile must be white irrespective of theme
       color: #fff;
       text-shadow: 0.5px 0.5px 2px rgba(#000, 0.55);
     }

--- a/packages/experiments/src/components/Tile/Tile.scss
+++ b/packages/experiments/src/components/Tile/Tile.scss
@@ -474,12 +474,12 @@
     }
 
     .name {
-      color: $ms-color-white;
+      color: #fff;
       text-shadow: 0.5px 0.5px 2px rgba(#000, 0.55);
     }
 
     .activity {
-      color: $ms-color-white;
+      color: #fff;
       text-shadow: 0.5px 0.5px 2px rgba(#000, 0.55);
     }
   }

--- a/packages/experiments/src/components/signals/Signal.scss
+++ b/packages/experiments/src/components/signals/Signal.scss
@@ -9,7 +9,7 @@
 
   .dark &,
   .dark.selected {
-    color: $ms-color-white;
+    color: #fff;
   }
 
   &:first-child {

--- a/packages/experiments/src/components/signals/Signal.scss
+++ b/packages/experiments/src/components/signals/Signal.scss
@@ -9,6 +9,7 @@
 
   .dark &,
   .dark.selected {
+    // color must be white irrespective of theme
     color: #fff;
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The text appearing over image use's $ms-color-white to set it's color styling. In case of dark mode, it gets translated to some shade of black which is not desired behavior. Below screenshots are from OneDrive for Consumers web.

Before:
![MicrosoftTeams-image (1)](https://user-images.githubusercontent.com/25812641/71651880-07805400-2d47-11ea-8615-dda380347aff.png)

After:
![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/25812641/71651887-0cdd9e80-2d47-11ea-9adb-86b59febb236.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11587)