### PR TITLE
Dialog/Panel: allow to set aria-level on header title

### DIFF
--- a/change/office-ui-fabric-react-2020-01-24-16-40-06-xgao-fix-aria-level.json
+++ b/change/office-ui-fabric-react-2020-01-24-16-40-06-xgao-fix-aria-level.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Dialog: allow to set aria-level on content title",
+  "comment": "Dialog/Panel: allow to set aria-level on header title",
   "packageName": "office-ui-fabric-react",
   "email": "xgao@microsoft.com",
   "commit": "ab70836609d88abc730d450a8de1f41225cefb00",

--- a/change/office-ui-fabric-react-2020-01-24-16-40-06-xgao-fix-aria-level.json
+++ b/change/office-ui-fabric-react-2020-01-24-16-40-06-xgao-fix-aria-level.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Dialog: allow to set aria-level on content title",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "ab70836609d88abc730d450a8de1f41225cefb00",
+  "dependentChangeType": "patch",
+  "date": "2020-01-25T00:40:06.480Z"
+}

--- a/change/office-ui-fabric-react-2020-01-24-16-40-06-xgao-fix-aria-level.json
+++ b/change/office-ui-fabric-react-2020-01-24-16-40-06-xgao-fix-aria-level.json
@@ -1,9 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Dialog/Panel: allow to set aria-level on header title",
-  "packageName": "office-ui-fabric-react",
-  "email": "xgao@microsoft.com",
-  "commit": "ab70836609d88abc730d450a8de1f41225cefb00",
-  "dependentChangeType": "patch",
-  "date": "2020-01-25T00:40:06.480Z"
-}

--- a/change/office-ui-fabric-react-2020-01-27-12-20-29-xgao-fix-aria-level.json
+++ b/change/office-ui-fabric-react-2020-01-27-12-20-29-xgao-fix-aria-level.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Dialog/Panel: allow to set aria-level on header title",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "c13defbe454a10ecc4c41e45b112003e911298db",
+  "dependentChangeType": "patch",
+  "date": "2020-01-27T20:20:29.839Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -3761,7 +3761,7 @@ export interface IDialogContentProps extends React.ClassAttributes<DialogContent
     title?: string | JSX.Element;
     // @deprecated
     titleId?: string;
-    titleProps?: IDialogContentTitleProps;
+    titleProps?: React.AllHTMLAttributes<HTMLDivElement>;
     topButtonsProps?: IButtonProps[];
     type?: DialogType;
 }
@@ -3797,10 +3797,6 @@ export interface IDialogContentStyles {
     title: IStyle;
     // (undocumented)
     topButton: IStyle;
-}
-
-// @public (undocumented)
-export interface IDialogContentTitleProps extends React.AllHTMLAttributes<HTMLDivElement> {
 }
 
 // @public (undocumented)
@@ -5859,10 +5855,6 @@ export interface IPanelHeaderRenderer extends IRenderFunction<IPanelProps> {
     (props?: IPanelProps, defaultRender?: IPanelHeaderRenderer, headerTextId?: string | undefined): JSX.Element | null;
 }
 
-// @public (undocumented)
-export interface IPanelHeaderTextProps extends React.AllHTMLAttributes<HTMLDivElement> {
-}
-
 // Warning: (ae-forgotten-export) The symbol "PanelBase" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -5883,7 +5875,7 @@ export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
     hasCloseButton?: boolean;
     headerClassName?: string;
     headerText?: string;
-    headerTextProps?: IPanelHeaderTextProps;
+    headerTextProps?: React.AllHTMLAttributes<HTMLDivElement>;
     // @deprecated
     ignoreExternalFocusing?: boolean;
     isBlocking?: boolean;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -3759,7 +3759,9 @@ export interface IDialogContentProps extends React.ClassAttributes<DialogContent
     subTextId?: string;
     theme?: ITheme;
     title?: string | JSX.Element;
+    // @deprecated
     titleId?: string;
+    titleProps?: IDialogContentTitleProps;
     topButtonsProps?: IButtonProps[];
     type?: DialogType;
 }
