### PR TITLE
Dropdown: Add aria role to multi-select dropdown

### DIFF
--- a/change/office-ui-fabric-react-2020-01-10-16-06-20-xgao-fix-dropdown-role.json
+++ b/change/office-ui-fabric-react-2020-01-10-16-06-20-xgao-fix-dropdown-role.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Add aria role to multi-select dropdown ",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "a015ed681c996bfac40b60665abd2191f4d241ed",
+  "date": "2020-01-11T00:06:20.653Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -227,7 +227,9 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
       : undefined;
     const ariaAttrs =
       multiSelect || disabled
-        ? {}
+        ? {
+            role: 'button'
+          }
         : // single select
           {
             role: 'listbox',

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -225,19 +225,20 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
       : isOpen && selectedIndices.length === 1 && selectedIndices[0] >= 0
       ? this._listId + selectedIndices[0]
       : undefined;
-    const ariaAttrs =
-      multiSelect || disabled
-        ? {
-            role: 'button'
-          }
-        : // single select
-          {
-            role: 'listbox',
-            childRole: 'option',
-            ariaSetSize: this._sizePosCache.optionSetSize,
-            ariaPosInSet: this._sizePosCache.positionInSet(selectedIndices[0]),
-            ariaSelected: selectedIndices[0] === undefined ? undefined : true
-          };
+
+    const ariaAttrs = multiSelect
+      ? {
+          role: 'button'
+        }
+      : // single select
+        {
+          role: 'listbox',
+          childRole: 'option',
+          ariaSetSize: this._sizePosCache.optionSetSize,
+          ariaPosInSet: this._sizePosCache.positionInSet(selectedIndices[0]),
+          ariaSelected: selectedIndices[0] === undefined ? undefined : true
+        };
+
     this._classNames = getClassNames(propStyles, {
       theme,
       className,

--- a/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -108,6 +108,7 @@ exports[`Dropdown multi-select Renders multiselect Dropdown correctly 1`] = `
     onKeyDown={[Function]}
     onKeyUp={[Function]}
     onMouseDown={[Function]}
+    role="button"
     tabIndex={0}
   >
     <span

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -286,6 +286,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                 onKeyDown={[Function]}
                 onKeyUp={[Function]}
                 onMouseDown={[Function]}
+                role="button"
                 tabIndex={-1}
               >
                 <span

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -286,13 +286,16 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                 onKeyDown={[Function]}
                 onKeyUp={[Function]}
                 onMouseDown={[Function]}
-                role="button"
+                role="listbox"
                 tabIndex={-1}
               >
                 <span
                   aria-atomic={true}
                   aria-invalid={false}
                   aria-live="polite"
+                  aria-posinset={1}
+                  aria-selected={true}
+                  aria-setsize={3}
                   className=
                       ms-Dropdown-title
                       {
@@ -327,6 +330,7 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
                         color: GrayText;
                       }
                   id="Dropdown2-option"
+                  role="option"
                 >
                   5 seconds
                 </span>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
@@ -357,6 +357,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       onKeyDown={[Function]}
       onKeyUp={[Function]}
       onMouseDown={[Function]}
+      role="button"
       tabIndex={-1}
     >
       <span
@@ -575,6 +576,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       onKeyDown={[Function]}
       onKeyUp={[Function]}
       onMouseDown={[Function]}
+      role="button"
       tabIndex={0}
     >
       <span

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
@@ -357,13 +357,16 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
       onKeyDown={[Function]}
       onKeyUp={[Function]}
       onMouseDown={[Function]}
-      role="button"
+      role="listbox"
       tabIndex={-1}
     >
       <span
         aria-atomic={true}
         aria-invalid={false}
         aria-live="polite"
+        aria-posinset={5}
+        aria-selected={true}
+        aria-setsize={7}
         className=
             ms-Dropdown-title
             {
@@ -398,6 +401,7 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
               color: GrayText;
             }
         id="Dropdown1-option"
+        role="option"
       >
         Broccoli
       </span>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.ControlledMulti.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.ControlledMulti.Example.tsx.shot
@@ -140,6 +140,7 @@ exports[`Component Examples renders Dropdown.ControlledMulti.Example.tsx correct
     onKeyDown={[Function]}
     onKeyUp={[Function]}
     onMouseDown={[Function]}
+    role="button"
     tabIndex={0}
   >
     <span


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #11657
- [X] Include a change request file using `$ yarn change`

#### Description of changes
For Multi-select uncontrolled example in https://developer.microsoft.com/en-us/fabric#/controls/web/dropdown,

Narrator: 
Before: Multi-select uncontrolled example Apple, Banana, Grape
After: Multi-select uncontrolled example Apple, Banana, Grape, menu item, collapsed

NVDA:
Before: Clickable After Multi-select uncontrolled example, Apple Banana Grape, Apple Banana Grape
After: Multi-select uncontrolled example Apple, Banana, Grape, menu button, collapsed, sub menu

VoiceOver:
Before: Apple, Banana, Grape, group
After: Multi-select uncontrolled example Apple, Banana, Grape, collapsed, button

#### Focus areas to test
Check how different screen readers behave after the change.
A11y insights tool test passed.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11678)