### PR TITLE
switching to using self-hosted agent pool for the CPU intensive jobs

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,135 +12,137 @@ pool:
 
 jobs:
   - job: Build
+    pool: 'Self Host Ubuntu'
     steps:
-    - template: azure-pipelines.tools.yml
+      - template: azure-pipelines.tools.yml
 
-    - script: |
-        yarn
-      displayName: yarn
+      - script: |
+          yarn
+        displayName: yarn
 
-    - script: |
-        yarn checkchange
-      displayName: check change
+      - script: |
+          yarn checkchange
+        displayName: check change
 
-    - script: |
-        yarn build
-      displayName: build
+      - script: |
+          yarn build
+        displayName: build
 
-    - task: ArchiveFiles@2
-      inputs:
-        rootFolderOrFile: $(Build.Repository.LocalPath)
-        # Include root folder so archive can just be extracted into $(Pipeline.Workspace)
-        includeRootFolder: true
-        archiveType: 'tar'
-        tarCompression: 'gz'
-        archiveFile: $(Build.ArtifactStagingDirectory)/build.tar.gz
-        replaceExistingArchive: true
+      - task: ArchiveFiles@2
+        inputs:
+          rootFolderOrFile: $(Build.Repository.LocalPath)
+          # Include root folder so archive can just be extracted into $(Pipeline.Workspace)
+          includeRootFolder: true
+          archiveType: 'tar'
+          tarCompression: 'gz'
+          archiveFile: $(Build.ArtifactStagingDirectory)/build.tar.gz
+          replaceExistingArchive: true
 
-    - publish: $(Build.ArtifactStagingDirectory)
-      artifact: Build
+      - publish: $(Build.ArtifactStagingDirectory)
+        artifact: Build
 
   - job: Validate
     dependsOn: Build
+    pool: 'Self Host Ubuntu'
     steps:
-    # No need for checkout since we're using build artifacts.
-    - checkout: none
-    - template: azure-pipelines.artifacts.yml
+      # No need for checkout since we're using build artifacts.
+      - checkout: none
+      - template: azure-pipelines.artifacts.yml
 
-    - script: |
-        yarn test
-      displayName: test
+      - script: |
+          yarn test
+        displayName: test
 
-    - script: |
-        yarn lint
-      displayName: lint
+      - script: |
+          yarn lint
+        displayName: lint
 
-    - script: |
-        yarn check-for-changed-files
-      displayName: check for changed files
+      - script: |
+          yarn check-for-changed-files
+        displayName: check for changed files
 
   - job: Deploy
     dependsOn: Build
+    pool: 'Self Host Ubuntu'
     steps:
-    # No need for checkout since we're using build artifacts.
-    - checkout: none
-    - template: azure-pipelines.artifacts.yml
+      # No need for checkout since we're using build artifacts.
+      - checkout: none
+      - template: azure-pipelines.artifacts.yml
 
-    - template: azure-pipelines.tools.yml
+      - template: azure-pipelines.tools.yml
 
-    - script: |
-        yarn bundle
-      displayName: bundle
+      - script: |
+          yarn bundle
+        displayName: bundle
 
-    - task: AzureUpload@1
-      displayName: Upload PR deploy site
-      inputs:
-        SourcePath: 'apps/pr-deploy-site/dist'
-        azureSubscription: 'UI Fabric (bac044cf-49e1-4843-8dda-1ce9662606c8)'
-        storage: fabricweb
-        ContainerName: '$web'
-        BlobPrefix: 'pr-deploy-site/$(Build.SourceBranch)'
+      - task: AzureUpload@1
+        displayName: Upload PR deploy site
+        inputs:
+          SourcePath: 'apps/pr-deploy-site/dist'
+          azureSubscription: 'UI Fabric (bac044cf-49e1-4843-8dda-1ce9662606c8)'
+          storage: fabricweb
+          ContainerName: '$web'
+          BlobPrefix: 'pr-deploy-site/$(Build.SourceBranch)'
 
   - job: PerfTest
     dependsOn: Build
     steps:
-    # No need for checkout since we're using build artifacts.
-    - checkout: none
-    - template: azure-pipelines.artifacts.yml
+      # No need for checkout since we're using build artifacts.
+      - checkout: none
+      - template: azure-pipelines.artifacts.yml
 
-    - template: azure-pipelines.tools.yml
+      - template: azure-pipelines.tools.yml
 
