### PR TITLE
Remove onBlur prop exclusion in Grid.Base

### DIFF
--- a/change/office-ui-fabric-react-2020-01-09-15-24-23-master.json
+++ b/change/office-ui-fabric-react-2020-01-09-15-24-23-master.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Remove onBlur from being excluded in grid",
+  "packageName": "office-ui-fabric-react",
+  "email": "chiechan@microsoft.com",
+  "commit": "ea8f7234b54a21f593e35d501885052bf92278a3",
+  "date": "2020-01-09T23:24:23.206Z"
+}

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.base.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.base.tsx
@@ -28,6 +28,7 @@ export class GridBase extends BaseComponent<IGridProps, {}> implements IGrid {
     const htmlProps = getNativeProps<React.HTMLAttributes<HTMLTableElement>>(
       this.props,
       htmlElementProperties,
+      // avoid applying onBlur on the table if it's being used in the FocusZone
       doNotContainWithinFocusZone ? [] : ['onBlur']
     );
 

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.base.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.base.tsx
@@ -15,9 +15,21 @@ export class GridBase extends BaseComponent<IGridProps, {}> implements IGrid {
 
   public render(): JSX.Element {
     const props = this.props;
-    const { items, columnCount, onRenderItem, ariaPosInSet = props.positionInSet, ariaSetSize = props.setSize, styles } = props;
+    const {
+      items,
+      columnCount,
+      onRenderItem,
+      ariaPosInSet = props.positionInSet,
+      ariaSetSize = props.setSize,
+      styles,
+      doNotContainWithinFocusZone
+    } = props;
 
-    const htmlProps = getNativeProps<React.HTMLAttributes<HTMLTableElement>>(this.props, htmlElementProperties);
+    const htmlProps = getNativeProps<React.HTMLAttributes<HTMLTableElement>>(
+      this.props,
+      htmlElementProperties,
+      doNotContainWithinFocusZone ? [] : ['onBlur']
+    );
 
     const classNames = getClassNames(styles!, { theme: this.props.theme! });
 
@@ -45,7 +57,7 @@ export class GridBase extends BaseComponent<IGridProps, {}> implements IGrid {
     );
 
     // Create the table/grid
-    return this.props.doNotContainWithinFocusZone ? (
+    return doNotContainWithinFocusZone ? (
       content
     ) : (
       <FocusZone

--- a/packages/office-ui-fabric-react/src/utilities/grid/Grid.base.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/grid/Grid.base.tsx
@@ -17,7 +17,7 @@ export class GridBase extends BaseComponent<IGridProps, {}> implements IGrid {
     const props = this.props;
     const { items, columnCount, onRenderItem, ariaPosInSet = props.positionInSet, ariaSetSize = props.setSize, styles } = props;
 
-    const htmlProps = getNativeProps<React.HTMLAttributes<HTMLTableElement>>(this.props, htmlElementProperties, ['onBlur']);
+    const htmlProps = getNativeProps<React.HTMLAttributes<HTMLTableElement>>(this.props, htmlElementProperties);
 
     const classNames = getClassNames(styles!, { theme: this.props.theme! });
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

In this PR https://github.com/OfficeDev/office-ui-fabric-react/pull/11526, we unintentionally fixed a bug where we didn't exclude an onBlur event from being included in the Grid component, however office has existing behaviors that relied on the onBlur event that the change caused to be excluded.

#### Focus areas to test

This is mostly relevant around the Swatch Color Picker area where we want events to be fired if focus is lost on the grid.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11662)