### PR TITLE
Use standard postprocess task for monaco-editor and fix TS compat issue

### DIFF
--- a/change/@uifabric-monaco-editor-2020-01-15-16-07-53-monaco-postprocess.json
+++ b/change/@uifabric-monaco-editor-2020-01-15-16-07-53-monaco-postprocess.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Use standard postprocess task for get/set transforms, and remove readonly parameters",
+  "packageName": "@uifabric/monaco-editor",
+  "email": "elcraig@microsoft.com",
+  "commit": "8c1cc1f80cc5797db9f652aca313d8a51b8f108b",
+  "date": "2020-01-16T00:07:53.146Z"
+}

--- a/packages/monaco-editor/just.config.js
+++ b/packages/monaco-editor/just.config.js
@@ -2,6 +2,7 @@
 const { just, preset } = require('@uifabric/build');
 const { task, series, parallel, copyInstructions, copyInstructionsTask, cleanTask } = just;
 const { ts } = require('@uifabric/build/tasks/ts');
+const { postprocessTask, defaultLibPaths } = require('@uifabric/build/tasks/postprocess');
 const path = require('path');
 const { transformCssTask } = require('./tasks/transformCssTask');
 const { transformDtsTask } = require('./tasks/transformDtsTask');
@@ -23,6 +24,7 @@ task('transform-css', transformCssTask);
 task('transform-dts', transformDtsTask);
 task('ts:esm', ts.esm);
 task('ts:commonjs', ts.commonjs);
-task('ts', parallel('ts:esm', 'ts:commonjs'));
+task('ts:postprocess', postprocessTask([...defaultLibPaths, 'esm/**/*.d.ts']));
+task('ts', series(parallel('ts:esm', 'ts:commonjs'), 'ts:postprocess'));
 
 task('build', series('clean', 'copy', 'transform-css', 'transform-dts', 'ts')).cached();

