### PR TITLE
[BaseFloatingPicker] Pass custom props to inner Callout

### DIFF
--- a/change/office-ui-fabric-react-2020-01-24-14-28-27-picker-callout-props.json
+++ b/change/office-ui-fabric-react-2020-01-24-14-28-27-picker-callout-props.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "BaseFloatingPicker: pass custom props to inner Callout",
+  "packageName": "office-ui-fabric-react",
+  "email": "rezha@microsoft.com",
+  "commit": "038c54870c5f0bb9edb81fc066031c8a1d3c8490",
+  "dependentChangeType": "patch",
+  "date": "2020-01-24T22:28:27.186Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1644,6 +1644,7 @@ export interface IBaseFloatingPickerProps<T> extends React.ClassAttributes<any> 
     onSuggestionsShown?: () => void;
     onValidateInput?: (input: string) => boolean;
     onZeroQuerySuggestion?: (selectedItems?: T[]) => T[] | PromiseLike<T[]> | null;
+    pickerCalloutProps?: ICalloutProps;
     pickerSuggestionsProps?: IBaseFloatingPickerSuggestionProps;
     resolveDelay?: number;
     searchingText?: ((props: {

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
@@ -226,7 +226,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extend
 
   protected onChange(item: T): void {
     if (this.props.onChange) {
-      (this.props.onChange as (items: T) => void)(item);
+      (this.props.onChange as ((items: T) => void))(item);
     }
   }
 
@@ -237,7 +237,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extend
 
   protected onSuggestionRemove = (ev: React.MouseEvent<HTMLElement>, item: T, index: number): void => {
     if (this.props.onRemoveSuggestion) {
-      (this.props.onRemoveSuggestion as (item: T) => void)(item);
+      (this.props.onRemoveSuggestion as ((item: T) => void))(item);
     }
 
     if (this.suggestionsControl.current) {
@@ -278,7 +278,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extend
           this.suggestionsControl.current.currentSuggestion &&
           ev.shiftKey
         ) {
-          (this.props.onRemoveSuggestion as (item: T) => void)(this.suggestionsControl.current.currentSuggestion!.item);
+          (this.props.onRemoveSuggestion as ((item: T) => void))(this.suggestionsControl.current.currentSuggestion!.item);
 
           this.suggestionsControl.current.removeSuggestion();
           this.forceUpdate();
@@ -324,9 +324,12 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extend
 
   private _onValidateInput = (): void => {
     if (this.state.queryString && this.props.onValidateInput && this.props.createGenericItem) {
-      const itemToConvert: ISuggestionModel<T> = (this.props.createGenericItem as (input: string, isValid: boolean) => ISuggestionModel<T>)(
+      const itemToConvert: ISuggestionModel<T> = (this.props.createGenericItem as ((
+        input: string,
+        isValid: boolean
+      ) => ISuggestionModel<T>))(
         this.state.queryString,
-        (this.props.onValidateInput as (input: string) => boolean)(this.state.queryString)
+        (this.props.onValidateInput as ((input: string) => boolean))(this.state.queryString)
       );
       const convertedItems = this.suggestionStore.convertSuggestionsToSuggestionItems([itemToConvert]);
       this.onChange(convertedItems[0].item);

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.tsx
@@ -165,6 +165,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extend
         directionalHint={DirectionalHint.bottomLeftEdge}
         directionalHintForRTL={DirectionalHint.bottomRightEdge}
         calloutWidth={this.props.calloutWidth ? this.props.calloutWidth : 0}
+        {...this.props.pickerCalloutProps}
       >
         <TypedSuggestionsControl
           onRenderSuggestion={this.props.onRenderSuggestionsItem}
@@ -225,7 +226,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extend
 
   protected onChange(item: T): void {
     if (this.props.onChange) {
-      (this.props.onChange as ((items: T) => void))(item);
+      (this.props.onChange as (items: T) => void)(item);
     }
   }
 
@@ -236,7 +237,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extend
 
   protected onSuggestionRemove = (ev: React.MouseEvent<HTMLElement>, item: T, index: number): void => {
     if (this.props.onRemoveSuggestion) {
-      (this.props.onRemoveSuggestion as ((item: T) => void))(item);
+      (this.props.onRemoveSuggestion as (item: T) => void)(item);
     }
 
     if (this.suggestionsControl.current) {
@@ -277,7 +278,7 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extend
           this.suggestionsControl.current.currentSuggestion &&
           ev.shiftKey
         ) {
-          (this.props.onRemoveSuggestion as ((item: T) => void))(this.suggestionsControl.current.currentSuggestion!.item);
+          (this.props.onRemoveSuggestion as (item: T) => void)(this.suggestionsControl.current.currentSuggestion!.item);
 
           this.suggestionsControl.current.removeSuggestion();
           this.forceUpdate();
@@ -323,12 +324,9 @@ export class BaseFloatingPicker<T, P extends IBaseFloatingPickerProps<T>> extend
 
   private _onValidateInput = (): void => {
     if (this.state.queryString && this.props.onValidateInput && this.props.createGenericItem) {
-      const itemToConvert: ISuggestionModel<T> = (this.props.createGenericItem as ((
-        input: string,
-        isValid: boolean
-      ) => ISuggestionModel<T>))(
+      const itemToConvert: ISuggestionModel<T> = (this.props.createGenericItem as (input: string, isValid: boolean) => ISuggestionModel<T>)(
         this.state.queryString,
-        (this.props.onValidateInput as ((input: string) => boolean))(this.state.queryString)
+        (this.props.onValidateInput as (input: string) => boolean)(this.state.queryString)
       );
       const convertedItems = this.suggestionStore.convertSuggestionsToSuggestionItems([itemToConvert]);
       this.onChange(convertedItems[0].item);

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.types.ts
@@ -4,6 +4,7 @@ import { ISuggestionsControlProps } from './Suggestions/Suggestions.types';
 import { SuggestionsStore } from './Suggestions/SuggestionsStore';
 import { IRefObject } from '../../Utilities';
 import { ISuggestionItemProps } from '../pickers/Suggestions/SuggestionsItem.types';
+import { ICalloutProps } from '../Callout';
 
 export interface IBaseFloatingPicker {
   /** Whether the suggestions are shown */
@@ -87,6 +88,12 @@ export interface IBaseFloatingPickerProps<T> extends React.ClassAttributes<any> 
    * The properties that will get passed to the Suggestions component.
    */
   pickerSuggestionsProps?: IBaseFloatingPickerSuggestionProps;
+
+  /**
+   * The properties that will get passed to the Callout component.
+   */
+  pickerCalloutProps?: ICalloutProps;
+
   /**
    * A callback for when an item is removed from the suggestion list
    */

--- a/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/FloatingPicker/BaseFloatingPicker.types.ts
@@ -4,7 +4,7 @@ import { ISuggestionsControlProps } from './Suggestions/Suggestions.types';
 import { SuggestionsStore } from './Suggestions/SuggestionsStore';
 import { IRefObject } from '../../Utilities';
 import { ISuggestionItemProps } from '../pickers/Suggestions/SuggestionsItem.types';
-import { ICalloutProps } from '../Callout';
+import { ICalloutProps } from '../Callout/Callout.types';
 
 export interface IBaseFloatingPicker {
   /** Whether the suggestions are shown */


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

There currently is a discrepancy between `BaseFloatingPicker` and `BasePicker` that the latter allows consumer to pass a `pickerCalloutProps` while the former doesn't thus preventing customization of the inner `Callout` component.

This PR fixes the issue by adding a `pickerCalloutProps` to `BaseFloatingPicker`'s props, and by doing so match `BasePicker`'s behavior.

#### Focus areas to test

This should be a fully backward-compatible fix. Currently behavior of `BaseFloatingPicker` should not be impacted.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11794)