### PR TITLE
FocusZone: clear disposable function references on unmount to avoid memory leak

### DIFF
--- a/change/office-ui-fabric-react-2020-01-03-13-05-22-keco-focuszone-leaks.json
+++ b/change/office-ui-fabric-react-2020-01-03-13-05-22-keco-focuszone-leaks.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "FocusZone: Delete function references on unmount",
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com",
+  "commit": "35c50bbe030217627f9f5df3b577129bace2edf4",
+  "date": "2020-01-03T21:05:22.458Z"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -199,6 +199,9 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     // Dispose all events.
     this._disposables.forEach(d => d());
 
+    // Clear function references.
+    delete this._disposables;
+
     // If this is the last outer zone, remove the keydown listener.
     if (_outerZones.size === 0 && _disposeGlobalKeyDownListener) {
       _disposeGlobalKeyDownListener();

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -199,7 +199,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     // Dispose all events.
     this._disposables.forEach(d => d());
 
-    // Clear function references.
+    // Clear function references so their closures can be garbage-collected.
     delete this._disposables;
 
     // If this is the last outer zone, remove the keydown listener.


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Currently, `FocusZone` maintains references to event handlers pushed on to `this._disposables` after unmount. Therefore, the callback context and element reference cannot be GC'ed.

This fix is similar to the pre-existing solution in `BaseComponent`, see https://github.com/OfficeDev/office-ui-fabric-react/blob/498eb74150d4aa2b724c178aa38b8a55cea1ce95/packages/utilities/src/BaseComponent.ts#L93

#### Heap snapshot

![image](https://user-images.githubusercontent.com/706967/71749448-53f09000-2e2a-11ea-9c50-048d7d538da2.png)


#### Focus areas to test

- CI should pass.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11605)