### PR TITLE
Fix export to codepen

### DIFF
--- a/change/@uifabric-example-app-base-2020-01-22-21-30-16-xgao-code-pen.json
+++ b/change/@uifabric-example-app-base-2020-01-22-21-30-16-xgao-code-pen.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix export to codepen for fabric 7 (#9450)",
+  "packageName": "@uifabric/example-app-base",
+  "email": "xgao@microsoft.com",
+  "commit": "d9e7b876c4f8e9fa506a2f8e03af880e9dfc4d24",
+  "date": "2020-01-23T05:30:09.904Z"
+}

--- a/change/@uifabric-tsx-editor-2020-01-22-21-30-16-xgao-code-pen.json
+++ b/change/@uifabric-tsx-editor-2020-01-22-21-30-16-xgao-code-pen.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix export to codepen for fabric 7 (#9450)",
+  "packageName": "@uifabric/tsx-editor",
+  "email": "xgao@microsoft.com",
+  "commit": "d9e7b876c4f8e9fa506a2f8e03af880e9dfc4d24",
+  "date": "2020-01-23T05:30:16.858Z"
+}

--- a/packages/example-app-base/src/components/CodepenComponent/CodepenComponent.tsx
+++ b/packages/example-app-base/src/components/CodepenComponent/CodepenComponent.tsx
@@ -20,6 +20,7 @@ interface ICodepenPrefill {
   head: string;
   js: string;
   js_pre_processor: string;
+  css: string;
   css_pre_processor: string;
   // and other options--see https://blog.codepen.io/documentation/api/prefill/
 }
@@ -56,6 +57,7 @@ const CodepenComponentBase: React.FunctionComponent<ICodepenProps> = props => {
       head: headContent,
       js: jsContentStr,
       js_pre_processor: 'typescript',
+      css: '',
       css_pre_processor: 'scss'
     };
 

--- a/packages/tsx-editor/src/transpiler/__snapshots__/exampleTransform.test.ts.snap
+++ b/packages/tsx-editor/src/transpiler/__snapshots__/exampleTransform.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`example transform can return component 1`] = `
 Object {
   "output": "(function(React) {
-const { Label, Fabric, initializeIcons } = window.Fabric;
+const { Label, Fabric: FabricComponent, initializeIcons } = window.Fabric;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -16,7 +16,7 @@ const LabelBasicExample = () => {
   );
 };
 
-const LabelBasicExampleWrapper = () => React.createElement(Fabric, null, React.createElement(LabelBasicExample, null));
+const LabelBasicExampleWrapper = () => React.createElement(FabricComponent, null, React.createElement(LabelBasicExample, null));
 return LabelBasicExampleWrapper;
 })",
 }
@@ -25,7 +25,7 @@ return LabelBasicExampleWrapper;
 exports[`example transform can return component with transpiled example 1`] = `
 Object {
   "output": "(function(React) {
-const { Label, Fabric, initializeIcons } = window.Fabric;
+const { Label, Fabric: FabricComponent, initializeIcons } = window.Fabric;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -35,7 +35,7 @@ var LabelBasicExample = function () {
         React.createElement(Label, null, \\"I'm a Label\\")));
 };
 
-const LabelBasicExampleWrapper = () => React.createElement(Fabric, null, React.createElement(LabelBasicExample, null));
+const LabelBasicExampleWrapper = () => React.createElement(FabricComponent, null, React.createElement(LabelBasicExample, null));
 return LabelBasicExampleWrapper;
 })",
 }
@@ -43,7 +43,7 @@ return LabelBasicExampleWrapper;
 
 exports[`example transform handles examples with class components 1`] = `
 Object {
-  "output": "const { SpinButton, Fabric, initializeIcons } = window.Fabric;
+  "output": "const { SpinButton, Fabric: FabricComponent, initializeIcons } = window.Fabric;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -67,7 +67,7 @@ class SpinButtonBasicExample extends React.Component<any, any> {
   }
 }
 
-const SpinButtonBasicExampleWrapper = () => <Fabric><SpinButtonBasicExample /></Fabric>;
+const SpinButtonBasicExampleWrapper = () => <FabricComponent><SpinButtonBasicExample /></FabricComponent>;
 ReactDOM.render(<SpinButtonBasicExampleWrapper />, document.getElementById('fake'))",
 }
 `;
