### PR TITLE
Change focus class behavior: Alternate between 'hidden' and 'visible'

### DIFF
--- a/change/@uifabric-utilities-2020-01-08-16-36-13-paflakst-add-focus-hidden-class.json
+++ b/change/@uifabric-utilities-2020-01-08-16-36-13-paflakst-add-focus-hidden-class.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Change focus class behavior: Alternate between 'hidden' and 'visible' classes",
+  "packageName": "@uifabric/utilities",
+  "email": "paflakst@microsoft.com",
+  "commit": "bee187d4f1dec7d264a9dea28ffd3b93fc56302e",
+  "date": "2020-01-08T15:36:13.239Z"
+}

--- a/change/office-ui-fabric-react-2020-01-08-16-36-13-paflakst-add-focus-hidden-class.json
+++ b/change/office-ui-fabric-react-2020-01-08-16-36-13-paflakst-add-focus-hidden-class.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Change focus class behavior: Alternate between 'hidden' and 'visible' classes",
+  "packageName": "office-ui-fabric-react",
+  "email": "paflakst@microsoft.com",
+  "commit": "bee187d4f1dec7d264a9dea28ffd3b93fc56302e",
+  "date": "2020-01-08T15:36:00.121Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
@@ -139,6 +139,8 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
       <div
         className=
             ms-Fabric
