### PR TITLE
Dropdown: fix exception when options change due to DropdownSizePosCache

### DIFF
--- a/change/office-ui-fabric-react-2020-01-14-15-37-45-xgao-fix-dropdown-exception.json
+++ b/change/office-ui-fabric-react-2020-01-14-15-37-45-xgao-fix-dropdown-exception.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Dropdown: fix exception when options change due to DropdownSizePosCache",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "6b16c8d6b2858b5b085a1a807ea74c21785f138a",
+  "date": "2020-01-14T23:37:45.933Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -109,12 +109,12 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
     if (this.props.multiSelect) {
       const selectedKeys = props.defaultSelectedKeys !== undefined ? props.defaultSelectedKeys : props.selectedKeys;
       selectedIndices = this._getSelectedIndexes(props.options, selectedKeys);
-      this._sizePosCache.updateOptions(props.options);
     } else {
       const selectedKey = props.defaultSelectedKey !== undefined ? props.defaultSelectedKey : props.selectedKey;
       selectedIndices = this._getSelectedIndexes(props.options, selectedKey!);
-      this._sizePosCache.updateOptions(props.options);
     }
+
+    this._sizePosCache.updateOptions(props.options);
 
     this.state = {
       isOpen: false,
@@ -169,8 +169,7 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
     }
 
     if (
-      newProps.options !== this.props.options && // preexisting code assumes purity of the options...
-      !newProps.multiSelect // only relevant in single selection
+      newProps.options !== this.props.options // preexisting code assumes purity of the options...
     ) {
       this._sizePosCache.updateOptions(newProps.options);
     }

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
@@ -425,12 +425,11 @@ describe('Dropdown', () => {
 
       expect(titleElement.text()).toEqual('1, 4');
 
-      const newOptions = DEFAULT_OPTIONS.slice(2);
-      wrapper.setProps({ options: newOptions });
+      wrapper.setProps({ options: DEFAULT_OPTIONS.slice(2) });
 
       wrapper.find('.ms-Dropdown').simulate('click');
       const options = document.querySelectorAll('.ms-Dropdown-item');
-      expect(options.length).toEqual(newOptions.length);
+      expect(options.length).toEqual(5);
     });
 
     it('Renders no selected item in default case', () => {

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.test.tsx
@@ -419,6 +419,20 @@ describe('Dropdown', () => {
       expect(tree).toMatchSnapshot();
     });
 
+    it('Renders multiselect Dropdown correctly when options change', () => {
+      wrapper = mount(<Dropdown options={DEFAULT_OPTIONS} multiSelect defaultSelectedKeys={['1', '4']} />);
+      const titleElement = wrapper.find('.ms-Dropdown-title');
+
+      expect(titleElement.text()).toEqual('1, 4');
+
+      const newOptions = DEFAULT_OPTIONS.slice(2);
+      wrapper.setProps({ options: newOptions });
+
+      wrapper.find('.ms-Dropdown').simulate('click');
+      const options = document.querySelectorAll('.ms-Dropdown-item');
+      expect(options.length).toEqual(newOptions.length);
+    });
+
     it('Renders no selected item in default case', () => {
       wrapper = mount(<Dropdown label="testgroup" options={DEFAULT_OPTIONS} multiSelect />);
 


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #11698
- [X] Include a change request file using `$ yarn change`

#### Description of changes
We should call `_sizePosCache.updateOptions` when it's multi-select, since `aria-posinset` and `aria-setsize` are used in option items in both single-select and multi-select dropdowns



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11707)