### PR TITLE
Revert "ContextualMenu: Fix disabled item being focusable"

### DIFF
--- a/change/office-ui-fabric-react-2020-01-13-15-11-26-xgao-fix-contextual-menu-keyboard.json
+++ b/change/office-ui-fabric-react-2020-01-13-15-11-26-xgao-fix-contextual-menu-keyboard.json
@@ -1,8 +1,0 @@
-{
-  "type": "patch",
-  "comment": "ContextualMenu: Fix disabled item being focusable",
-  "packageName": "office-ui-fabric-react",
-  "email": "xgao@microsoft.com",
-  "commit": "e07cba4de908eb62656cd8263f2a68782e73f59e",
-  "date": "2020-01-13T23:11:26.708Z"
-}

--- a/change/office-ui-fabric-react-2020-01-13-15-11-26-xgao-fix-contextual-menu-keyboard.json
+++ b/change/office-ui-fabric-react-2020-01-13-15-11-26-xgao-fix-contextual-menu-keyboard.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "ContextualMenu: Fix disabled item being focusable",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "e07cba4de908eb62656cd8263f2a68782e73f59e",
+  "date": "2020-01-13T23:11:26.708Z"
+}

--- a/change/office-ui-fabric-react-2020-01-15-09-45-31-revert-11693-xgao-fix-contextual-menu-keyboard.json
+++ b/change/office-ui-fabric-react-2020-01-15-09-45-31-revert-11693-xgao-fix-contextual-menu-keyboard.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Revert \"ContextualMenu: Fix disabled item being focusable (#11693)\"",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "ea6136f7d45b6abe94cb972d304909e6010465ce",
+  "date": "2020-01-15T17:45:31.673Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -473,14 +473,13 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
     const subMenuIconClassName = item.submenuIconProps ? item.submenuIconProps.className : '';
 
     let itemClassNames: IMenuItemClassNames;
