### PR TITLE
DatePicker: day in calendar is announced with blank role

### DIFF
--- a/change/office-ui-fabric-react-2020-01-14-16-43-10-xgao-datepicker-a11y.json
+++ b/change/office-ui-fabric-react-2020-01-14-16-43-10-xgao-datepicker-a11y.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "DatePicker accessibility: day in calendar is announced with blank role",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "beb2ad19fd8688e552d6162a1efca8b905f133a5",
+  "date": "2020-01-15T00:43:10.177Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
+++ b/packages/office-ui-fabric-react/src/components/Calendar/CalendarDay.tsx
@@ -319,7 +319,6 @@ export class CalendarDay extends BaseComponent<ICalendarDayProps, ICalendarDaySt
                             ['ms-DatePicker-day--disabled ' + styles.dayIsDisabled]: !day.isInBounds,
                             ['ms-DatePicker-day--today ' + styles.dayIsToday]: day.isToday
                           })}
-                          role="gridcell"
                           onKeyDown={this._onDayKeyDown(day.originalDate, weekIndex, dayIndex)}
                           aria-label={dateTimeFormatter.formatMonthDayYear(day.originalDate, strings)}
                           id={isNavigatedDate ? activeDescendantId : undefined}

--- a/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Calendar/__snapshots__/Calendar.test.tsx.snap
@@ -205,7 +205,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -230,7 +229,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -256,7 +254,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         id="DatePickerDay-active0"
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -281,7 +278,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -306,7 +302,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -331,7 +326,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -356,7 +350,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -383,7 +376,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -408,7 +400,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -433,7 +424,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -458,7 +448,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -483,7 +472,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -508,7 +496,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -533,7 +520,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -560,7 +546,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -585,7 +570,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -610,7 +594,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -635,7 +618,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -660,7 +642,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -685,7 +666,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -710,7 +690,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -737,7 +716,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -762,7 +740,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -787,7 +764,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -812,7 +788,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -837,7 +812,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -862,7 +836,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -887,7 +860,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -914,7 +886,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -939,7 +910,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -964,7 +934,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -989,7 +958,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -1014,7 +982,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -1039,7 +1006,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span
@@ -1064,7 +1030,6 @@ exports[`Calendar Test rendering simplest calendar Renders simple calendar corre
                         disabled={false}
                         onClick={[Function]}
                         onKeyDown={[Function]}
-                        role="gridcell"
                         type="button"
                       >
                         <span


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11704
- [x] Include a change request file using `$ yarn change`

#### Description of changes
`button` should not have `role=gridcell`, which is already defined on its parent `td`.

Before fix:
![image](https://user-images.githubusercontent.com/1207059/72395374-1aebd180-36ee-11ea-95ae-59de8090d88f.png)

After fix:
![image](https://user-images.githubusercontent.com/1207059/72395454-62725d80-36ee-11ea-96ee-deb2a1a78c85.png)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11708)