-    - script: |
-        yarn
-      displayName: yarn
+      - script: |
+          yarn
+        displayName: yarn
 
-    - script: |
-        yarn just perf-test
-      workingDirectory: apps/perf-test
-      displayName: Perf Test
+      - script: |
+          yarn just perf-test
+        workingDirectory: apps/perf-test
+        displayName: Perf Test
 
-    - task: AzureUpload@1
-      displayName: Upload Perf Test Result to PR deploy site
-      inputs:
-        SourcePath: 'apps/perf-test/dist'
-        azureSubscription: 'UI Fabric (bac044cf-49e1-4843-8dda-1ce9662606c8)'
-        storage: fabricweb
-        ContainerName: '$web'
-        BlobPrefix: 'pr-deploy-site/$(Build.SourceBranch)/perf-test'
+      - task: AzureUpload@1
+        displayName: Upload Perf Test Result to PR deploy site
+        inputs:
+          SourcePath: 'apps/perf-test/dist'
+          azureSubscription: 'UI Fabric (bac044cf-49e1-4843-8dda-1ce9662606c8)'
+          storage: fabricweb
+          ContainerName: '$web'
+          BlobPrefix: 'pr-deploy-site/$(Build.SourceBranch)/perf-test'
 
-    - task: GithubPRComment@0
-      displayName: 'Post Perf Results to Github Pull Request'
-      inputs:
-        githubOwner: OfficeDev
-        githubRepo: 'office-ui-fabric-react'
-        blobFilePath: '$(Build.SourcesDirectory)/$(PerfCommentFilePath)'
-        status: '$(PerfCommentStatus)'
-        uniqueId: 'perfComment9423'
+      - task: GithubPRComment@0
+        displayName: 'Post Perf Results to Github Pull Request'
+        inputs:
+          githubOwner: OfficeDev
+          githubRepo: 'office-ui-fabric-react'
+          blobFilePath: '$(Build.SourcesDirectory)/$(PerfCommentFilePath)'
+          status: '$(PerfCommentStatus)'
+          uniqueId: 'perfComment9423'
 
-    - task: GithubPRStatus@0
-      displayName: 'Update Github Pull Request Status'
-      inputs:
-        githubOwner: OfficeDev
-        githubRepo: 'office-ui-fabric-react'
-        githubContext: 'Pull Request Deployed Site'
-        githubDescription: 'Click "Details" to go to the Deployed Site'
-        githubTargetLink: 'http://fabricweb.z5.web.core.windows.net/pr-deploy-site/$(Build.SourceBranch)/'
+      - task: GithubPRStatus@0
+        displayName: 'Update Github Pull Request Status'
+        inputs:
+          githubOwner: OfficeDev
+          githubRepo: 'office-ui-fabric-react'
+          githubContext: 'Pull Request Deployed Site'
+          githubDescription: 'Click "Details" to go to the Deployed Site'
+          githubTargetLink: 'http://fabricweb.z5.web.core.windows.net/pr-deploy-site/$(Build.SourceBranch)/'
 
   - job: VRTest
     dependsOn: Build
     steps:
-    # No need for checkout since we're using build artifacts.
-    - checkout: none
-    - template: azure-pipelines.artifacts.yml
+      # No need for checkout since we're using build artifacts.
+      - checkout: none
+      - template: azure-pipelines.artifacts.yml
 
-    - script: |
-        git config --global user.email "fabrictactical@microsoft.com"
-        git config --global user.name "Fabric Tactical"
-        yarn vrtest -- --debug
-      displayName: run VR Test
-      env:
-        SCREENER_API_KEY: $(screener.key)
-
+      - script: |
+          git config --global user.email "fabrictactical@microsoft.com"
+          git config --global user.name "Fabric Tactical"
+          yarn vrtest -- --debug
+        displayName: run VR Test
+        env:
+          SCREENER_API_KEY: $(screener.key)
     # a11y-tests disabled until occasional local and CI timeout issue can be resolved.
     # If/when re-enabled, analyze job strategy to optimize build time. Make standalone job or append to another test job?
     #- task: PublishBuildArtifacts@1


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

With this change, we should be bringing our builds from ~20minutes (thanks @JasonGore!) to ~12-15 minutes. 

Obviously with this kind of change, we are now the masters of our own destiny (and burden is on us to manintain these boxes). However, I have automated the process to scale up or down our VMs in use so that it isn't a huge burden. I'm separately sending out an email about how to maintain the Azure DevOps agent pool to an internal audience.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11645)