-    const disabled = isItemDisabled(item);
 
     // IContextualMenuItem#getItemClassNames for backwards compatibility
     // otherwise uses mergeStyles for class names.
     if (getItemClassNames) {
       itemClassNames = getItemClassNames(
         this.props.theme!,
-        disabled,
+        isItemDisabled(item),
         this.state.expandedMenuItemKey === item.key,
         !!getIsChecked(item),
         !!item.href,
@@ -494,7 +493,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
     } else {
       const itemStyleProps: IContextualMenuItemStyleProps = {
         theme: this.props.theme!,
-        disabled,
+        disabled: isItemDisabled(item),
         expanded: this.state.expandedMenuItemKey === item.key,
         checked: !!getIsChecked(item),
         isAnchorLink: !!item.href,

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuAnchor.tsx
@@ -69,7 +69,6 @@ export class ContextualMenuAnchor extends ContextualMenuItemWrapper {
               aria-posinset={focusableElementIndex + 1}
               aria-setsize={totalItemCount}
               aria-disabled={isItemDisabled(item)}
-              data-is-focusable={!item.disabled}
               style={item.style}
               onClick={this._onItemClick}
               onMouseEnter={this._onItemMouseEnter}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
@@ -65,7 +65,6 @@ export class ContextualMenuButton extends ContextualMenuItemWrapper {
       'aria-posinset': focusableElementIndex + 1,
       'aria-setsize': totalItemCount,
       'aria-disabled': isItemDisabled(item),
-      'data-is-focusable': !item.disabled,
       role: item.role || defaultRole,
       style: item.style
     };

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
@@ -74,7 +74,7 @@ export class ContextualMenuSplitButton extends ContextualMenuItemWrapper {
             onClick={this._executeItemClick}
             onTouchStart={this._onTouchStart}
             tabIndex={0}
-            data-is-focusable={!item.disabled}
+            data-is-focusable={true}
             aria-roledescription={item['aria-roledescription']}
           >
             {this._renderSplitPrimaryButton(item, classNames, index, hasCheckmarks!, hasIcons!)}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuAnchor.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuAnchor.deprecated.test.tsx.snap
@@ -7,7 +7,6 @@ exports[`ContextualMenuButton creates a normal button renders the contextual men
     aria-posinset={1}
     aria-setsize={1}
     className="root"
-    data-is-focusable={true}
     onClick={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuAnchor.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuAnchor.test.tsx.snap
@@ -7,7 +7,6 @@ exports[`ContextualMenuButton creates a normal button renders the contextual men
     aria-posinset={1}
     aria-setsize={1}
     className="root"
-    data-is-focusable={true}
     onClick={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuButton.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuButton.deprecated.test.tsx.snap
@@ -6,7 +6,6 @@ exports[`ContextualMenuButton creates a normal button renders the contextual men
   aria-posinset={1}
   aria-setsize={1}
   className="root"
-  data-is-focusable={true}
   onClick={[Function]}
   onMouseDown={[Function]}
   onMouseEnter={[Function]}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuButton.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/__snapshots__/ContextualMenuButton.test.tsx.snap
@@ -6,7 +6,6 @@ exports[`ContextualMenuButton creates a normal button renders the contextual men
   aria-posinset={1}
   aria-setsize={1}
   className="root"
-  data-is-focusable={true}
   onClick={[Function]}
   onMouseDown={[Function]}
   onMouseEnter={[Function]}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
@@ -413,7 +413,6 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
                             .ms-Fabric--isFocusVisible &:hover {
                               background: inherit;
                             }
-                        data-is-focusable={true}
                         onClick={[Function]}
                         onKeyDown={[Function]}
                         onMouseDown={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Basic.Example.tsx.shot
@@ -288,7 +288,6 @@ exports[`Component Examples renders ContextualMenu.Basic.Example.tsx correctly 1
                           .ms-Fabric--isFocusVisible &:hover {
                             background: inherit;
                           }
-                      data-is-focusable={true}
                       onClick={[Function]}
                       onMouseDown={[Function]}
                       onMouseEnter={[Function]}
@@ -437,7 +436,6 @@ exports[`Component Examples renders ContextualMenu.Basic.Example.tsx correctly 1
                           .ms-Fabric--isFocusVisible &:hover {
                             background: inherit;
                           }
-                      data-is-focusable={true}
                       onClick={[Function]}
                       onMouseDown={[Function]}
                       onMouseEnter={[Function]}
@@ -574,7 +572,6 @@ exports[`Component Examples renders ContextualMenu.Basic.Example.tsx correctly 1
                           .ms-Fabric--isFocusVisible &:hover {
                             background: inherit;
                           }
-                      data-is-focusable={true}
                       onClick={[Function]}
                       onMouseDown={[Function]}
                       onMouseEnter={[Function]}
@@ -711,7 +708,6 @@ exports[`Component Examples renders ContextualMenu.Basic.Example.tsx correctly 1
                           .ms-Fabric--isFocusVisible &:hover {
                             background: inherit;
                           }
-                      data-is-focusable={true}
                       onClick={[Function]}
                       onMouseDown={[Function]}
                       onMouseEnter={[Function]}
@@ -857,7 +853,6 @@ exports[`Component Examples renders ContextualMenu.Basic.Example.tsx correctly 1
                             .ms-Fabric--isFocusVisible &:hover {
                               background: inherit;
                             }
-                        data-is-focusable={true}
                         href="http://bing.com"
                         onClick={[Function]}
                         onMouseEnter={[Function]}
@@ -1004,7 +999,6 @@ exports[`Component Examples renders ContextualMenu.Basic.Example.tsx correctly 1
                             .ms-Fabric--isFocusVisible &:hover {
                               background: inherit;
                             }
-                        data-is-focusable={true}
                         href="http://bing.com"
                         onClick={[Function]}
                         onMouseEnter={[Function]}
@@ -1153,7 +1147,6 @@ exports[`Component Examples renders ContextualMenu.Basic.Example.tsx correctly 1
                             .ms-Fabric--isFocusVisible &:hover {
                               background: inherit;
                             }
-                        data-is-focusable={true}
                         href="http://bing.com"
                         name="Link click"
                         onClick={[Function]}
@@ -1260,7 +1253,6 @@ exports[`Component Examples renders ContextualMenu.Basic.Example.tsx correctly 1
                             color: GrayText;
                             opacity: 1;
                           }
-                      data-is-focusable={false}
                       onClick={[Function]}
                       onMouseDown={[Function]}
                       onMouseEnter={[Function]}


### PR DESCRIPTION
Reverts OfficeDev/office-ui-fabric-react#11693

Discussed with @jspurlin , we should keep disabled item focusable. Dropdown and ComboBox should be the same. For context, here are some conversations I had offline with @jspurlin :

[9:16 AM] Jeremy Spurlin
    There's a been a lot of discussion around this in the past with internal/external accessible users and fabric stakeholders. If the items are not focusable, a blind user potentially will never know that the control is there in the first place. Additionally, if disabled items are not focusable, it breaks the muscle memory that accessible users (and power users for that matter) build for executing controls
[9:18 AM] Jeremy Spurlin
    For example, users learn to press the downArrow key x times when this menu is open to execute a specific control, if that changes because an item above it is disabled then they will potentially accidentally execute an incorrect control
[9:20 AM] Jeremy Spurlin
    There was an agreement that they should be focusable, but the existing behavior was to not have them focusable which aligns with traditional HTML behavior. Note, traditional HTML behavior was created for much simpler HTML pages and does not align with web application behaviors (which is to focus disabled controls). Fabric added the ability to have disabled items be focusable
​[9:20 AM] Jeremy Spurlin
    in general and office online uses that
​[9:21 AM] Jeremy Spurlin
    for menus, there's no native HTML behavior and it's unique to modern web applications and hence we decided to make those controls focusable by default when disabled


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11718)