### PR TITLE
Button: Adding support for onPointerDown and onPointerUp

### DIFF
--- a/change/office-ui-fabric-react-2020-01-24-16-55-07-buttonOnPointerDown.json
+++ b/change/office-ui-fabric-react-2020-01-24-16-55-07-buttonOnPointerDown.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Button: Adding support for onPointerDown and onPointerUp.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "de7423dcbcf1bbe6c7ed90f93554db705c8b38ac",
+  "dependentChangeType": "patch",
+  "date": "2020-01-25T00:55:07.151Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -240,8 +240,13 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     // For split buttons, touching anywhere in the button should drop the dropdown, which should contain the primary action.
     // This gives more hit target space for touch environments. We're setting the onpointerdown here, because React
     // does not support Pointer events yet.
-    if (this._isSplitButton && this._splitButtonContainer.current && 'onpointerdown' in this._splitButtonContainer.current) {
-      this._events.on(this._splitButtonContainer.current, 'pointerdown', this._onPointerDown, true);
+    if (this._isSplitButton && this._splitButtonContainer.current) {
+      if ('onpointerdown' in this._splitButtonContainer.current) {
+        this._events.on(this._splitButtonContainer.current, 'pointerdown', this._onPointerDown, true);
+      }
+      if ('onpointerup' in this._splitButtonContainer.current && this.props.onPointerUp) {
+        this._events.on(this._splitButtonContainer.current, 'pointerup', this.props.onPointerUp, true);
+      }
     }
   }
 
@@ -540,6 +545,8 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
 
     assign(buttonProps, {
       onClick: undefined,
+      onPointerDown: undefined,
+      onPointerUp: undefined,
       tabIndex: -1,
       'data-is-focusable': false
     });
@@ -769,7 +776,14 @@ export class BaseButton extends BaseComponent<IBaseButtonProps, IBaseButtonState
     }
   };
 
-  private _onPointerDown(ev: PointerEvent) {
+  private _onPointerDown(
+    ev: PointerEvent & React.PointerEvent<HTMLAnchorElement | HTMLButtonElement | HTMLDivElement | BaseButton | HTMLSpanElement>
+  ) {
+    const { onPointerDown } = this.props;
+    if (onPointerDown) {
+      onPointerDown(ev);
+    }
+
     if (ev.pointerType === 'touch') {
       this._handleTouchAndPointerEvent();
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11767 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The `Button` component was swallowing user provided `onPointerDown` events and was not forwarding the correct `onPointerUp` events to the `MenuButton` part of `SplitButton` components. This PR fixes both of these issues.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11797)