### PR TITLE
Dialog/Panel: allow user to specify heading aria level

### DIFF
--- a/change/office-ui-fabric-react-2020-01-13-19-08-10-xgao-dialog-heading-level.json
+++ b/change/office-ui-fabric-react-2020-01-13-19-08-10-xgao-dialog-heading-level.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "Dialog: allow prop to set aria-level for title heading",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "bd5f04f01ecf5a16079e9765b9e4b462c2b34832",
+  "date": "2020-01-14T03:08:10.815Z"
+}

--- a/change/office-ui-fabric-react-2020-01-13-19-08-10-xgao-dialog-heading-level.json
+++ b/change/office-ui-fabric-react-2020-01-13-19-08-10-xgao-dialog-heading-level.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Dialog: allow prop to set aria-level for title heading",
+  "comment": "Dialog/Panel: allow prop to set aria-level for the heading",
   "packageName": "office-ui-fabric-react",
   "email": "xgao@microsoft.com",
   "commit": "bd5f04f01ecf5a16079e9765b9e4b462c2b34832",

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -3759,6 +3759,7 @@ export interface IDialogContentProps extends React.ClassAttributes<DialogContent
     subTextId?: string;
     theme?: ITheme;
     title?: string | JSX.Element;
+    titleAriaLevel?: number;
     titleId?: string;
     topButtonsProps?: IButtonProps[];
     type?: DialogType;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -5872,6 +5872,7 @@ export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
     hasCloseButton?: boolean;
     headerClassName?: string;
     headerText?: string;
+    headerTextAriaLevel?: number;
     // @deprecated
     ignoreExternalFocusing?: boolean;
     isBlocking?: boolean;

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.base.tsx
@@ -31,6 +31,7 @@ export class DialogContentBase extends BaseComponent<IDialogContentProps, {}> {
       onDismiss,
       subTextId,
       subText,
+      titleAriaLevel,
       titleId,
       title,
       type,
@@ -60,7 +61,7 @@ export class DialogContentBase extends BaseComponent<IDialogContentProps, {}> {
     return (
       <div className={classNames.content}>
         <div className={classNames.header}>
-          <p className={classNames.title} id={titleId} role="heading" aria-level={2}>
+          <p className={classNames.title} id={titleId} role="heading" aria-level={titleAriaLevel || 2}>
             {title}
           </p>
           <div className={classNames.topButton}>

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.types.ts
@@ -58,17 +58,22 @@ export interface IDialogContentProps extends React.ClassAttributes<DialogContent
   onDismiss?: (ev?: React.MouseEvent<HTMLButtonElement>) => any;
 
   /**
-   * The Id for subText container
+   * Id of the subText container.
    */
   subTextId?: string;
 
   /**
-   * The subtext to display in the dialog
+   * The subtext to display in the dialog.
    */
   subText?: string;
 
   /**
-   * The Id for title container
+   * Aria level of the title container.
+   */
+  titleAriaLevel?: number;
+
+  /**
+   * Id of the title container.
    */
   titleId?: string;
 

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -342,7 +342,7 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
     if (headerText) {
       return (
         <div className={this._classNames.header}>
-          <p className={this._classNames.headerText} id={headerTextId} role="heading" aria-level={2}>
+          <p className={this._classNames.headerText} id={headerTextId} role="heading" aria-level={props.headerTextAriaLevel || 2}>
             {headerText}
           </p>
         </div>

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -78,6 +78,11 @@ export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
   headerText?: string;
 
   /**
+   * Aria level of the header text for the Panel.
+   */
+  headerTextAriaLevel?: number;
+
+  /**
    * A callback function for when the Panel is opened, before the animation completes.
    */
   onOpen?: () => void;


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #11666
- [X] Include a change request file using `$ yarn change`

#### Description of changes
For the header with `role=heading` in Dialog/Panel, we set `aria-level` to 2 and there is no way to override that for user. Adding `AriaLevel` prop to enable this. I don't like adding this type of `Aria` prop, because it doesn't feel ergonomic. But for the short/mid-term, this is more consistent with what we have else where.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11703)