### PR TITLE
TextField: fix focused bottom border mis-alignment when errorMessage is set

### DIFF
--- a/change/@uifabric-styling-2020-01-16-10-20-16-users-v-jajach-fixed-issue-11714.json
+++ b/change/@uifabric-styling-2020-01-16-10-20-16-users-v-jajach-fixed-issue-11714.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "TextField: fix focused bottom border mis-alignment when errorMessage is set",
+  "packageName": "@uifabric/styling",
+  "email": "v-jajach@microsoft.com",
+  "commit": "c6ec87ce96332e37c2e6fc723701e29275030c50",
+  "date": "2020-01-16T09:20:16.288Z"
+}

--- a/change/office-ui-fabric-react-2020-01-16-10-20-16-users-v-jajach-fixed-issue-11714.json
+++ b/change/office-ui-fabric-react-2020-01-16-10-20-16-users-v-jajach-fixed-issue-11714.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "TextField: fix focused bottom border mis-alignment when errorMessage is set",
+  "packageName": "office-ui-fabric-react",
+  "email": "v-jajach@microsoft.com",
+  "commit": "c6ec87ce96332e37c2e6fc723701e29275030c50",
+  "date": "2020-01-16T09:20:01.825Z"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -157,12 +157,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
           {
             position: 'relative'
           },
-          getInputFocusStyle(
-            !hasErrorMessage ? semanticColors.inputFocusBorderAlt : semanticColors.errorText,
-            effects.roundedCorner2,
-            'borderBottom',
-            -2
-          )
+          getInputFocusStyle(!hasErrorMessage ? semanticColors.inputFocusBorderAlt : semanticColors.errorText, 0, 'borderBottom')
         ]
       ]
     ],

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -153,12 +153,17 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
             }
           }
         },
-        focused &&
+        focused && [
+          {
+            position: 'relative'
+          },
           getInputFocusStyle(
             !hasErrorMessage ? semanticColors.inputFocusBorderAlt : semanticColors.errorText,
             effects.roundedCorner2,
-            'borderBottom'
+            'borderBottom',
+            -2
           )
+        ]
       ]
     ],
     fieldGroup: [

--- a/packages/styling/src/styles/getFocusStyle.ts
+++ b/packages/styling/src/styles/getFocusStyle.ts
@@ -148,25 +148,29 @@ export const getInputFocusStyle = (
   borderRadius: string | number,
   borderType: 'border' | 'borderBottom' = 'border',
   borderPosition: number = -1
-): IRawStyle => ({
-  borderColor,
-  selectors: {
-    ':after': {
-      pointerEvents: 'none',
-      content: "''",
-      position: 'absolute',
-      left: borderPosition,
-      top: borderPosition,
-      bottom: borderPosition,
-      right: borderPosition,
-      [borderType]: `2px solid ${borderColor}`,
-      borderRadius,
-      width: borderType === 'borderBottom' ? '100%' : undefined,
-      selectors: {
-        [HighContrastSelector]: {
-          [borderType === 'border' ? 'borderColor' : 'borderBottomColor']: 'Highlight'
+): IRawStyle => {
+  const isBorderBottom = borderType === 'borderBottom';
+
+  return {
+    borderColor,
+    selectors: {
+      ':after': {
+        pointerEvents: 'none',
+        content: "''",
+        position: 'absolute',
+        left: isBorderBottom ? 0 : borderPosition,
+        top: borderPosition,
+        bottom: borderPosition,
+        right: isBorderBottom ? 0 : borderPosition,
+        [borderType]: `2px solid ${borderColor}`,
+        borderRadius,
+        width: borderType === 'borderBottom' ? '100%' : undefined,
+        selectors: {
+          [HighContrastSelector]: {
+            [borderType === 'border' ? 'borderColor' : 'borderBottomColor']: 'Highlight'
+          }
         }
       }
     }
-  }
-});
+  };
+};


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11714
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Updated `getInputFocusStyle` method parameter `borderPosition` to use an object instead of just a number so we have a better control on border's position.

#### Before
![image](https://user-images.githubusercontent.com/56690996/72446119-3a006700-37b3-11ea-8fa0-bfdd18469919.png)

#### After
![image](https://user-images.githubusercontent.com/56690996/72446233-75029a80-37b3-11ea-991e-38e4f39f9c69.png)


#### Focus areas to test

- Undertlined TextField focused / blured 


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11715)