### PR TITLE
TagPicker: Define `title` for TagItem in case text overflows.

### DIFF
--- a/change/office-ui-fabric-react-2020-01-02-10-35-00-tag-item-title.json
+++ b/change/office-ui-fabric-react-2020-01-02-10-35-00-tag-item-title.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "TagPicker: Define `title` for TagItem in case text overflows.",
+  "packageName": "office-ui-fabric-react",
+  "email": "jdh@microsoft.com",
+  "commit": "1305118f16f025f9517b4a25ad0fc3df16b7f882",
+  "date": "2020-01-02T18:35:00.592Z"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.tsx
@@ -40,7 +40,7 @@ export const TagItemBase = (props: ITagItemProps) => {
       data-selection-index={index}
       data-is-focusable={(enableTagFocusInDisabledPicker || !disabled) && true}
     >
-      <span className={classNames.text} aria-label={children as string}>
+      <span className={classNames.text} aria-label={children as string} title={children as string}>
         {children}
       </span>
       <IconButton

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
@@ -134,6 +134,7 @@ exports[`TagPicker renders correctly 1`] = `
                     text-overflow: ellipsis;
                     white-space: nowrap;
                   }
+              title="black"
             >
               black
             </span>
@@ -442,6 +443,7 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
                     text-overflow: ellipsis;
                     white-space: nowrap;
                   }
+              title="text"
             >
               text
             </span>


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #11586
- [X] Include a change request file using `$ yarn change`

## Question

- Does anyone have context as to why we have `overflow: ellipsis` on `TagItem`? Seems a better solution to this problem would be to show the entire tag always. (Especially considering tags are generally short strings and not very long.)

## Other comments

- `title` isn't a great attribute to use for a variety of reasons, but in this case it feels like the correct lightweight solution, especially as there are lots of other contextual clues to indicate which tags are in the list. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11592)