### PR TITLE
FocusTrapZone: Fix event handler and element reference memory leaks

### DIFF
--- a/change/office-ui-fabric-react-2020-01-06-17-07-18-keco-focustrapzone-leaks.json
+++ b/change/office-ui-fabric-react-2020-01-06-17-07-18-keco-focustrapzone-leaks.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "FocusTrapZone: Release event handlers and element references for garbage-collection",
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com",
+  "commit": "48919fcf5f091b25b4b21931164e5572084f2e98",
+  "date": "2020-01-07T01:07:18.640Z"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusTrapZone/FocusTrapZone.tsx
@@ -72,6 +72,21 @@ export class FocusTrapZone extends React.Component<IFocusTrapZoneProps, {}> impl
     ) {
       this._returnFocusToInitiator();
     }
+
+    // Dispose of event handlers so their closures can be garbage-collected
+    if (this._disposeClickHandler) {
+      this._disposeClickHandler();
+      this._disposeClickHandler = undefined;
+    }
+
+    if (this._disposeFocusHandler) {
+      this._disposeFocusHandler();
+      this._disposeFocusHandler = undefined;
+    }
+
+    // Dispose of element references so the DOM Nodes can be garbage-collected
+    delete this._previouslyFocusedElementInTrapZone;
+    delete this._previouslyFocusedElementOutsideTrapZone;
   }
 
   public render(): JSX.Element {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Fixes memory leaks in `FocusTrapZone` due to element references and event listeners in script that cannot be GC'ed.

Discovered this testing SPFx WebPart "PropertyPane" in SharePoint Online. Currently, we leak the focused DOM Node(s) when PropertyPane(s) are opened then closed.

#### Heap snapshot

Highlighted are the script references I am cleaning-up in this PR. Note the `+2` DOM Nodes that are not GC'ed when the Panel is closed (the snapshot I have selected). I have a similar `Popup` PR to follow.

![image](https://user-images.githubusercontent.com/706967/71860382-7e02b600-30a7-11ea-8159-ecef397db9e4.png)

To capture the above, I opened and closed the "A Dialog nested in a Panel" example on http://localhost:4322/#/examples/focustrapzone capturing heap snapshots before and after for comparison and filtering by "Detached".

#### Focus areas to test

- CI should pass.

cc: @patmill 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11618)