### PR TITLE
Huaxi/contextual menu hide checkmark

### DIFF
--- a/change/office-ui-fabric-react-2020-01-14-18-58-31-huaxi-contextual-menu-hide-checkmark.json
+++ b/change/office-ui-fabric-react-2020-01-14-18-58-31-huaxi-contextual-menu-hide-checkmark.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "add hideCheckmark props for IContextualMenuItem",
+  "packageName": "office-ui-fabric-react",
+  "email": "huaxi@microsoft.com",
+  "commit": "368c5017ae87efd2682df1f72e65933c78abbf28",
+  "date": "2020-01-15T02:58:31.503Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -3002,6 +3002,7 @@ export interface IContextualMenuItemStyleProps {
     disabled: boolean;
     dividerClassName?: string;
     expanded: boolean;
+    hideCheckmark?: boolean;
     iconClassName?: string;
     isAnchorLink: boolean;
     itemClassName?: string;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.base.tsx
@@ -22,11 +22,12 @@ const renderItemIcon = (props: IContextualMenuItemProps) => {
 
 const renderCheckMarkIcon = ({ onCheckmarkClick, item, classNames }: IContextualMenuItemProps) => {
   const isItemChecked = getIsChecked(item);
+  const hideCheckmark = !!item.hideCheckmark;
   if (onCheckmarkClick) {
     // Ensures that the item is passed as the first argument to the checkmark click callback.
     const onClick = (e: React.MouseEvent<HTMLElement>) => onCheckmarkClick(item, e);
 
-    return <Icon iconName={isItemChecked ? 'CheckMark' : ''} className={classNames.checkmarkIcon} onClick={onClick} />;
+    return <Icon iconName={!hideCheckmark && isItemChecked ? 'CheckMark' : ''} className={classNames.checkmarkIcon} onClick={onClick} />;
   }
   return null;
 };

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.test.tsx
@@ -48,6 +48,49 @@ describe('ContextMenuItemChildren', () => {
     });
   });
 
+  describe('when hide checkmark icon for toggle command', () => {
+    let onCheckmarkClick: jest.Mock;
+    let menuItem: IContextualMenuItem;
+    let menuClassNames: IMenuItemClassNames;
+    let wrapper: ShallowWrapper<IContextualMenuItemProps, {}>;
+
+    beforeEach(() => {
+      menuItem = { key: '123', hideCheckmark: true };
+      menuClassNames = getMenuItemClassNames();
+      onCheckmarkClick = jest.fn();
+
+      wrapper = shallow(
+        <ContextualMenuItemBase
+          item={menuItem}
+          classNames={menuClassNames}
+          index={1}
+          hasIcons={undefined}
+          onCheckmarkClick={onCheckmarkClick}
+        />
+      );
+    });
+
+    it('renders the component with the checkmark', () => {
+      expect(wrapper).toMatchSnapshot();
+    });
+
+    describe('when the checkmark is clicked', () => {
+      let event: jest.Mock;
+      beforeEach(() => {
+        event = jest.fn();
+        wrapper.find('.checkmarkIcon').simulate('click', event);
+      });
+
+      it('invokes the onCheckmarkClick callback', () => {
+        expect(onCheckmarkClick).toHaveBeenCalledWith(menuItem, event);
+      });
+
+      it('should not show checkmark', () => {
+        expect(wrapper.find('.ms-ContextualMenu-checkmarkIcon').length).toEqual(0);
+      });
+    });
+  });
+
   describe('when it has icons', () => {
     describe('when it has iconProps', () => {
       let menuItem: IContextualMenuItem;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItem.types.ts
@@ -162,6 +162,11 @@ export interface IContextualMenuItemStyleProps {
    * Whether or not the primary section of a split menu item is disabled.
    */
   primaryDisabled?: boolean;
+
+  /**
+   * Optional to hide checkmark for a toggle command
+   */
+  hideCheckmark?: boolean;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenuItem.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenuItem.test.tsx.snap
@@ -1,8 +1,8 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-// FABRIC7TODO these should be richer models
-
 exports[`ContextMenuItemChildren when a checkmark icon renders the component with the checkmark 1`] = `ShallowWrapper {}`;
+
+exports[`ContextMenuItemChildren when hide checkmark icon for toggle command renders the component with the checkmark 1`] = `ShallowWrapper {}`;
 
 exports[`ContextMenuItemChildren when it has a sub menu renders the menu icon 1`] = `ShallowWrapper {}`;
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Checkmarks.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.Checkmarks.Example.tsx
@@ -193,6 +193,17 @@ export class ContextualMenuCheckmarksExample extends React.Component<{}, IContex
               name: 'Split Button Disabled Primary',
               split: true,
               primaryDisabled: true
+            },
+            {
+              key: keys[13],
+              iconProps: {
+                iconName: selection![keys[13]] ? 'SingleBookmarkSolid' : 'SingleBookmark'
+              },
+              name: selection![keys[13]] ? 'Toogled command no checkmark' : 'Toogle command no checkmark',
+              canCheck: true,
+              isChecked: selection![keys[13]],
+              onClick: this._onToggleSelect,
+              hideCheckmark: true
             }
           ]
         }}


### PR DESCRIPTION
#### Pull request checklist

- [x ] Addresses an existing issue: Fixes #0000
- [x ] Include a change request file using `$ yarn change`

#### Description of changes
1. Add `hideCheckmark` to provide flexibility to hide checkmark for toggle contextual command.
2. Add an example under toggleable contextualMenu
a) When command is not toggled
![Screen Shot 2020-01-14 at 7 02 29 PM](https://user-images.githubusercontent.com/3360621/72401367-a40c0400-3700-11ea-9206-940c9c48b756.png)

b) When command is toggled
![Screen Shot 2020-01-14 at 7 02 39 PM](https://user-images.githubusercontent.com/3360621/72401375-a8382180-3700-11ea-8102-1a5d04902a2f.png)

#### Focus areas to test
Contextual menu




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11710)