### PR TITLE
Search focus

### DIFF
--- a/change/office-ui-fabric-react-2020-01-03-11-09-17-search-focus.json
+++ b/change/office-ui-fabric-react-2020-01-03-11-09-17-search-focus.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "SearchBox: Use native input onBlur to fix blur getting called twice",
+  "packageName": "office-ui-fabric-react",
+  "email": "mgodbolt@microsoft.com",
+  "commit": "e07d7d3a1fc807e7bf47e04477e5251759d0e301",
+  "date": "2020-01-03T19:09:17.357Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -8805,8 +8805,6 @@ export const SearchBox: React.FunctionComponent<ISearchBoxProps>;
 export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxState> {
     constructor(props: ISearchBoxProps);
     // (undocumented)
-    componentWillUnmount(): void;
-    // (undocumented)
     static defaultProps: Pick<ISearchBoxProps, 'disableAnimation' | 'clearButtonProps'>;
     focus(): void;
     hasFocus(): boolean;

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -3,7 +3,6 @@ import { ISearchBoxProps, ISearchBoxStyleProps, ISearchBoxStyles } from './Searc
 import {
   initializeComponentRef,
   warnDeprecations,
-  EventGroup,
   getId,
   KeyCodes,
   classNamesFunction,
@@ -32,7 +31,6 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
   private _inputElement = React.createRef<HTMLInputElement>();
   private _latestValue: string;
   private _fallbackId: string;
-  private _events: EventGroup | undefined;
 
   public constructor(props: ISearchBoxProps) {
     super(props);
@@ -62,12 +60,6 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
       this.setState({
         value: newProps.value || ''
       });
-    }
-  }
-
-  public componentWillUnmount() {
-    if (this._events) {
-      this._events.dispose();
     }
   }
 
@@ -115,7 +107,6 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
         <input
           {...nativeProps}
           id={id}
-          onFocusCapture={() => console.log('focus capture')}
           className={classNames.field}
           placeholder={placeholderValue}
           onChange={this._onInputChange}
@@ -126,6 +117,7 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
           role="searchbox"
           aria-label={ariaLabel}
           ref={this._inputElement}
+          onBlur={this._onBlur}
         />
         {value!.length > 0 && (
           <div className={classNames.clearButton}>
@@ -185,11 +177,6 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
       hasFocus: true
     });
 
-    if (!this._events) {
-      this._events = new EventGroup(this);
-    }
-    this._events.on(ev.currentTarget, 'blur', this._onBlur, true);
-
     if (this.props.onFocus) {
       this.props.onFocus(ev as React.FocusEvent<HTMLInputElement>);
     }
@@ -238,10 +225,6 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
   };
 
   private _onBlur = (ev: React.FocusEvent<HTMLInputElement>): void => {
-    console.log(ev);
-    if (this._events) {
-      this._events.off();
-    }
     this.setState({
       hasFocus: false
     });

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -100,13 +100,7 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
     ]);
 
     return (
-      <div
-        role="search"
-        ref={this._rootElement}
-        className={classNames.root}
-        onBlurCapture={this._onBlur}
-        onFocusCapture={this._onFocusCapture}
-      >
+      <div role="search" ref={this._rootElement} className={classNames.root} onFocusCapture={this._onFocusCapture}>
         <div className={classNames.iconContainer} onClick={this._onClickFocus} aria-hidden={true}>
           <Icon iconName="Search" {...iconProps} className={classNames.icon} />
         </div>
@@ -117,6 +111,7 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
           placeholder={placeholderValue}
           onChange={this._onInputChange}
           onInput={this._onInputChange}
+          onBlur={this._onBlur}
           onKeyDown={this._onKeyDown}
           value={value}
           disabled={disabled}
@@ -127,6 +122,7 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
         {value!.length > 0 && (
           <div className={classNames.clearButton}>
             <IconButton
+              onBlur={this._onBlur}
               styles={{ root: { height: 'auto' }, icon: { fontSize: '12px' } }}
               iconProps={{ iconName: 'Clear' }}
               {...clearButtonProps}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -100,7 +100,13 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
     ]);
 
     return (
-      <div role="search" ref={this._rootElement} className={classNames.root} onFocusCapture={this._onFocusCapture}>
+      <div
+        role="search"
+        ref={this._rootElement}
+        className={classNames.root}
+        onBlurCapture={this._onBlur}
+        onFocusCapture={this._onFocusCapture}
+      >
         <div className={classNames.iconContainer} onClick={this._onClickFocus} aria-hidden={true}>
           <Icon iconName="Search" {...iconProps} className={classNames.icon} />
         </div>
@@ -117,7 +123,6 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
           role="searchbox"
           aria-label={ariaLabel}
           ref={this._inputElement}
-          onBlur={this._onBlur}
         />
         {value!.length > 0 && (
           <div className={classNames.clearButton}>

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -115,6 +115,7 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
         <input
           {...nativeProps}
           id={id}
+          onFocusCapture={() => console.log('focus capture')}
           className={classNames.field}
           placeholder={placeholderValue}
           onChange={this._onInputChange}
@@ -237,6 +238,7 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
   };
 
   private _onBlur = (ev: React.FocusEvent<HTMLInputElement>): void => {
+    console.log(ev);
     if (this._events) {
       this._events.off();
     }

--- a/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
@@ -125,6 +125,7 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
           display: none;
         }
     id="SearchBox0"
+    onBlur={[Function]}
     onChange={[Function]}
     onInput={[Function]}
     onKeyDown={[Function]}
@@ -257,6 +258,7 @@ exports[`SearchBox renders SearchBox without animation correctly 1`] = `
           display: none;
         }
     id="SearchBox5"
+    onBlur={[Function]}
     onChange={[Function]}
     onInput={[Function]}
     onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
@@ -42,6 +42,7 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
       &:hover .ms-SearchBox-iconContainer {
         color: #005a9e;
       }
+  onBlurCapture={[Function]}
   onFocusCapture={[Function]}
   role="search"
 >
@@ -125,7 +126,6 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
           display: none;
         }
     id="SearchBox0"
-    onBlur={[Function]}
     onChange={[Function]}
     onInput={[Function]}
     onKeyDown={[Function]}
@@ -177,6 +177,7 @@ exports[`SearchBox renders SearchBox without animation correctly 1`] = `
       &:hover .ms-SearchBox-iconContainer {
         color: #005a9e;
       }
+  onBlurCapture={[Function]}
   onFocusCapture={[Function]}
   role="search"
 >
@@ -258,7 +259,6 @@ exports[`SearchBox renders SearchBox without animation correctly 1`] = `
           display: none;
         }
     id="SearchBox5"
-    onBlur={[Function]}
     onChange={[Function]}
     onInput={[Function]}
     onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/__snapshots__/SearchBox.test.tsx.snap
@@ -42,7 +42,6 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
       &:hover .ms-SearchBox-iconContainer {
         color: #005a9e;
       }
-  onBlurCapture={[Function]}
   onFocusCapture={[Function]}
   role="search"
 >
@@ -126,6 +125,7 @@ exports[`SearchBox renders SearchBox correctly 1`] = `
           display: none;
         }
     id="SearchBox0"
+    onBlur={[Function]}
     onChange={[Function]}
     onInput={[Function]}
     onKeyDown={[Function]}
@@ -177,7 +177,6 @@ exports[`SearchBox renders SearchBox without animation correctly 1`] = `
       &:hover .ms-SearchBox-iconContainer {
         color: #005a9e;
       }
-  onBlurCapture={[Function]}
   onFocusCapture={[Function]}
   role="search"
 >
@@ -259,6 +258,7 @@ exports[`SearchBox renders SearchBox without animation correctly 1`] = `
           display: none;
         }
     id="SearchBox5"
+    onBlur={[Function]}
     onChange={[Function]}
     onInput={[Function]}
     onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Small.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Small.Example.tsx
@@ -1,44 +1,24 @@
 import * as React from 'react';
-import { SearchBox, DefaultButton } from 'office-ui-fabric-react';
+import { SearchBox } from 'office-ui-fabric-react/lib/SearchBox';
 
 // tslint:disable:jsx-no-lambda
 export class SearchBoxSmallExample extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <>
-        <SearchBox
-          styles={{ root: { width: 200 } }}
-          placeholder="Search"
-          // onEscape={ev => {
-          //   console.log('Custom onEscape Called');
-          // }}
-          // onClear={ev => {
-          //   console.log('Custom onClear Called');
-          // }}
-          // onChange={(_, newValue) => console.log('SearchBox onChange fired: ' + newValue)}
-          // onSearch={newValue => console.log('SearchBox onSearch fired: ' + newValue)}
-          // onFocus={() => console.log('onFocus called')}
-          // onBlur={() => console.log('onBlur called')}
-        />
-        <DefaultButton
-          menuProps={{
-            items: [
-              {
-                key: 'emailMessage',
-                text: 'Email message',
-                iconProps: { iconName: 'Mail' }
-              },
-              {
-                key: 'calendarEvent',
-                text: 'Calendar event',
-                iconProps: { iconName: 'Calendar' }
-              }
-            ]
-          }}
-        >
-          Click Me
-        </DefaultButton>
-      </>
+      <SearchBox
+        styles={{ root: { width: 200 } }}
+        placeholder="Search"
+        onEscape={ev => {
+          console.log('Custom onEscape Called');
+        }}
+        onClear={ev => {
+          console.log('Custom onClear Called');
+        }}
+        onChange={(_, newValue) => console.log('SearchBox onChange fired: ' + newValue)}
+        onSearch={newValue => console.log('SearchBox onSearch fired: ' + newValue)}
+        onFocus={() => console.log('onFocus called')}
+        onBlur={() => console.log('onBlur called')}
+      />
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Small.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/examples/SearchBox.Small.Example.tsx
@@ -1,24 +1,44 @@
 import * as React from 'react';
-import { SearchBox } from 'office-ui-fabric-react/lib/SearchBox';
+import { SearchBox, DefaultButton } from 'office-ui-fabric-react';
 
 // tslint:disable:jsx-no-lambda
 export class SearchBoxSmallExample extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <SearchBox
-        styles={{ root: { width: 200 } }}
-        placeholder="Search"
-        onEscape={ev => {
-          console.log('Custom onEscape Called');
-        }}
-        onClear={ev => {
-          console.log('Custom onClear Called');
-        }}
-        onChange={(_, newValue) => console.log('SearchBox onChange fired: ' + newValue)}
-        onSearch={newValue => console.log('SearchBox onSearch fired: ' + newValue)}
-        onFocus={() => console.log('onFocus called')}
-        onBlur={() => console.log('onBlur called')}
-      />
+      <>
+        <SearchBox
+          styles={{ root: { width: 200 } }}
+          placeholder="Search"
+          // onEscape={ev => {
+          //   console.log('Custom onEscape Called');
+          // }}
+          // onClear={ev => {
+          //   console.log('Custom onClear Called');
+          // }}
+          // onChange={(_, newValue) => console.log('SearchBox onChange fired: ' + newValue)}
+          // onSearch={newValue => console.log('SearchBox onSearch fired: ' + newValue)}
+          // onFocus={() => console.log('onFocus called')}
+          // onBlur={() => console.log('onBlur called')}
+        />
+        <DefaultButton
+          menuProps={{
+            items: [
+              {
+                key: 'emailMessage',
+                text: 'Email message',
+                iconProps: { iconName: 'Mail' }
+              },
+              {
+                key: 'calendarEvent',
+                text: 'Calendar event',
+                iconProps: { iconName: 'Calendar' }
+              }
+            ]
+          }}
+        >
+          Click Me
+        </DefaultButton>
+      </>
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
@@ -133,6 +133,7 @@ exports[`Component Examples renders FloatingPeoplePicker.Basic.Example.tsx corre
               display: none;
             }
         id="SearchBox0"
+        onBlur={[Function]}
         onChange={[Function]}
         onInput={[Function]}
         onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
@@ -50,7 +50,6 @@ exports[`Component Examples renders FloatingPeoplePicker.Basic.Example.tsx corre
           &:hover .ms-SearchBox-iconContainer {
             color: #005a9e;
           }
-      onBlurCapture={[Function]}
       onFocusCapture={[Function]}
       role="search"
     >
@@ -134,6 +133,7 @@ exports[`Component Examples renders FloatingPeoplePicker.Basic.Example.tsx corre
               display: none;
             }
         id="SearchBox0"
+        onBlur={[Function]}
         onChange={[Function]}
         onInput={[Function]}
         onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FloatingPeoplePicker.Basic.Example.tsx.shot
@@ -50,6 +50,7 @@ exports[`Component Examples renders FloatingPeoplePicker.Basic.Example.tsx corre
           &:hover .ms-SearchBox-iconContainer {
             color: #005a9e;
           }
+      onBlurCapture={[Function]}
       onFocusCapture={[Function]}
       role="search"
     >
@@ -133,7 +134,6 @@ exports[`Component Examples renders FloatingPeoplePicker.Basic.Example.tsx corre
               display: none;
             }
         id="SearchBox0"
-        onBlur={[Function]}
         onChange={[Function]}
         onInput={[Function]}
         onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.CustomIcon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.CustomIcon.Example.tsx.shot
@@ -125,6 +125,7 @@ exports[`Component Examples renders SearchBox.CustomIcon.Example.tsx correctly 1
           display: none;
         }
     id="SearchBox0"
+    onBlur={[Function]}
     onChange={[Function]}
     onInput={[Function]}
     onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.CustomIcon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.CustomIcon.Example.tsx.shot
@@ -42,7 +42,6 @@ exports[`Component Examples renders SearchBox.CustomIcon.Example.tsx correctly 1
       &:hover .ms-SearchBox-iconContainer {
         color: #005a9e;
       }
-  onBlurCapture={[Function]}
   onFocusCapture={[Function]}
   role="search"
 >
@@ -126,6 +125,7 @@ exports[`Component Examples renders SearchBox.CustomIcon.Example.tsx correctly 1
           display: none;
         }
     id="SearchBox0"
+    onBlur={[Function]}
     onChange={[Function]}
     onInput={[Function]}
     onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.CustomIcon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.CustomIcon.Example.tsx.shot
@@ -42,6 +42,7 @@ exports[`Component Examples renders SearchBox.CustomIcon.Example.tsx correctly 1
       &:hover .ms-SearchBox-iconContainer {
         color: #005a9e;
       }
+  onBlurCapture={[Function]}
   onFocusCapture={[Function]}
   role="search"
 >
@@ -125,7 +126,6 @@ exports[`Component Examples renders SearchBox.CustomIcon.Example.tsx correctly 1
           display: none;
         }
     id="SearchBox0"
-    onBlur={[Function]}
     onChange={[Function]}
     onInput={[Function]}
     onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
@@ -151,6 +151,7 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
           }
       disabled={true}
       id="SearchBox0"
+      onBlur={[Function]}
       onChange={[Function]}
       onInput={[Function]}
       onKeyDown={[Function]}
@@ -290,6 +291,7 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
           }
       disabled={true}
       id="SearchBox1"
+      onBlur={[Function]}
       onChange={[Function]}
       onInput={[Function]}
       onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
@@ -67,6 +67,7 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
         &:hover .ms-SearchBox-iconContainer {
           color: #005a9e;
         }
+    onBlurCapture={[Function]}
     onFocusCapture={[Function]}
     role="search"
   >
@@ -151,7 +152,6 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
           }
       disabled={true}
       id="SearchBox0"
