### PR TITLE
Adding a cleanup step for the build job because we host our own VMs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -24,7 +24,8 @@ jest.config.js @kenotron @ecraig12345
 tsconfig.json @kenotron @ecraig12345
 lerna.json @kenotron @ecraig12345
 LICENSE @kenotron @ecraig12345
-azure-pipelines.yml @ecraig12345 @kenotron
+azure-pipelines.yml @ecraig12345 @kenotron @JasonGore
+azure-pipelines.*.yml @ecraig12345 @kenotron @JasonGore
 .appveyor.yml @kenotron @ecraig12345
 .npmrc @kenotron @ecraig12345
 .npmignore @kenotron @ecraig12345

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -93,8 +93,8 @@ jobs:
           BlobPrefix: 'pr-deploy-site/$(Build.SourceBranch)'
 
        - task: DeleteFiles@1
-        inputs:
-          SourceFolder: $(Build.SourceDirectory)
+         inputs:
+           SourceFolder: $(Build.SourceDirectory)
 
   - job: PerfTest
     dependsOn: Build
@@ -142,8 +142,8 @@ jobs:
           githubTargetLink: 'http://fabricweb.z5.web.core.windows.net/pr-deploy-site/$(Build.SourceBranch)/'
 
        - task: DeleteFiles@1
-        inputs:
-          SourceFolder: $(Build.SourceDirectory)
+         inputs:
+           SourceFolder: $(Build.SourceDirectory)
 
   - job: VRTest
     dependsOn: Build
@@ -161,8 +161,8 @@ jobs:
           SCREENER_API_KEY: $(screener.key)
 
        - task: DeleteFiles@1
-        inputs:
-          SourceFolder: $(Build.SourceDirectory)
+         inputs:
+           SourceFolder: $(Build.SourceDirectory)
     # a11y-tests disabled until occasional local and CI timeout issue can be resolved.
     # If/when re-enabled, analyze job strategy to optimize build time. Make standalone job or append to another test job?
     #- task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,6 +44,7 @@ jobs:
       - task: DeleteFiles@1
         inputs:
           SourceFolder: $(Build.SourceDirectory)
+          Contents: '**/*'
 
   - job: Validate
     dependsOn: Build
@@ -68,6 +69,7 @@ jobs:
       - task: DeleteFiles@1
         inputs:
           SourceFolder: $(Build.SourceDirectory)
+          Contents: '**/*'
 
   - job: Deploy
     dependsOn: Build
@@ -95,6 +97,7 @@ jobs:
       - task: DeleteFiles@1
         inputs:
           SourceFolder: $(Build.SourceDirectory)
+          Contents: '**/*'
 
   - job: PerfTest
     dependsOn: Build
@@ -144,6 +147,7 @@ jobs:
       - task: DeleteFiles@1
         inputs:
           SourceFolder: $(Build.SourceDirectory)
+          Contents: '**/*'
 
   - job: VRTest
     dependsOn: Build
@@ -163,6 +167,7 @@ jobs:
       - task: DeleteFiles@1
         inputs:
           SourceFolder: $(Build.SourceDirectory)
+          Contents: '**/*'
     # a11y-tests disabled until occasional local and CI timeout issue can be resolved.
     # If/when re-enabled, analyze job strategy to optimize build time. Make standalone job or append to another test job?
     #- task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,9 +92,9 @@ jobs:
           ContainerName: '$web'
           BlobPrefix: 'pr-deploy-site/$(Build.SourceBranch)'
 
-       - task: DeleteFiles@1
-         inputs:
-           SourceFolder: $(Build.SourceDirectory)
+      - task: DeleteFiles@1
+        inputs:
+          SourceFolder: $(Build.SourceDirectory)
 
   - job: PerfTest
     dependsOn: Build
@@ -141,9 +141,9 @@ jobs:
           githubDescription: 'Click "Details" to go to the Deployed Site'
           githubTargetLink: 'http://fabricweb.z5.web.core.windows.net/pr-deploy-site/$(Build.SourceBranch)/'
 
-       - task: DeleteFiles@1
-         inputs:
-           SourceFolder: $(Build.SourceDirectory)
+      - task: DeleteFiles@1
+        inputs:
+          SourceFolder: $(Build.SourceDirectory)
 
   - job: VRTest
     dependsOn: Build
