### PR TITLE
remove test-bundle from PR gate; move it to only be done inside the bundle job

### DIFF
--- a/apps/pr-deploy-site/index.html
+++ b/apps/pr-deploy-site/index.html
@@ -118,9 +118,12 @@
       <li class="Tile">
         <a href="./date-time/dist/index.html" class="Tile-link"><i class="ms-Icon ms-Icon--PrimaryCalendar"></i>Date Time</a>
       </li>
+      <!--
+        TODO: temporarily disabling this for now until a new pipeline is created for PR Deploy Site builds
       <li class="Tile">
         <a href="./test-bundles/test-bundles.stats.html" class="Tile-link"><i class="ms-Icon ms-Icon--SpeedHigh"></i>Bundle Analyzer</a>
       </li>
+      -->
       <li class="Tile">
         <a href="./todo-app/index.html" class="Tile-link"><i class="ms-Icon ms-Icon--CheckMark"></i>Todo Example</a>
       </li>

--- a/apps/pr-deploy-site/package.json
+++ b/apps/pr-deploy-site/package.json
@@ -18,7 +18,6 @@
     "@uifabric/fabric-website": "^7.7.5",
     "@uifabric/foundation-scenarios": "^0.102.7",
     "perf-test": "^7.0.0",
-    "test-bundles": "^7.0.0",
     "theming-designer": "^7.0.0",
     "todo-app": "^7.0.0"
   },

--- a/apps/test-bundles/package.json
+++ b/apps/test-bundles/package.json
@@ -12,7 +12,7 @@
   "license": "MIT",
   "scripts": {
     "build": "just-scripts build",
-    "bundle": "just-scripts bundle",
+    "bundle:size": "just-scripts bundle",
     "lint": "just-scripts lint",
     "test": "just-scripts test",
     "just": "just-scripts",

--- a/azure-pipelines.bundlesize.yml
+++ b/azure-pipelines.bundlesize.yml
@@ -15,7 +15,7 @@ jobs:
       - script: yarn buildto test-bundles
         displayName: yarn build to test-bundles
 
-      - script: yarn workspace test-bundles bundle
+      - script: yarn workspace test-bundles bundle:size
         displayName: yarn bundle test-bundles
 
       - script: yarn workspace office-ui-fabric-react just webpack

--- a/change/@uifabric-pr-deploy-site-2020-01-10-12-58-45-test-bundle.json
+++ b/change/@uifabric-pr-deploy-site-2020-01-10-12-58-45-test-bundle.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "getting rid of test-bundles dep from pr-deploy-site",
+  "packageName": "@uifabric/pr-deploy-site",
+  "email": "kchau@microsoft.com",
+  "commit": "94ac80c98368f12fe5fd63cd37f0ad24e3efe8c4",
+  "date": "2020-01-10T20:58:45.260Z"
+}


### PR DESCRIPTION
#### Description of changes

test-bundle is doing a bundle step that is not needed inside the main PR gate job. Its purpose is creating bundles for testing for bundle sizes. We scope the heavy bundle step to only size auditor builds. This should speed up local full  bundle runs as well.

We also remove the defunct test-bundles in the pr-deploy-site because:

1. it never worked in the first place
2. the test-bundle bundle job won't get run at the PR gate anymore

Note: the size auditor continues to work independently.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11673)