### PR TITLE
Text: Fixing children check so it can render {0} value

### DIFF
--- a/change/office-ui-fabric-react-2020-01-09-11-08-17-textChildrenCheck.json
+++ b/change/office-ui-fabric-react-2020-01-09-11-08-17-textChildrenCheck.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Text: Fixing children check so it can render {0} value.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "dc2170110070272040a4bf7c0508d725dfa61eec",
+  "date": "2020-01-09T19:08:17.440Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Text/Text.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Text/Text.test.tsx
@@ -9,4 +9,10 @@ describe('Text', () => {
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
+
+  it('renders Text with {0} as its children correctly', () => {
+    const component = renderer.create(<Text>{0}</Text>);
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/Text/Text.view.tsx
+++ b/packages/office-ui-fabric-react/src/components/Text/Text.view.tsx
@@ -1,10 +1,11 @@
 /** @jsx withSlots */
+import * as React from 'react';
 import { withSlots, getSlots } from '../../Foundation';
 import { getNativeProps, htmlElementProperties } from '../../Utilities';
 import { ITextComponent, ITextProps, ITextSlots } from './Text.types';
 
 export const TextView: ITextComponent['view'] = props => {
-  if (!props.children) {
+  if (React.Children.count(props.children) === 0) {
     return null;
   }
 

--- a/packages/office-ui-fabric-react/src/components/Text/__snapshots__/Text.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Text/__snapshots__/Text.test.tsx.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Text renders Text with {0} as its children correctly 1`] = `
+<span
+  className=
+
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        color: inherit;
+        display: inline;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        moz-osx-font-smoothing: grayscale;
+        webkit-font-smoothing: antialiased;
+      }
+>
+  0
+</span>
+`;
+
 exports[`Text renders default Text correctly 1`] = `
 <span
   className=


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11641 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR fixes an issue with `Text` that returned `null` on render if its `children` was `{0}` because it evaluated the condition to false. I searched for similar issues in the repo and couldn't find any.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11659)