### PR TITLE
Fix UHF "skip to main content" link and update focus properly when jumping to anchors

### DIFF
--- a/apps/fabric-website/index.html
+++ b/apps/fabric-website/index.html
@@ -20,10 +20,44 @@
         height: 100vh;
         justify-content: center;
       }
+
+      /* Copied from UHF site */
+      a.m-skip-to-main {
+        left: -999px;
+        position: absolute;
+        top: auto;
+        width: 1px;
+        height: 1px;
+        overflow: hidden;
+        z-index: -2;
+      }
+
+      a.m-skip-to-main:focus {
+        border: 1px dashed #000;
+      }
+      a.m-skip-to-main:focus,
+      a.m-skip-to-main:active {
+        background: #e6e6e6;
+        color: #0067b8;
+        position: fixed;
+        top: 0;
+        left: 0;
+        padding: 24px;
+        width: auto;
+        height: auto;
+        overflow: auto;
+        right: 0;
+        text-decoration: underline;
+        text-align: center;
+        z-index: 800;
+        outline: none;
+      }
     </style>
   </head>
 
   <body>
+    <!-- Copied from UHF site -->
+    <a id="uhfSkipToMain" class="m-skip-to-main" href="#mainContent" tabindex="0">Skip to main content</a>
     <div id="main">
       <div class="loading">
         <img

--- a/apps/fabric-website/src/components/Site/Site.module.scss
+++ b/apps/fabric-website/src/components/Site/Site.module.scss
@@ -50,6 +50,10 @@
 .siteContent {
   position: relative;
 
+  // This element is programmatically focusable to simulate jumping to an anchor,
+  // but it shouldn't have a focus outline
+  outline: none;
+
   @include high-contrast {
     border-right: 1px solid WindowText;
     border-left: 1px solid WindowText;

--- a/apps/fabric-website/src/components/Site/Site.tsx
+++ b/apps/fabric-website/src/components/Site/Site.tsx
@@ -151,7 +151,14 @@ export class Site<TPlatforms extends string = string> extends React.Component<IS
         {this._renderMessageBar()}
         <div className={css(styles.siteWrapper, isContentFullBleed && styles.fullWidth)}>
           {this._renderPageNav()}
-          <div className={styles.siteContent} data-is-scrollable="true" data-app-content-div="true" role="main">
+          <div
+            className={styles.siteContent}
+            data-is-scrollable="true"
+            data-app-content-div="true"
+            // This needs to be programmatically focusable for "jump to main content" functionality
+            tabIndex={-1}
+            role="main"
+          >
             {childrenWithPlatform}
           </div>
         </div>

--- a/apps/fabric-website/src/root.tsx
+++ b/apps/fabric-website/src/root.tsx
@@ -1,4 +1,4 @@
-import { registerIcons } from 'office-ui-fabric-react';
+import { registerIcons, on, KeyCodes } from 'office-ui-fabric-react';
 import { initializeFileTypeIcons } from '@uifabric/file-type-icons';
 import { createSite } from './utilities/createSite';
 import * as platformPickerStyles from '@uifabric/example-app-base/lib/components/PlatformPicker/PlatformPicker.module.scss';
@@ -24,5 +24,27 @@ registerIcons({
     })
   }
 });
+
+const skipToMain = document.getElementById('uhfSkipToMain') as HTMLAnchorElement;
+if (skipToMain) {
+  // This link points to #mainContent by default, which would be interpreted as a route in our app.
+  // Handle focusing the main content manually instead.
+  const focusMainContent = (ev: Event) => {
+    ev.preventDefault(); // don't navigate
+
+    // focus content root
+    const mainContent = document.querySelector('[data-app-content-div="true"]') as HTMLDivElement | null;
+    if (mainContent) {
+      mainContent.focus();
+    }
+  };
+
+  on(skipToMain, 'click', focusMainContent);
+  on(skipToMain, 'keydown', (ev: KeyboardEvent) => {
+    if (ev.which === KeyCodes.enter) {
+      focusMainContent(ev);
+    }
+  });
+}
 
 createSite(SiteDefinition, [NotFoundPage, HomePage]);

--- a/change/@uifabric-example-app-base-2020-01-07-18-52-53-skip-to-main.json
+++ b/change/@uifabric-example-app-base-2020-01-07-18-52-53-skip-to-main.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Update focus properly when scrolling to anchors",
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com",
+  "commit": "8b8801ab977cc1e8e1e64474ab5f99aefa7d6d47",
+  "date": "2020-01-08T02:52:53.468Z"
+}

--- a/change/@uifabric-fabric-website-2020-01-07-18-52-53-skip-to-main.json
+++ b/change/@uifabric-fabric-website-2020-01-07-18-52-53-skip-to-main.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix UHF \"skip to main content\" link, and update focus properly when scrolling to anchors",
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com",
+  "commit": "8b8801ab977cc1e8e1e64474ab5f99aefa7d6d47",
+  "date": "2020-01-08T02:52:45.597Z"
+}

