### PR TITLE
Basepicker/Suggestions: Fix an issue where hasSuggestedAction would return true incorrectly

### DIFF
--- a/change/office-ui-fabric-react-2020-01-16-13-21-02-fix-suggestions-hasaction.json
+++ b/change/office-ui-fabric-react-2020-01-16-13-21-02-fix-suggestions-hasaction.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Basepicker/Suggestions: Fix an issue where hasSuggestedAction would return true incorrectly",
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com",
+  "commit": "e4793ce1f7232d25f6f3bdd8dd94890d3aa2f0d9",
+  "date": "2020-01-16T21:21:02.724Z"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.test.tsx
@@ -4,7 +4,7 @@ import * as renderer from 'react-test-renderer';
 import { styled } from '../../../Utilities';
 import { Suggestions } from './Suggestions';
 import { getStyles as suggestionsStyles } from './Suggestions.styles';
-import { ISuggestionModel, ISuggestionsProps, ISuggestionsStyleProps, ISuggestionsStyles } from './Suggestions.types';
+import { ISuggestionModel, ISuggestionsProps, ISuggestionsStyleProps, ISuggestionsStyles, ISuggestions } from './Suggestions.types';
 
 const suggestions = [
   'black',
@@ -88,5 +88,47 @@ describe('Suggestions', () => {
     );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
+  });
+
+  it('hasSuggestedAction is true when action provided', () => {
+    const compRef = React.createRef<ISuggestions<ISimple>>();
+    const StyledSuggestions = styled<ISuggestionsProps<ISimple>, ISuggestionsStyleProps, ISuggestionsStyles>(
+      Suggestions,
+      suggestionsStyles
+    );
+
+    renderer.create(
+      <StyledSuggestions
+        onRenderSuggestion={basicSuggestionRenderer}
+        onSuggestionClick={mockOnClick}
+        suggestions={generateSimpleSuggestions()}
+        searchForMoreText={'foo'}
+        moreSuggestionsAvailable={true}
+        componentRef={compRef}
+      />
+    );
+
+    expect(compRef.current).toBeTruthy();
+    expect(compRef.current!.hasSuggestedAction()).toEqual(true);
+  });
+
+  it('hasSuggestedAction is false when no action provided', () => {
+    const compRef = React.createRef<ISuggestions<ISimple>>();
+    const StyledSuggestions = styled<ISuggestionsProps<ISimple>, ISuggestionsStyleProps, ISuggestionsStyles>(
+      Suggestions,
+      suggestionsStyles
+    );
+
+    renderer.create(
+      <StyledSuggestions
+        onRenderSuggestion={basicSuggestionRenderer}
+        onSuggestionClick={mockOnClick}
+        suggestions={generateSimpleSuggestions()}
+        componentRef={compRef}
+      />
+    );
+
+    expect(compRef.current).toBeTruthy();
+    expect(compRef.current!.hasSuggestedAction()).toEqual(false);
   });
 });

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.tsx
@@ -251,7 +251,7 @@ export class Suggestions<T> extends BaseComponent<ISuggestionsProps<T>, ISuggest
   };
 
   public hasSuggestedAction(): boolean {
-    return this._searchForMoreButton.current !== undefined || this._forceResolveButton.current !== undefined;
+    return !!this._searchForMoreButton.current || !!this._forceResolveButton.current;
   }
 
   public hasSuggestedActionSelected(): boolean {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11696 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

I'm unsure when the refs underwent a change, but ref.current is now always either null or the component. That means that ref.current !== undefined will always be true. This fix now just checks to make sure that the component actually exists. 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11737)