### PR TITLE
Fix yarn start

### DIFF
--- a/apps/fabric-website-resources/tsconfig.json
+++ b/apps/fabric-website-resources/tsconfig.json
@@ -3,11 +3,7 @@
     "baseUrl": ".",
     "outDir": "lib",
     "target": "es5",
-    // Setting this to esnext is required to make webpack code splitting work with import() and React.lazy
-    // https://github.com/webpack/webpack/issues/5703#issuecomment-357512412
-    // (the setting in tsconfig.json only affects serve mode; in non-serve mode webpack runs against
-    // <package>/lib which is also in esnext format)
-    "module": "esnext",
+    "module": "commonjs",
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,

--- a/change/@uifabric-fabric-website-resources-2020-01-08-15-51-03-fix-start.json
+++ b/change/@uifabric-fabric-website-resources-2020-01-08-15-51-03-fix-start.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Switch tsconfig back to commonjs modules",
+  "packageName": "@uifabric/fabric-website-resources",
+  "email": "elcraig@microsoft.com",
+  "commit": "f70e51cc627c99f0b6151f14e7bbca5f07fa5a81",
+  "date": "2020-01-08T23:50:21.996Z"
+}

--- a/change/@uifabric-monaco-editor-2020-01-08-15-51-03-fix-start.json
+++ b/change/@uifabric-monaco-editor-2020-01-08-15-51-03-fix-start.json
@@ -1,0 +1,8 @@
+{
+  "type": "none",
+  "comment": "Remove note about using with typescript",
+  "packageName": "@uifabric/monaco-editor",
+  "email": "elcraig@microsoft.com",
+  "commit": "f70e51cc627c99f0b6151f14e7bbca5f07fa5a81",
+  "date": "2020-01-08T23:50:48.392Z"
+}

--- a/change/@uifabric-tsx-editor-2020-01-03-20-45-07-editor-bugs.json
+++ b/change/@uifabric-tsx-editor-2020-01-03-20-45-07-editor-bugs.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Update Monaco; fix worker loader in Chrome; add notes on bundling",
+  "comment": "Update Monaco; fix worker loader in Chrome; fix bundling",
   "packageName": "@uifabric/tsx-editor",
   "email": "elcraig@microsoft.com",
   "commit": "29c174fac706f1131912e9db3aa993b59473f939",

--- a/change/@uifabric-tsx-editor-2020-01-08-15-51-03-fix-start.json
+++ b/change/@uifabric-tsx-editor-2020-01-08-15-51-03-fix-start.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Switch dynamic imports in tsx-editor to require.ensure",
+  "packageName": "@uifabric/tsx-editor",
+  "email": "elcraig@microsoft.com",
+  "commit": "f70e51cc627c99f0b6151f14e7bbca5f07fa5a81",
+  "date": "2020-01-08T23:51:03.069Z"
+}

--- a/packages/monaco-editor/README.md
+++ b/packages/monaco-editor/README.md
@@ -29,10 +29,6 @@ Parameters:
   - `false` (default): Imports for `@uifabric/monaco-editor` will be remapped to `@uifabric/monaco-editor/lib/monacoCoreBundle`, which includes only core editor features and TypeScript language features. Entry configs will be added for the main editor worker (`editor.worker.js`) and TS worker (`ts.worker.js`) but not other languages.
   - `true`: Imports for `@uifabric/monaco-editor` will be remapped to `@uifabric/monaco-editor/lib/monacoBundle`, which includes all language contributions. Also, entry configs will be added for CSS/HTML/JSON workers in addition to TS.
 
