### PR TITLE
FocusZone: removing keydown listener correctly.

### DIFF
--- a/change/office-ui-fabric-react-2020-01-13-09-02-40-focuszone-listener-fix.json
+++ b/change/office-ui-fabric-react-2020-01-13-09-02-40-focuszone-listener-fix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "FocusZone: remove keydown listener correctly to avoid a leak with inner zones.",
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com",
+  "commit": "37992c637e8071f70a85d23aee51da9f7cbbdf46",
+  "date": "2020-01-13T17:02:40.676Z"
+}

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -196,6 +196,11 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
 
     if (!this._isInnerZone) {
       _outerZones.delete(this);
+
+      // If this is the last outer zone, remove the keydown listener.
+      if (_outerZones.size === 0 && _disposeGlobalKeyDownListener) {
+        _disposeGlobalKeyDownListener();
+      }
     }
 
     // Dispose all events.
@@ -203,11 +208,6 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
 
     // Clear function references so their closures can be garbage-collected.
     delete this._disposables;
-
-    // If this is the last outer zone, remove the keydown listener.
-    if (_outerZones.size === 0 && _disposeGlobalKeyDownListener) {
-      _disposeGlobalKeyDownListener();
-    }
   }
 
   public render() {

--- a/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
+++ b/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx
@@ -153,11 +153,12 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
 
       if (!this._isInnerZone) {
         _outerZones.add(this);
+
+        if (windowElement && _outerZones.size === 1) {
+          _disposeGlobalKeyDownListener = on(windowElement, 'keydown', this._onKeyDownCapture, true);
+        }
       }
 
-      if (windowElement && _outerZones.size === 1) {
-        _disposeGlobalKeyDownListener = on(windowElement, 'keydown', this._onKeyDownCapture, true);
-      }
       this._disposables.push(on(root, 'blur', this._onBlur, true));
 
       // Assign initial tab indexes so that we can set initial focus as appropriate.


### PR DESCRIPTION
In nested FocusZones, a global keydown listener is added but not removed. This should address this and only add it on the first outer zone and remove it on the last outer zone.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11689)