### PR TITLE
GroupedList: Add ability to pass role to groupProps

### DIFF
--- a/change/office-ui-fabric-react-2020-01-24-10-54-34-GroupedList-role.json
+++ b/change/office-ui-fabric-react-2020-01-24-10-54-34-GroupedList-role.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "GroupedList: Add role prop to groupProps",
+  "packageName": "office-ui-fabric-react",
+  "email": "erabelle@microsoft.com",
+  "commit": "c457462537a257458d2df6571f70e743974036e2",
+  "date": "2020-01-24T18:54:34.656Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -4882,6 +4882,7 @@ export interface IGroupRenderProps {
     onRenderHeader?: IRenderFunction<IGroupHeaderProps>;
     onRenderShowAll?: IRenderFunction<IGroupShowAllProps>;
     onToggleCollapseAll?: (isAllCollapsed: boolean) => void;
+    role?: string;
     showAllProps?: IGroupShowAllProps;
     showEmptyGroups?: boolean;
 }

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.types.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedList.types.ts
@@ -239,6 +239,11 @@ export interface IGroupRenderProps {
    * @defaultvalue false
    */
   showEmptyGroups?: boolean;
+
+  /**
+   * Override which allows the caller to provide a custom aria role
+   */
+  role?: string;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
@@ -308,13 +308,13 @@ export class GroupedListSection extends React.Component<IGroupedListSectionProps
   }
 
   private _onRenderGroup(renderCount: number): JSX.Element {
-    const { group, items, onRenderCell, listProps, groupNestingDepth, onShouldVirtualize } = this.props;
+    const { group, items, onRenderCell, listProps, groupNestingDepth, onShouldVirtualize, groupProps } = this.props;
     const count = group && !group.isShowingAll ? group.count : items.length;
     const startIndex = group ? group.startIndex : 0;
 
     return (
       <List
-        role="grid"
+        role={groupProps && groupProps.role ? groupProps.role : 'grid'}
         items={items}
         onRenderCell={this._onRenderGroupCell(onRenderCell, groupNestingDepth)}
         ref={this._list}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Add ability to pass `role` to `groupProps` for GroupedList to override the default role of `grid` for grouped list sections. Role `grid` remains the default with this change.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11791)