+            is-focusHidden
+            ms-Fabric--isFocusHidden
             ms-Layer-content
             {
               -moz-osx-font-smoothing: grayscale;

--- a/packages/office-ui-fabric-react/src/components/Fabric/Fabric.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Fabric/Fabric.styles.ts
@@ -16,10 +16,12 @@ export interface IFabricClassNames {
 export const getStyles = (props: IFabricStyleProps): IFabricStyles => {
   const { theme, className, isFocusVisible, applyTheme } = props;
   const classNames = getGlobalClassNames(GlobalClassNames, theme);
+  const focusVisibility = isFocusVisible ? 'Visible' : 'Hidden';
   return {
     root: [
       classNames.root,
-      isFocusVisible && 'is-focusVisible ms-Fabric--isFocusVisible',
+      // keywords for search: is-focusVisible ms-Fabric--isFocusVisible ms-Fabric--isFocusHidden
+      `is-focus${focusVisibility} ms-Fabric--isFocus${focusVisibility}`,
       theme.fonts.medium,
       {
         direction: theme.rtl ? 'rtl' : undefined,

--- a/packages/office-ui-fabric-react/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
@@ -4,6 +4,8 @@ exports[`Fabric renders a Fabric component correctly 1`] = `
 <div
   className=
       ms-Fabric
+      is-focusHidden
+      ms-Fabric--isFocusHidden
       {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;
@@ -173,6 +175,8 @@ exports[`Fabric renders a Fabric component in RTL 1`] = `
   <div
     className=
         ms-Fabric
+        is-focusHidden
+        ms-Fabric--isFocusHidden
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
@@ -337,6 +341,8 @@ exports[`Fabric renders a Fabric component in RTL 1`] = `
     <div
       className=
           ms-Fabric
+          is-focusHidden
+          ms-Fabric--isFocusHidden
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
@@ -501,6 +507,8 @@ exports[`Fabric renders a Fabric component in RTL 1`] = `
       <div
         className=
             ms-Fabric
+            is-focusHidden
+            ms-Fabric--isFocusHidden
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
@@ -673,6 +681,8 @@ exports[`Fabric renders a Fabric component with applyTheme correctly 1`] = `
 <div
   className=
       ms-Fabric
+      is-focusHidden
+      ms-Fabric--isFocusHidden
       {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;
@@ -700,6 +710,8 @@ exports[`Fabric renders as a span using the "as" prop 1`] = `
 <span
   className=
       ms-Fabric
+      is-focusHidden
+      ms-Fabric--isFocusHidden
       {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/HoverCard/__snapshots__/HoverCard.test.tsx.snap
@@ -7,6 +7,8 @@ exports[`HoverCard renders ExpandingCard correctly 1`] = `
   <div
     className=
         ms-Fabric
+        is-focusHidden
+        ms-Fabric--isFocusHidden
         ms-Layer-content
         {
           -moz-osx-font-smoothing: grayscale;
@@ -174,6 +176,8 @@ exports[`HoverCard renders PlainCard correctly 1`] = `
   <div
     className=
         ms-Fabric
+        is-focusHidden
+        ms-Fabric--isFocusHidden
         ms-Layer-content
         {
           -moz-osx-font-smoothing: grayscale;

--- a/packages/office-ui-fabric-react/src/components/Layer/__snapshots__/Layer.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Layer/__snapshots__/Layer.test.tsx.snap
@@ -7,6 +7,8 @@ exports[`Layer renders Layer correctly 1`] = `
   <div
     className=
         ms-Fabric
+        is-focusHidden
+        ms-Fabric--isFocusHidden
         ms-Layer-content
         {
           -moz-osx-font-smoothing: grayscale;

--- a/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Modal/__snapshots__/Modal.test.tsx.snap
@@ -7,6 +7,8 @@ exports[`Modal renders Draggable Modal correctly 1`] = `
   <div
     className=
         ms-Fabric
+        is-focusHidden
+        ms-Fabric--isFocusHidden
         ms-Layer-content
         {
           -moz-osx-font-smoothing: grayscale;
@@ -175,6 +177,8 @@ exports[`Modal renders Modal correctly 1`] = `
   <div
     className=
         ms-Fabric
+        is-focusHidden
+        ms-Fabric--isFocusHidden
         ms-Layer-content
         {
           -moz-osx-font-smoothing: grayscale;
@@ -354,6 +358,8 @@ exports[`Modal renders Modeless Modal correctly 1`] = `
   <div
     className=
         ms-Fabric
+        is-focusHidden
+        ms-Fabric--isFocusHidden
         ms-Layer-content
         {
           -moz-osx-font-smoothing: grayscale;

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -7,6 +7,8 @@ exports[`Panel renders Panel correctly 1`] = `
   <div
     className=
         ms-Fabric
+        is-focusHidden
+        ms-Fabric--isFocusHidden
         ms-Layer-content
         {
           -moz-osx-font-smoothing: grayscale;

--- a/packages/office-ui-fabric-react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/__snapshots__/Tooltip.test.tsx.snap
@@ -7,6 +7,8 @@ exports[`Tooltip renders default Tooltip correctly 1`] = `
   <div
     className=
         ms-Fabric
+        is-focusHidden
+        ms-Fabric--isFocusHidden
         ms-Layer-content
         {
           -moz-osx-font-smoothing: grayscale;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -4,6 +4,8 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
 <div
   className=
       ms-Fabric
+      is-focusHidden
+      ms-Fabric--isFocusHidden
       {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;
@@ -1785,6 +1787,8 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
       <div
         className=
             ms-Fabric
+            is-focusHidden
+            ms-Fabric--isFocusHidden
             ms-Layer-content
             {
               -moz-osx-font-smoothing: grayscale;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
@@ -4,6 +4,8 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
 <div
   className=
       ms-Fabric
+      is-focusHidden
+      ms-Fabric--isFocusHidden
       {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
@@ -4,6 +4,8 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
 <div
   className=
       ms-Fabric
+      is-focusHidden
+      ms-Fabric--isFocusHidden
       {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -4,6 +4,8 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
 <div
   className=
       ms-Fabric
+      is-focusHidden
+      ms-Fabric--isFocusHidden
       {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
@@ -4,6 +4,8 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
 <div
   className=
       ms-Fabric
+      is-focusHidden
+      ms-Fabric--isFocusHidden
       ms-ComboBoxExample
       {
         -moz-osx-font-smoothing: grayscale;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
@@ -613,6 +613,8 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
               <div
                 className=
                     ms-Fabric
+                    is-focusHidden
+                    ms-Fabric--isFocusHidden
                     ms-Layer-content
                     {
                       -moz-osx-font-smoothing: grayscale;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Basic.Example.tsx.shot
@@ -18,6 +18,8 @@ exports[`Component Examples renders ContextualMenu.Basic.Example.tsx correctly 1
     <div
       className=
           ms-Fabric
+          is-focusHidden
+          ms-Fabric--isFocusHidden
           ms-Layer-content
           {
             -moz-osx-font-smoothing: grayscale;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Animation.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Animation.Example.tsx.shot
@@ -4,6 +4,8 @@ exports[`Component Examples renders DetailsList.Animation.Example.tsx correctly 
 <div
   className=
       ms-Fabric
+      is-focusHidden
+      ms-Fabric--isFocusHidden
       {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -4,6 +4,8 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
 <div
   className=
       ms-Fabric
+      is-focusHidden
+      ms-Fabric--isFocusHidden
       {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -4,6 +4,8 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
 <div
   className=
       ms-Fabric
+      is-focusHidden
+      ms-Fabric--isFocusHidden
       {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -4,6 +4,8 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
 <div
   className=
       ms-Fabric
+      is-focusHidden
+      ms-Fabric--isFocusHidden
       {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Basic.Example.tsx.shot
@@ -4,6 +4,8 @@ exports[`Component Examples renders HoverCard.Basic.Example.tsx correctly 1`] = 
 <div
   className=
       ms-Fabric
+      is-focusHidden
+      ms-Fabric--isFocusHidden
       {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.EventListenerTarget.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.EventListenerTarget.Example.tsx.shot
@@ -4,6 +4,8 @@ exports[`Component Examples renders HoverCard.EventListenerTarget.Example.tsx co
 <div
   className=
       ms-Fabric
+      is-focusHidden
+      ms-Fabric--isFocusHidden
       {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.PlainCard.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.PlainCard.Example.tsx.shot
@@ -4,6 +4,8 @@ exports[`Component Examples renders HoverCard.PlainCard.Example.tsx correctly 1`
 <div
   className=
       ms-Fabric
+      is-focusHidden
+      ms-Fabric--isFocusHidden
       {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Target.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.Target.Example.tsx.shot
@@ -4,6 +4,8 @@ exports[`Component Examples renders HoverCard.Target.Example.tsx correctly 1`] =
 <div
   className=
       ms-Fabric
+      is-focusHidden
+      ms-Fabric--isFocusHidden
       {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Basic.Example.tsx.shot
@@ -4,6 +4,8 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
 <div
   className=
       ms-Fabric
+      is-focusHidden
+      ms-Fabric--isFocusHidden
       {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.CustomElements.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.CustomElements.Example.tsx.shot
@@ -4,6 +4,8 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
 <div
   className=
       ms-Fabric
+      is-focusHidden
+      ms-Fabric--isFocusHidden
       {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;

--- a/packages/utilities/src/initializeFocusRects.test.ts
+++ b/packages/utilities/src/initializeFocusRects.test.ts
@@ -1,4 +1,5 @@
-import { IsFocusVisibleClassName, initializeFocusRects } from './initializeFocusRects';
+import { initializeFocusRects } from './initializeFocusRects';
+import { IsFocusHiddenClassName, IsFocusVisibleClassName } from './setFocusVisibility';
 import { KeyCodes } from './KeyCodes';
 import { addDirectionalKeyCode } from './keyboard';
 
@@ -13,8 +14,8 @@ describe('initializeFocusRects', () => {
       body: {
         classList: {
           contains: (name: string) => classNames.indexOf(name) > -1,
-          add: (name: string) => classNames.push(name),
-          remove: (name: string) => classNames.splice(classNames.indexOf(name), 1),
+          add: (name: string) => classNames.indexOf(name) < 0 && classNames.push(name),
+          remove: (name: string) => classNames.indexOf(name) > -1 && classNames.splice(classNames.indexOf(name), 1),
           toggle: (name: string, val: boolean) => {
             const hasClass = classNames.indexOf(name) > -1;
             if (hasClass !== val) {
@@ -40,62 +41,76 @@ describe('initializeFocusRects', () => {
     initializeFocusRects(mockWindow as Window);
   });
 
-  it('can show focus when you press a directional key', () => {
+  it('can hint to show focus when you press a directional key', () => {
     mockWindow.keydown({ target: mockTarget, which: KeyCodes.up });
+    expect(classNames.indexOf(IsFocusHiddenClassName) > -1).toEqual(false);
     expect(classNames.indexOf(IsFocusVisibleClassName) > -1).toEqual(true);
 
     classNames = [];
     mockWindow.keydown({ target: mockTarget, which: KeyCodes.down });
+    expect(classNames.indexOf(IsFocusHiddenClassName) > -1).toEqual(false);
     expect(classNames.indexOf(IsFocusVisibleClassName) > -1).toEqual(true);
 
     classNames = [];
     mockWindow.keydown({ target: mockTarget, which: KeyCodes.left });
+    expect(classNames.indexOf(IsFocusHiddenClassName) > -1).toEqual(false);
     expect(classNames.indexOf(IsFocusVisibleClassName) > -1).toEqual(true);
 
     classNames = [];
     mockWindow.keydown({ target: mockTarget, which: KeyCodes.right });
+    expect(classNames.indexOf(IsFocusHiddenClassName) > -1).toEqual(false);
     expect(classNames.indexOf(IsFocusVisibleClassName) > -1).toEqual(true);
 
     classNames = [];
     mockWindow.keydown({ target: mockTarget, which: KeyCodes.tab });
+    expect(classNames.indexOf(IsFocusHiddenClassName) > -1).toEqual(false);
     expect(classNames.indexOf(IsFocusVisibleClassName) > -1).toEqual(true);
 
     classNames = [];
     mockWindow.keydown({ target: mockTarget, which: KeyCodes.pageUp });
+    expect(classNames.indexOf(IsFocusHiddenClassName) > -1).toEqual(false);
     expect(classNames.indexOf(IsFocusVisibleClassName) > -1).toEqual(true);
 
     classNames = [];
     mockWindow.keydown({ target: mockTarget, which: KeyCodes.pageDown });
+    expect(classNames.indexOf(IsFocusHiddenClassName) > -1).toEqual(false);
     expect(classNames.indexOf(IsFocusVisibleClassName) > -1).toEqual(true);
 
     classNames = [];
     mockWindow.keydown({ target: mockTarget, which: KeyCodes.home });
+    expect(classNames.indexOf(IsFocusHiddenClassName) > -1).toEqual(false);
     expect(classNames.indexOf(IsFocusVisibleClassName) > -1).toEqual(true);
 
     classNames = [];
     mockWindow.keydown({ target: mockTarget, which: KeyCodes.end });
+    expect(classNames.indexOf(IsFocusHiddenClassName) > -1).toEqual(false);
     expect(classNames.indexOf(IsFocusVisibleClassName) > -1).toEqual(true);
   });
 
   it('no-ops when you press a non-directional key', () => {
     mockWindow.keydown({ target: mockTarget, which: 127 });
     expect(classNames.indexOf(IsFocusVisibleClassName) > -1).toEqual(false);
+    // don't care about the state of the "hidden" class in this case
   });
 
-  it('removes the class when you click the mouse', () => {
+  it('can hint to hide focus on mouse click', () => {
     mockWindow.keydown({ target: mockTarget, which: KeyCodes.down });
+    expect(classNames.indexOf(IsFocusHiddenClassName) > -1).toEqual(false);
     expect(classNames.indexOf(IsFocusVisibleClassName) > -1).toEqual(true);
     mockWindow.mousedown({ target: mockTarget });
+    expect(classNames.indexOf(IsFocusHiddenClassName) > -1).toEqual(true);
     expect(classNames.indexOf(IsFocusVisibleClassName) > -1).toEqual(false);
   });
 
-  it('can show focus when you press a custom directional key', () => {
+  it('can hint to show focus when you press a custom directional key', () => {
     mockWindow.keydown({ target: mockTarget, which: KeyCodes.f6 });
     expect(classNames.indexOf(IsFocusVisibleClassName) > -1).toEqual(false);
+    // don't care about the state of the "hidden" class in this case
 
     addDirectionalKeyCode(KeyCodes.f6);
 
     mockWindow.keydown({ target: mockTarget, which: KeyCodes.f6 });
+    expect(classNames.indexOf(IsFocusHiddenClassName) > -1).toEqual(false);
     expect(classNames.indexOf(IsFocusVisibleClassName) > -1).toEqual(true);
   });
 });

--- a/packages/utilities/src/initializeFocusRects.ts
+++ b/packages/utilities/src/initializeFocusRects.ts
@@ -1,7 +1,8 @@
 import { getWindow } from './dom/getWindow';
 import { isDirectionalKeyCode } from './keyboard';
+import { setFocusVisibility } from './setFocusVisibility';
 
-export const IsFocusVisibleClassName = 'ms-Fabric--isFocusVisible';
+export { IsFocusVisibleClassName } from './setFocusVisibility';
 
 /**
  * Initializes the logic which:
@@ -9,11 +10,12 @@ export const IsFocusVisibleClassName = 'ms-Fabric--isFocusVisible';
  * 1. Subscribes keydown and mousedown events. (It will only do it once per window,
  *    so it's safe to call this method multiple times.)
  * 2. When the user presses directional keyboard keys, adds the 'ms-Fabric--isFocusVisible' classname
- *    to the document body.
- * 3. When the user clicks a mouse button, we remove the classname if it exists.
+ *    to the document body, removes the 'ms-Fabric-isFocusHidden' classname.
+ * 3. When the user clicks a mouse button, adds the 'ms-Fabric-isFocusHidden' classname to the
+ *    document body, removes the 'ms-Fabric--isFocusVisible' classname.
  *
- * This logic allows components on the page to conditionally render focus treatments only
- * if the global classname exists, which simplifies logic overall.
+ * This logic allows components on the page to conditionally render focus treatments based on
+ * the existence of global classnames, which simplifies logic overall.
  *
  * @param window - the window used to add the event listeners
  */
@@ -28,25 +30,9 @@ export function initializeFocusRects(window?: Window): void {
 }
 
 function _onMouseDown(ev: MouseEvent): void {
-  const win = getWindow(ev.target as Element);
-
-  if (win) {
-    const { classList } = win.document.body;
-
-    if (classList.contains(IsFocusVisibleClassName)) {
-      classList.remove(IsFocusVisibleClassName);
-    }
-  }
+  setFocusVisibility(false, ev.target as Element);
 }
 
 function _onKeyDown(ev: KeyboardEvent): void {
-  const win = getWindow(ev.target as Element);
-
-  if (win) {
-    const { classList } = win.document.body;
-
-    if (isDirectionalKeyCode(ev.which) && !classList.contains(IsFocusVisibleClassName)) {
-      classList.add(IsFocusVisibleClassName);
-    }
-  }
+  isDirectionalKeyCode(ev.which) && setFocusVisibility(true, ev.target as Element);
 }

--- a/packages/utilities/src/setFocusVisibility.test.ts
+++ b/packages/utilities/src/setFocusVisibility.test.ts
@@ -1,5 +1,5 @@
-import { IsFocusVisibleClassName, initializeFocusRects } from './initializeFocusRects';
-import { setFocusVisibility } from './setFocusVisibility';
+import { initializeFocusRects } from './initializeFocusRects';
+import { IsFocusHiddenClassName, IsFocusVisibleClassName, setFocusVisibility } from './setFocusVisibility';
 import * as getWindow from './dom/getWindow';
 
 describe('setFocusVisibility', () => {
@@ -14,8 +14,8 @@ describe('setFocusVisibility', () => {
       body: {
         classList: {
           contains: (name: string) => classNames.indexOf(name) > -1,
-          add: (name: string) => classNames.push(name),
-          remove: (name: string) => classNames.splice(classNames.indexOf(name), 1),
+          add: (name: string) => classNames.indexOf(name) < 0 && classNames.push(name),
+          remove: (name: string) => classNames.indexOf(name) > -1 && classNames.splice(classNames.indexOf(name), 1),
           toggle: (name: string, val: boolean) => {
             const hasClass = classNames.indexOf(name) > -1;
             if (hasClass !== val) {
@@ -42,27 +42,33 @@ describe('setFocusVisibility', () => {
     initializeFocusRects(mockWindow as Window);
   });
 
-  it('sets focus', () => {
+  it('hints to show focus', () => {
     setFocusVisibility(true);
+    expect(classNames.indexOf(IsFocusHiddenClassName) > -1).toEqual(false);
     expect(classNames.indexOf(IsFocusVisibleClassName) > -1).toEqual(true);
   });
 
-  it('removes focus', () => {
+  it('hints to hide focus', () => {
     setFocusVisibility(true);
+    expect(classNames.indexOf(IsFocusHiddenClassName) > -1).toEqual(false);
     expect(classNames.indexOf(IsFocusVisibleClassName) > -1).toEqual(true);
     setFocusVisibility(false);
+    expect(classNames.indexOf(IsFocusHiddenClassName) > -1).toEqual(true);
     expect(classNames.indexOf(IsFocusVisibleClassName) > -1).toEqual(false);
   });
 
-  it('sets focus with target specified', () => {
+  it('hints to show focus with target specified', () => {
     setFocusVisibility(true, mockTarget as Element);
+    expect(classNames.indexOf(IsFocusHiddenClassName) > -1).toEqual(false);
     expect(classNames.indexOf(IsFocusVisibleClassName) > -1).toEqual(true);
   });
 
-  it('removes focus with target specified', () => {
+  it('hints to hide focus with target specified', () => {
     setFocusVisibility(true, mockTarget as Element);
+    expect(classNames.indexOf(IsFocusHiddenClassName) > -1).toEqual(false);
     expect(classNames.indexOf(IsFocusVisibleClassName) > -1).toEqual(true);
     setFocusVisibility(false, mockTarget as Element);
+    expect(classNames.indexOf(IsFocusHiddenClassName) > -1).toEqual(true);
     expect(classNames.indexOf(IsFocusVisibleClassName) > -1).toEqual(false);
   });
 });

--- a/packages/utilities/src/setFocusVisibility.ts
+++ b/packages/utilities/src/setFocusVisibility.ts
@@ -1,10 +1,11 @@
 import { getWindow } from './dom/getWindow';
 export const IsFocusVisibleClassName = 'ms-Fabric--isFocusVisible';
+export const IsFocusHiddenClassName = 'ms-Fabric--isFocusHidden';
 
 /**
  * Sets the visibility of focus styling.
  * By default, focus styling (the box surrounding a focused Button, for example) only show up when navigational
- * keypresses occur (through TAB, arrows, pgup/down, home and end), and are hidden when mouse interactions occur.
+ * keypresses occur (through Tab, arrows, PgUp/PgDn, Home and End), and are hidden when mouse interactions occur.
  * This API provides an imperative way to turn them on/off.
  * A use case might be when you have a keypress like ctrl-f6 navigate to a particular region on the page, and want focus to show up.
  *
@@ -16,11 +17,7 @@ export function setFocusVisibility(enabled: boolean, target?: Element): void {
 
   if (win) {
     const { classList } = win.document.body;
-
-    if (enabled) {
-      classList.add(IsFocusVisibleClassName);
-    } else {
-      classList.remove(IsFocusVisibleClassName);
-    }
+    classList.add(enabled ? IsFocusVisibleClassName : IsFocusHiddenClassName);
+    classList.remove(enabled ? IsFocusHiddenClassName : IsFocusVisibleClassName);
   }
 }


### PR DESCRIPTION
This change aims to enable an approach where **visible focus indication** is the default/baseline treatment, and hidden focus indication is the special treatment.

The current Fabric approach is the opposite, and this encourages disabling focus indication as the baseline. In short: Fabric wants focus indication to depend on Fabric. Accessibility-wise this feels wrong – and perhaps rightly so?

Reasons why visible focus indication as the baseline might be better:
- It seems like a better fail-safe than hidden, as it doesn’t entail obstructing users or breaking the law. (_Think f. ex. if a version update changed the class name, or if the <Fabric> component was removed or replaced. Temporary situations, sure, but still._)
- The best-practice principle would probably favor it. (_For one, all major browsers have visible focus indication as their default._)
- We don’t know what kind of interface a non-mouse user might be using. We do however know it won’t necessarily be a keyboard, so keyboard interaction should not be a prerequisite for focus indication. Even though WCAG only talks about a requirement for visible keyboard focus, we might want to keep this in mind.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11642)