### PR TITLE
Forward supportedPackages to TsxEditor

### DIFF
--- a/change/@uifabric-tsx-editor-2020-01-17-10-51-44-patch-1.json
+++ b/change/@uifabric-tsx-editor-2020-01-17-10-51-44-patch-1.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Forward supportedPackages from EditorWrapper to TsxEditor",
+  "packageName": "@uifabric/tsx-editor",
+  "email": "jimkyndemeyer@gmail.com",
+  "commit": "98ecc14cae342612339373063ce7d0ab078f20c0",
+  "date": "2020-01-17T09:51:44.775Z"
+}

--- a/packages/tsx-editor/src/components/EditorWrapper.tsx
+++ b/packages/tsx-editor/src/components/EditorWrapper.tsx
@@ -64,6 +64,7 @@ export const EditorWrapper: React.FunctionComponent<IEditorWrapperProps> = props
             <TsxEditorLazy
               editorProps={{ code, width, height, modelRef, ariaLabel: editorAriaLabel }}
               onTransformFinished={onTransformFinished}
+              supportedPackages={supportedPackages}
             />
           </React.Suspense>
         ) : (


### PR DESCRIPTION
#### Description of changes

`<EditorWrapper>` exposes a `supportedPackages` prop, but doesn't pass that along to the wrapped `<TsxEditor>`.

This PR forwards the missing prop to `<TsxEditor>` such that additional packages can be used in the editor.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11734)