### PR TITLE
User/v sivsar/minimun legend container height

### DIFF
--- a/change/@uifabric-charting-2020-01-22-14-51-54-user-v-sivsar-MinimunLegendContainerHeight.json
+++ b/change/@uifabric-charting-2020-01-22-14-51-54-user-v-sivsar-MinimunLegendContainerHeight.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "adding minimun legend container height",
+  "packageName": "@uifabric/charting",
+  "email": "v-sivsar@microsoft.com",
+  "commit": "8c0f660b6ed8df0a804cc0b4be7e5eea8c7b6c43",
+  "dependentChangeType": "patch",
+  "date": "2020-01-22T09:21:54.474Z"
+}

--- a/packages/charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/charting/src/components/LineChart/LineChart.base.tsx
@@ -44,6 +44,7 @@ export class LineChartBase extends React.Component<
   private legendContainer: HTMLDivElement;
   // These margins are necessary for d3Scales to appear without cutting off
   private margins = { top: 20, right: 20, bottom: 35, left: 40 };
+  private minLegendContainerHeight: number = 32;
   constructor(props: ILineChartProps) {
     super(props);
     this.state = {
@@ -154,7 +155,7 @@ export class LineChartBase extends React.Component<
     this._reqID = requestAnimationFrame(() => {
       const legendContainerComputedStyles = getComputedStyle(this.legendContainer);
       const legendContainerHeight =
-        this.legendContainer.getBoundingClientRect().height +
+        (this.legendContainer.getBoundingClientRect().height || this.minLegendContainerHeight) +
         parseFloat(legendContainerComputedStyles.marginTop || '0') +
         parseFloat(legendContainerComputedStyles.marginBottom || '0');
 


### PR DESCRIPTION


#### Description of changes

i am adding 32 pixel height to the `legendContainerHeight` when this `this.legendContainer.getBoundingClientRect().height` value evaluates to zero.

sometimes it happens that legends will not get painted to the dom, then the above code get's value `0` which in results will increase the height of the chart, when  legends get's painted to the dom then the x-axis values from the the chart are getting hidden .. see below screen shot
![image](https://user-images.githubusercontent.com/33802398/72881919-b05b1700-3d27-11ea-848e-e25492a27dcf.png)

to resolve the above issue i am adding 32 pixel height to the legendcontainer.

NOTE:- 32 is not a magical number. it is the height of the legend(16px) + margin-bottom(16px) of the legend.

**after fix**
![image](https://user-images.githubusercontent.com/33802398/72882203-36775d80-3d28-11ea-8b26-6e2b968d9894.png)


#### Focus areas to test

line chart


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11759)