-#### Using with TypeScript
-
-If your project uses TypeScript, you **must** use `"module": "esnext"` (not `"module": "commonjs"`) in your `tsconfig.json`. Otherwise, dynamic imports in the editor code will be transformed into `require` statements which break code splitting. [More info here.](https://github.com/webpack/webpack/issues/5703#issuecomment-357512412)
-
 ### 2. Runtime configuration
 
 This project provides two options for setting up global Monaco configuration at runtime. The options are outlined below, but both involve a config object with the following properties:

--- a/packages/tsx-editor/README.md
+++ b/packages/tsx-editor/README.md
@@ -16,7 +16,7 @@ By default, the editor will load types for React and UI Fabric. It can also be c
 
 ### Delay loading
 
-Monaco's code is very large and should be loaded after main page content is ready. When consumed with Webpack, this package takes care of delay loading Monaco. (See Setup step 2 for a caveat if using Webpack with TypeScript.)
+Monaco's code is very large and should be loaded after main page content is ready. When consumed with Webpack, this package takes care of delay loading Monaco.
 
 ### Read-only rendering in unsupported browsers
 
@@ -24,13 +24,12 @@ If the user's browser can't support the editor (mainly IE 11 and some mobile bro
 
 ## Setup
 
-1. Follow the Webpack and runtime configuration instructions from the [`@uifabric/monaco-editor` readme](https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/monaco-editor/README.md). Note that the helpers used are re-exported from this package for convenience:
-  - `addMonacoWebpackConfig`: import from `@uifabric/tsx-editor/scripts/addMonacoWebpackConfig`
-  - `configureEnvironment` and `IMonacoConfig`: import from `@uifabric/tsx-editor`
+Follow the Webpack and runtime configuration instructions from the [`@uifabric/monaco-editor` readme](https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/monaco-editor/README.md). Note that the helpers used are re-exported from this package for convenience:
 
-2. If your project uses TypeScript, you **must** use `"module": "esnext"` (not `"module": "commonjs"`) in your `tsconfig.json`. Otherwise, dynamic imports in the editor code will be transformed into `require` statements which break code splitting. [More info here.](https://github.com/webpack/webpack/issues/5703#issuecomment-357512412)
+- `addMonacoWebpackConfig`: import from `@uifabric/tsx-editor/scripts/addMonacoWebpackConfig`
+- `configureEnvironment` and `IMonacoConfig`: import from `@uifabric/tsx-editor`
 
-3. Choose one of the API options below for rendering the editor.
+Then choose one of the API options below for rendering the editor.
 
 ## API options
 

--- a/packages/tsx-editor/src/components/EditorWrapper.tsx
+++ b/packages/tsx-editor/src/components/EditorWrapper.tsx
@@ -7,9 +7,16 @@ import { isEditorSupported } from '../utilities/index';
 import { ITransformedExample } from '../interfaces/index';
 import { DEFAULT_HEIGHT } from './consts';
 
-// This file MUST NOT directly load the main TsxEditor module which depends on Monaco, to avoid
-// pulling it into a bundle. Importing/rendering with React.lazy solves this.
-const TsxEditorLazy = React.lazy(() => import('./TsxEditor'));
+// This file MUST NOT directly load the main TsxEditor module which depends on Monaco
+// (aside from for typing purposes), to avoid pulling it into a bundle.
+import * as TsxEditorModule from './TsxEditor';
+const TsxEditorLazy = React.lazy(
+  () =>
+    // Theoretically we could use import() here, but that pulls things into bundles when using
+    // commonjs modules due to the way import is transpiled for commonjs
+    // https://github.com/webpack/webpack/issues/5703#issuecomment-357512412
+    new Promise<typeof TsxEditorModule>(resolve => require.ensure([], require => resolve(require('./TsxEditor'))))
+);
 
 export const EditorWrapper: React.FunctionComponent<IEditorWrapperProps> = props => {
   const {

--- a/packages/tsx-editor/src/interfaces/packageGroup.ts
+++ b/packages/tsx-editor/src/interfaces/packageGroup.ts
@@ -7,8 +7,13 @@
 export interface IPackageGroup {
   /** Name of the global this group of packages' exports will be available from at runtime */
   globalName: string;
-  /** Load the module which will be made available under `globalName */
-  loadGlobal: () => Promise<any>; // tslint:disable-line:no-any
+
+  /**
+   * Load the module which will be made available under `globalName`.
+   * The loader function can either return a promise or take a callback.
+   */
+  loadGlobal: (() => Promise<any>) | ((cb: (globalResult: any) => void) => void); // tslint:disable-line:no-any
+
   /** Packages whose exports are available at runtime from `globalName` */
   packages: IPackage[];
 }

--- a/packages/tsx-editor/src/utilities/defaultSupportedPackages.ts
+++ b/packages/tsx-editor/src/utilities/defaultSupportedPackages.ts
@@ -1,20 +1,25 @@
 import { IPackageGroup } from '../interfaces/index';
 
+// tslint:disable:no-any
 const fabricGroup: IPackageGroup = {
   globalName: 'Fabric',
-  loadGlobal: () => import('office-ui-fabric-react'),
+  // Theoretically we could use import() here, but that pulls things into bundles when using
+  // commonjs modules due to the way import is transpiled for commonjs
+  // https://github.com/webpack/webpack/issues/5703#issuecomment-357512412
+  loadGlobal: cb => require.ensure([], require => cb(require('office-ui-fabric-react'))),
   packages: []
 };
 const hooksGroup: IPackageGroup = {
   globalName: 'FabricReactHooks',
-  loadGlobal: () => import('@uifabric/react-hooks'),
+  loadGlobal: cb => require.ensure([], require => cb(require('@uifabric/react-hooks'))),
   packages: []
 };
 const exampleDataGroup: IPackageGroup = {
   globalName: 'FabricExampleData',
-  loadGlobal: () => import('@uifabric/example-data'),
+  loadGlobal: cb => require.ensure([], require => cb(require('@uifabric/example-data'))),
   packages: []
 };
+// tslint:enable:no-any
 
 let typesContext: __WebpackModuleApi.RequireContext | undefined;
 try {

--- a/packages/tsx-editor/tsconfig.json
+++ b/packages/tsx-editor/tsconfig.json
@@ -3,11 +3,7 @@
     "baseUrl": ".",
     "outDir": "dist",
     "target": "es5",
-    // Setting this to esnext is required to make webpack code splitting work with import() and React.lazy
-    // https://github.com/webpack/webpack/issues/5703#issuecomment-357512412
-    // (the setting in tsconfig.json only affects serve mode; in non-serve mode webpack runs against
-    // <package>/lib which is also in esnext format)
-    "module": "esnext",
+    "module": "commonjs",
     "jsx": "react",
     "declaration": true,
     "sourceMap": true,


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Changing the `fabric-website-resources` `tsconfig.json` to use `module: esnext` for some reason causes spurious errors during `yarn start`. The most obvious fix is to revert this change (go back to `commonjs`) and make updates in `tsx-editor` instead to work around the issue that motivated the change.

The change to `module: esnext` was done to prevent dynamic `import()` statements in tsx-editor from breaking code splitting, which happens because for `commonjs`, `import()` is transformed into `require` (see https://github.com/webpack/webpack/issues/5703#issuecomment-357512412). To keep us or consumers using commonjs from running into this issue, I switched all dynamic imports to use `require.ensure` instead. This isn't as clean or modern, but it's effective at preventing subtle bundling issues for either us or consumers, which I think is more important for now.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11647)