### PR TITLE
Fix event listener and debounced function memory leaks in List component

### DIFF
--- a/change/office-ui-fabric-react-2020-01-02-13-37-03-keco-memory-leaks.json
+++ b/change/office-ui-fabric-react-2020-01-02-13-37-03-keco-memory-leaks.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Terminate List event listeners on unmount to fix memory leaks",
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com",
+  "commit": "34344ceaaec0e21eb4b3cf394a7169a86e4e9f29",
+  "date": "2020-01-02T21:37:03.449Z"
+}

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -316,6 +316,14 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
   }
 
   public componentWillUnmount(): void {
+    this._events.off(window, 'resize', this._onAsyncResize);
+    this._events.off(this._scrollElement, 'scroll', this._onScroll);
+    this._events.off(this._scrollElement, 'scroll', this._onAsyncScroll);
+
+    this._onAsyncIdle();
+    this._onAsyncResize();
+    this._onAsyncScroll();
+
     this._async.dispose();
     this._events.dispose();
   }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

There are a number of event listener callbacks that are not unsubscribed when the List unmounts. This leads to run-time memory leaks (**~15 kB** in this example) captured in the below _before_ and _after_ heap snapshots.

---

The fix is to terminate the event listeners both via `EventGroup#off` and invoke the debounced / throttled callbacks in `componentWillUnmount` e.g. `this._onAsyncResize()`.

To debug and verify, I performed the following steps:

1. Rendered "Shimmer" List example in isolation locally.
1. Invoked garbage collection and captured the initial heap "Snapshot 1".
1. Toggled Shimmer "Off", invoked garbage collection, and captured heap "Snapshot 2".
1. Compared "Snapshot 2" against "Snapshot 1" and filtered by "Detached".

#### Before fix

In the "Shimmer" List example, ~15 kB of DOM Nodes are reported as "Detached" and therefore cannot be reclaimed by GC.

![before_heap](https://user-images.githubusercontent.com/706967/71694907-75d40f00-2d65-11ea-9f68-3a04c1404234.PNG)

Here are the object retainers:

![before_heap_retainers](https://user-images.githubusercontent.com/706967/71694924-81bfd100-2d65-11ea-9b0f-55919c12ebc0.PNG)

#### After fix

![after_heap](https://user-images.githubusercontent.com/706967/71694909-78366900-2d65-11ea-95de-3a5fa23d9cf9.PNG)

#### Focus areas to test

- CI passes
- List examples render as expected

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11594)