### PR TITLE
User/v sivsar/close tooltip on esc on donut chart

### DIFF
--- a/change/@uifabric-charting-2020-01-22-16-29-19-user-v-sivsar-CloseTooltipOnEscOnDonutChart.json
+++ b/change/@uifabric-charting-2020-01-22-16-29-19-user-v-sivsar-CloseTooltipOnEscOnDonutChart.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "closing callout on pressing esc key",
+  "packageName": "@uifabric/charting",
+  "email": "v-sivsar@microsoft.com",
+  "commit": "ebf2aaa92353d0f95f735bcdfa63161fa968b605",
+  "dependentChangeType": "patch",
+  "date": "2020-01-22T10:59:19.753Z"
+}

--- a/packages/charting/src/components/DonutChart/DonutChart.base.tsx
+++ b/packages/charting/src/components/DonutChart/DonutChart.base.tsx
@@ -113,6 +113,7 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
             isBeakVisible={false}
             directionalHint={DirectionalHint.bottomRightEdge}
             gapSpace={5}
+            onDismiss={this._closeCallout}
           >
             <div className={this._classNames.hoverCardRoot}>
               <div className={this._classNames.hoverCardTextStyles}>{this.state.legend}</div>
@@ -124,6 +125,12 @@ export class DonutChartBase extends React.Component<IDonutChartProps, IDonutChar
       </div>
     );
   }
+
+  private _closeCallout = () => {
+    this.setState({
+      showHover: false
+    });
+  };
 
   private _setViewBox(node: SVGElement | null): void {
     if (node === null) {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #11699 

#### Description of changes

adding onDismiss function to the `callout` so that when the user presses the ESC key we can execute this function and can close the tooltip / callout

#### Focus areas to test

donut Chart


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11761)