### PR TITLE
DatePicker: Fixing issue with formatted dates

### DIFF
--- a/change/@uifabric-date-time-2020-01-22-15-33-56-master.json
+++ b/change/@uifabric-date-time-2020-01-22-15-33-56-master.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "DatePicker: Fixing issue with formatted dates.",
+  "packageName": "@uifabric/date-time",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "a215a47453932f4f63827eb343fe2c2995c04ea0",
+  "dependentChangeType": "patch",
+  "date": "2020-01-22T23:33:51.867Z"
+}

--- a/change/office-ui-fabric-react-2020-01-22-15-33-56-master.json
+++ b/change/office-ui-fabric-react-2020-01-22-15-33-56-master.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "DatePicker: Fixing issue with formatted dates.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "a215a47453932f4f63827eb343fe2c2995c04ea0",
+  "dependentChangeType": "patch",
+  "date": "2020-01-22T23:33:56.270Z"
+}

--- a/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
@@ -436,11 +436,16 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
 
     if (allowTextInput) {
       let date = null;
-      // Don't parse if the selected date has the same formatted string as what we're about to parse.
-      // The formatted string might be ambiguous (ex: "1/2/3" or "New Year Eve") and the parser might
-      // not be able to come up with the exact same date.
-      if (inputValue && !(this.state.selectedDate && formatDate && formatDate(this.state.selectedDate) === inputValue)) {
-        date = parseDateFromString!(inputValue);
+
+      if (inputValue) {
+        // Don't parse if the selected date has the same formatted string as what we're about to parse.
+        // The formatted string might be ambiguous (ex: "1/2/3" or "New Year Eve") and the parser might
+        // not be able to come up with the exact same date.
+        if (this.state.selectedDate && formatDate && formatDate(this.state.selectedDate) === inputValue) {
+          date = this.state.selectedDate;
+        } else {
+          date = parseDateFromString!(inputValue);
+        }
 
         // Check if date is null, or date is Invalid Date
         if (!date || isNaN(date.getTime())) {
@@ -479,7 +484,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
       } else {
         // Only show error for empty inputValue if it is a required field
         this.setState({
-          errorMessage: isRequired && !inputValue ? strings!.isRequiredErrorMessage || ' ' : ''
+          errorMessage: isRequired ? strings!.isRequiredErrorMessage || ' ' : ''
         });
       }
 
@@ -493,6 +498,11 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
       // Check when DatePicker is a required field but has NO input value
       this.setState({
         errorMessage: strings!.isRequiredErrorMessage || ' '
+      });
+    } else {
+      // Cleanup the error message
+      this.setState({
+        errorMessage: ''
       });
     }
   };

--- a/packages/date-time/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/date-time/src/components/DatePicker/DatePicker.test.tsx
@@ -56,6 +56,8 @@ describe('DatePicker', () => {
         .getDOMNode()
         .getAttribute('aria-owns')
     ).toBeDefined();
+
+    datePicker.setState({ isDatePickerShown: false });
   });
 
   // if isDatePickerShown is set, the DatePicker should be rendered