-      onBlur={[Function]}
       onChange={[Function]}
       onInput={[Function]}
       onKeyDown={[Function]}
@@ -207,6 +207,7 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
         &:hover .ms-SearchBox-iconContainer {
           color: #005a9e;
         }
+    onBlurCapture={[Function]}
     onFocusCapture={[Function]}
     role="search"
   >
@@ -291,7 +292,6 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
           }
       disabled={true}
       id="SearchBox1"
-      onBlur={[Function]}
       onChange={[Function]}
       onInput={[Function]}
       onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Disabled.Example.tsx.shot
@@ -67,7 +67,6 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
         &:hover .ms-SearchBox-iconContainer {
           color: #005a9e;
         }
-    onBlurCapture={[Function]}
     onFocusCapture={[Function]}
     role="search"
   >
@@ -152,6 +151,7 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
           }
       disabled={true}
       id="SearchBox0"
+      onBlur={[Function]}
       onChange={[Function]}
       onInput={[Function]}
       onKeyDown={[Function]}
@@ -207,7 +207,6 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
         &:hover .ms-SearchBox-iconContainer {
           color: #005a9e;
         }
-    onBlurCapture={[Function]}
     onFocusCapture={[Function]}
     role="search"
   >
@@ -292,6 +291,7 @@ exports[`Component Examples renders SearchBox.Disabled.Example.tsx correctly 1`]
           }
       disabled={true}
       id="SearchBox1"
