### PR TITLE
Use aria-current for active nav links

### DIFF
--- a/change/office-ui-fabric-react-2020-01-24-14-44-48-nav-link-current.json
+++ b/change/office-ui-fabric-react-2020-01-24-14-44-48-nav-link-current.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Updates the Nav component's links to use aria-current",
+  "packageName": "office-ui-fabric-react",
+  "email": "sarah.higley@microsoft.com",
+  "commit": "e3f3b9a6d0705feeade76041a1f8a183a9f16d00",
+  "dependentChangeType": "patch",
+  "date": "2020-01-24T14:44:48.969Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -5592,6 +5592,7 @@ export interface INavButtonProps extends IButtonProps {
 // @public (undocumented)
 export interface INavLink {
     [propertyName: string]: any;
+    ariaCurrent?: 'page' | 'step' | 'location' | 'date' | 'time' | 'true';
     ariaLabel?: string;
     automationId?: string;
     collapseAriaLabel?: string;
@@ -5639,6 +5640,7 @@ export interface INavProps {
     onLinkExpandClick?: (ev?: React.MouseEvent<HTMLElement>, item?: INavLink) => void;
     onRenderGroupHeader?: IRenderFunction<INavLinkGroup>;
     onRenderLink?: IRenderFunction<INavLink>;
+    // @deprecated
     selectedAriaLabel?: string;
     selectedKey?: string;
     styles?: IStyleFunctionOrObject<INavStyleProps, INavStyles>;

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -92,6 +92,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
     const { styles, groups, theme } = this.props;
     const isLinkWithIcon = link.icon || link.iconProps;
     const isSelectedLink = this._isLinkSelected(link);
+    const { ariaCurrent = 'page' } = link;
     const classNames = getClassNames(styles!, {
       theme: theme!,
       isSelected: isSelectedLink,
@@ -118,7 +119,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
         target={link.target}
         rel={rel}
         disabled={link.disabled}
-        aria-current={isSelectedLink ? 'page' : undefined}
+        aria-current={isSelectedLink ? ariaCurrent : undefined}
         aria-label={link.ariaLabel ? link.ariaLabel : undefined}
         link={link}
       >

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -89,7 +89,7 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
   };
 
   private _renderNavLink(link: INavLink, linkIndex: number, nestingLevel: number): JSX.Element {
-    const { styles, groups, theme, selectedAriaLabel } = this.props;
+    const { styles, groups, theme } = this.props;
     const isLinkWithIcon = link.icon || link.iconProps;
     const isSelectedLink = this._isLinkSelected(link);
     const classNames = getClassNames(styles!, {
@@ -103,7 +103,6 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
 
     // Prevent hijacking of the parent window if link.target is defined
     const rel = link.url && link.target && !isRelativeUrl(link.url) ? 'noopener noreferrer' : undefined;
-    const selectedStateAriaLabel = isSelectedLink && selectedAriaLabel ? selectedAriaLabel : undefined;
 
     const LinkAs = this.props.linkAs ? composeComponentAs(this.props.linkAs, ActionButton) : ActionButton;
     const onRenderLink = this.props.onRenderLink ? composeRenderFunction(this.props.onRenderLink, this._onRenderLink) : this._onRenderLink;
@@ -119,15 +118,8 @@ export class NavBase extends React.Component<INavProps, INavState> implements IN
         target={link.target}
         rel={rel}
         disabled={link.disabled}
-        aria-label={
-          link.ariaLabel && selectedStateAriaLabel
-            ? `${link.ariaLabel} ${selectedStateAriaLabel}`
-            : selectedStateAriaLabel
-            ? selectedStateAriaLabel
-            : link.ariaLabel
-            ? link.ariaLabel
-            : undefined
-        }
+        aria-current={isSelectedLink ? 'page' : undefined}
+        aria-label={link.ariaLabel ? link.ariaLabel : undefined}
         link={link}
       >
         {onRenderLink(link)}

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.types.ts
@@ -111,7 +111,8 @@ export interface INavProps {
    */
   expandButtonAriaLabel?: string;
   /**
-   * (Optional) The nav link selected state aria label.
+   * (Deprecated) Use ariaCurrent on links instead
+   * @deprecated Use ariaCurrent on links instead
    */
   selectedAriaLabel?: string;
 }
@@ -217,6 +218,11 @@ export interface INavLink {
    * Whether or not the link is in an expanded state
    */
   isExpanded?: boolean;
+
+  /**
+   * Aria-current token for active nav links. Must be a valid token value, and defaults to 'page'.
+   */
+  ariaCurrent?: 'page' | 'step' | 'location' | 'date' | 'time' | 'true';
 
   /**
    * Aria label for nav link. Ignored if `collapseAriaLabel` or `expandAriaLabel` is provided.

--- a/packages/office-ui-fabric-react/src/components/Nav/examples/Nav.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/examples/Nav.Basic.Example.tsx
@@ -6,7 +6,6 @@ export const NavBasicExample: React.FunctionComponent = () => {
     <Nav
       onLinkClick={_onLinkClick}
       selectedKey="key3"
-      selectedAriaLabel="Selected"
       ariaLabel="Nav basic example"
       styles={{
         root: {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
@@ -639,7 +639,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
               name="Documents"
             >
               <a
-                aria-label="Selected"
+                aria-current="page"
                 className=
                     ms-Button
                     ms-Button--action


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11788
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add `aria-current="page"` to active links, and remove logic that modifies the accessible name of selected links.

#### Choosing "page"
Though `aria-current` takes multiple token values, the only two that could potentially be used with the Nav component are `page` and `step`. The overwhelming majority of Nav component use cases will likely fit best with "page", and even for the minority where "step" may be a good choice, the use of "step" over "page" would be a relatively minor augment. It's hard to imagine a use of the Nav component where `aria-current="page"` would be entirely inappropriate.

#### Removing `selectedAriaLabel` behavior

The current `selectedAriaLabel` property has two possible behaviors: it replaces the accessible name of links without an `ariaLabel` property, or it appends text to the label of links with an `ariaLabel` property.

The first behavior is a serious bug, and the second is not broken, but is less than ideal. Using an ARIA state attribute instead of a modified accessible name has the benefits of creating a more uniform, accessible experience across the web, and keeps the visible name matching the programmatic name.

This PR removes the `aria-label` logic associated with `selectedAriaLabel`, but keeps the property in the Nav API for backward compat (though I'd be happy to remove it entirely if desired).

___

Thanks for looking at this, and please let me know if I've missed anything 😊

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11789)