--- a/packages/monaco-editor/tasks/transformDtsTask.js
+++ b/packages/monaco-editor/tasks/transformDtsTask.js
@@ -10,8 +10,8 @@ exports.transformDtsTask = function() {
   for (let dtsFile of dtsFiles) {
     let content = fs.readFileSync(dtsFile, 'utf-8');
 
-    // Remove ambient get accessors, added in TS > 3.5 and incompatible with earlier versions.
-    content = content.replace(/^    get (\w+)\(\)/gm, '    readonly $1');
+    // Remove readonly parameters (added in TS 3.4)
+    content = content.replace(/: readonly /gm, ': ');
 
     const dtsDirname = path.dirname(dtsFile).replace(/\\/g, '/');
     if (dtsDirname.endsWith('/language/typescript') && content.includes(' monaco.')) {

--- a/scripts/just.config.js
+++ b/scripts/just.config.js
@@ -46,7 +46,7 @@ module.exports = function preset() {
   task('jest', jest);
   task('jest-watch', jestWatch);
   task('sass', sass);
-  task('ts:postprocess', postprocessTask);
+  task('ts:postprocess', postprocessTask());
   task('postprocess:amd', postprocessAmdTask);
   task('postprocess:commonjs', postprocessCommonjsTask);
   task('ts:commonjs', ts.commonjs);

--- a/scripts/tasks/postprocess.js
+++ b/scripts/tasks/postprocess.js
@@ -1,70 +1,77 @@
 // @ts-check
-module.exports.postprocessTask = function() {
-  const path = require('path');
-  const ts = require('typescript');
-  const { mod } = require('riceburn');
 
-  const libPaths = ['lib/**/*.d.ts', 'lib-commonjs/**/*.d.ts', 'lib-amd/**/*.d.ts'];
+const defaultLibPaths = ['lib/**/*.d.ts', 'lib-commonjs/**/*.d.ts', 'lib-amd/**/*.d.ts'];
 
-  libPaths.forEach(path => {
-    mod(path).asTypescript((node, modder) => {
-      // TS3.7 changes emits for class fields from readonly to get/set, which breaks
-      // TS3.5 users. This mod reverts these emits for TS3.5 compatibility.
-      // This mod would be better written with something like ts-morph. For now, TS API and regexes are used.
-      // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#class-field-mitigations
+/**
+ * @param {string[]} [libPaths] Globs to .d.ts files which need postprocessing
+ */
+function postprocessTask(libPaths = defaultLibPaths) {
+  return function() {
+    const ts = require('typescript');
+    const { mod } = require('riceburn');
 
-      // Very roughly modeled after downlevel-dts which is not ready for consumption.
-      // https://github.com/sandersn/downlevel-dts/blob/master/index.js
+    libPaths.forEach(path => {
+      mod(path).asTypescript((node, modder) => {
+        // TS3.7 changes emits for class fields from readonly to get/set, which breaks
+        // TS3.5 users. This mod reverts these emits for TS3.5 compatibility.
+        // This mod would be better written with something like ts-morph. For now, TS API and regexes are used.
+        // https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-7.html#class-field-mitigations
 
-      // Rules:
-      // 1) Find get accessors
-      //    If they have a matching set, remove the set accessor entirely and remove the 'get' keyword.
-      //    If they do not have a matching set accessor, replace 'get' with 'readonly' and remove functional declaration.
-      // 2) Find set accessors
-      //    If they do not have a matching get, remove the keyword 'set' and remove functional declaration while keeping type.
-      //    Other cases already handled as part of #1.
+        // Very roughly modeled after downlevel-dts which is not ready for consumption.
+        // https://github.com/sandersn/downlevel-dts/blob/master/index.js
 
-      const mods = [];
+        // Rules:
+        // 1) Find get accessors
+        //    If they have a matching set, remove the set accessor entirely and remove the 'get' keyword.
+        //    If they do not have a matching set accessor, replace 'get' with 'readonly' and remove functional declaration.
+        // 2) Find set accessors
+        //    If they do not have a matching get, remove the keyword 'set' and remove functional declaration while keeping type.
+        //    Other cases already handled as part of #1.
 
-      if (ts.isGetAccessor(node)) {
-        let hasMatchingSetAccessor = false;
+        const mods = [];
 
-        if (ts.isClassDeclaration(node.parent)) {
+        if (ts.isGetAccessor(node)) {
+          let hasMatchingSetAccessor = false;
+
+          if (ts.isClassDeclaration(node.parent)) {
+            node.parent.forEachChild(child => {
+              if (ts.isSetAccessor(child) && node.name.getText() === child.name.getText()) {
+                hasMatchingSetAccessor = true;
+                mods.push(modder.removeFull(child));
+              }
+            });
+
+            const removeParentheses = new RegExp(`(${node.name.getText()})\\(\\)`, 'gm');
+
+            let replacement = node.getText().replace(/(^|\W)get /gm, hasMatchingSetAccessor ? '$1' : '$1readonly ');
+            replacement = replacement.replace(removeParentheses, '$1');
+
+            mods.push(modder.replace(node, replacement));
+          }
+        }
+
+        if (ts.isSetAccessor(node)) {
+          let hasMatchingGetAccessor = false;
           node.parent.forEachChild(child => {
-            if (ts.isSetAccessor(child) && node.name.getText() === child.name.getText()) {
-              hasMatchingSetAccessor = true;
-              mods.push(modder.removeFull(child));
+            if (ts.isGetAccessor(child) && node.name.getText() === child.name.getText()) {
+              hasMatchingGetAccessor = true;
             }
           });
 
-          const removeParentheses = new RegExp(`(${node.name.getText()})\\(\\)`, 'gm');
+          if (!hasMatchingGetAccessor) {
+            const removeParentheses = new RegExp(`(${node.name.getText()})\\(.*\(: .*\)\\)`, 'gm');
 
-          let replacement = node.getText().replace(/(^|\W)get /gm, hasMatchingSetAccessor ? '$1' : '$1readonly ');
-          replacement = replacement.replace(removeParentheses, '$1');
+            let replacement = node.getText().replace(/(^|\W)set /gm, '$1');
+            replacement = replacement.replace(removeParentheses, '$1$2');
 
-          mods.push(modder.replace(node, replacement));
-        }
-      }
-
-      if (ts.isSetAccessor(node)) {
-        let hasMatchingGetAccessor = false;
-        node.parent.forEachChild(child => {
-          if (ts.isGetAccessor(child) && node.name.getText() === child.name.getText()) {
-            hasMatchingGetAccessor = true;
+            mods.push(modder.replace(node, replacement));
           }
-        });
-
-        if (!hasMatchingGetAccessor) {
-          const removeParentheses = new RegExp(`(${node.name.getText()})\\(.*\(: .*\)\\)`, 'gm');
-
-          let replacement = node.getText().replace(/(^|\W)set /gm, '$1');
-          replacement = replacement.replace(removeParentheses, '$1$2');
-
-          mods.push(modder.replace(node, replacement));
         }
-      }
 
-      return mods;
+        return mods;
+      });
     });
-  });
-};
+  };
+}
+
+module.exports = { defaultLibPaths, postprocessTask };


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Use @JasonGore's new postprocess task for removing get/set from .d.ts files in monaco-editor.

The custom transformDtsTask is still needed to deal with a different issue. I also added basic handling for removing `readonly` modifiers from parameters, because I just learned today that this breaks TS 3.4. (This could also be added to the main postprocess task, but that would require figuring out how to do it with the TS API...)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11725)