### PR TITLE
Fabric: Render wrapper container correctly if dir prop changes.

### DIFF
--- a/change/office-ui-fabric-react-2020-01-07-08-59-17-sort-out-rtl-redux.json
+++ b/change/office-ui-fabric-react-2020-01-07-08-59-17-sort-out-rtl-redux.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fabric: Fix for RTL/LTR switching.",
+  "packageName": "office-ui-fabric-react",
+  "email": "jdh@microsoft.com",
+  "commit": "337a6ea1862def7b83bd4f46e9728a1ee0a033e0",
+  "date": "2020-01-07T16:59:17.415Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
@@ -341,6 +341,7 @@ exports[`Fabric renders a Fabric component in RTL 1`] = `
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             color: #323130;
+            direction: rtl;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
             font-weight: 400;
@@ -505,7 +506,6 @@ exports[`Fabric renders a Fabric component in RTL 1`] = `
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
               color: #323130;
-              direction: rtl;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
               font-weight: 400;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: #11561 (this does not fix *all* LTR in RTL issues, but does fix several)
- [X] Include a change request file using `$ yarn change`

#### Description of changes

When nested in a context with `dir` specified in theme, this control would not correctly render the container with the opposite direction specified in the outer `div`, causing confusing results.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11597)