### PR TITLE
Added prop to restrict the max length in TextField

### DIFF
--- a/change/office-ui-fabric-react-2020-01-13-11-32-09-catalina-TextFieldMaxLength.json
+++ b/change/office-ui-fabric-react-2020-01-13-11-32-09-catalina-TextFieldMaxLength.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Added prop to restrict the max length accepted for the input in TextField component",
+  "packageName": "office-ui-fabric-react",
+  "email": "catalina@microsoft.com",
+  "commit": "577adf3293a03d1ccff545cf8e2a36e7036cfd2a",
+  "date": "2020-01-13T19:32:09.658Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -7622,6 +7622,7 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
     maskFormat?: {
         [key: string]: RegExp;
     };
+    maxLength?: number;
     multiline?: boolean;
     onChange?: (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => void;
     onGetErrorMessage?: (value: string) => string | JSX.Element | PromiseLike<string | JSX.Element> | undefined;

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.base.tsx
@@ -481,11 +481,17 @@ export class TextFieldBase extends React.Component<ITextFieldProps, ITextFieldSt
     // tests (ours and maybe consumers' too), so it seemed best to do the switch in a major bump.
 
     const element = event.target as HTMLInputElement;
-    const value = element.value;
+
     // Ignore this event if the value is undefined (in case one of the IE bugs comes back)
-    if (value === undefined || value === this._lastChangeValue) {
+    if (element.value === undefined || element.value === this._lastChangeValue) {
       return;
     }
+
+    const value =
+      this.props.maxLength !== undefined && element.value.length >= this.props.maxLength
+        ? element.value.substring(0, this.props.maxLength)
+        : element.value;
+
     this._lastChangeValue = value;
 
     // This is so developers can access the event properties in asynchronous callbacks

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.types.ts
@@ -143,6 +143,11 @@ export interface ITextFieldProps extends React.AllHTMLAttributes<HTMLInputElemen
   value?: string;
 
   /**
+   * Maximum number of characters accepted in the text field.
+   */
+  maxLength?: number;
+
+  /**
    * Disabled state of the text field.
    * @defaultvalue false
    */

--- a/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.Controlled.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.Controlled.Example.tsx
@@ -23,8 +23,9 @@ export class TextFieldControlledExample extends React.Component<{}, ITextFieldCo
         <TextField
           label="Controlled TextField limiting length of value to 5"
           value={this.state.value2}
-          onChange={this._onChange2}
           styles={{ fieldGroup: { width: 100 } }}
+          maxLength={5}
+          onChange={this._onChange2}
         />
       </Stack>
     );
@@ -35,16 +36,6 @@ export class TextFieldControlledExample extends React.Component<{}, ITextFieldCo
   };
 
   private _onChange2 = (ev: React.FormEvent<HTMLInputElement>, newValue?: string) => {
-    if (!newValue || newValue.length <= 5) {
-      this.setState({ value2: newValue || '' });
-    } else {
-      // This block should NOT be necessary, but there's currently a bug (#1350) where a controlled
-      // TextField will continue to accept input even if its `value` prop isn't updated.
-      // (The correct behavior is that the displayed value should *always* match the `value` prop.
-      // If the `value` prop isn't updated in response to user input, the input should be ignored.)
-      // Because this is a large behavior change, the bug won't be fixed until Fabric 7.
-      // As a workaround, force re-rendering with the existing value.
-      this.setState({ value2: this.state.value2 });
-    }
+    this.setState({ value2: newValue || '' });
   };
 }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Controlled.Example.tsx.shot
@@ -350,6 +350,7 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
                 opacity: 1;
               }
           id="TextField3"
+          maxLength={5}
           onBlur={[Function]}
           onChange={[Function]}
           onFocus={[Function]}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11691 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Exposed the maxLength prop which users can leverage to restrict the length of the input in the TextField component. This works with manually typed inputs as well as text copied from the clipboard.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11692)