+      onBlur={[Function]}
       onChange={[Function]}
       onInput={[Function]}
       onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
@@ -146,6 +146,7 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
             display: none;
           }
       id="SearchBox0"
+      onBlur={[Function]}
       onChange={[Function]}
       onInput={[Function]}
       onKeyDown={[Function]}
@@ -276,6 +277,7 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
             display: none;
           }
       id="SearchBox1"
+      onBlur={[Function]}
       onChange={[Function]}
       onInput={[Function]}
       onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
@@ -63,6 +63,7 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
         &:hover .ms-SearchBox-iconContainer {
           color: #005a9e;
         }
+    onBlurCapture={[Function]}
     onFocusCapture={[Function]}
     role="search"
   >
@@ -146,7 +147,6 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
             display: none;
           }
       id="SearchBox0"
-      onBlur={[Function]}
       onChange={[Function]}
       onInput={[Function]}
       onKeyDown={[Function]}
@@ -196,6 +196,7 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
         &:hover .ms-SearchBox-iconContainer {
           color: #005a9e;
         }
+    onBlurCapture={[Function]}
     onFocusCapture={[Function]}
     role="search"
   >
@@ -277,7 +278,6 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
             display: none;
           }
       id="SearchBox1"
-      onBlur={[Function]}
       onChange={[Function]}
       onInput={[Function]}
       onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.FullSize.Example.tsx.shot