@@ -160,9 +160,9 @@ jobs:
         env:
           SCREENER_API_KEY: $(screener.key)
 
-       - task: DeleteFiles@1
-         inputs:
-           SourceFolder: $(Build.SourceDirectory)
+      - task: DeleteFiles@1
+        inputs:
+          SourceFolder: $(Build.SourceDirectory)
     # a11y-tests disabled until occasional local and CI timeout issue can be resolved.
     # If/when re-enabled, analyze job strategy to optimize build time. Make standalone job or append to another test job?
     #- task: PublishBuildArtifacts@1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -43,7 +43,7 @@ jobs:
 
       - task: DeleteFiles@1
         inputs:
-          SourceFolder: $(Build.SourceDirectory)
+          SourceFolder: $(Build.SourcesDirectory)
           Contents: '**/*'
 
   - job: Validate
@@ -68,7 +68,7 @@ jobs:
 
       - task: DeleteFiles@1
         inputs:
-          SourceFolder: $(Build.SourceDirectory)
+          SourceFolder: $(Build.SourcesDirectory)
           Contents: '**/*'
 
   - job: Deploy
@@ -96,7 +96,7 @@ jobs:
 
       - task: DeleteFiles@1
         inputs:
-          SourceFolder: $(Build.SourceDirectory)
+          SourceFolder: $(Build.SourcesDirectory)
           Contents: '**/*'
 
   - job: PerfTest
@@ -146,7 +146,7 @@ jobs:
 
       - task: DeleteFiles@1
         inputs:
-          SourceFolder: $(Build.SourceDirectory)
+          SourceFolder: $(Build.SourcesDirectory)
           Contents: '**/*'
 
   - job: VRTest
@@ -166,7 +166,7 @@ jobs:
 
       - task: DeleteFiles@1
         inputs:
-          SourceFolder: $(Build.SourceDirectory)
+          SourceFolder: $(Build.SourcesDirectory)
           Contents: '**/*'
     # a11y-tests disabled until occasional local and CI timeout issue can be resolved.
     # If/when re-enabled, analyze job strategy to optimize build time. Make standalone job or append to another test job?

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -41,6 +41,10 @@ jobs:
       - publish: $(Build.ArtifactStagingDirectory)
         artifact: Build
 
+      - task: DeleteFiles@1
+        inputs:
+          SourceFolder: $(Build.SourceDirectory)
+
   - job: Validate
     dependsOn: Build
     pool: 'Self Host Ubuntu'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,6 +65,10 @@ jobs:
           yarn check-for-changed-files
         displayName: check for changed files
 
+      - task: DeleteFiles@1
+        inputs:
+          SourceFolder: $(Build.SourceDirectory)
+
   - job: Deploy
     dependsOn: Build
     pool: 'Self Host Ubuntu'
@@ -87,6 +91,10 @@ jobs:
           storage: fabricweb
           ContainerName: '$web'
           BlobPrefix: 'pr-deploy-site/$(Build.SourceBranch)'
+
+       - task: DeleteFiles@1
+        inputs:
+          SourceFolder: $(Build.SourceDirectory)
 
   - job: PerfTest
     dependsOn: Build
@@ -133,6 +141,10 @@ jobs:
           githubDescription: 'Click "Details" to go to the Deployed Site'
           githubTargetLink: 'http://fabricweb.z5.web.core.windows.net/pr-deploy-site/$(Build.SourceBranch)/'
 
+       - task: DeleteFiles@1
+        inputs:
+          SourceFolder: $(Build.SourceDirectory)
+
   - job: VRTest
     dependsOn: Build
     steps:
@@ -147,6 +159,10 @@ jobs:
         displayName: run VR Test
         env:
           SCREENER_API_KEY: $(screener.key)
+
+       - task: DeleteFiles@1
+        inputs:
+          SourceFolder: $(Build.SourceDirectory)
     # a11y-tests disabled until occasional local and CI timeout issue can be resolved.
     # If/when re-enabled, analyze job strategy to optimize build time. Make standalone job or append to another test job?
     #- task: PublishBuildArtifacts@1


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

We used to have a built-in cleanup step done by the MS hosted agents. We now have to clean up after ourselves.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11648)