### PR TITLE
ColorPicker: Fix click on color rectangle not working in Safari/Firefox browsers

### DIFF
--- a/change/office-ui-fabric-react-2020-01-14-20-32-34-bnslanuj-ColorRectangleFix.json
+++ b/change/office-ui-fabric-react-2020-01-14-20-32-34-bnslanuj-ColorRectangleFix.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fixing click handling for colorrectangle for bug #11680",
+  "packageName": "office-ui-fabric-react",
+  "email": "anuku@microsoft.com",
+  "commit": "3594dd074bebb4aacda53676f628986a887dd32c",
+  "date": "2020-01-14T15:02:34.147Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle/ColorRectangle.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle/ColorRectangle.base.tsx
@@ -168,14 +168,6 @@ export class ColorRectangleBase extends React.Component<IColorRectangleProps, IC
       return;
     }
 
-    // If the primary button (1) isn't pressed, the user is no longer dragging, so turn off the
-    // event handlers and exit. (this may only be relevant while debugging)
-    // tslint:disable-next-line:no-bitwise
-    if (!(ev.buttons & 1)) {
-      this._disableEvents();
-      return;
-    }
-
     const newColor = _getNewColor(ev, this.state.color, this._root.current);
     if (newColor) {
       this._updateColor(ev, newColor);

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle/ColorRectangle.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/ColorRectangle/ColorRectangle.base.tsx
@@ -168,6 +168,15 @@ export class ColorRectangleBase extends React.Component<IColorRectangleProps, IC
       return;
     }
 
+    // Leaving the following commented code which is sometimes necessary for debugging:
+    // If the primary button (1) isn't pressed, the user is no longer dragging, so turn off
+    // the event handlers and exit.
+    // tslint:disable-next-line:no-bitwise
+    // if (!(ev.buttons & 1)) {
+    //   this._disableEvents();
+    //   return;
+    // }
+
     const newColor = _getNewColor(ev, this.state.color, this._root.current);
     if (newColor) {
       this._updateColor(ev, newColor);


### PR DESCRIPTION
#### Pull request checklist

- [x] Fixes #11680 

#### Description of changes

There was a check for ev.buttons in mouse event handler method, which i believe was added for debugging purpose. Also, according to the notes mentioned here ([MouseEvent.Buttons](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons)) ev.buttons always return 0 in case of safari browsers. So, removing that if condition.




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11702)