@@ -63,7 +63,6 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
         &:hover .ms-SearchBox-iconContainer {
           color: #005a9e;
         }
-    onBlurCapture={[Function]}
     onFocusCapture={[Function]}
     role="search"
   >
@@ -147,6 +146,7 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
             display: none;
           }
       id="SearchBox0"
+      onBlur={[Function]}
       onChange={[Function]}
       onInput={[Function]}
       onKeyDown={[Function]}
@@ -196,7 +196,6 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
         &:hover .ms-SearchBox-iconContainer {
           color: #005a9e;
         }
-    onBlurCapture={[Function]}
     onFocusCapture={[Function]}
     role="search"
   >
@@ -278,6 +277,7 @@ exports[`Component Examples renders SearchBox.FullSize.Example.tsx correctly 1`]
             display: none;
           }
       id="SearchBox1"
+      onBlur={[Function]}
       onChange={[Function]}
       onInput={[Function]}
       onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
@@ -126,6 +126,7 @@ exports[`Component Examples renders SearchBox.Small.Example.tsx correctly 1`] = 
           display: none;
         }
     id="SearchBox0"
+    onBlur={[Function]}
     onChange={[Function]}
     onInput={[Function]}
     onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
@@ -43,6 +43,7 @@ exports[`Component Examples renders SearchBox.Small.Example.tsx correctly 1`] = 
       &:hover .ms-SearchBox-iconContainer {
         color: #005a9e;
       }
