### PR TITLE
Popup: focus fix

### DIFF
--- a/change/office-ui-fabric-react-2020-01-07-12-55-14-popup-focus-fix.json
+++ b/change/office-ui-fabric-react-2020-01-07-12-55-14-popup-focus-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Popup: fix an issue where onBlur would not correctly update focus state",
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com",
+  "commit": "bf10fc8ca151deb07bcc5ba33993f8c849eb9e14",
+  "date": "2020-01-07T20:55:14.687Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
+++ b/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
@@ -143,6 +143,14 @@ export class Popup extends React.Component<IPopupProps, IPopupState> {
   };
 
   private _onBlur = (ev: FocusEvent): void => {
+    /** The popup should update this._containsFocus when:
+     * relatedTarget exists AND
+     * the relatedTarget is not contained within the popup.
+     * If the relatedTarget is within the popup, that means the popup still has focus
+     * and focused moved from one element to another within the popup.
+     * If relatedTarget is undefined or null that usually means that a
+     * keyboard event occured and focus didn't change
+     */
     if (this._root.current && ev.relatedTarget && !this._root.current.contains(ev.relatedTarget as HTMLElement)) {
       this._containsFocus = false;
     }

--- a/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
+++ b/packages/office-ui-fabric-react/src/components/Popup/Popup.tsx
@@ -143,7 +143,7 @@ export class Popup extends React.Component<IPopupProps, IPopupState> {
   };
 
   private _onBlur = (ev: FocusEvent): void => {
-    if (this._root.current && this._root.current.contains(ev.relatedTarget as HTMLElement)) {
+    if (this._root.current && ev.relatedTarget && !this._root.current.contains(ev.relatedTarget as HTMLElement)) {
       this._containsFocus = false;
     }
   };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Currently, popup's `this._containsFocus` would never be set to false because ev.relatedTarget will be outside of the popup when focus is leaving the popup.

The following checks are necessary:

1. Ensure that root.current is not undefined
2. Ensure that relatedTarget is not undefined
3. Ensure that root.current does not contain relatedTarget.

This ensures that the popup will mark itself as having lost focus when an element outside of popup receives focus.

See [pr #4804](https://github.com/OfficeDev/office-ui-fabric-react/pull/4804) for more context

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11630)