### PR TITLE
Updates _onTextFieldChanged

### DIFF
--- a/change/@uifabric-date-time-2020-01-23-09-48-17-master.json
+++ b/change/@uifabric-date-time-2020-01-23-09-48-17-master.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Updates _onTextFieldChanged in date-time package",
+  "packageName": "@uifabric/date-time",
+  "email": "chce@netcompany.com",
+  "commit": "981f2259375f3a70e209d032bad4d79d0712261f",
+  "dependentChangeType": "patch",
+  "date": "2020-01-23T08:48:17.320Z"
+}

--- a/change/@uifabric-date-time-2020-01-23-09-48-17-master.json
+++ b/change/@uifabric-date-time-2020-01-23-09-48-17-master.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Updates _onTextFieldChanged in date-time package",
+  "comment": "Updating text field validation in date-time package to check new value rather than old one.",
   "packageName": "@uifabric/date-time",
   "email": "chce@netcompany.com",
   "commit": "981f2259375f3a70e209d032bad4d79d0712261f",

--- a/change/office-ui-fabric-react-2020-01-22-11-15-18-master.json
+++ b/change/office-ui-fabric-react-2020-01-22-11-15-18-master.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Updates textfield validation in Datepicker to validate text input rathundefineder than value",
+  "packageName": "office-ui-fabric-react",
+  "email": "chce@netcompany.com",
+  "commit": "7065b61c3f1df297a774d42672a21e89f8b88783",
+  "dependentChangeType": "patch",
+  "date": "2020-01-22T10:15:18.479Z"
+}

--- a/change/office-ui-fabric-react-2020-01-22-11-15-18-master.json
+++ b/change/office-ui-fabric-react-2020-01-22-11-15-18-master.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Updates textfield validation in Datepicker to validate text input rathundefineder than value",
+  "comment": "Updating text field validation in date-time package to check new value rather than old one.",
   "packageName": "office-ui-fabric-react",
   "email": "chce@netcompany.com",
   "commit": "7065b61c3f1df297a774d42672a21e89f8b88783",

--- a/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
@@ -330,10 +330,10 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
         this._dismissDatePickerPopup();
       }
 
-      const { isRequired, value, strings } = this.props;
+      const { isRequired, strings } = this.props;
 
       this.setState({
-        errorMessage: isRequired && !value ? strings!.isRequiredErrorMessage || ' ' : undefined,
+        errorMessage: isRequired && !newValue ? strings!.isRequiredErrorMessage || ' ' : undefined,
         formattedDate: newValue
       });
     }

--- a/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
@@ -330,10 +330,10 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
         this._dismissDatePickerPopup();
       }
 
-      const { isRequired, strings } = this.props;
+      const { isRequired, value, strings } = this.props;
 
       this.setState({
-        errorMessage: isRequired && !newValue ? strings!.isRequiredErrorMessage || ' ' : undefined,
+        errorMessage: isRequired && !value ? strings!.isRequiredErrorMessage || ' ' : undefined,
         formattedDate: newValue
       });
     }

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -333,10 +333,10 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
         this._dismissDatePickerPopup();
       }
 
-      const { isRequired, value, strings } = this.props;
+      const { isRequired, strings } = this.props;
 
       this.setState({
-        errorMessage: isRequired && !value ? strings!.isRequiredErrorMessage || ' ' : undefined,
+        errorMessage: isRequired && !newValue ? strings!.isRequiredErrorMessage || ' ' : undefined,
         formattedDate: newValue
       });
     }

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -333,10 +333,10 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
         this._dismissDatePickerPopup();
       }
 
-      const { isRequired, strings } = this.props;
+      const { isRequired, value, strings } = this.props;
 
       this.setState({
-        errorMessage: isRequired && !newValue ? strings!.isRequiredErrorMessage || ' ' : undefined,
+        errorMessage: isRequired && !value ? strings!.isRequiredErrorMessage || ' ' : undefined,
         formattedDate: newValue
       });
     }


### PR DESCRIPTION
Updates _onTextFieldChanged to validate the text that the user has entered, rather than the selected value.

#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11744
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Updates _onTextFieldChanged to validate the text that the user has entered, rather than the selected value.
Causes the text field to give a required error in the following cases:
_The text field blurs_ or _The user deletes the whole input, but doesn't blur_

#### Focus areas to test

This should only affect error messages when the user inputs text, so focus on textual input, and whether error messages show up correctly when allowTextInput={true}


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11760)