### PR TITLE
Add ability to pass custom packages for editor through ExampleCard

### DIFF
--- a/change/@uifabric-example-app-base-2020-01-06-16-00-56-example-editor.json
+++ b/change/@uifabric-example-app-base-2020-01-06-16-00-56-example-editor.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "ExampleCard: add prop for custom supportedPackages for editor",
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com",
+  "commit": "a84e7752d10a977cd8fe148a12004113808f573f",
+  "date": "2020-01-07T00:00:56.694Z"
+}

--- a/change/@uifabric-example-app-base-2020-01-06-16-00-56-example-editor.json
+++ b/change/@uifabric-example-app-base-2020-01-06-16-00-56-example-editor.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "ExampleCard: add prop for custom supportedPackages for editor",
+  "comment": "Add ExampleCard prop for custom editorSupportedPackages, and add support for ICustomizations in IAppDefinition.customizations for customizing all ExampleCards.",
   "packageName": "@uifabric/example-app-base",
   "email": "elcraig@microsoft.com",
   "commit": "a84e7752d10a977cd8fe148a12004113808f573f",

--- a/packages/example-app-base/README.md
+++ b/packages/example-app-base/README.md
@@ -3,3 +3,89 @@
 Components and utilities used to build documentation sites for various [Office UI Fabric React](https://dev.microsoft.com/fabric) packages.
 
 These components are primarily intended for use within the office-ui-fabric-react repo. Therefore, the APIs may be unstable.
+
+## Live editor support
+
+To set up the live code editor in the demo app for a package other than the `office-ui-fabric-react` package itself:
+
+1. Follow the setup steps from the [`@uifabric/monaco-editor` readme](https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/monaco-editor/README.md) (the helpers mentioned are also re-exported from `@uifabric/tsx-editor` for convenience).
+
+2. Set up a `.d.ts` rollup file for your package using API Extractor.
+
+3. Add a dependency on `raw-loader` to the package containing your demo app.
+
+4. Define the custom list of supported packages. For demonstration purposes, we'll assume:
+
+   - You're building off the default set of supported packages
+   - The package you're demoing is `my-package`
+   - `my-package` re-exports another package called `my-package-utilities` (it's not required that your package export anything else, but this is included to demonstrate setting it up)
+   - Each package's `.d.ts` rollup lives under `<package-name>/dist/<package-name>.d.ts`
+
+```ts
+import { IPackageGroup } from '@uifabric/tsx-editor';
+import { defaultSupportedPackages } from '@uifabric/tsx-editor/lib/utilities/defaultSupportedPackages';
+
+export const editorSupportedPackages: IPackageGroup[] = [
+  ...defaultSupportedPackages,
+  {
+    // Package's exports will be made available under this global name at runtime
+    globalName: 'MyPackage',
+    // Loader for the package's contents
+    loadGlobal: () => import('my-package'),
+    // Alternatively, for non-delayed loading:
+    //   loadGlobal: () => require('my-package'),
+    // Or at the top of the file, `import * as MyPackage from 'my-package'`, then:
+    //   loadGlobal: () => Promise.resolve(MyPackage)
+    packages: [
+      {
+        packageName: 'my-package',
+        loadTypes: () => {
+          // Use import() so the types can potentially be split into a separate chunk and delay loaded.
+          // If you don't care about that, you could use require() instead.
+          // @ts-ignore: import is handled by webpack
+          return import('!raw-loader!my-package/dist/my-package.d.ts');
+        }
+      },
+      {
+        // my-package re-exports my-package-utilities from its root, so it goes under the same global
+        packageName: 'my-package-utilities',
+        loadTypes: () => {
+          // @ts-ignore: import is handled by webpack
+          return import('!raw-loader!my-package-utilities/dist/my-package-utilities.d.ts');
+        }
+      }
+    ]
+  }
+];
+```
+
+5. To apply to a single `ExampleCard`:
+
+```tsx
+import { editorSupportedPackages } from '<file path>';
+import { MyExample } from './MyExample.Example';
+const MyExampleCode = require('!raw-loader!./MyExample.Example.tsx');
+
+<ExampleCard title="My example" code={MyExampleCode} editorSupportedPackages={editorSupportedPackages}>
+  <MyExample />
+</ExampleCard>;
+```
+
+6. To apply to all `ExampleCard` instances in your app:
+
+```ts
+import { editorSupportedPackages } from '<file path>';
+import { IExampleCardProps, IAppDefinition } from '@uifabric/example-app-base';
+
+const exampleCardProps: IExampleCardProps = { editorSupportedPackages };
+
+// same applies with ISiteDefinition
+const appDefinition: IAppDefinition = {
+  // ...
+  customizations: {
+    scopedSettings: {
+      ExampleCard: exampleCardProps
+    }
+  }
+};
+```

--- a/packages/example-app-base/src/components/App/App.tsx
+++ b/packages/example-app-base/src/components/App/App.tsx
@@ -101,11 +101,7 @@ export class AppBase extends React.Component<IAppProps, IAppState> {
         );
       }
       if (Object.keys(otherCustomizations).length) {
-        app = (
-          <Customizer settings={{}} scopedSettings={{}} {...otherCustomizations}>
-            {app}
-          </Customizer>
-        );
+        app = <Customizer {...otherCustomizations}>{app}</Customizer>;
       }
     }
     return app;

