### PR TITLE
Calendar today high contrast

### DIFF
--- a/change/office-ui-fabric-react-2020-01-07-13-51-15-calendarTodayHighContrast.json
+++ b/change/office-ui-fabric-react-2020-01-07-13-51-15-calendarTodayHighContrast.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Calendar: Fixing text color of 'today's day cell' when in High Contrast Mode.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "92cfe30b9cc98ceaeab52d4bd95eb17d98a0dfe2",
+  "date": "2020-01-07T21:51:15.319Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
+++ b/packages/office-ui-fabric-react/src/components/Calendar/Calendar.scss
@@ -173,12 +173,6 @@ $Calendar-dayPicker-margin: 10px;
   @include high-contrast {
     background-color: highlight;
   }
-  span {
-    @include high-contrast {
-      -ms-high-contrast-adjust: none;
-      color: window;
-    }
-  }
   &:hover {
     border-radius: 100%;
   }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11617 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The text of "today's day cell" was presented in a non-visible color in High Contrast Mode. This PR fixes this by setting a correct color.

**Before:**
![image](https://user-images.githubusercontent.com/7798177/71932687-30dd1d80-3155-11ea-8b3b-f4601f581fb9.png)

**After:**
![image](https://user-images.githubusercontent.com/7798177/71932688-333f7780-3155-11ea-9caa-f25f85b5d25d.png)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11633)