@@ -3795,6 +3797,10 @@ export interface IDialogContentStyles {
     title: IStyle;
     // (undocumented)
     topButton: IStyle;
+}
+
+// @public (undocumented)
+export interface IDialogContentTitleProps extends React.AllHTMLAttributes<HTMLDivElement> {
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -5859,6 +5859,10 @@ export interface IPanelHeaderRenderer extends IRenderFunction<IPanelProps> {
     (props?: IPanelProps, defaultRender?: IPanelHeaderRenderer, headerTextId?: string | undefined): JSX.Element | null;
 }
 
+// @public (undocumented)
+export interface IPanelHeaderTextProps extends React.AllHTMLAttributes<HTMLDivElement> {
+}
+
 // Warning: (ae-forgotten-export) The symbol "PanelBase" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
@@ -5879,6 +5883,7 @@ export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
     hasCloseButton?: boolean;
     headerClassName?: string;
     headerText?: string;
+    headerTextProps?: IPanelHeaderTextProps;
     // @deprecated
     ignoreExternalFocusing?: boolean;
     isBlocking?: boolean;

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -3761,7 +3761,7 @@ export interface IDialogContentProps extends React.ClassAttributes<DialogContent
     title?: string | JSX.Element;
     // @deprecated
     titleId?: string;
-    titleProps?: React.AllHTMLAttributes<HTMLDivElement>;
+    titleProps?: React.HTMLAttributes<HTMLDivElement>;
     topButtonsProps?: IButtonProps[];
     type?: DialogType;
 }
@@ -5875,7 +5875,7 @@ export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
     hasCloseButton?: boolean;
     headerClassName?: string;
     headerText?: string;
