### PR TITLE
ComboBox: Fix focus border and chevron button styling issues

### DIFF
--- a/change/@uifabric-experiments-2020-01-07-17-49-22-xgao-fix-combobox-styles.json
+++ b/change/@uifabric-experiments-2020-01-07-17-49-22-xgao-fix-combobox-styles.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "ComboBox: fix chevron button and focus border styling",
+  "packageName": "@uifabric/experiments",
+  "email": "xgao@microsoft.com",
+  "commit": "b1f23673efec6c713219c81d02be736f3dc7a373",
+  "date": "2020-01-08T01:48:44.522Z"
+}

--- a/change/@uifabric-styling-2020-01-07-18-22-34-xgao-fix-combobox-styles.json
+++ b/change/@uifabric-styling-2020-01-07-18-22-34-xgao-fix-combobox-styles.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "add borderPosition param to getInputFocusStyle",
+  "packageName": "@uifabric/styling",
+  "email": "xgao@microsoft.com",
+  "commit": "927aefb4447731b6eb0aa84f1fb57e3adc638bdb",
+  "date": "2020-01-08T02:22:34.442Z"
+}

--- a/change/office-ui-fabric-react-2020-01-07-17-49-22-xgao-fix-combobox-styles.json
+++ b/change/office-ui-fabric-react-2020-01-07-17-49-22-xgao-fix-combobox-styles.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update snapshot test after fixing combobox styling",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "b1f23673efec6c713219c81d02be736f3dc7a373",
+  "date": "2020-01-08T01:49:22.211Z"
+}

--- a/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -1411,10 +1411,8 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
             height: 32px;
             margin-left: 0;
             outline: 0;
-            padding-bottom: 1px;
             padding-left: 9px;
             padding-right: 32px;
-            padding-top: 1px;
             position: relative;
             text-overflow: ellipsis;
             user-select: none;
@@ -1427,8 +1425,10 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open:after {
+            border-color: Highlight;
           }
           &:after {
             border-color: #605e5c;
@@ -1443,7 +1443,7 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
             right: 0px;
             top: 0px;
           }
