### PR TITLE
DatePicker: error message for required field is not cleared when date is selected from calendar

### DIFF
--- a/change/@uifabric-date-time-2020-01-16-14-57-10-xgao-fix-datepicker-validation.json
+++ b/change/@uifabric-date-time-2020-01-16-14-57-10-xgao-fix-datepicker-validation.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "DatePicker: error message for required field is not cleared when date is selected from calendar",
+  "packageName": "@uifabric/date-time",
+  "email": "xgao@microsoft.com",
+  "commit": "ab9fe1c2d9033071770cba02c00728f120feac45",
+  "date": "2020-01-16T22:57:10.093Z"
+}

--- a/change/office-ui-fabric-react-2020-01-15-17-50-48-xgao-fix-datepicker-validation.json
+++ b/change/office-ui-fabric-react-2020-01-15-17-50-48-xgao-fix-datepicker-validation.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "DatePicker: error message for required field is not cleared when date is selected from calendar",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "bfc640d963af3c6979046b32ae78d6f732f68135",
+  "date": "2020-01-16T01:50:48.337Z"
+}

--- a/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
@@ -436,54 +436,50 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
 
     if (allowTextInput) {
       let date = null;
-      if (inputValue) {
-        // Don't parse if the selected date has the same formatted string as what we're about to parse.
-        // The formatted string might be ambiguous (ex: "1/2/3" or "New Year Eve") and the parser might
-        // not be able to come up with the exact same date.
-        if (this.state.selectedDate && formatDate && formatDate(this.state.selectedDate) === inputValue) {
-          return;
-        } else {
-          date = parseDateFromString!(inputValue);
+      // Don't parse if the selected date has the same formatted string as what we're about to parse.
+      // The formatted string might be ambiguous (ex: "1/2/3" or "New Year Eve") and the parser might
+      // not be able to come up with the exact same date.
+      if (inputValue && !(this.state.selectedDate && formatDate && formatDate(this.state.selectedDate) === inputValue)) {
+        date = parseDateFromString!(inputValue);
 
-          // Check if date is null, or date is Invalid Date
-          if (!date || isNaN(date.getTime())) {
-            // Reset invalid input field, if formatting is available
-            if (formatDate) {
-              date = this.state.selectedDate;
-              this.setState({
-                formattedDate: formatDate(date!).toString()
-              });
-            }
-
+        // Check if date is null, or date is Invalid Date
+        if (!date || isNaN(date.getTime())) {
+          // Reset invalid input field, if formatting is available
+          if (formatDate) {
+            date = this.state.selectedDate;
             this.setState({
-              errorMessage: strings!.invalidInputErrorMessage || ' '
+              formattedDate: formatDate(date!).toString()
+            });
+          }
+
+          this.setState({
+            errorMessage: strings!.invalidInputErrorMessage || ' '
+          });
+        } else {
+          // Check against optional date boundaries
+          if (this._isDateOutOfBounds(date, minDate, maxDate)) {
+            this.setState({
+              errorMessage: strings!.isOutOfBoundsErrorMessage || ' '
             });
           } else {
-            // Check against optional date boundaries
-            if (this._isDateOutOfBounds(date, minDate, maxDate)) {
-              this.setState({
-                errorMessage: strings!.isOutOfBoundsErrorMessage || ' '
-              });
-            } else {
-              this.setState({
-                selectedDate: date,
-                errorMessage: ''
-              });
+            this.setState({
+              selectedDate: date,
+              errorMessage: ''
+            });
 
-              // When formatting is available. If formatted date is valid, but is different from input, update with formatted date
-              // This occurs when an invalid date is entered twice
-              if (formatDate && formatDate(date) !== inputValue) {
-                this.setState({
-                  formattedDate: formatDate(date).toString()
-                });
-              }
+            // When formatting is available. If formatted date is valid, but is different from input, update with formatted date
+            // This occurs when an invalid date is entered twice
+            if (formatDate && formatDate(date) !== inputValue) {
+              this.setState({
+                formattedDate: formatDate(date).toString()
+              });
             }
           }
         }
       } else {
         // Only show error for empty inputValue if it is a required field
         this.setState({
-          errorMessage: isRequired ? strings!.isRequiredErrorMessage || ' ' : ''
+          errorMessage: isRequired && !inputValue ? strings!.isRequiredErrorMessage || ' ' : ''
         });
       }
 

--- a/packages/date-time/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/date-time/src/components/DatePicker/DatePicker.test.tsx
@@ -93,6 +93,39 @@ describe('DatePicker', () => {
     datePicker.unmount();
   });
 
+  it('should clear error message when required input has date text and allowTextInput is true', () => {
+    const datePicker = mount(<DatePickerBase isRequired={true} allowTextInput={true} />);
+    const textField = datePicker.find('input');
+    expect(textField).toBeDefined();
+    expect(datePicker.state('errorMessage')).toBeUndefined();
+
+    textField.simulate('click').simulate('click'); // open the datepicker then dismiss
+    expect(datePicker.state('errorMessage')).toBe(' ');
+    textField.simulate('change', { target: { value: 'Jan 1 2030' } }).simulate('blur');
+    expect(datePicker.state('errorMessage')).toBe('');
+
+    datePicker.unmount();
+  });
+
+  it('should clear error message when required input has date selected from calendar and allowTextInput is true', () => {
+    const datePicker = mount(<DatePickerBase isRequired={true} allowTextInput={true} />);
+    const textField = datePicker.find('input');
+
+    expect(textField).toBeDefined();
+    expect(datePicker.state('errorMessage')).toBeUndefined();
+    textField.simulate('click').simulate('click'); // open the datepicker then dismiss
+    expect(datePicker.state('errorMessage')).toBe(' ');
+
+    // open calendar and select first day
+    textField.simulate('click');
+    const selectableDateInCalender = datePicker.find('.ms-DatePicker td button[data-is-focusable=true]').at(0);
+    selectableDateInCalender.simulate('click');
+
+    expect(datePicker.state('errorMessage')).toBe('');
+
+    datePicker.unmount();
+  });
+
   // @todo: usage of document.querySelector is incorrectly testing DOM mounted by previous tests and needs to be fixed.
   it.skip('should call onSelectDate only once when allowTextInput is true and popup is used to select the value', () => {
     const onSelectDate = jest.fn();

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -433,6 +433,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
   private _validateTextInput = (): void => {
     const { isRequired, allowTextInput, strings, parseDateFromString, onSelectDate, formatDate, minDate, maxDate } = this.props;
     const inputValue = this.state.formattedDate;
+    console.log('_validateTextInput', inputValue);
 
     // Do validation only if DatePicker's popup is dismissed
     if (this.state.isDatePickerShown) {
@@ -441,54 +442,54 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
 
     if (allowTextInput) {
       let date = null;
-      if (inputValue) {
-        // Don't parse if the selected date has the same formatted string as what we're about to parse.
-        // The formatted string might be ambiguous (ex: "1/2/3" or "New Year Eve") and the parser might
-        // not be able to come up with the exact same date.
-        if (this.state.selectedDate && formatDate && formatDate(this.state.selectedDate) === inputValue) {
-          return;
-        } else {
-          date = parseDateFromString!(inputValue);
+      // Don't parse if the selected date has the same formatted string as what we're about to parse.
+      // The formatted string might be ambiguous (ex: "1/2/3" or "New Year Eve") and the parser might
+      // not be able to come up with the exact same date.
+      if (inputValue && !(this.state.selectedDate && formatDate && formatDate(this.state.selectedDate) === inputValue)) {
+        date = parseDateFromString!(inputValue);
 
-          // Check if date is null, or date is Invalid Date
-          if (!date || isNaN(date.getTime())) {
-            // Reset invalid input field, if formatting is available
-            if (formatDate) {
-              date = this.state.selectedDate;
-              this.setState({
-                formattedDate: formatDate(date!).toString()
-              });
-            }
-
+        // Check if date is null, or date is Invalid Date
+        if (!date || isNaN(date.getTime())) {
+          // Reset invalid input field, if formatting is available
+          if (formatDate) {
+            date = this.state.selectedDate;
             this.setState({
-              errorMessage: strings!.invalidInputErrorMessage || ' '
+              formattedDate: formatDate(date!).toString()
+            });
+          }
+
+          console.log('_validateTextInput 1', strings!.invalidInputErrorMessage || ' ');
+          this.setState({
+            errorMessage: strings!.invalidInputErrorMessage || ' '
+          });
+        } else {
+          // Check against optional date boundaries
+          if (this._isDateOutOfBounds(date, minDate, maxDate)) {
+            console.log('_validateTextInput 2', strings!.isOutOfBoundsErrorMessage || ' ');
+            this.setState({
+              errorMessage: strings!.isOutOfBoundsErrorMessage || ' '
             });
           } else {
-            // Check against optional date boundaries
-            if (this._isDateOutOfBounds(date, minDate, maxDate)) {
-              this.setState({
-                errorMessage: strings!.isOutOfBoundsErrorMessage || ' '
-              });
-            } else {
-              this.setState({
-                selectedDate: date,
-                errorMessage: ''
-              });
+            console.log('_validateTextInput 3', 'empty string');
+            this.setState({
+              selectedDate: date,
+              errorMessage: ''
+            });
 
-              // When formatting is available. If formatted date is valid, but is different from input, update with formatted date
-              // This occurs when an invalid date is entered twice
-              if (formatDate && formatDate(date) !== inputValue) {
-                this.setState({
-                  formattedDate: formatDate(date).toString()
-                });
-              }
+            // When formatting is available. If formatted date is valid, but is different from input, update with formatted date
+            // This occurs when an invalid date is entered twice
+            if (formatDate && formatDate(date) !== inputValue) {
+              this.setState({
+                formattedDate: formatDate(date).toString()
+              });
             }
           }
         }
       } else {
         // Only show error for empty inputValue if it is a required field
+        console.log('_validateTextInput 4', isRequired && !inputValue ? strings!.isRequiredErrorMessage || ' ' : '');
         this.setState({
-          errorMessage: isRequired ? strings!.isRequiredErrorMessage || ' ' : ''
+          errorMessage: isRequired && !inputValue ? strings!.isRequiredErrorMessage || ' ' : ''
         });
       }
 
@@ -499,6 +500,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
         onSelectDate(date);
       }
     } else if (isRequired && !inputValue) {
+      console.log('_validateTextInput 5', isRequired && !inputValue ? strings!.isRequiredErrorMessage || ' ' : '');
       // Check when DatePicker is a required field but has NO input value
       this.setState({
         errorMessage: strings!.isRequiredErrorMessage || ' '

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -433,7 +433,6 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
   private _validateTextInput = (): void => {
     const { isRequired, allowTextInput, strings, parseDateFromString, onSelectDate, formatDate, minDate, maxDate } = this.props;
     const inputValue = this.state.formattedDate;
-    console.log('_validateTextInput', inputValue);
 
     // Do validation only if DatePicker's popup is dismissed
     if (this.state.isDatePickerShown) {
@@ -458,19 +457,16 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
             });
           }
 
-          console.log('_validateTextInput 1', strings!.invalidInputErrorMessage || ' ');
           this.setState({
             errorMessage: strings!.invalidInputErrorMessage || ' '
           });
         } else {
           // Check against optional date boundaries
           if (this._isDateOutOfBounds(date, minDate, maxDate)) {
-            console.log('_validateTextInput 2', strings!.isOutOfBoundsErrorMessage || ' ');
             this.setState({
               errorMessage: strings!.isOutOfBoundsErrorMessage || ' '
             });
           } else {
-            console.log('_validateTextInput 3', 'empty string');
             this.setState({
               selectedDate: date,
               errorMessage: ''
@@ -487,7 +483,6 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
         }
       } else {
         // Only show error for empty inputValue if it is a required field
-        console.log('_validateTextInput 4', isRequired && !inputValue ? strings!.isRequiredErrorMessage || ' ' : '');
         this.setState({
           errorMessage: isRequired && !inputValue ? strings!.isRequiredErrorMessage || ' ' : ''
         });
@@ -500,7 +495,6 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
         onSelectDate(date);
       }
     } else if (isRequired && !inputValue) {
-      console.log('_validateTextInput 5', isRequired && !inputValue ? strings!.isRequiredErrorMessage || ' ' : '');
       // Check when DatePicker is a required field but has NO input value
       this.setState({
         errorMessage: strings!.isRequiredErrorMessage || ' '

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
@@ -12,6 +12,27 @@ import { Callout } from 'office-ui-fabric-react/lib/Callout';
 import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 
 describe('DatePicker', () => {
+  const DayPickerStrings: IDatePickerStrings = {
+    months: ['January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December'],
+
+    shortMonths: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+
+    days: ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'],
+
+    shortDays: ['S', 'M', 'T', 'W', 'T', 'F', 'S'],
+
+    goToToday: 'Go to today',
+    prevMonthAriaLabel: 'Go to previous month',
+    nextMonthAriaLabel: 'Go to next month',
+    prevYearAriaLabel: 'Go to previous year',
+    nextYearAriaLabel: 'Go to next year',
+    closeButtonAriaLabel: 'Close date picker',
+
+    isRequiredErrorMessage: 'Field is required.',
+
+    invalidInputErrorMessage: 'Invalid date format.'
+  };
+
   beforeEach(() => {
     resetIds();
   });
@@ -79,7 +100,7 @@ describe('DatePicker', () => {
     expect(wrapper.state('isDatePickerShown')).toBe(false);
   });
 
-  it('should call onSelectDate even when required input is empty when allowTextInput is true', () => {
+  xit('should call onSelectDate even when required input is empty when allowTextInput is true', () => {
     const onSelectDate = jest.fn();
     const datePicker = mount(<DatePickerBase isRequired={true} allowTextInput={true} onSelectDate={onSelectDate} />);
     const textField = datePicker.find('input');
@@ -90,6 +111,42 @@ describe('DatePicker', () => {
     textField.simulate('change', { target: { value: '' } }).simulate('blur');
 
     expect(onSelectDate).toHaveBeenCalledTimes(2);
+
+    datePicker.unmount();
+  });
+
+  it('should clear error message when required input has date text and allowTextInput is true', () => {
+    const datePicker = mount(<DatePickerBase isRequired={true} allowTextInput={true} strings={DayPickerStrings} />);
+    const textField = datePicker.find('input');
+
+    expect(textField).toBeDefined();
+    expect(datePicker.state('errorMessage')).toBeUndefined();
+    textField.simulate('click').simulate('click'); // open the datepicker then dismiss
+    expect(datePicker.state('errorMessage')).toBe(DayPickerStrings.isRequiredErrorMessage);
+    textField.simulate('change', { target: { value: 'Jan 1 2030' } }).simulate('blur');
+    expect(datePicker.state('errorMessage')).toBe('');
+
+    datePicker.unmount();
+  });
+
+  // datePicker.find('.ms-DatePicker')
+  it('should clear error message when required input has date selected from calendar and allowTextInput is true', () => {
+    const datePicker = mount(<DatePickerBase isRequired={true} allowTextInput={true} strings={DayPickerStrings} />);
+    const textField = datePicker.find('input');
+
+    expect(textField).toBeDefined();
+    expect(datePicker.state('errorMessage')).toBeUndefined();
+    textField.simulate('click').simulate('click'); // open the datepicker then dismiss
+    expect(datePicker.state('errorMessage')).toBe(DayPickerStrings.isRequiredErrorMessage);
+
+    // open calendar and select first day
+    textField.simulate('click');
+    datePicker
+      .find('.ms-DatePicker td')
+      .at(0)
+      .simulate('click');
+
+    expect(datePicker.state('errorMessage')).toBe('');
 
     datePicker.unmount();
   });

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
@@ -118,9 +118,9 @@ describe('DatePicker', () => {
   it('should clear error message when required input has date text and allowTextInput is true', () => {
     const datePicker = mount(<DatePickerBase isRequired={true} allowTextInput={true} strings={DayPickerStrings} />);
     const textField = datePicker.find('input');
-
     expect(textField).toBeDefined();
     expect(datePicker.state('errorMessage')).toBeUndefined();
+
     textField.simulate('click').simulate('click'); // open the datepicker then dismiss
     expect(datePicker.state('errorMessage')).toBe(DayPickerStrings.isRequiredErrorMessage);
     textField.simulate('change', { target: { value: 'Jan 1 2030' } }).simulate('blur');
@@ -132,18 +132,16 @@ describe('DatePicker', () => {
   it('should clear error message when required input has date selected from calendar and allowTextInput is true', () => {
     const datePicker = mount(<DatePickerBase isRequired={true} allowTextInput={true} strings={DayPickerStrings} />);
     const textField = datePicker.find('input');
-
     expect(textField).toBeDefined();
     expect(datePicker.state('errorMessage')).toBeUndefined();
+
     textField.simulate('click').simulate('click'); // open the datepicker then dismiss
     expect(datePicker.state('errorMessage')).toBe(DayPickerStrings.isRequiredErrorMessage);
 
     // open calendar and select first day
     textField.simulate('click');
-    datePicker
-      .find('.ms-DatePicker td')
-      .at(0)
-      .simulate('click');
+    const selectableDateInCalender = datePicker.find('.ms-DatePicker td button[data-is-focusable=true]').at(0);
+    selectableDateInCalender.simulate('click');
 
     expect(datePicker.state('errorMessage')).toBe('');
 

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
@@ -129,7 +129,6 @@ describe('DatePicker', () => {
     datePicker.unmount();
   });
 
-  // datePicker.find('.ms-DatePicker')
   it('should clear error message when required input has date selected from calendar and allowTextInput is true', () => {
     const datePicker = mount(<DatePickerBase isRequired={true} allowTextInput={true} strings={DayPickerStrings} />);
     const textField = datePicker.find('input');

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
@@ -100,7 +100,7 @@ describe('DatePicker', () => {
     expect(wrapper.state('isDatePickerShown')).toBe(false);
   });
 
-  xit('should call onSelectDate even when required input is empty when allowTextInput is true', () => {
+  it('should call onSelectDate even when required input is empty when allowTextInput is true', () => {
     const onSelectDate = jest.fn();
     const datePicker = mount(<DatePickerBase isRequired={true} allowTextInput={true} onSelectDate={onSelectDate} />);
     const textField = datePicker.find('input');

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Required.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Required.Example.tsx
@@ -57,6 +57,7 @@ export class DatePickerRequiredExample extends React.Component<{}, IDatePickerRe
           strings={DayPickerStrings}
           placeholder="Select a date..."
           ariaLabel="Select a date"
+          allowTextInput
         />
         <DatePicker
           className={controlClass.control}

--- a/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Required.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/examples/DatePicker.Required.Example.tsx
@@ -57,7 +57,6 @@ export class DatePickerRequiredExample extends React.Component<{}, IDatePickerRe
           strings={DayPickerStrings}
           placeholder="Select a date..."
           ariaLabel="Select a date"
-          allowTextInput
         />
         <DatePicker
           className={controlClass.control}


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #11700
- [X] Include a change request file using `$ yarn change`

#### Description of changes
The bug is with this line:
https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx#L449

If selected date matches the input text, we return and don't have a chance to clear the `errorMessage`.
I merged the 2 conditions below into 1 without any change inside the 2nd `if` statement.
```
if (inputValue) {
  if (this.state.selectedDate && formatDate && formatDate(this.state.selectedDate) === inputValue) {
```
and the `else` case will cover updating the `errorMessage`.

Added unit tests coverage.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11727)