-    headerTextProps?: React.AllHTMLAttributes<HTMLDivElement>;
+    headerTextProps?: React.HTMLAttributes<HTMLDivElement>;
     // @deprecated
     ignoreExternalFocusing?: boolean;
     isBlocking?: boolean;

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.base.tsx
@@ -153,9 +153,9 @@ export class DialogBase extends React.Component<IDialogProps, {}> {
         titleAriaId={this._getTitleTextId()}
       >
         <DialogContent
-          titleId={this._defaultTitleTextId}
           subTextId={this._defaultSubTextId}
           title={title}
+          titleProps={{ id: this._defaultTitleTextId }}
           subText={subText}
           showCloseButton={isBlocking !== undefined ? !isBlocking : !mergedModalProps.isBlocking}
           topButtonsProps={topButtonsProps ? topButtonsProps : dialogContentProps!.topButtonsProps}

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.test.tsx
@@ -33,6 +33,23 @@ describe('Dialog', () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it('renders DialogContent with titleProps', () => {
+    const component = renderer.create(
+      <DialogContent
+        type={DialogType.normal}
+        title="sample title"
+        subText="Sample subtext"
+        titleProps={{
+          className: 'title_class',
+          'aria-level': 3,
+          title: 'tooltip'
+        }}
+      />
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it('Fires dismissed after closing', () => {
     jest.useFakeTimers();
     let dismissedCalled = false;

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, classNamesFunction } from '../../Utilities';
+import { BaseComponent, classNamesFunction, getNativeProps, divProperties, css } from '../../Utilities';
 import { DialogType, IDialogContentProps, IDialogContentStyleProps, IDialogContentStyles } from './DialogContent.types';
 import { IconButton } from '../../Button';
 import { DialogFooter } from './DialogFooter';
@@ -21,6 +21,12 @@ export class DialogContentBase extends BaseComponent<IDialogContentProps, {}> {
 
   constructor(props: IDialogContentProps) {
     super(props);
+
+    if (process.env.NODE_ENV !== 'production') {
+      this._warnDeprecations({
+        titleId: 'titleProps.id'
+      });
+    }
   }
 
   public render(): JSX.Element {
@@ -31,6 +37,7 @@ export class DialogContentBase extends BaseComponent<IDialogContentProps, {}> {
       onDismiss,
       subTextId,
       subText,
+      titleProps = {},
       titleId,
       title,
       type,
@@ -57,12 +64,20 @@ export class DialogContentBase extends BaseComponent<IDialogContentProps, {}> {
       );
     }
 
+    const titleNativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(titleProps, divProperties, ['id', 'className']);
+
     return (
       <div className={classNames.content}>
         <div className={classNames.header}>
-          <p className={classNames.title} id={titleId} role="heading" aria-level={2}>
+          <div
+            className={css(classNames.title, titleProps.className)}
+            id={titleProps.id || titleId}
+            role="heading"
+            aria-level={2}
+            {...titleNativeProps}
+          >
             {title}
-          </p>
+          </div>
           <div className={classNames.topButton}>
             {this.props.topButtonsProps!.map((props, index) => (
               <IconButton key={props.uniqueId || index} {...props} />

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.base.tsx
@@ -67,13 +67,7 @@ export class DialogContentBase extends BaseComponent<IDialogContentProps, {}> {
     return (
       <div className={classNames.content}>
         <div className={classNames.header}>
-          <div
-            role="heading"
-            aria-level={2}
-            {...titleProps}
-            id={titleProps.id || titleId}
-            className={css(classNames.title, titleProps.className)}
-          >
+          <div id={titleId} role="heading" aria-level={2} {...titleProps} className={css(classNames.title, titleProps.className)}>
             {title}
           </div>
           <div className={classNames.topButton}>

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, classNamesFunction, getNativeProps, divProperties, css } from '../../Utilities';
+import { BaseComponent, classNamesFunction, css } from '../../Utilities';
 import { DialogType, IDialogContentProps, IDialogContentStyleProps, IDialogContentStyles } from './DialogContent.types';
 import { IconButton } from '../../Button';
 import { DialogFooter } from './DialogFooter';
@@ -64,17 +64,15 @@ export class DialogContentBase extends BaseComponent<IDialogContentProps, {}> {
       );
     }
 
-    const titleNativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(titleProps, divProperties, ['id', 'className']);
-
     return (
       <div className={classNames.content}>
         <div className={classNames.header}>
           <div
-            className={css(classNames.title, titleProps.className)}
-            id={titleProps.id || titleId}
             role="heading"
             aria-level={2}
-            {...titleNativeProps}
+            {...titleProps}
+            id={titleProps.id || titleId}
+            className={css(classNames.title, titleProps.className)}
           >
             {title}
           </div>

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.types.ts
@@ -69,6 +69,8 @@ export interface IDialogContentProps extends React.ClassAttributes<DialogContent
 
   /**
    * The Id for title container
+   *
+   * @deprecated use titleProps.id instead.
    */
   titleId?: string;
 
@@ -76,6 +78,11 @@ export interface IDialogContentProps extends React.ClassAttributes<DialogContent
    * The title text to display at the top of the dialog.
    */
   title?: string | JSX.Element;
+
+  /**
+   * The props for title container.
+   */
+  titleProps?: IDialogContentTitleProps;
 
   /**
    * Responsive mode passed in from decorator.
@@ -111,6 +118,11 @@ export enum DialogType {
   /** Dialog with an 'x' close button in the upper-right corner */
   close = 2
 }
+
+/**
+ * {@docCategory Dialog}
+ */
+export interface IDialogContentTitleProps extends React.AllHTMLAttributes<HTMLDivElement> {}
 
 /**
  * {@docCategory Dialog}

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.types.ts
@@ -82,7 +82,7 @@ export interface IDialogContentProps extends React.ClassAttributes<DialogContent
   /**
    * The props for title container.
    */
-  titleProps?: React.AllHTMLAttributes<HTMLDivElement>;
+  titleProps?: React.HTMLAttributes<HTMLDivElement>;
 
   /**
    * Responsive mode passed in from decorator.

--- a/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Dialog/DialogContent.types.ts
@@ -70,7 +70,7 @@ export interface IDialogContentProps extends React.ClassAttributes<DialogContent
   /**
    * The Id for title container
    *
-   * @deprecated use titleProps.id instead.
+   * @deprecated use the `id` attribute in `titleProps` instead.
    */
   titleId?: string;
 
@@ -82,7 +82,7 @@ export interface IDialogContentProps extends React.ClassAttributes<DialogContent
   /**
    * The props for title container.
    */
-  titleProps?: IDialogContentTitleProps;
+  titleProps?: React.AllHTMLAttributes<HTMLDivElement>;
 
   /**
    * Responsive mode passed in from decorator.
@@ -118,11 +118,6 @@ export enum DialogType {
   /** Dialog with an 'x' close button in the upper-right corner */
   close = 2
 }
-
-/**
- * {@docCategory Dialog}
- */
-export interface IDialogContentTitleProps extends React.AllHTMLAttributes<HTMLDivElement> {}
 
 /**
  * {@docCategory Dialog}

--- a/packages/office-ui-fabric-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Dialog/__snapshots__/Dialog.test.tsx.snap
@@ -18,7 +18,7 @@ exports[`Dialog renders Dialog correctly 1`] = `
           width: 100%;
         }
   >
-    <p
+    <div
       aria-level={2}
       className=
           ms-Dialog-title
@@ -126,7 +126,7 @@ exports[`Dialog renders Dialog with a jsx title 1`] = `
           width: 100%;
         }
   >
-    <p
+    <div
       aria-level={2}
       className=
           ms-Dialog-title
@@ -163,7 +163,7 @@ exports[`Dialog renders Dialog with a jsx title 1`] = `
           I am span 2
         </span>
       </div>
-    </p>
+    </div>
     <div
       className=
 
@@ -221,6 +221,139 @@ exports[`Dialog renders Dialog with a jsx title 1`] = `
             width: 100%;
           }
     />
+  </div>
+</div>
+`;
+
+exports[`Dialog renders DialogContent with titleProps 1`] = `
+<div
+  className=
+
+      {
+        flex-grow: 1;
+        overflow-y: hidden;
+      }
+>
+  <div
+    className=
+        ms-Dialog-header
+        {
+          box-sizing: border-box;
+          position: relative;
+          width: 100%;
+        }
+  >
+    <div
+      aria-level={3}
+      className=
+          ms-Dialog-title
+          title_class
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            color: #323130;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 20px;
+            font-weight: 600;
+            line-height: normal;
+            margin-bottom: 0;
+            margin-left: 0;
+            margin-right: 0;
+            margin-top: 0;
+            padding-bottom: 20px;
+            padding-left: 24px;
+            padding-right: 46px;
+            padding-top: 16px;
+          }
+          @media (min-width: 320px) and (max-width: 479px){& {
+            padding-bottom: 16px;
+            padding-left: 16px;
+            padding-right: 46px;
+            padding-top: 16px;
+          }
+      role="heading"
+      title="tooltip"
+    >
+      sample title
+    </div>
+    <div
+      className=
+
+          {
+            display: flex;
+            flex-direction: row;
+            flex-wrap: nowrap;
+            padding-bottom: 0;
+            padding-left: 0;
+            padding-right: 15px;
+            padding-top: 15px;
+            position: absolute;
+            right: 0;
+            top: 0;
+          }
+          & > * {
+            flex: 0 0 auto;
+          }
+          & .ms-Dialog-button {
+            color: #323130;
+          }
+          & .ms-Dialog-button:hover {
+            border-radius: 2px;
+            color: #201f1e;
+          }
+          @media (min-width: 320px) and (max-width: 479px){& {
+            padding-bottom: 0;
+            padding-left: 0;
+            padding-right: 8px;
+            padding-top: 15px;
+          }
+    />
+  </div>
+  <div
+    className=
+        ms-Dialog-inner
+        {
+          padding-bottom: 24px;
+          padding-left: 24px;
+          padding-right: 24px;
+          padding-top: 0;
+        }
+        @media (min-width: 320px) and (max-width: 479px){& {
+          padding-bottom: 16px;
+          padding-left: 16px;
+          padding-right: 16px;
+          padding-top: 0;
+        }
+  >
+    <div
+      className=
+          ms-Dialog-content
+          {
+            position: relative;
+            width: 100%;
+          }
+    >
+      <p
+        className=
+            ms-Dialog-subText
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              color: #605e5c;
+              font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+              font-size: 14px;
+              font-weight: 400;
+              line-height: 1.5;
+              margin-bottom: 24px;
+              margin-left: 0;
+              margin-right: 0;
+              margin-top: 0;
+              word-wrap: break-word;
+            }
+      >
+        Sample subtext
+      </p>
+    </div>
   </div>
 </div>
 `;

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -13,7 +13,8 @@ import {
   elementContains,
   getId,
   getNativeProps,
-  getRTL
+  getRTL,
+  css
 } from '../../Utilities';
 import { FocusTrapZone } from '../FocusTrapZone/index';
 import { IPanel, IPanelProps, IPanelStyleProps, IPanelStyles, PanelType } from './Panel.types';
@@ -347,14 +348,21 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
     defaultRender?: (props?: IPanelProps) => JSX.Element | null,
     headerTextId?: string | undefined
   ): JSX.Element | null => {
-    const { headerText } = props;
+    const { headerText, headerTextProps = {} } = props;
+    const headerTextNativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(headerTextProps, divProperties, ['id', 'className']);
 
     if (headerText) {
       return (
         <div className={this._classNames.header}>
-          <p className={this._classNames.headerText} id={headerTextId} role="heading" aria-level={2}>
+          <div
+            className={css(this._classNames.headerText, headerTextProps.className)}
+            id={headerTextProps.id || headerTextId}
+            role="heading"
+            aria-level={2}
+            {...headerTextNativeProps}
+          >
             {headerText}
-          </p>
+          </div>
         </div>
       );
     }

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -354,11 +354,11 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
       return (
         <div className={this._classNames.header}>
           <div
+            id={headerTextId}
             role="heading"
             aria-level={2}
             {...headerTextProps}
             className={css(this._classNames.headerText, headerTextProps.className)}
-            id={headerTextProps.id || headerTextId}
           >
             {headerText}
           </div>

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.base.tsx
@@ -349,17 +349,16 @@ export class PanelBase extends BaseComponent<IPanelProps, IPanelState> implement
     headerTextId?: string | undefined
   ): JSX.Element | null => {
     const { headerText, headerTextProps = {} } = props;
-    const headerTextNativeProps = getNativeProps<React.HTMLAttributes<HTMLDivElement>>(headerTextProps, divProperties, ['id', 'className']);
 
     if (headerText) {
       return (
         <div className={this._classNames.header}>
           <div
-            className={css(this._classNames.headerText, headerTextProps.className)}
-            id={headerTextProps.id || headerTextId}
             role="heading"
             aria-level={2}
-            {...headerTextNativeProps}
+            {...headerTextProps}
+            className={css(this._classNames.headerText, headerTextProps.className)}
+            id={headerTextProps.id || headerTextId}
           >
             {headerText}
           </div>

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.test.tsx
@@ -19,7 +19,14 @@ describe('Panel', () => {
     });
 
     const component = renderer.create(
-      <Panel isOpen={true} headerText="Test Panel">
+      <Panel
+        isOpen={true}
+        headerText="Test Panel"
+        headerTextProps={{
+          className: 'panel_class',
+          'aria-level': 3
+        }}
+      >
         <span>Content goes here</span>
       </Panel>
     );

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -80,7 +80,7 @@ export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
   /**
    * The props for header text container.
    */
-  headerTextProps?: React.AllHTMLAttributes<HTMLDivElement>;
+  headerTextProps?: React.HTMLAttributes<HTMLDivElement>;
 
   /**
    * A callback function for when the Panel is opened, before the animation completes.

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -78,6 +78,11 @@ export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
   headerText?: string;
 
   /**
+   * The props for header text container.
+   */
+  headerTextProps?: IPanelHeaderTextProps;
+
+  /**
    * A callback function for when the Panel is opened, before the animation completes.
    */
   onOpen?: () => void;
@@ -250,6 +255,11 @@ export interface IPanelHeaderRenderer extends IRenderFunction<IPanelProps> {
    */
   (props?: IPanelProps, defaultRender?: IPanelHeaderRenderer, headerTextId?: string | undefined): JSX.Element | null;
 }
+
+/**
+ * {@docCategory Panel}
+ */
+export interface IPanelHeaderTextProps extends React.AllHTMLAttributes<HTMLDivElement> {}
 
 /**
  * {@docCategory Panel}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.types.ts
@@ -80,7 +80,7 @@ export interface IPanelProps extends React.HTMLAttributes<PanelBase> {
   /**
    * The props for header text container.
    */
-  headerTextProps?: IPanelHeaderTextProps;
+  headerTextProps?: React.AllHTMLAttributes<HTMLDivElement>;
 
   /**
    * A callback function for when the Panel is opened, before the animation completes.
@@ -255,11 +255,6 @@ export interface IPanelHeaderRenderer extends IRenderFunction<IPanelProps> {
    */
   (props?: IPanelProps, defaultRender?: IPanelHeaderRenderer, headerTextId?: string | undefined): JSX.Element | null;
 }
-
-/**
- * {@docCategory Panel}
- */
-export interface IPanelHeaderTextProps extends React.AllHTMLAttributes<HTMLDivElement> {}
 
 /**
  * {@docCategory Panel}
@@ -490,7 +485,7 @@ export interface IPanelStyles {
   header: IStyle;
 
   /**
-   * Style for the header inner p element.
+   * Style for the header text div element.
    */
   headerText: IStyle;
 

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -194,10 +194,11 @@ exports[`Panel renders Panel correctly 1`] = `
                       padding-right: 24px;
                     }
               >
-                <p
-                  aria-level={2}
+                <div
+                  aria-level={3}
                   className=
                       ms-Panel-headerText
+                      panel_class
                       {
                         -moz-osx-font-smoothing: grayscale;
                         -webkit-font-smoothing: antialiased;
@@ -219,7 +220,7 @@ exports[`Panel renders Panel correctly 1`] = `
                   role="heading"
                 >
                   Test Panel
-                </p>
+                </div>
               </div>
               <button
                 className=


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11666
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Added "props" prop which allow user to set `aria-level` as well as other div html attributes on the container element of the title.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11798)