+  onBlurCapture={[Function]}
   onFocusCapture={[Function]}
   role="search"
 >
@@ -126,7 +127,6 @@ exports[`Component Examples renders SearchBox.Small.Example.tsx correctly 1`] = 
           display: none;
         }
     id="SearchBox0"
-    onBlur={[Function]}
     onChange={[Function]}
     onInput={[Function]}
     onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Small.Example.tsx.shot
@@ -43,7 +43,6 @@ exports[`Component Examples renders SearchBox.Small.Example.tsx correctly 1`] = 
       &:hover .ms-SearchBox-iconContainer {
         color: #005a9e;
       }
-  onBlurCapture={[Function]}
   onFocusCapture={[Function]}
   role="search"
 >
@@ -127,6 +126,7 @@ exports[`Component Examples renders SearchBox.Small.Example.tsx correctly 1`] = 
           display: none;
         }
     id="SearchBox0"
+    onBlur={[Function]}
     onChange={[Function]}
     onInput={[Function]}
     onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
@@ -127,6 +127,7 @@ exports[`Component Examples renders SearchBox.Underlined.Example.tsx correctly 1
           display: none;
         }
     id="SearchBox0"
+    onBlur={[Function]}
     onChange={[Function]}
     onInput={[Function]}
     onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
@@ -44,7 +44,6 @@ exports[`Component Examples renders SearchBox.Underlined.Example.tsx correctly 1
       &:hover .ms-SearchBox-iconContainer {
         color: #005a9e;
       }
-  onBlurCapture={[Function]}
   onFocusCapture={[Function]}
   role="search"
 >
@@ -128,6 +127,7 @@ exports[`Component Examples renders SearchBox.Underlined.Example.tsx correctly 1
           display: none;
         }
     id="SearchBox0"
+    onBlur={[Function]}
     onChange={[Function]}
     onInput={[Function]}
     onKeyDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SearchBox.Underlined.Example.tsx.shot
@@ -44,6 +44,7 @@ exports[`Component Examples renders SearchBox.Underlined.Example.tsx correctly 1
       &:hover .ms-SearchBox-iconContainer {
         color: #005a9e;
       }
+  onBlurCapture={[Function]}
   onFocusCapture={[Function]}
   role="search"
 >
@@ -127,7 +128,6 @@ exports[`Component Examples renders SearchBox.Underlined.Example.tsx correctly 1
           display: none;
         }
     id="SearchBox0"
-    onBlur={[Function]}
     onChange={[Function]}
     onInput={[Function]}
     onKeyDown={[Function]}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #8261
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

To put search more in line with Textfield, i removed the event group and put onBlur back on the input. The event group has been there since before 2017, so i'm not 100% why someone thought it was necessary. 

If you know why this approach wouldn't work, please do tell, otherwise it fixes #8261

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11604)