--- a/packages/example-app-base/src/components/App/App.tsx
+++ b/packages/example-app-base/src/components/App/App.tsx
@@ -92,8 +92,8 @@ export class AppBase extends React.Component<IAppProps, IAppState> {
       </Fabric>
     );
 
-    if (appDefinition.customizations) {
-      const { exampleCardCustomizations, hideSchemes, ...otherCustomizations } = appDefinition.customizations;
+    if (customizations) {
+      const { exampleCardCustomizations, hideSchemes, ...otherCustomizations } = customizations;
 
       if (exampleCardCustomizations || typeof hideSchemes === 'boolean') {
         app = (

--- a/packages/example-app-base/src/components/App/App.tsx
+++ b/packages/example-app-base/src/components/App/App.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { AppCustomizationsContext } from '../../utilities/customizations';
-import { classNamesFunction, css, styled } from 'office-ui-fabric-react/lib/Utilities';
+import { classNamesFunction, css, styled, Customizer } from 'office-ui-fabric-react/lib/Utilities';
 import { ExampleStatus, IAppProps, IAppStyleProps, IAppStyles } from './App.types';
 import { Fabric } from 'office-ui-fabric-react/lib/Fabric';
 import { getStyles } from './App.styles';
@@ -53,7 +53,7 @@ export class AppBase extends React.Component<IAppProps, IAppState> {
       />
     );
 
-    const app = (
+    let app = (
       <Fabric className={classNames.root}>
         {!onlyExamples && (
           <div className={classNames.headerContainer}>
@@ -92,7 +92,23 @@ export class AppBase extends React.Component<IAppProps, IAppState> {
       </Fabric>
     );
 
-    return customizations ? <AppCustomizationsContext.Provider value={customizations}>{app}</AppCustomizationsContext.Provider> : app;
+    if (appDefinition.customizations) {
+      const { exampleCardCustomizations, hideSchemes, ...otherCustomizations } = appDefinition.customizations;
+
+      if (exampleCardCustomizations || typeof hideSchemes === 'boolean') {
+        app = (
+          <AppCustomizationsContext.Provider value={{ exampleCardCustomizations, hideSchemes }}>{app}</AppCustomizationsContext.Provider>
+        );
+      }
+      if (Object.keys(otherCustomizations).length) {
+        app = (
+          <Customizer settings={{}} scopedSettings={{}} {...otherCustomizations}>
+            {app}
+          </Customizer>
+        );
+      }
+    }
+    return app;
   }
 
   private _onIsMenuVisibleChanged = (isMenuVisible: boolean): void => {

--- a/packages/example-app-base/src/components/App/App.types.ts
+++ b/packages/example-app-base/src/components/App/App.types.ts
@@ -1,5 +1,5 @@
 import { IStyle, ITheme } from 'office-ui-fabric-react/lib/Styling';
-import { IStyleFunctionOrObject } from 'office-ui-fabric-react/lib/Utilities';
+import { IStyleFunctionOrObject, ICustomizations } from 'office-ui-fabric-react/lib/Utilities';
 import { IWithResponsiveModeState } from 'office-ui-fabric-react/lib/utilities/decorators/withResponsiveMode';
 import { INavLink, INavLinkGroup, INavStyleProps } from 'office-ui-fabric-react/lib/Nav';
 import { IPanelStyleProps } from 'office-ui-fabric-react/lib/Panel';
@@ -30,8 +30,14 @@ export interface IAppDefinition {
   headerLinks: IAppLink[];
   /**
    * Optional customizations to apply to the application.
+   *
+   * `IAppCustomizations` members (`exampleCardCustomizations` and `hideSchemes`), if provided,
+   * are applied using `AppCustomizationsContext`.
+   *
+   * `ICustomizations` members (`settings` and `scopedSettings`), if provided, are applied
+   * using `Customizer`.
    */
-  customizations?: IAppCustomizations;
+  customizations?: IAppCustomizations & Partial<ICustomizations>;
 }
 
 export interface IAppProps extends IWithResponsiveModeState {

--- a/packages/example-app-base/src/components/ExampleCard/ExampleCard.tsx
+++ b/packages/example-app-base/src/components/ExampleCard/ExampleCard.tsx
@@ -81,7 +81,8 @@ export class ExampleCardBase extends React.Component<IExampleCardProps, IExample
       isScrollable = true,
       codepenJS,
       theme,
-      isCodeVisible = this.state.isCodeVisible
+      isCodeVisible = this.state.isCodeVisible,
+      editorSupportedPackages = SUPPORTED_PACKAGES
     } = this.props;
     const { themeIndex, schemeIndex, latestCode } = this.state;
 
@@ -155,7 +156,7 @@ export class ExampleCardBase extends React.Component<IExampleCardProps, IExample
               {isCodeVisible ? (
                 <EditorWrapper
                   code={latestCode}
-                  supportedPackages={SUPPORTED_PACKAGES}
+                  supportedPackages={editorSupportedPackages}
                   editorClassName={classNames.code}
                   editorAriaLabel={`Editor for the example "${title}". The example will be updated as you type.`}
                   modelRef={this._monacoModelRef}

--- a/packages/example-app-base/src/components/ExampleCard/ExampleCard.types.ts
+++ b/packages/example-app-base/src/components/ExampleCard/ExampleCard.types.ts
@@ -1,6 +1,7 @@
 import { IStyle, ITheme } from 'office-ui-fabric-react/lib/Styling';
 import { IStyleFunctionOrObject } from 'office-ui-fabric-react/lib/Utilities';
 import { IDropdownStyleProps } from 'office-ui-fabric-react/lib/Dropdown';
+import { IPackageGroup } from '@uifabric/tsx-editor';
 
 export interface IExampleCardProps {
   /** Example title */
@@ -37,6 +38,13 @@ export interface IExampleCardProps {
 
   /** Whether code example is visible */
   isCodeVisible?: boolean;
+
+  /**
+   * Custom supported packages for the live code editor. Defaults to core Fabric packages plus
+   * example-data. If you want to build off the default list of packages, it's exported from
+   * `@uifabric/tsx-editor/lib/utilities/defaultSupportedPackages`.
+   */
+  editorSupportedPackages?: IPackageGroup[];
 }
 
 export type IExampleCardStyleProps = Pick<IExampleCardProps, 'isRightAligned' | 'isScrollable' | 'theme'> & {


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add a prop `editorSupportedPackages` to ExampleCard, for passing custom supported package definitions through to the editor. This lets non-Fabric consumers of example-app-base make their packages work in the editor.

Add `scopedSettings` support in `IAppDefinition.customizations` to help with customizing all ExampleCards in a demo app.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11616)