@@ -89,7 +89,7 @@ ReactDOM.render(<FooExample />, document.getElementById('fake'))",
 
 exports[`example transform handles examples with custom supportedPackages and Fabric 1`] = `
 Object {
-  "output": "const { Stack, Fabric, initializeIcons } = window.Fabric;
+  "output": "const { Stack, Fabric: FabricComponent, initializeIcons } = window.Fabric;
 const { FooLabel } = window.Foo;
 
 // Initialize icons in case this example uses them
@@ -103,14 +103,14 @@ const FooExample = () => {
   );
 };
 
-const FooExampleWrapper = () => <Fabric><FooExample /></Fabric>;
+const FooExampleWrapper = () => <FabricComponent><FooExample /></FabricComponent>;
 ReactDOM.render(<FooExampleWrapper />, document.getElementById('fake'))",
 }
 `;
 
 exports[`example transform handles examples with function components 1`] = `
 Object {
-  "output": "const { Label, Fabric, initializeIcons } = window.Fabric;
+  "output": "const { Label, Fabric: FabricComponent, initializeIcons } = window.Fabric;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -123,14 +123,14 @@ const LabelBasicExample = () => {
   );
 };
 
-const LabelBasicExampleWrapper = () => <Fabric><LabelBasicExample /></Fabric>;
+const LabelBasicExampleWrapper = () => <FabricComponent><LabelBasicExample /></FabricComponent>;
 ReactDOM.render(<LabelBasicExampleWrapper />, document.getElementById('fake'))",
 }
 `;
 
 exports[`example transform handles transpiled examples with class components 1`] = `
 Object {
-  "output": "const { SpinButton, Fabric, initializeIcons } = window.Fabric;
+  "output": "const { SpinButton, Fabric: FabricComponent, initializeIcons } = window.Fabric;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -163,14 +163,14 @@ var SpinButtonBasicExample = /** @class */ (function (_super) {
 }(React.Component));
 { SpinButtonBasicExample };
 
-const SpinButtonBasicExampleWrapper = () => <Fabric><SpinButtonBasicExample /></Fabric>;
+const SpinButtonBasicExampleWrapper = () => <FabricComponent><SpinButtonBasicExample /></FabricComponent>;
 ReactDOM.render(<SpinButtonBasicExampleWrapper />, document.getElementById('fake'))",
 }
 `;
 
 exports[`example transform handles transpiled examples with function components 1`] = `
 Object {
-  "output": "const { Label, Fabric, initializeIcons } = window.Fabric;
+  "output": "const { Label, Fabric: FabricComponent, initializeIcons } = window.Fabric;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -180,7 +180,7 @@ var LabelBasicExample = function () {
         React.createElement(Label, null, \\"I'm a Label\\")));
 };
 
-const LabelBasicExampleWrapper = () => <Fabric><LabelBasicExample /></Fabric>;
+const LabelBasicExampleWrapper = () => <FabricComponent><LabelBasicExample /></FabricComponent>;
 ReactDOM.render(<LabelBasicExampleWrapper />, document.getElementById('fake'))",
 }
 `;

--- a/packages/tsx-editor/src/transpiler/exampleTransform.ts
+++ b/packages/tsx-editor/src/transpiler/exampleTransform.ts
@@ -39,9 +39,9 @@ export interface ITransformExampleParams {
 }
 
 const win = getWindow() as
-  | Window & {
+  | (Window & {
       transformLogging?: boolean;
-    }
+    })
   | undefined;
 
 /**
@@ -91,14 +91,17 @@ export function transformExample(params: ITransformExampleParams): ITransformedC
     // and initialize icons in case the example uses them.
     finalComponent = component + 'Wrapper';
 
+    // rename to avoid conflict with window.Fabric
+    const renamedFabricComponent = 'FabricComponent';
+
     // If eval-ing the code, the component can't use JSX format
     const wrapperCode = returnFunction
-      ? `React.createElement(Fabric, null, React.createElement(${component}, null))`
-      : `<Fabric><${component} /></Fabric>`;
+      ? `React.createElement(${renamedFabricComponent}, null, React.createElement(${component}, null))`
+      : `<${renamedFabricComponent}><${component} /></${renamedFabricComponent}>`;
     lines.push('', `const ${finalComponent} = () => ${wrapperCode};`);
 
     if (identifiersByGlobal.Fabric.indexOf('Fabric') === -1) {
-      identifiersByGlobal.Fabric.push('Fabric');
+      identifiersByGlobal.Fabric.push(`Fabric: ${renamedFabricComponent}`);
     }
 
     if (identifiersByGlobal.Fabric.indexOf('initializeIcons') === -1) {


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #11756
- [X] Include a change request file using `$ yarn change`

#### Description of changes
Some change happened on codepen side and caused the following issues:
1. Export to CodePen gives empty JS 
2. JS error `pen.js:1 Uncaught SyntaxError: Identifier 'Fabric' has already been declared`. see https://codepen.io/xugao/pen/gObqWBZ
3. JS error `pen.js:3 Uncaught TypeError: Cannot destructure property 'TextField' of 'window.Fabric' as it is undefined.` on first opening the pen by "Export to CodePen", but the error goes away once pen is saved.

My changes only fix issue 1 & 2. But not issue 3, which I believe is a bug on codepen side and there is nothing I can do



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11771)