-          &:hover {
+          &:hover:after {
             border-color: #323130;
           }
           &:hover .ms-ComboBox-Input {
@@ -1475,8 +1475,10 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active){&:hover:after {
+            border-color: Highlight;
           }
           &:active {
             position: relative;
@@ -1484,8 +1486,10 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&:active {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active){&:active:after {
+            border-color: Highlight;
           }
           &:focus {
             border-color: #0078d4;
@@ -1501,8 +1505,10 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&:focus {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus:after {
+            border-color: Highlight;
           }
           &:focus:after {
             border-radius: 2px;
@@ -1514,9 +1520,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
             position: absolute;
             right: 0px;
             top: 0px;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus:after {
-            border-color: Highlight;
           }
       id="ComboBox6wrapper"
     >
@@ -1613,7 +1616,7 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
               padding-bottom: 0;
               padding-left: 4px;
               padding-right: 4px;
-              padding-top: 1px;
+              padding-top: 0;
               position: absolute;
               text-align: center;
               text-decoration: none;

--- a/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -1400,10 +1400,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             background-color: #ffffff;
-            border-color: #605e5c;
-            border-radius: 2px;
-            border-style: solid;
-            border-width: 1px;
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
@@ -1415,9 +1411,8 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
             height: 32px;
             margin-left: 0;
             outline: 0;
-            overflow: hidden;
             padding-bottom: 1px;
-            padding-left: 8px;
+            padding-left: 9px;
             padding-right: 32px;
             padding-top: 1px;
             position: relative;
@@ -1434,6 +1429,19 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
             background-color: Window;
             border-color: Highlight;
             color: HighlightText;
+          }
+          &:after {
+            border-color: #605e5c;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
           }
           &:hover {
             border-color: #323130;
@@ -1471,7 +1479,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
             color: HighlightText;
           }
           &:active {
-            border-color: #0078d4;
             position: relative;
           }
           @media screen and (-ms-high-contrast: active){&:active {
@@ -1479,20 +1486,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
             background-color: Window;
             border-color: Highlight;
             color: HighlightText;
-          }
-          &:active:after {
-            border-radius: 2px;
-            border: 2px solid #0078d4;
-            bottom: -1px;
-            content: '';
-            left: -1px;
-            pointer-events: none;
-            position: absolute;
-            right: -1px;
-            top: -1px;
-          }
-          @media screen and (-ms-high-contrast: active){&:active:after {
-            border-color: Highlight;
           }
           &:focus {
             border-color: #0078d4;
@@ -1514,13 +1507,13 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           &:focus:after {
             border-radius: 2px;
             border: 2px solid #0078d4;
-            bottom: -1px;
+            bottom: 0px;
             content: '';
-            left: -1px;
+            left: 0px;
             pointer-events: none;
             position: absolute;
-            right: -1px;
-            top: -1px;
+            right: 0px;
+            top: 0px;
           }
           @media screen and (-ms-high-contrast: active){&:focus:after {
             border-color: Highlight;
@@ -1540,7 +1533,7 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
               box-sizing: border-box;
               color: #323130;
               font: inherit;
-              height: 28px;
+              height: 100%;
               outline: none;
               padding-bottom: 0;
               padding-left: 0;
@@ -1614,16 +1607,17 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 12px;
               font-weight: 400;
-              height: 32px;
+              height: 100%;
               line-height: 30px;
               outline: transparent;
               padding-bottom: 0;
               padding-left: 4px;
               padding-right: 4px;
-              padding-top: 0;
+              padding-top: 1px;
               position: absolute;
               text-align: center;
               text-decoration: none;
+              top: 0px;
               user-select: none;
               vertical-align: top;
               width: 32px;

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -192,7 +192,9 @@ export const getCaretDownButtonStyles = memoizeFunction(
         color: caret.buttonTextColor,
         fontSize: fonts.small.fontSize,
         position: 'absolute',
-        height: ComboBoxHeight,
+        top: 0,
+        height: '100%',
+        paddingTop: 1, // make the chevron down visually vertically centered
         lineHeight: ComboBoxLineHeight,
         width: ComboBoxCaretDownWidth,
         textAlign: 'center',

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -33,8 +33,12 @@ const getDisabledStyles = memoizeFunction(
           borderColor: semanticColors.disabledBackground
         },
         [HighContrastSelector]: {
-          borderColor: 'GrayText',
-          color: 'GrayText'
+          color: 'GrayText',
+          selectors: {
+            ':after': {
+              borderColor: 'GrayText'
+            }
+          }
         }
       }
     };

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -26,10 +26,12 @@ const getDisabledStyles = memoizeFunction(
 
     return {
       backgroundColor: semanticColors.disabledBackground,
-      borderColor: semanticColors.disabledBackground,
       color: semanticColors.disabledText,
       cursor: 'default',
       selectors: {
+        ':after': {
+          borderColor: semanticColors.disabledBackground
+        },
         [HighContrastSelector]: {
           borderColor: 'GrayText',
           color: 'GrayText'
@@ -194,7 +196,6 @@ export const getCaretDownButtonStyles = memoizeFunction(
         position: 'absolute',
         top: 0,
         height: '100%',
-        paddingTop: 1, // make the chevron down visually vertically centered
         lineHeight: ComboBoxLineHeight,
         width: ComboBoxCaretDownWidth,
         textAlign: 'center',
@@ -299,12 +300,28 @@ export const getStyles = memoizeFunction(
 
     const ComboBoxRootHighContrastFocused = {
       color: 'HighlightText',
-      borderColor: 'Highlight',
       backgroundColor: 'Window',
-      MsHighContrastAdjust: 'none'
+      MsHighContrastAdjust: 'none',
+      selectors: {
+        ':after': {
+          borderColor: 'Highlight'
+        }
+      }
     };
 
-    const focusBorderStyles: IStyle = getInputFocusStyle(root.borderPressedColor, effects.roundedCorner2);
+    const focusBorderStyles: IStyle = [
+      getInputFocusStyle(root.borderPressedColor, effects.roundedCorner2),
+      {
+        selectors: {
+          ':after': {
+            top: 0,
+            bottom: 0,
+            left: 0,
+            right: 0
+          }
+        }
+      }
+    ];
 
     const styles: IComboBoxStyles = {
       container: {},
@@ -315,10 +332,8 @@ export const getStyles = memoizeFunction(
         {
           boxShadow: 'none',
           marginLeft: '0',
-          paddingTop: 1, // The 1px padding centers the input field, avoiding overlap in the browser
-          paddingBottom: 1,
           paddingRight: ComboBoxCaretDownWidth,
-          paddingLeft: 8,
+          paddingLeft: 9,
           color: root.textColor,
           position: 'relative',
           outline: '0',
@@ -327,14 +342,9 @@ export const getStyles = memoizeFunction(
           cursor: 'text',
           display: 'block',
           height: ComboBoxHeight,
-          overflow: 'hidden',
           whiteSpace: 'nowrap',
           textOverflow: 'ellipsis',
           boxSizing: 'border-box', // Border-box matches Dropdown and TextField
-          borderWidth: '1px',
-          borderStyle: 'solid',
-          borderColor: root.borderColor,
-          borderRadius: effects.roundedCorner2,
           selectors: {
             '.ms-Label': {
               display: 'inline-block',
@@ -344,14 +354,29 @@ export const getStyles = memoizeFunction(
               selectors: {
                 [HighContrastSelector]: ComboBoxRootHighContrastFocused
               }
+            },
+            ':after': {
+              pointerEvents: 'none',
+              content: "''",
+              position: 'absolute',
+              left: 0,
+              top: 0,
+              bottom: 0,
+              right: 0,
+              borderWidth: '1px',
+              borderStyle: 'solid',
+              borderColor: root.borderColor,
+              borderRadius: effects.roundedCorner2
             }
           }
         }
       ],
 
       rootHovered: {
-        borderColor: root.borderHoveredColor,
         selectors: {
+          ':after': {
+            borderColor: root.borderHoveredColor
+          },
           '.ms-ComboBox-Input': [
             {
               color: semanticColors.inputTextHovered
@@ -363,7 +388,11 @@ export const getStyles = memoizeFunction(
             color: 'HighlightText',
             backgroundColor: 'Window',
             MsHighContrastAdjust: 'none',
-            borderColor: 'Highlight'
+            selectors: {
+              ':after': {
+                borderColor: 'Highlight'
+              }
+            }
           }
         }
       },
@@ -374,8 +403,7 @@ export const getStyles = memoizeFunction(
           selectors: {
             [HighContrastSelector]: ComboBoxRootHighContrastFocused
           }
-        },
-        focusBorderStyles
+        }
       ],
 
       rootFocused: [
@@ -413,7 +441,7 @@ export const getStyles = memoizeFunction(
           color: root.textColor,
           boxSizing: 'border-box',
           width: '100%',
-          height: '28px',
+          height: '100%',
           borderStyle: 'none',
           outline: 'none',
           font: 'inherit',

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -347,6 +347,8 @@ export const getStyles = memoizeFunction(
                 [HighContrastSelector]: ComboBoxRootHighContrastFocused
               }
             },
+            // setting border using pseudo-element here in order to
+            // prevent chevron button to overlap ComboBox border under certain resolutions
             ':after': {
               pointerEvents: 'none',
               content: "''",

--- a/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/ComboBox.styles.ts
@@ -313,19 +313,7 @@ export const getStyles = memoizeFunction(
       }
     };
 
-    const focusBorderStyles: IStyle = [
-      getInputFocusStyle(root.borderPressedColor, effects.roundedCorner2),
-      {
-        selectors: {
-          ':after': {
-            top: 0,
-            bottom: 0,
-            left: 0,
-            right: 0
-          }
-        }
-      }
-    ];
+    const focusBorderStyles: IStyle = getInputFocusStyle(root.borderPressedColor, effects.roundedCorner2, 'border', 0);
 
     const styles: IComboBoxStyles = {
       container: {},

--- a/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -11,10 +11,6 @@ exports[`ComboBox Renders correctly 1`] = `
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
           background-color: #ffffff;
-          border-color: #605e5c;
-          border-radius: 2px;
-          border-style: solid;
-          border-width: 1px;
           box-shadow: none;
           box-sizing: border-box;
           color: #323130;
@@ -26,11 +22,8 @@ exports[`ComboBox Renders correctly 1`] = `
           height: 32px;
           margin-left: 0;
           outline: 0;
-          overflow: hidden;
-          padding-bottom: 1px;
-          padding-left: 8px;
+          padding-left: 9px;
           padding-right: 32px;
-          padding-top: 1px;
           position: relative;
           text-overflow: ellipsis;
           user-select: none;
@@ -43,10 +36,25 @@ exports[`ComboBox Renders correctly 1`] = `
         @media screen and (-ms-high-contrast: active){&.is-open {
           -ms-high-contrast-adjust: none;
           background-color: Window;
-          border-color: Highlight;
           color: HighlightText;
         }
-        &:hover {
+        @media screen and (-ms-high-contrast: active){&.is-open:after {
+          border-color: Highlight;
+        }
+        &:after {
+          border-color: #605e5c;
+          border-radius: 2px;
+          border-style: solid;
+          border-width: 1px;
+          bottom: 0px;
+          content: '';
+          left: 0px;
+          pointer-events: none;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+        }
+        &:hover:after {
           border-color: #323130;
         }
         &:hover .ms-ComboBox-Input {
@@ -78,29 +86,18 @@ exports[`ComboBox Renders correctly 1`] = `
         @media screen and (-ms-high-contrast: active){&:hover {
           -ms-high-contrast-adjust: none;
           background-color: Window;
-          border-color: Highlight;
           color: HighlightText;
         }
+        @media screen and (-ms-high-contrast: active){&:hover:after {
+          border-color: Highlight;
+        }
         &:active {
-          border-color: #0078d4;
           position: relative;
         }
         @media screen and (-ms-high-contrast: active){&:active {
           -ms-high-contrast-adjust: none;
           background-color: Window;
-          border-color: Highlight;
           color: HighlightText;
-        }
-        &:active:after {
-          border-radius: 2px;
-          border: 2px solid #0078d4;
-          bottom: -1px;
-          content: '';
-          left: -1px;
-          pointer-events: none;
-          position: absolute;
-          right: -1px;
-          top: -1px;
         }
         @media screen and (-ms-high-contrast: active){&:active:after {
           border-color: Highlight;
@@ -119,22 +116,21 @@ exports[`ComboBox Renders correctly 1`] = `
         @media screen and (-ms-high-contrast: active){&:focus {
           -ms-high-contrast-adjust: none;
           background-color: Window;
-          border-color: Highlight;
           color: HighlightText;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus:after {
+          border-color: Highlight;
         }
         &:focus:after {
           border-radius: 2px;
           border: 2px solid #0078d4;
-          bottom: -1px;
+          bottom: 0px;
           content: '';
-          left: -1px;
+          left: 0px;
           pointer-events: none;
           position: absolute;
-          right: -1px;
-          top: -1px;
-        }
-        @media screen and (-ms-high-contrast: active){&:focus:after {
-          border-color: Highlight;
+          right: 0px;
+          top: 0px;
         }
     id="ComboBox0wrapper"
   >
@@ -151,7 +147,7 @@ exports[`ComboBox Renders correctly 1`] = `
             box-sizing: border-box;
             color: #323130;
             font: inherit;
-            height: 28px;
+            height: 100%;
             outline: none;
             padding-bottom: 0;
             padding-left: 0;
@@ -225,7 +221,7 @@ exports[`ComboBox Renders correctly 1`] = `
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 12px;
             font-weight: 400;
-            height: 32px;
+            height: 100%;
             line-height: 30px;
             outline: transparent;
             padding-bottom: 0;
@@ -235,6 +231,7 @@ exports[`ComboBox Renders correctly 1`] = `
             position: absolute;
             text-align: center;
             text-decoration: none;
+            top: 0px;
             user-select: none;
             vertical-align: top;
             width: 32px;
@@ -381,10 +378,6 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
           background-color: #ffffff;
-          border-color: #605e5c;
-          border-radius: 2px;
-          border-style: solid;
-          border-width: 1px;
           box-shadow: none;
           box-sizing: border-box;
           color: #323130;
@@ -396,11 +389,8 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
           height: 32px;
           margin-left: 0;
           outline: 0;
-          overflow: hidden;
-          padding-bottom: 1px;
-          padding-left: 8px;
+          padding-left: 9px;
           padding-right: 32px;
-          padding-top: 1px;
           position: relative;
           text-overflow: ellipsis;
           user-select: none;
@@ -413,10 +403,25 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
         @media screen and (-ms-high-contrast: active){&.is-open {
           -ms-high-contrast-adjust: none;
           background-color: Window;
-          border-color: Highlight;
           color: HighlightText;
         }
-        &:hover {
+        @media screen and (-ms-high-contrast: active){&.is-open:after {
+          border-color: Highlight;
+        }
+        &:after {
+          border-color: #605e5c;
+          border-radius: 2px;
+          border-style: solid;
+          border-width: 1px;
+          bottom: 0px;
+          content: '';
+          left: 0px;
+          pointer-events: none;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+        }
+        &:hover:after {
           border-color: #323130;
         }
         &:hover .ms-ComboBox-Input {
@@ -448,29 +453,18 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
         @media screen and (-ms-high-contrast: active){&:hover {
           -ms-high-contrast-adjust: none;
           background-color: Window;
-          border-color: Highlight;
           color: HighlightText;
         }
+        @media screen and (-ms-high-contrast: active){&:hover:after {
+          border-color: Highlight;
+        }
         &:active {
-          border-color: #0078d4;
           position: relative;
         }
         @media screen and (-ms-high-contrast: active){&:active {
           -ms-high-contrast-adjust: none;
           background-color: Window;
-          border-color: Highlight;
           color: HighlightText;
-        }
-        &:active:after {
-          border-radius: 2px;
-          border: 2px solid #0078d4;
-          bottom: -1px;
-          content: '';
-          left: -1px;
-          pointer-events: none;
-          position: absolute;
-          right: -1px;
-          top: -1px;
         }
         @media screen and (-ms-high-contrast: active){&:active:after {
           border-color: Highlight;
@@ -489,22 +483,21 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
         @media screen and (-ms-high-contrast: active){&:focus {
           -ms-high-contrast-adjust: none;
           background-color: Window;
-          border-color: Highlight;
           color: HighlightText;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus:after {
+          border-color: Highlight;
         }
         &:focus:after {
           border-radius: 2px;
           border: 2px solid #0078d4;
-          bottom: -1px;
+          bottom: 0px;
           content: '';
-          left: -1px;
+          left: 0px;
           pointer-events: none;
           position: absolute;
-          right: -1px;
-          top: -1px;
-        }
-        @media screen and (-ms-high-contrast: active){&:focus:after {
-          border-color: Highlight;
+          right: 0px;
+          top: 0px;
         }
     data-ktp-target="ktp-a"
     id="ComboBox4wrapper"
@@ -523,7 +516,7 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
             box-sizing: border-box;
             color: #323130;
             font: inherit;
-            height: 28px;
+            height: 100%;
             outline: none;
             padding-bottom: 0;
             padding-left: 0;
@@ -598,7 +591,7 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 12px;
             font-weight: 400;
-            height: 32px;
+            height: 100%;
             line-height: 30px;
             outline: transparent;
             padding-bottom: 0;
@@ -608,6 +601,7 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
             position: absolute;
             text-align: center;
             text-decoration: none;
+            top: 0px;
             user-select: none;
             vertical-align: top;
             width: 32px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -4389,8 +4389,10 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             top: 0px;
           }
           @media screen and (-ms-high-contrast: active){& {
-            border-color: GrayText;
             color: GrayText;
+          }
+          @media screen and (-ms-high-contrast: active){&:after {
+            border-color: GrayText;
           }
       id="ComboBox27wrapper"
     >
@@ -4443,11 +4445,13 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active){& {
               -ms-high-contrast-adjust: none;
               background-color: Window;
-              border-color: GrayText;
               color: GrayText;
             }
             &:after {
               border-color: #f3f2f1;
+            }
+            @media screen and (-ms-high-contrast: active){&:after {
+              border-color: GrayText;
             }
         data-is-interactable={false}
         data-lpignore={true}
@@ -4537,7 +4541,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active){& {
               -ms-high-contrast-adjust: none;
               background-color: ButtonFace;
-              border-color: GrayText;
+              border-color: grayText;
               color: GrayText;
             }
             &:hover {
@@ -4548,6 +4552,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             }
             &:after {
               border-color: #f3f2f1;
+            }
+            @media screen and (-ms-high-contrast: active){&:after {
+              border-color: GrayText;
             }
         data-is-focusable={false}
         disabled={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -69,10 +69,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
               background-color: #ffffff;
-              border-color: #605e5c;
-              border-radius: 2px;
-              border-style: solid;
-              border-width: 1px;
               box-shadow: none;
               box-sizing: border-box;
               color: #323130;
@@ -84,11 +80,8 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               height: 32px;
               margin-left: 0;
               outline: 0;
-              overflow: hidden;
-              padding-bottom: 1px;
-              padding-left: 8px;
+              padding-left: 9px;
               padding-right: 32px;
-              padding-top: 1px;
               position: relative;
               text-overflow: ellipsis;
               user-select: none;
@@ -101,10 +94,25 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active){&.is-open {
               -ms-high-contrast-adjust: none;
               background-color: Window;
-              border-color: Highlight;
               color: HighlightText;
             }
-            &:hover {
+            @media screen and (-ms-high-contrast: active){&.is-open:after {
+              border-color: Highlight;
+            }
+            &:after {
+              border-color: #605e5c;
+              border-radius: 2px;
+              border-style: solid;
+              border-width: 1px;
+              bottom: 0px;
+              content: '';
+              left: 0px;
+              pointer-events: none;
+              position: absolute;
+              right: 0px;
+              top: 0px;
+            }
+            &:hover:after {
               border-color: #323130;
             }
             &:hover .ms-ComboBox-Input {
@@ -136,29 +144,18 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active){&:hover {
               -ms-high-contrast-adjust: none;
               background-color: Window;
-              border-color: Highlight;
               color: HighlightText;
             }
+            @media screen and (-ms-high-contrast: active){&:hover:after {
+              border-color: Highlight;
+            }
             &:active {
-              border-color: #0078d4;
               position: relative;
             }
             @media screen and (-ms-high-contrast: active){&:active {
               -ms-high-contrast-adjust: none;
               background-color: Window;
-              border-color: Highlight;
               color: HighlightText;
-            }
-            &:active:after {
-              border-radius: 2px;
-              border: 2px solid #0078d4;
-              bottom: -1px;
-              content: '';
-              left: -1px;
-              pointer-events: none;
-              position: absolute;
-              right: -1px;
-              top: -1px;
             }
             @media screen and (-ms-high-contrast: active){&:active:after {
               border-color: Highlight;
@@ -177,22 +174,21 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active){&:focus {
               -ms-high-contrast-adjust: none;
               background-color: Window;
-              border-color: Highlight;
               color: HighlightText;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus:after {
+              border-color: Highlight;
             }
             &:focus:after {
               border-radius: 2px;
               border: 2px solid #0078d4;
-              bottom: -1px;
+              bottom: 0px;
               content: '';
-              left: -1px;
+              left: 0px;
               pointer-events: none;
               position: absolute;
-              right: -1px;
-              top: -1px;
-            }
-            @media screen and (-ms-high-contrast: active){&:focus:after {
-              border-color: Highlight;
+              right: 0px;
+              top: 0px;
             }
         id="ComboBox0wrapper"
       >
@@ -210,7 +206,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                 box-sizing: border-box;
                 color: #323130;
                 font: inherit;
-                height: 28px;
+                height: 100%;
                 outline: none;
                 padding-bottom: 0;
                 padding-left: 0;
@@ -284,7 +280,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 12px;
                 font-weight: 400;
-                height: 32px;
+                height: 100%;
                 line-height: 30px;
                 outline: transparent;
                 padding-bottom: 0;
@@ -294,6 +290,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                 position: absolute;
                 text-align: center;
                 text-decoration: none;
+                top: 0px;
                 user-select: none;
                 vertical-align: top;
                 width: 32px;
@@ -626,10 +623,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             background-color: #ffffff;
-            border-color: #605e5c;
-            border-radius: 2px;
-            border-style: solid;
-            border-width: 1px;
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
@@ -641,11 +634,8 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             height: 32px;
             margin-left: 0;
             outline: 0;
-            overflow: hidden;
-            padding-bottom: 1px;
-            padding-left: 8px;
+            padding-left: 9px;
             padding-right: 32px;
-            padding-top: 1px;
             position: relative;
             text-overflow: ellipsis;
             user-select: none;
@@ -658,10 +648,25 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
           }
-          &:hover {
+          @media screen and (-ms-high-contrast: active){&.is-open:after {
+            border-color: Highlight;
+          }
+          &:after {
+            border-color: #605e5c;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+          &:hover:after {
             border-color: #323130;
           }
           &:hover .ms-ComboBox-Input {
@@ -693,29 +698,18 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
           }
+          @media screen and (-ms-high-contrast: active){&:hover:after {
+            border-color: Highlight;
+          }
           &:active {
-            border-color: #0078d4;
             position: relative;
           }
           @media screen and (-ms-high-contrast: active){&:active {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
-          }
-          &:active:after {
-            border-radius: 2px;
-            border: 2px solid #0078d4;
-            bottom: -1px;
-            content: '';
-            left: -1px;
-            pointer-events: none;
-            position: absolute;
-            right: -1px;
-            top: -1px;
           }
           @media screen and (-ms-high-contrast: active){&:active:after {
             border-color: Highlight;
@@ -734,22 +728,21 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&:focus {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus:after {
+            border-color: Highlight;
           }
           &:focus:after {
             border-radius: 2px;
             border: 2px solid #0078d4;
-            bottom: -1px;
+            bottom: 0px;
             content: '';
-            left: -1px;
+            left: 0px;
             pointer-events: none;
             position: absolute;
-            right: -1px;
-            top: -1px;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus:after {
-            border-color: Highlight;
+            right: 0px;
+            top: 0px;
           }
       id="ComboBox7wrapper"
     >
@@ -767,7 +760,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               box-sizing: border-box;
               color: #323130;
               font: inherit;
-              height: 28px;
+              height: 100%;
               outline: none;
               padding-bottom: 0;
               padding-left: 0;
@@ -841,7 +834,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 12px;
               font-weight: 400;
-              height: 32px;
+              height: 100%;
               line-height: 30px;
               outline: transparent;
               padding-bottom: 0;
@@ -851,6 +844,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               position: absolute;
               text-align: center;
               text-decoration: none;
+              top: 0px;
               user-select: none;
               vertical-align: top;
               width: 32px;
@@ -1022,10 +1016,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             background-color: #ffffff;
-            border-color: #605e5c;
-            border-radius: 2px;
-            border-style: solid;
-            border-width: 1px;
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
@@ -1037,11 +1027,8 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             height: 32px;
             margin-left: 0;
             outline: 0;
-            overflow: hidden;
-            padding-bottom: 1px;
-            padding-left: 8px;
+            padding-left: 9px;
             padding-right: 32px;
-            padding-top: 1px;
             position: relative;
             text-overflow: ellipsis;
             user-select: none;
@@ -1054,10 +1041,25 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
           }
-          &:hover {
+          @media screen and (-ms-high-contrast: active){&.is-open:after {
+            border-color: Highlight;
+          }
+          &:after {
+            border-color: #605e5c;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+          &:hover:after {
             border-color: #323130;
           }
           &:hover .ms-ComboBox-Input {
@@ -1089,29 +1091,18 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
           }
+          @media screen and (-ms-high-contrast: active){&:hover:after {
+            border-color: Highlight;
+          }
           &:active {
-            border-color: #0078d4;
             position: relative;
           }
           @media screen and (-ms-high-contrast: active){&:active {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
-          }
-          &:active:after {
-            border-radius: 2px;
-            border: 2px solid #0078d4;
-            bottom: -1px;
-            content: '';
-            left: -1px;
-            pointer-events: none;
-            position: absolute;
-            right: -1px;
-            top: -1px;
           }
           @media screen and (-ms-high-contrast: active){&:active:after {
             border-color: Highlight;
@@ -1130,22 +1121,21 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&:focus {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus:after {
+            border-color: Highlight;
           }
           &:focus:after {
             border-radius: 2px;
             border: 2px solid #0078d4;
-            bottom: -1px;
+            bottom: 0px;
             content: '';
-            left: -1px;
+            left: 0px;
             pointer-events: none;
             position: absolute;
-            right: -1px;
-            top: -1px;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus:after {
-            border-color: Highlight;
+            right: 0px;
+            top: 0px;
           }
       id="ComboBox11wrapper"
     >
@@ -1163,7 +1153,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               box-sizing: border-box;
               color: #323130;
               font: inherit;
-              height: 28px;
+              height: 100%;
               outline: none;
               padding-bottom: 0;
               padding-left: 0;
@@ -1238,7 +1228,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 12px;
               font-weight: 400;
-              height: 32px;
+              height: 100%;
               line-height: 30px;
               outline: transparent;
               padding-bottom: 0;
@@ -1248,6 +1238,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               position: absolute;
               text-align: center;
               text-decoration: none;
+              top: 0px;
               user-select: none;
               vertical-align: top;
               width: 32px;
@@ -1419,10 +1410,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             background-color: #ffffff;
-            border-color: #605e5c;
-            border-radius: 2px;
-            border-style: solid;
-            border-width: 1px;
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
@@ -1434,11 +1421,8 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             height: 32px;
             margin-left: 0;
             outline: 0;
-            overflow: hidden;
-            padding-bottom: 1px;
-            padding-left: 8px;
+            padding-left: 9px;
             padding-right: 32px;
-            padding-top: 1px;
             position: relative;
             text-overflow: ellipsis;
             user-select: none;
@@ -1451,10 +1435,25 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
           }
-          &:hover {
+          @media screen and (-ms-high-contrast: active){&.is-open:after {
+            border-color: Highlight;
+          }
+          &:after {
+            border-color: #605e5c;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+          &:hover:after {
             border-color: #323130;
           }
           &:hover .ms-ComboBox-Input {
@@ -1486,29 +1485,18 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
           }
+          @media screen and (-ms-high-contrast: active){&:hover:after {
+            border-color: Highlight;
+          }
           &:active {
-            border-color: #0078d4;
             position: relative;
           }
           @media screen and (-ms-high-contrast: active){&:active {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
-          }
-          &:active:after {
-            border-radius: 2px;
-            border: 2px solid #0078d4;
-            bottom: -1px;
-            content: '';
-            left: -1px;
-            pointer-events: none;
-            position: absolute;
-            right: -1px;
-            top: -1px;
           }
           @media screen and (-ms-high-contrast: active){&:active:after {
             border-color: Highlight;
@@ -1527,22 +1515,21 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&:focus {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus:after {
+            border-color: Highlight;
           }
           &:focus:after {
             border-radius: 2px;
             border: 2px solid #0078d4;
-            bottom: -1px;
+            bottom: 0px;
             content: '';
-            left: -1px;
+            left: 0px;
             pointer-events: none;
             position: absolute;
-            right: -1px;
-            top: -1px;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus:after {
-            border-color: Highlight;
+            right: 0px;
+            top: 0px;
           }
       id="ComboBox15wrapper"
     >
@@ -1560,7 +1547,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               box-sizing: border-box;
               color: #323130;
               font: inherit;
-              height: 28px;
+              height: 100%;
               outline: none;
               padding-bottom: 0;
               padding-left: 0;
@@ -1634,7 +1621,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 12px;
               font-weight: 400;
-              height: 32px;
+              height: 100%;
               line-height: 30px;
               outline: transparent;
               padding-bottom: 0;
@@ -1644,6 +1631,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               position: absolute;
               text-align: center;
               text-decoration: none;
+              top: 0px;
               user-select: none;
               vertical-align: top;
               width: 32px;
@@ -3615,9 +3603,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             -webkit-font-smoothing: antialiased;
             background-color: #ffffff;
             border-color: #a4262c;
-            border-radius: 2px;
-            border-style: solid;
-            border-width: 1px;
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
@@ -3629,11 +3614,8 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             height: 32px;
             margin-left: 0;
             outline: 0;
-            overflow: hidden;
-            padding-bottom: 1px;
-            padding-left: 8px;
+            padding-left: 9px;
             padding-right: 32px;
-            padding-top: 1px;
             position: relative;
             text-overflow: ellipsis;
             user-select: none;
@@ -3649,8 +3631,23 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open:after {
+            border-color: Highlight;
+          }
+          &:after {
+            border-color: #605e5c;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
           }
           &:hover:hover {
             border-color: #323130;
@@ -3684,7 +3681,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               box-sizing: border-box;
               color: #323130;
               font: inherit;
-              height: 28px;
+              height: 100%;
               outline: none;
               padding-bottom: 0;
               padding-left: 0;
@@ -3758,7 +3755,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 12px;
               font-weight: 400;
-              height: 32px;
+              height: 100%;
               line-height: 30px;
               outline: transparent;
               padding-bottom: 0;
@@ -3768,6 +3765,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               position: absolute;
               text-align: center;
               text-decoration: none;
+              top: 0px;
               user-select: none;
               vertical-align: top;
               width: 32px;
@@ -3949,10 +3947,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             background-color: #ffffff;
-            border-color: #605e5c;
-            border-radius: 2px;
-            border-style: solid;
-            border-width: 1px;
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
@@ -3964,11 +3958,8 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             height: 32px;
             margin-left: 0;
             outline: 0;
-            overflow: hidden;
-            padding-bottom: 1px;
-            padding-left: 8px;
+            padding-left: 9px;
             padding-right: 32px;
-            padding-top: 1px;
             position: relative;
             text-overflow: ellipsis;
             user-select: none;
@@ -3981,10 +3972,25 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
           }
-          &:hover {
+          @media screen and (-ms-high-contrast: active){&.is-open:after {
+            border-color: Highlight;
+          }
+          &:after {
+            border-color: #605e5c;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+          &:hover:after {
             border-color: #323130;
           }
           &:hover .ms-ComboBox-Input {
@@ -4016,29 +4022,18 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
           }
+          @media screen and (-ms-high-contrast: active){&:hover:after {
+            border-color: Highlight;
+          }
           &:active {
-            border-color: #0078d4;
             position: relative;
           }
           @media screen and (-ms-high-contrast: active){&:active {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
-          }
-          &:active:after {
-            border-radius: 2px;
-            border: 2px solid #0078d4;
-            bottom: -1px;
-            content: '';
-            left: -1px;
-            pointer-events: none;
-            position: absolute;
-            right: -1px;
-            top: -1px;
           }
           @media screen and (-ms-high-contrast: active){&:active:after {
             border-color: Highlight;
@@ -4057,22 +4052,21 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&:focus {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus:after {
+            border-color: Highlight;
           }
           &:focus:after {
             border-radius: 2px;
             border: 2px solid #0078d4;
-            bottom: -1px;
+            bottom: 0px;
             content: '';
-            left: -1px;
+            left: 0px;
             pointer-events: none;
             position: absolute;
-            right: -1px;
-            top: -1px;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus:after {
-            border-color: Highlight;
+            right: 0px;
+            top: 0px;
           }
       id="ComboBox23wrapper"
     >
@@ -4091,7 +4085,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               box-sizing: border-box;
               color: #323130;
               font: inherit;
-              height: 28px;
+              height: 100%;
               outline: none;
               padding-bottom: 0;
               padding-left: 0;
@@ -4165,7 +4159,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 12px;
               font-weight: 400;
-              height: 32px;
+              height: 100%;
               line-height: 30px;
               outline: transparent;
               padding-bottom: 0;
@@ -4175,6 +4169,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               position: absolute;
               text-align: center;
               text-decoration: none;
+              top: 0px;
               user-select: none;
               vertical-align: top;
               width: 32px;
@@ -4350,10 +4345,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             background-color: #f3f2f1;
-            border-color: #f3f2f1;
-            border-radius: 2px;
-            border-style: solid;
-            border-width: 1px;
             box-shadow: none;
             box-sizing: border-box;
             color: #a19f9d;
@@ -4365,11 +4356,8 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             height: 32px;
             margin-left: 0;
             outline: 0;
-            overflow: hidden;
-            padding-bottom: 1px;
-            padding-left: 8px;
+            padding-left: 9px;
             padding-right: 32px;
-            padding-top: 1px;
             position: relative;
             text-overflow: ellipsis;
             user-select: none;
@@ -4382,8 +4370,23 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active){&.is-open:after {
+            border-color: Highlight;
+          }
+          &:after {
+            border-color: #f3f2f1;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
           }
           @media screen and (-ms-high-contrast: active){& {
             border-color: GrayText;
@@ -4402,13 +4405,12 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             ms-ComboBox-Input
             {
               background-color: #f3f2f1;
-              border-color: #f3f2f1;
               border-style: none;
               box-sizing: border-box;
               color: #a19f9d;
               cursor: default;
               font: inherit;
-              height: 28px;
+              height: 100%;
               outline: none;
               padding-bottom: 0;
               padding-left: 0;
@@ -4443,6 +4445,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               background-color: Window;
               border-color: GrayText;
               color: GrayText;
+            }
+            &:after {
+              border-color: #f3f2f1;
             }
         data-is-interactable={false}
         data-lpignore={true}
@@ -4486,7 +4491,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 12px;
               font-weight: 400;
-              height: 32px;
+              height: 100%;
               line-height: 30px;
               outline: transparent;
               padding-bottom: 0;
@@ -4497,6 +4502,7 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               position: absolute;
               text-align: center;
               text-decoration: none;
+              top: 0px;
               user-select: none;
               vertical-align: top;
               width: 32px;
@@ -4539,6 +4545,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             }
             &:focus {
               outline: 0px;
+            }
+            &:after {
+              border-color: #f3f2f1;
             }
         data-is-focusable={false}
         disabled={true}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
@@ -66,10 +66,6 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             background-color: #ffffff;
-            border-color: #605e5c;
-            border-radius: 2px;
-            border-style: solid;
-            border-width: 1px;
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
@@ -81,11 +77,8 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
             height: 32px;
             margin-left: 0;
             outline: 0;
-            overflow: hidden;
-            padding-bottom: 1px;
-            padding-left: 8px;
+            padding-left: 9px;
             padding-right: 32px;
-            padding-top: 1px;
             position: relative;
             text-overflow: ellipsis;
             user-select: none;
@@ -98,10 +91,25 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
           }
-          &:hover {
+          @media screen and (-ms-high-contrast: active){&.is-open:after {
+            border-color: Highlight;
+          }
+          &:after {
+            border-color: #605e5c;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+          &:hover:after {
             border-color: #323130;
           }
           &:hover .ms-ComboBox-Input {
@@ -133,29 +141,18 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
           }
+          @media screen and (-ms-high-contrast: active){&:hover:after {
+            border-color: Highlight;
+          }
           &:active {
-            border-color: #0078d4;
             position: relative;
           }
           @media screen and (-ms-high-contrast: active){&:active {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
-          }
-          &:active:after {
-            border-radius: 2px;
-            border: 2px solid #0078d4;
-            bottom: -1px;
-            content: '';
-            left: -1px;
-            pointer-events: none;
-            position: absolute;
-            right: -1px;
-            top: -1px;
           }
           @media screen and (-ms-high-contrast: active){&:active:after {
             border-color: Highlight;
@@ -174,22 +171,21 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
           @media screen and (-ms-high-contrast: active){&:focus {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus:after {
+            border-color: Highlight;
           }
           &:focus:after {
             border-radius: 2px;
             border: 2px solid #0078d4;
-            bottom: -1px;
+            bottom: 0px;
             content: '';
-            left: -1px;
+            left: 0px;
             pointer-events: none;
             position: absolute;
-            right: -1px;
-            top: -1px;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus:after {
-            border-color: Highlight;
+            right: 0px;
+            top: 0px;
           }
       id="ComboBox0wrapper"
     >
@@ -207,7 +203,7 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
               box-sizing: border-box;
               color: #323130;
               font: inherit;
-              height: 28px;
+              height: 100%;
               outline: none;
               padding-bottom: 0;
               padding-left: 0;
@@ -281,7 +277,7 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 12px;
               font-weight: 400;
-              height: 32px;
+              height: 100%;
               line-height: 30px;
               outline: transparent;
               padding-bottom: 0;
@@ -291,6 +287,7 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
               position: absolute;
               text-align: center;
               text-decoration: none;
+              top: 0px;
               user-select: none;
               vertical-align: top;
               width: 32px;
@@ -463,10 +460,6 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             background-color: #ffffff;
-            border-color: #605e5c;
-            border-radius: 2px;
-            border-style: solid;
-            border-width: 1px;
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
@@ -478,11 +471,8 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
             height: 32px;
             margin-left: 0;
             outline: 0;
-            overflow: hidden;
-            padding-bottom: 1px;
-            padding-left: 8px;
+            padding-left: 9px;
             padding-right: 32px;
-            padding-top: 1px;
             position: relative;
             text-overflow: ellipsis;
             user-select: none;
@@ -495,10 +485,25 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
           }
-          &:hover {
+          @media screen and (-ms-high-contrast: active){&.is-open:after {
+            border-color: Highlight;
+          }
+          &:after {
+            border-color: #605e5c;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+          &:hover:after {
             border-color: #323130;
           }
           &:hover .ms-ComboBox-Input {
@@ -530,29 +535,18 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
           }
+          @media screen and (-ms-high-contrast: active){&:hover:after {
+            border-color: Highlight;
+          }
           &:active {
-            border-color: #0078d4;
             position: relative;
           }
           @media screen and (-ms-high-contrast: active){&:active {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
-          }
-          &:active:after {
-            border-radius: 2px;
-            border: 2px solid #0078d4;
-            bottom: -1px;
-            content: '';
-            left: -1px;
-            pointer-events: none;
-            position: absolute;
-            right: -1px;
-            top: -1px;
           }
           @media screen and (-ms-high-contrast: active){&:active:after {
             border-color: Highlight;
@@ -571,22 +565,21 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
           @media screen and (-ms-high-contrast: active){&:focus {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus:after {
+            border-color: Highlight;
           }
           &:focus:after {
             border-radius: 2px;
             border: 2px solid #0078d4;
-            bottom: -1px;
+            bottom: 0px;
             content: '';
-            left: -1px;
+            left: 0px;
             pointer-events: none;
             position: absolute;
-            right: -1px;
-            top: -1px;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus:after {
-            border-color: Highlight;
+            right: 0px;
+            top: 0px;
           }
       id="ComboBox4wrapper"
     >
@@ -604,7 +597,7 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
               box-sizing: border-box;
               color: #323130;
               font: inherit;
-              height: 28px;
+              height: 100%;
               outline: none;
               padding-bottom: 0;
               padding-left: 0;
@@ -678,7 +671,7 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 12px;
               font-weight: 400;
-              height: 32px;
+              height: 100%;
               line-height: 30px;
               outline: transparent;
               padding-bottom: 0;
@@ -688,6 +681,7 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
               position: absolute;
               text-align: center;
               text-decoration: none;
+              top: 0px;
               user-select: none;
               vertical-align: top;
               width: 32px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
@@ -70,10 +70,6 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             background-color: #b4a0ff;
-            border-color: #605e5c;
-            border-radius: 2px;
-            border-style: solid;
-            border-width: 1px;
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
@@ -85,11 +81,8 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
             height: 32px;
             margin-left: 0;
             outline: 0;
-            overflow: hidden;
-            padding-bottom: 1px;
-            padding-left: 8px;
+            padding-left: 9px;
             padding-right: 32px;
-            padding-top: 1px;
             position: relative;
             text-overflow: ellipsis;
             user-select: none;
@@ -102,10 +95,25 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
           }
-          &:hover {
+          @media screen and (-ms-high-contrast: active){&.is-open:after {
+            border-color: Highlight;
+          }
+          &:after {
+            border-color: #605e5c;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+          &:hover:after {
             border-color: #323130;
           }
           &:hover .ms-ComboBox-Input {
@@ -137,29 +145,18 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
           }
+          @media screen and (-ms-high-contrast: active){&:hover:after {
+            border-color: Highlight;
+          }
           &:active {
-            border-color: #0078d4;
             position: relative;
           }
           @media screen and (-ms-high-contrast: active){&:active {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
-          }
-          &:active:after {
-            border-radius: 2px;
-            border: 2px solid #0078d4;
-            bottom: -1px;
-            content: '';
-            left: -1px;
-            pointer-events: none;
-            position: absolute;
-            right: -1px;
-            top: -1px;
           }
           @media screen and (-ms-high-contrast: active){&:active:after {
             border-color: Highlight;
@@ -178,22 +175,21 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
           @media screen and (-ms-high-contrast: active){&:focus {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus:after {
+            border-color: Highlight;
           }
           &:focus:after {
             border-radius: 2px;
             border: 2px solid #0078d4;
-            bottom: -1px;
+            bottom: 0px;
             content: '';
-            left: -1px;
+            left: 0px;
             pointer-events: none;
             position: absolute;
-            right: -1px;
-            top: -1px;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus:after {
-            border-color: Highlight;
+            right: 0px;
+            top: 0px;
           }
       id="ComboBox0wrapper"
     >
@@ -211,7 +207,7 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
               box-sizing: border-box;
               color: #323130;
               font: inherit;
-              height: 28px;
+              height: 100%;
               outline: none;
               padding-bottom: 0;
               padding-left: 0;
@@ -285,7 +281,7 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 12px;
               font-weight: 400;
-              height: 32px;
+              height: 100%;
               line-height: 30px;
               outline: transparent;
               padding-bottom: 0;
@@ -295,6 +291,7 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
               position: absolute;
               text-align: center;
               text-decoration: none;
+              top: 0px;
               user-select: none;
               vertical-align: top;
               width: 32px;
@@ -466,10 +463,6 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             background-color: #ffffff;
-            border-color: #605e5c;
-            border-radius: 2px;
-            border-style: solid;
-            border-width: 1px;
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
@@ -481,11 +474,8 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
             height: 32px;
             margin-left: 0;
             outline: 0;
-            overflow: hidden;
-            padding-bottom: 1px;
-            padding-left: 8px;
+            padding-left: 9px;
             padding-right: 32px;
-            padding-top: 1px;
             position: relative;
             text-overflow: ellipsis;
             user-select: none;
@@ -498,10 +488,25 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
           }
-          &:hover {
+          @media screen and (-ms-high-contrast: active){&.is-open:after {
+            border-color: Highlight;
+          }
+          &:after {
+            border-color: #605e5c;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+          &:hover:after {
             border-color: #323130;
           }
           &:hover .ms-ComboBox-Input {
@@ -533,29 +538,18 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
           }
+          @media screen and (-ms-high-contrast: active){&:hover:after {
+            border-color: Highlight;
+          }
           &:active {
-            border-color: #0078d4;
             position: relative;
           }
           @media screen and (-ms-high-contrast: active){&:active {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
-          }
-          &:active:after {
-            border-radius: 2px;
-            border: 2px solid #0078d4;
-            bottom: -1px;
-            content: '';
-            left: -1px;
-            pointer-events: none;
-            position: absolute;
-            right: -1px;
-            top: -1px;
           }
           @media screen and (-ms-high-contrast: active){&:active:after {
             border-color: Highlight;
@@ -574,22 +568,21 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
           @media screen and (-ms-high-contrast: active){&:focus {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus:after {
+            border-color: Highlight;
           }
           &:focus:after {
             border-radius: 2px;
             border: 2px solid #0078d4;
-            bottom: -1px;
+            bottom: 0px;
             content: '';
-            left: -1px;
+            left: 0px;
             pointer-events: none;
             position: absolute;
-            right: -1px;
-            top: -1px;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus:after {
-            border-color: Highlight;
+            right: 0px;
+            top: 0px;
           }
       id="ComboBox4wrapper"
     >
@@ -607,7 +600,7 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
               box-sizing: border-box;
               color: #323130;
               font: inherit;
-              height: 28px;
+              height: 100%;
               outline: none;
               padding-bottom: 0;
               padding-left: 0;
@@ -681,7 +674,7 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 12px;
               font-weight: 400;
-              height: 32px;
+              height: 100%;
               line-height: 30px;
               outline: transparent;
               padding-bottom: 0;
@@ -691,6 +684,7 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
               position: absolute;
               text-align: center;
               text-decoration: none;
+              top: 0px;
               user-select: none;
               vertical-align: top;
               width: 32px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -67,10 +67,6 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             background-color: #ffffff;
-            border-color: #605e5c;
-            border-radius: 2px;
-            border-style: solid;
-            border-width: 1px;
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
@@ -82,11 +78,8 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
             height: 32px;
             margin-left: 0;
             outline: 0;
-            overflow: hidden;
-            padding-bottom: 1px;
-            padding-left: 8px;
+            padding-left: 9px;
             padding-right: 32px;
-            padding-top: 1px;
             position: relative;
             text-overflow: ellipsis;
             user-select: none;
@@ -99,10 +92,25 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
           }
-          &:hover {
+          @media screen and (-ms-high-contrast: active){&.is-open:after {
+            border-color: Highlight;
+          }
+          &:after {
+            border-color: #605e5c;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+          &:hover:after {
             border-color: #323130;
           }
           &:hover .ms-ComboBox-Input {
@@ -134,29 +142,18 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
           }
+          @media screen and (-ms-high-contrast: active){&:hover:after {
+            border-color: Highlight;
+          }
           &:active {
-            border-color: #0078d4;
             position: relative;
           }
           @media screen and (-ms-high-contrast: active){&:active {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
-          }
-          &:active:after {
-            border-radius: 2px;
-            border: 2px solid #0078d4;
-            bottom: -1px;
-            content: '';
-            left: -1px;
-            pointer-events: none;
-            position: absolute;
-            right: -1px;
-            top: -1px;
           }
           @media screen and (-ms-high-contrast: active){&:active:after {
             border-color: Highlight;
@@ -175,22 +172,21 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
           @media screen and (-ms-high-contrast: active){&:focus {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus:after {
+            border-color: Highlight;
           }
           &:focus:after {
             border-radius: 2px;
             border: 2px solid #0078d4;
-            bottom: -1px;
+            bottom: 0px;
             content: '';
-            left: -1px;
+            left: 0px;
             pointer-events: none;
             position: absolute;
-            right: -1px;
-            top: -1px;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus:after {
-            border-color: Highlight;
+            right: 0px;
+            top: 0px;
           }
       id="ComboBox0wrapper"
     >
@@ -208,7 +204,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
               box-sizing: border-box;
               color: #323130;
               font: inherit;
-              height: 28px;
+              height: 100%;
               outline: none;
               padding-bottom: 0;
               padding-left: 0;
@@ -282,7 +278,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 12px;
               font-weight: 400;
-              height: 32px;
+              height: 100%;
               line-height: 30px;
               outline: transparent;
               padding-bottom: 0;
@@ -292,6 +288,7 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
               position: absolute;
               text-align: center;
               text-decoration: none;
+              top: 0px;
               user-select: none;
               vertical-align: top;
               width: 32px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
@@ -61,10 +61,6 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
             background-color: #ffffff;
-            border-color: #605e5c;
-            border-radius: 2px;
-            border-style: solid;
-            border-width: 1px;
             box-shadow: none;
             box-sizing: border-box;
             color: #323130;
@@ -77,11 +73,8 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
             margin-left: 0;
             max-width: 300px;
             outline: 0;
-            overflow: hidden;
-            padding-bottom: 1px;
-            padding-left: 8px;
+            padding-left: 9px;
             padding-right: 32px;
-            padding-top: 1px;
             position: relative;
             text-overflow: ellipsis;
             user-select: none;
@@ -94,10 +87,25 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
           @media screen and (-ms-high-contrast: active){&.is-open {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
           }
-          &:hover {
+          @media screen and (-ms-high-contrast: active){&.is-open:after {
+            border-color: Highlight;
+          }
+          &:after {
+            border-color: #605e5c;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+          &:hover:after {
             border-color: #323130;
           }
           &:hover .ms-ComboBox-Input {
@@ -129,29 +137,18 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
           @media screen and (-ms-high-contrast: active){&:hover {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
           }
+          @media screen and (-ms-high-contrast: active){&:hover:after {
+            border-color: Highlight;
+          }
           &:active {
-            border-color: #0078d4;
             position: relative;
           }
           @media screen and (-ms-high-contrast: active){&:active {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
-          }
-          &:active:after {
-            border-radius: 2px;
-            border: 2px solid #0078d4;
-            bottom: -1px;
-            content: '';
-            left: -1px;
-            pointer-events: none;
-            position: absolute;
-            right: -1px;
-            top: -1px;
           }
           @media screen and (-ms-high-contrast: active){&:active:after {
             border-color: Highlight;
@@ -170,22 +167,21 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
           @media screen and (-ms-high-contrast: active){&:focus {
             -ms-high-contrast-adjust: none;
             background-color: Window;
-            border-color: Highlight;
             color: HighlightText;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus:after {
+            border-color: Highlight;
           }
           &:focus:after {
             border-radius: 2px;
             border: 2px solid #0078d4;
-            bottom: -1px;
+            bottom: 0px;
             content: '';
-            left: -1px;
+            left: 0px;
             pointer-events: none;
             position: absolute;
-            right: -1px;
-            top: -1px;
-          }
-          @media screen and (-ms-high-contrast: active){&:focus:after {
-            border-color: Highlight;
+            right: 0px;
+            top: 0px;
           }
       id="ComboBox0wrapper"
     >
@@ -203,7 +199,7 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
               box-sizing: border-box;
               color: #323130;
               font: inherit;
-              height: 28px;
+              height: 100%;
               outline: none;
               padding-bottom: 0;
               padding-left: 0;
@@ -277,7 +273,7 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 12px;
               font-weight: 400;
-              height: 32px;
+              height: 100%;
               line-height: 30px;
               outline: transparent;
               padding-bottom: 0;
@@ -287,6 +283,7 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
               position: absolute;
               text-align: center;
               text-decoration: none;
+              top: 0px;
               user-select: none;
               vertical-align: top;
               width: 32px;

--- a/packages/styling/etc/styling.api.md
+++ b/packages/styling/etc/styling.api.md
@@ -140,7 +140,7 @@ export function getIcon(name?: string): IIconRecord | undefined;
 export function getIconClassName(name: string): string;
 
 // @public
-export const getInputFocusStyle: (borderColor: string, borderRadius: string | number, borderType?: "border" | "borderBottom") => IRawStyle;
+export const getInputFocusStyle: (borderColor: string, borderRadius: string | number, borderType?: "border" | "borderBottom", borderPositionOffset?: number) => IRawStyle;
 
 // @public
 export function getPlaceholderStyles(styles: IStyle): IStyle;

--- a/packages/styling/etc/styling.api.md
+++ b/packages/styling/etc/styling.api.md
@@ -140,7 +140,7 @@ export function getIcon(name?: string): IIconRecord | undefined;
 export function getIconClassName(name: string): string;
 
 // @public
-export const getInputFocusStyle: (borderColor: string, borderRadius: string | number, borderType?: "border" | "borderBottom", borderPositionOffset?: number) => IRawStyle;
+export const getInputFocusStyle: (borderColor: string, borderRadius: string | number, borderType?: "border" | "borderBottom", borderPosition?: number) => IRawStyle;
 
 // @public
 export function getPlaceholderStyles(styles: IStyle): IStyle;

--- a/packages/styling/src/styles/getFocusStyle.ts
+++ b/packages/styling/src/styles/getFocusStyle.ts
@@ -139,12 +139,15 @@ export function getFocusOutlineStyle(theme: ITheme, inset: number = 0, width: nu
  * @param borderColor - Color of the border.
  * @param borderRadius - Radius of the border.
  * @param borderType - Type of the border.
+ * @param borderPosition - Position of the border relative to the input element (default to -1
+ * as it's the most common border width of the input element)
  * @returns The style object.
  */
 export const getInputFocusStyle = (
   borderColor: string,
   borderRadius: string | number,
-  borderType: 'border' | 'borderBottom' = 'border'
+  borderType: 'border' | 'borderBottom' = 'border',
+  borderPosition: number = -1
 ): IRawStyle => ({
   borderColor,
   selectors: {
@@ -152,10 +155,10 @@ export const getInputFocusStyle = (
       pointerEvents: 'none',
       content: "''",
       position: 'absolute',
-      left: -1,
-      top: -1,
-      bottom: -1,
-      right: -1,
+      left: borderPosition,
+      top: borderPosition,
+      bottom: borderPosition,
+      right: borderPosition,
       [borderType]: `2px solid ${borderColor}`,
       borderRadius,
       width: borderType === 'borderBottom' ? '100%' : undefined,


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #11631
- [X] Include a change request file using `$ yarn change`

#### Description of changes
1. Fixed chevron down button miss alignment in combobox
2. Fix focus border style bug under certain resolution:
before:
![image](https://user-images.githubusercontent.com/1207059/71945312-541ac380-317b-11ea-9ad6-c64a24a6756b.png)
after:
![image](https://user-images.githubusercontent.com/1207059/71945250-29c90600-317b-11ea-9b22-265238f064bd.png)

#### Train of thoughts on the changes I made:
The reason the focus border was rendering incorrectly was due to `overflow: hidden` on the `ms-ComboBox`. I believe the reason that it was added is that to make the chevron button doesn't overflow out of the comboBox like this:
![image](https://user-images.githubusercontent.com/1207059/72001805-ffb72880-31fa-11ea-9c38-e69f0c56c47c.png)
After correcting the positioning of the chevron button to be correctly sized and aligned, it's still cutting off the border under certain resolutions, like:
![image](https://user-images.githubusercontent.com/1207059/72001906-3c831f80-31fb-11ea-8fe5-584177c6617a.png)
This leads me to make the change to remove the border styles we had in ComboBox and moved to instead setting border using `:after` content. And some styles were updated due to this change.

#### Focus areas to test
- Browsers: Edge, Chrome, FF
- Different zoom levels
- High contrast mode


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11638)