--- a/packages/example-app-base/src/components/ApiReferencesTable/ApiReferencesTable.tsx
+++ b/packages/example-app-base/src/components/ApiReferencesTable/ApiReferencesTable.tsx
@@ -155,7 +155,8 @@ export class ApiReferencesTable extends React.Component<IApiReferencesTableProps
     const { title, name } = this.props;
 
     return title ? (
-      <Text variant="xLarge" as="h3" styles={{ root: { marginTop: 0 } }} id={name}>
+      // This heading must be programmatically focusable for simulating jumping to an anchor
+      <Text variant="xLarge" as="h3" styles={{ root: { marginTop: 0 } }} id={name} tabIndex={-1}>
         {title}
       </Text>
     ) : (

--- a/packages/example-app-base/src/components/Page/Page.module.scss
+++ b/packages/example-app-base/src/components/Page/Page.module.scss
@@ -194,6 +194,9 @@ $usageListPadding: 24px;
 
 .subHeading {
   @include ms-fontSize-24;
+  // These headings are programmatically focusable to simulate jumping to an anchor,
+  // but they shouldn't have a focus outline
+  outline: none;
 }
 
 .smallSubHeading {

--- a/packages/example-app-base/src/components/Page/sections/BestPracticesSection.tsx
+++ b/packages/example-app-base/src/components/Page/sections/BestPracticesSection.tsx
@@ -19,7 +19,7 @@ export const BestPracticesSection: React.StatelessComponent<IBestPracticesSectio
     componentUrl,
     platform,
     sectionName,
-    readableSectionName,
+    readableSectionName = sectionName,
     bestPractices,
     dos,
     donts,
@@ -39,8 +39,9 @@ export const BestPracticesSection: React.StatelessComponent<IBestPracticesSectio
     <div className={className} style={style}>
       <div className={styles.subSection}>
         <div className={styles.sectionHeader}>
-          <h2 className={styles.subHeading} id={id}>
-            {readableSectionName || sectionName}
+          {/* This heading must be programmatically focusable for simulating jumping to an anchor */}
+          <h2 className={styles.subHeading} id={id} tabIndex={-1}>
+            {readableSectionName}
           </h2>
           {!!(bestPractices && bestPracticesUrl) && (
             <EditSection className={styles.edit} title={title} section="Best Practices" url={bestPracticesUrl} />

--- a/packages/example-app-base/src/components/Page/sections/ExamplesSection.tsx
+++ b/packages/example-app-base/src/components/Page/sections/ExamplesSection.tsx
@@ -11,14 +11,15 @@ export interface IExamplesSectionProps extends IPageSectionPropsWithSectionName 
 }
 
 export const ExamplesSection: React.StatelessComponent<IExamplesSectionProps> = props => {
-  const { className, examples, exampleKnobs, sectionName, readableSectionName, style, id } = props;
+  const { className, examples, exampleKnobs, readableSectionName = props.sectionName, style, id } = props;
   const [activeEditorTitle, setActiveEditorTitle] = React.useState('');
 
   return (
     <div className={className} style={style}>
       <div className={styles.sectionHeader}>
-        <h2 className={styles.subHeading} id={id}>
-          {readableSectionName || sectionName}
+        {/* This heading must be programmatically focusable for simulating jumping to an anchor */}
+        <h2 className={styles.subHeading} id={id} tabIndex={-1}>
+          {readableSectionName}
         </h2>
       </div>
       <div>

--- a/packages/example-app-base/src/components/Page/sections/FeedbackSection.tsx
+++ b/packages/example-app-base/src/components/Page/sections/FeedbackSection.tsx
@@ -5,13 +5,14 @@ import { IPageSectionPropsWithSectionName } from '../Page.types';
 import * as styles from '../Page.module.scss';
 
 export const FeedbackSection: React.StatelessComponent<IPageSectionPropsWithSectionName> = props => {
-  const { className, sectionName, readableSectionName, style, title, id } = props;
+  const { className, readableSectionName = props.sectionName, style, title, id } = props;
 
   return (
     <div className={css(styles.feedbackSection, className)} style={style}>
       <div className={styles.sectionHeader}>
-        <h2 className={styles.subHeading} id={id}>
-          {readableSectionName || sectionName}
+        {/* This heading must be programmatically focusable for simulating jumping to an anchor */}
+        <h2 className={styles.subHeading} id={id} tabIndex={-1}>
+          {readableSectionName}
         </h2>
       </div>
       <div className={styles.feedbackList}>

--- a/packages/example-app-base/src/components/Page/sections/ImplementationSection.tsx
+++ b/packages/example-app-base/src/components/Page/sections/ImplementationSection.tsx
@@ -16,13 +16,22 @@ export interface IImplementationSectionProps extends IPageSectionPropsWithSectio
 }
 
 export const ImplementationSection: React.StatelessComponent<IImplementationSectionProps> = props => {
-  const { className, sectionName, readableSectionName, style, propertiesTablesSources, jsonDocs, hideImplementationTitle, id } = props;
+  const {
+    className,
+    readableSectionName = props.sectionName,
+    style,
+    propertiesTablesSources,
+    jsonDocs,
+    hideImplementationTitle,
+    id
+  } = props;
   return (
     <div className={className} style={style}>
       {!hideImplementationTitle && (
         <div className={styles.sectionHeader}>
-          <h2 className={styles.subHeading} id={id}>
-            {readableSectionName || sectionName}
+          {/* This heading must be programmatically focusable for simulating jumping to an anchor */}
+          <h2 className={styles.subHeading} id={id} tabIndex={-1}>
+            {readableSectionName}
           </h2>
         </div>
       )}

--- a/packages/example-app-base/src/components/Page/sections/MarkdownSection.tsx
+++ b/packages/example-app-base/src/components/Page/sections/MarkdownSection.tsx
@@ -32,7 +32,8 @@ export const MarkdownSection: React.StatelessComponent<IPageSectionProps> = prop
     <div className={className} style={style}>
       {readableSectionName ? (
         <div className={styles.sectionHeader}>
-          <h2 className={styles.subHeading} id={id}>
+          {/* This heading must be programmatically focusable for simulating jumping to an anchor */}
+          <h2 className={styles.subHeading} id={id} tabIndex={-1}>
             {readableSectionName}
           </h2>
           {editSection}

--- a/packages/example-app-base/src/components/Page/sections/OtherPageSection.tsx
+++ b/packages/example-app-base/src/components/Page/sections/OtherPageSection.tsx
@@ -26,7 +26,8 @@ export const OtherPageSection: React.StatelessComponent<IPageSectionProps> = pro
     <div className={className} style={style}>
       {readableSectionName ? (
         <div className={styles.sectionHeader}>
-          <h2 className={styles.subHeading} id={id}>
+          {/* This heading must be programmatically focusable for simulating jumping to an anchor */}
+          <h2 className={styles.subHeading} id={id} tabIndex={-1}>
             {readableSectionName}
           </h2>
           {editSection}

--- a/packages/example-app-base/src/components/Page/sections/OverviewSection.tsx
+++ b/packages/example-app-base/src/components/Page/sections/OverviewSection.tsx
@@ -13,7 +13,7 @@ export const OverviewSection: React.StatelessComponent<IPageSectionPropsWithSect
     componentUrl,
     platform,
     sectionName,
-    readableSectionName,
+    readableSectionName = sectionName,
     style,
     id,
     title = 'Page'
@@ -25,8 +25,9 @@ export const OverviewSection: React.StatelessComponent<IPageSectionPropsWithSect
   return (
     <div className={className} style={style}>
       <div className={styles.sectionHeader}>
-        <h2 className={styles.subHeading} id={id}>
-          {readableSectionName || sectionName}
+        {/* This heading must be programmatically focusable for simulating jumping to an anchor */}
+        <h2 className={styles.subHeading} id={id} tabIndex={-1}>
+          {readableSectionName}
         </h2>
         {editUrl && <EditSection className={styles.edit} title={title} section={readableSectionName!} url={editUrl} />}
       </div>

--- a/packages/example-app-base/src/utilities/jumpToAnchor.ts
+++ b/packages/example-app-base/src/utilities/jumpToAnchor.ts
@@ -2,6 +2,13 @@ import { extractAnchorLink } from './extractAnchorLink';
 
 const SCROLL_DISTANCE = 52;
 
+/**
+ * Scroll to and focus an element, similar to native functionality for jumping to an anchor link.
+ *
+ * @param anchor - ID of the element to jump to. This element should be programmatically focusable
+ * (set tabIndex=-1 if not natively focusable) to fully simulate the native jumping behavior.
+ * @param scrollDistance - Offset from the top
+ */
 export function jumpToAnchor(anchor?: string, scrollDistance: number = SCROLL_DISTANCE): void {
   const hash = anchor || extractAnchorLink(window.location.hash);
   const el = hash && document.getElementById(hash);
@@ -21,5 +28,6 @@ export function jumpToAnchor(anchor?: string, scrollDistance: number = SCROLL_DI
         });
       }
     }
+    el.focus();
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #9563
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The UHF (website host) injects a "Skip to main content" link for accessibility purposes, with `href="#mainContent"`. This doesn't work in our website because 1) it's not the right main content element, and 2) `#mainContent` will be interpreted as a route, not an anchor. Fix is to add click/key handlers to this link which prevent default handling and properly update focus instead. To make this work, the main content div needed `tabindex=-1` so it can accept programmatic focus.

For testing purposes, I added a link with the same ID, href, and styles as the UHF one to the website `index.html`. (After loading the page, press tab once to make the link show up.)

While working on this, I noticed that the `jumpToAnchor` utility used for in-page anchor links didn't properly update focus (it just scrolls). Fix is to update the utility to focus the target element, and add `tabindex=-1` to all relevant headers so they can be focusable.

Also fix an issue where the tooltip on the overview section's edit button said `Edit <component name> undefined` (`<component name>` was the proper component name, but it was followed by a literal `undefined`).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11639)