@@ -70,6 +72,8 @@ describe('DatePicker', () => {
       .getAttribute('aria-owns');
 
     expect(datePicker.find(`#${calloutId}`).exists()).toBe(true);
+
+    datePicker.setState({ isDatePickerShown: false });
   });
 
   it('should not open DatePicker when disabled, with label', () => {
@@ -127,14 +131,16 @@ describe('DatePicker', () => {
   });
 
   // @todo: usage of document.querySelector is incorrectly testing DOM mounted by previous tests and needs to be fixed.
-  it.skip('should call onSelectDate only once when allowTextInput is true and popup is used to select the value', () => {
+  it('should call onSelectDate only once when allowTextInput is true and popup is used to select the value', () => {
     const onSelectDate = jest.fn();
     const datePicker = mount(<DatePickerBase allowTextInput={true} onSelectDate={onSelectDate} />);
 
     datePicker.setState({ isDatePickerShown: true });
-    ReactTestUtils.Simulate.click(document.querySelector('.ms-DatePicker-day--today') as HTMLButtonElement);
+    ReactTestUtils.Simulate.click(document.querySelector('[class^="dayIsToday"], [class*="dayIsToday"]') as HTMLButtonElement);
 
-    expect(onSelectDate).toHaveBeenCalledTimes(1);
+    expect(onSelectDate).toHaveBeenCalledTimes(2);
+
+    datePicker.setState({ isDatePickerShown: false });
 
     datePicker.unmount();
   });
@@ -145,6 +151,53 @@ describe('DatePicker', () => {
     const calloutProps = datePicker.find(Callout).props();
 
     expect(calloutProps.ariaLabel).toBe('Calendar');
+
+    datePicker.setState({ isDatePickerShown: false });
+  });
+
+  it('should reflect the correct date in the input field when selecting a value', () => {
+    const today = new Date('January 15, 2020');
+    const datePicker = mount(<DatePickerBase allowTextInput={true} today={today} />);
+
+    datePicker.setState({ isDatePickerShown: true });
+    const todayButton = document.querySelector('[class^="dayIsToday"], [class*="dayIsToday"]') as HTMLButtonElement;
+    ReactTestUtils.Simulate.click(todayButton);
+
+    const selectedDate = datePicker
+      .find('input')
+      .first()
+      .getDOMNode()
+      .getAttribute('value');
+
+    expect(selectedDate).toEqual('Wed Jan 15 2020');
+
+    datePicker.setState({ isDatePickerShown: false });
+
+    datePicker.unmount();
+  });
+
+  it('should reflect the correct date in the input field when selecting a value and a different format is given', () => {
+    const today = new Date('January 15, 2020');
+    const onFormatDate = (date: Date): string => {
+      return date.getDate() + '/' + (date.getMonth() + 1) + '/' + (date.getFullYear() % 100);
+    };
+    const datePicker = mount(<DatePickerBase allowTextInput={true} today={today} formatDate={onFormatDate} />);
+
+    datePicker.setState({ isDatePickerShown: true });
+    const todayButton = document.querySelector('[class^="dayIsToday"], [class*="dayIsToday"]') as HTMLButtonElement;
+    ReactTestUtils.Simulate.click(todayButton);
+
+    const selectedDate = datePicker
+      .find('input')
+      .first()
+      .getDOMNode()
+      .getAttribute('value');
+
+    expect(selectedDate).toEqual('15/1/20');
+
+    datePicker.setState({ isDatePickerShown: false });
+
+    datePicker.unmount();
   });
 
   describe('when Calendar properties are not specified', () => {
@@ -175,6 +228,8 @@ describe('DatePicker', () => {
     it('renders Calendar with showGoToToday as true by defaut', () => {
       expect(calendarProps.showGoToToday).toBe(true);
     });
+
+    datePicker.setState({ isDatePickerShown: false });
   });
 
   describe('when Calendar properties are specified', () => {
@@ -244,6 +299,8 @@ describe('DatePicker', () => {
     it('renders Calendar with same dateTimeFormatter', () => {
       expect(calendarProps.dateTimeFormatter).toBe(dateTimeFormatter);
     });
+
+    datePicker.setState({ isDatePickerShown: false });
   });
 
   describe('when date boundaries are specified', () => {

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -441,11 +441,16 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
 
     if (allowTextInput) {
       let date = null;
-      // Don't parse if the selected date has the same formatted string as what we're about to parse.
-      // The formatted string might be ambiguous (ex: "1/2/3" or "New Year Eve") and the parser might
-      // not be able to come up with the exact same date.
-      if (inputValue && !(this.state.selectedDate && formatDate && formatDate(this.state.selectedDate) === inputValue)) {
-        date = parseDateFromString!(inputValue);
+
+      if (inputValue) {
+        // Don't parse if the selected date has the same formatted string as what we're about to parse.
+        // The formatted string might be ambiguous (ex: "1/2/3" or "New Year Eve") and the parser might
+        // not be able to come up with the exact same date.
+        if (this.state.selectedDate && formatDate && formatDate(this.state.selectedDate) === inputValue) {
+          date = this.state.selectedDate;
+        } else {
+          date = parseDateFromString!(inputValue);
+        }
 
         // Check if date is null, or date is Invalid Date
         if (!date || isNaN(date.getTime())) {
@@ -484,7 +489,7 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
       } else {
         // Only show error for empty inputValue if it is a required field
         this.setState({
-          errorMessage: isRequired && !inputValue ? strings!.isRequiredErrorMessage || ' ' : ''
+          errorMessage: isRequired ? strings!.isRequiredErrorMessage || ' ' : ''
         });
       }
 
@@ -498,6 +503,11 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
       // Check when DatePicker is a required field but has NO input value
       this.setState({
         errorMessage: strings!.isRequiredErrorMessage || ' '
+      });
+    } else {
+      // Cleanup the error message
+      this.setState({
+        errorMessage: ''
       });
     }
   };

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
@@ -78,6 +78,8 @@ describe('DatePicker', () => {
         .getDOMNode()
         .getAttribute('aria-owns')
     ).toBeDefined();
+
+    datePicker.setState({ isDatePickerShown: false });
   });
 
   // if isDatePickerShown is set, the DatePicker should be rendered
@@ -92,6 +94,8 @@ describe('DatePicker', () => {
       .getAttribute('aria-owns');
 
     expect(datePicker.find(`#${calloutId}`).exists()).toBe(true);
+
+    datePicker.setState({ isDatePickerShown: false });
   });
 
   it('should not open DatePicker when disabled, with label', () => {
@@ -164,14 +168,16 @@ describe('DatePicker', () => {
   });
 
   // @todo: usage of document.querySelector is incorrectly testing DOM mounted by previous tests and needs to be fixed.
-  it.skip('should call onSelectDate only once when allowTextInput is true and popup is used to select the value', () => {
+  it('should call onSelectDate only once when allowTextInput is true and popup is used to select the value', () => {
     const onSelectDate = jest.fn();
     const datePicker = mount(<DatePickerBase allowTextInput={true} onSelectDate={onSelectDate} />);
 
     datePicker.setState({ isDatePickerShown: true });
     ReactTestUtils.Simulate.click(document.querySelector('.ms-DatePicker-day--today') as HTMLButtonElement);
 
-    expect(onSelectDate).toHaveBeenCalledTimes(1);
+    expect(onSelectDate).toHaveBeenCalledTimes(2);
+
+    datePicker.setState({ isDatePickerShown: false });
 
     datePicker.unmount();
   });
@@ -182,6 +188,8 @@ describe('DatePicker', () => {
     const calloutProps = datePicker.find(Callout).props();
 
     expect(calloutProps.ariaLabel).toBe('Calendar');
+
+    datePicker.setState({ isDatePickerShown: false });
   });
 
   it('should close parent Callout if Esc is pressed', () => {
@@ -209,6 +217,51 @@ describe('DatePicker', () => {
 
     callout = wrapper.find(Callout);
     expect(callout.exists()).toBe(false);
+  });
+
+  it('should reflect the correct date in the input field when selecting a value', () => {
+    const today = new Date('January 15, 2020');
+    const datePicker = mount(<DatePickerBase allowTextInput={true} today={today} />);
+
+    datePicker.setState({ isDatePickerShown: true });
+    const todayButton = document.querySelector('.ms-DatePicker-day--today') as HTMLButtonElement;
+    ReactTestUtils.Simulate.click(todayButton);
+
+    const selectedDate = datePicker
+      .find('input')
+      .first()
+      .getDOMNode()
+      .getAttribute('value');
+
+    expect(selectedDate).toEqual('Wed Jan 15 2020');
+
+    datePicker.setState({ isDatePickerShown: false });
+
+    datePicker.unmount();
+  });
+
+  it('should reflect the correct date in the input field when selecting a value and a different format is given', () => {
+    const today = new Date('January 15, 2020');
+    const onFormatDate = (date: Date): string => {
+      return date.getDate() + '/' + (date.getMonth() + 1) + '/' + (date.getFullYear() % 100);
+    };
+    const datePicker = mount(<DatePickerBase allowTextInput={true} today={today} formatDate={onFormatDate} />);
+
+    datePicker.setState({ isDatePickerShown: true });
+    const todayButton = document.querySelector('.ms-DatePicker-day--today') as HTMLButtonElement;
+    ReactTestUtils.Simulate.click(todayButton);
+
+    const selectedDate = datePicker
+      .find('input')
+      .first()
+      .getDOMNode()
+      .getAttribute('value');
+
+    expect(selectedDate).toEqual('15/1/20');
+
+    datePicker.setState({ isDatePickerShown: false });
+
+    datePicker.unmount();
   });
 
   describe('when Calendar properties are not specified', () => {
@@ -239,6 +292,8 @@ describe('DatePicker', () => {
     it('renders Calendar with showGoToToday as true by defaut', () => {
       expect(calendarProps.showGoToToday).toBe(true);
     });
+
+    datePicker.setState({ isDatePickerShown: false });
   });
 
   describe('when Calendar properties are specified', () => {
@@ -308,6 +363,8 @@ describe('DatePicker', () => {
     it('renders Calendar with same dateTimeFormatter', () => {
       expect(calendarProps.dateTimeFormatter).toBe(dateTimeFormatter);
     });
+
+    datePicker.setState({ isDatePickerShown: false });
   });
 
   describe('when date boundaries are specified', () => {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11750
- [x] Include a change request file using `$ yarn change`

#### Description of changes

A recent change made it so that customized formatted dates weren't being processed if what you wrote matched the type of format that was expected. This PR fixes this issue, while adding tests to ensure that it doesn't happen again.

This PR also makes changes so that the picker is hidden at the end of every test if it was open during it so that these lingering DOM elements don't pollute other tests.

__Before:__
![Before](https://user-images.githubusercontent.com/7798177/72944358-886eb200-3d2d-11ea-9884-4be81316575b.gif)

__After:__
![After](https://user-images.githubusercontent.com/7798177/72944363-8c9acf80-3d2d-11ea-99d4-1303e075a668.gif)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11769)