### PR TITLE
Updates persona primary text default line height

### DIFF
--- a/change/office-ui-fabric-react-2020-01-14-15-19-35-updates-persona-PrimaryText-defaultLineHeight.json
+++ b/change/office-ui-fabric-react-2020-01-14-15-19-35-updates-persona-PrimaryText-defaultLineHeight.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "updates persona styles to use normal line-height",
+  "packageName": "office-ui-fabric-react",
+  "email": "whitehan@msu.edu",
+  "commit": "277e6e234fdbdd66ccd6dd7fa98bc38f6f93e799",
+  "date": "2020-01-14T23:19:35.256Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.styles.ts
@@ -224,7 +224,6 @@ export const getStyles = (props: IPersonaStyleProps): IPersonaStyles => {
 
       showSecondaryText && {
         height: showSecondaryTextDefaultHeight,
-        lineHeight: showSecondaryTextDefaultHeight,
         overflowX: 'hidden'
       },
 
@@ -264,7 +263,6 @@ export const getStyles = (props: IPersonaStyleProps): IPersonaStyles => {
       showSecondaryText && {
         display: 'block',
         height: showSecondaryTextDefaultHeight,
-        lineHeight: showSecondaryTextDefaultHeight,
         overflowX: 'hidden'
       },
 

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Alternate.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Alternate.Example.tsx.shot
@@ -156,7 +156,6 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               font-size: 14px;
               font-weight: 400;
               height: 18px;
-              line-height: 16px;
               overflow-x: hidden;
               overflow: hidden;
               text-overflow: ellipsis;
@@ -191,7 +190,6 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               font-size: 12px;
               font-weight: 400;
               height: 18px;
-              line-height: 16px;
               overflow-x: hidden;
               overflow: hidden;
               text-overflow: ellipsis;
@@ -408,7 +406,6 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               font-size: 14px;
               font-weight: 400;
               height: 18px;
-              line-height: 16px;
               overflow-x: hidden;
               overflow: hidden;
               text-overflow: ellipsis;
@@ -443,7 +440,6 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               font-size: 12px;
               font-weight: 400;
               height: 16px;
-              line-height: 16px;
               overflow-x: hidden;
               overflow: hidden;
               text-overflow: ellipsis;
@@ -685,7 +681,6 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               font-size: 14px;
               font-weight: 400;
               height: 18px;
-              line-height: 16px;
               overflow-x: hidden;
               overflow: hidden;
               text-overflow: ellipsis;
@@ -720,7 +715,6 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               font-size: 12px;
               font-weight: 400;
               height: 16px;
-              line-height: 16px;
               overflow-x: hidden;
               overflow: hidden;
               text-overflow: ellipsis;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes https://github.com/OfficeDev/office-ui-fabric-react/issues/11719
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Text is being clipped in certain Persona scenarios.

Screenshot:

![image](https://user-images.githubusercontent.com/11093219/72391419-e83bdc00-36e1-11ea-8943-6882ae28a88c.png)

_(This was grabbed from the Search suggestions list in the latest version of OWA.)_

Changes:
The current Persona styles enforce a line-height on the `primaryText` that can be too small depending on the text's font-size and height. Rather than upping the `const` value to a larger number, it seems that removing the use of an explicit value and instead defaulting to `line-height: normal` is a more lasting fix to the bug.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11706)