### PR TITLE
Nav: Fixing regular expression used to determine if URL is protocol relative or not.

### DIFF
--- a/change/office-ui-fabric-react-2020-01-24-11-45-34-navRelLink.json
+++ b/change/office-ui-fabric-react-2020-01-24-11-45-34-navRelLink.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Nav: Fixing regular expression used to determine if URL is protocol relative or not.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "eadbfa6f02f782e8252c37dfe577d4000ff741dd",
+  "dependentChangeType": "patch",
+  "date": "2020-01-24T19:45:33.986Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.base.tsx
@@ -18,7 +18,7 @@ let _urlResolver: HTMLAnchorElement | undefined;
 
 export function isRelativeUrl(url: string): boolean {
   // A URL is relative if it has no protocol.
-  return !!url && !/^[a-z0-9+-.]:\/\//i.test(url);
+  return !!url && !/^[a-z0-9+-.]+:\/\//i.test(url);
 }
 
 const getClassNames = classNamesFunction<INavStyleProps, INavStyles>();

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.test.tsx
@@ -129,4 +129,40 @@ describe('Nav', () => {
     expect(nav.getDOMNode().querySelectorAll('.ms-Nav-compositeLink.is-selected').length).toBe(1);
     expect(nav.getDOMNode().querySelectorAll('.ms-Nav-compositeLink.is-selected')[0].textContent).toEqual(linkOne.name);
   });
+
+  it('places the correct values on rel depending on the url and target specified', () => {
+    const linkWithNoTargetSpecified: INavLink = {
+      key: 'Link1',
+      name: 'Link1',
+      url: 'https://cdpn.io/bar'
+    };
+    const linkWithRelativeURL: INavLink = {
+      key: 'Link2',
+      name: 'Link2',
+      target: '_blank',
+      url: '/foo'
+    };
+    const linkWithNonRelativeURL: INavLink = {
+      key: 'Link3',
+      name: 'Link3',
+      target: '_blank',
+      url: 'https://cdpn.io/bar'
+    };
+    const linkWithNonRelativeURL2: INavLink = {
+      key: 'Link4',
+      name: 'Link4',
+      target: '_blank',
+      url: 'http://cdpn.io/bar'
+    };
+    const nav = mount<NavBase>(
+      <Nav groups={[{ links: [linkWithNoTargetSpecified, linkWithRelativeURL, linkWithNonRelativeURL, linkWithNonRelativeURL2] }]} />
+    );
+
+    const links = nav.getDOMNode().querySelectorAll('.ms-Nav-link');
+    expect(links.length).toBe(4);
+    expect(links[0].getAttribute('rel')).toBeFalsy();
+    expect(links[1].getAttribute('rel')).toBeFalsy();
+    expect(links[2].getAttribute('rel')).toBe('noopener noreferrer');
+    expect(links[3].getAttribute('rel')).toBe('noopener noreferrer');
+  });
 });

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
@@ -432,6 +432,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                     onKeyUp={[Function]}
                     onMouseDown={[Function]}
                     onMouseUp={[Function]}
+                    rel="noopener noreferrer"
                     target="_blank"
                     title="Activity"
                   >
@@ -744,6 +745,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                 onKeyUp={[Function]}
                 onMouseDown={[Function]}
                 onMouseUp={[Function]}
+                rel="noopener noreferrer"
                 target="_blank"
                 title="Documents"
               >
@@ -896,6 +898,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                 onKeyUp={[Function]}
                 onMouseDown={[Function]}
                 onMouseUp={[Function]}
+                rel="noopener noreferrer"
                 target="_blank"
                 title="Pages"
               >
@@ -1193,6 +1196,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                 onKeyUp={[Function]}
                 onMouseDown={[Function]}
                 onMouseUp={[Function]}
+                rel="noopener noreferrer"
                 target="_blank"
                 title="Communication and Media"
               >
@@ -1345,6 +1349,7 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                 onKeyUp={[Function]}
                 onMouseDown={[Function]}
                 onMouseUp={[Function]}
+                rel="noopener noreferrer"
                 target="_blank"
                 title="News"
               >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.CustomGroupHeaders.Example.tsx.shot
@@ -182,6 +182,7 @@ exports[`Component Examples renders Nav.CustomGroupHeaders.Example.tsx correctly
                 onKeyUp={[Function]}
                 onMouseDown={[Function]}
                 onMouseUp={[Function]}
+                rel="noopener noreferrer"
                 target="_blank"
                 title="Activity"
               >
@@ -334,6 +335,7 @@ exports[`Component Examples renders Nav.CustomGroupHeaders.Example.tsx correctly
                 onKeyUp={[Function]}
                 onMouseDown={[Function]}
                 onMouseUp={[Function]}
+                rel="noopener noreferrer"
                 target="_blank"
                 title="News"
               >
@@ -526,6 +528,7 @@ exports[`Component Examples renders Nav.CustomGroupHeaders.Example.tsx correctly
                 onKeyUp={[Function]}
                 onMouseDown={[Function]}
                 onMouseUp={[Function]}
+                rel="noopener noreferrer"
                 target="_blank"
                 title="Settings"
               >
@@ -678,6 +681,7 @@ exports[`Component Examples renders Nav.CustomGroupHeaders.Example.tsx correctly
                 onKeyUp={[Function]}
                 onMouseDown={[Function]}
                 onMouseUp={[Function]}
+                rel="noopener noreferrer"
                 target="_blank"
                 title="Notes"
               >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Nested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Nested.Example.tsx.shot
@@ -260,6 +260,7 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
                 onKeyUp={[Function]}
                 onMouseDown={[Function]}
                 onMouseUp={[Function]}
+                rel="noopener noreferrer"
                 target="_blank"
                 title="Parent link 1"
               >
@@ -493,6 +494,7 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
                 onKeyUp={[Function]}
                 onMouseDown={[Function]}
                 onMouseUp={[Function]}
+                rel="noopener noreferrer"
                 target="_blank"
                 title="Parent link 2"
               >


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11785
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The regular expression we were using to determine if a URL was protocol relative or not was wrong, which was causing `Nav` links to not have `rel="noopener noreferrer"` set up, causing a potential security risk. This PR corrects this by fixing the regular expression.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11792)