### PR TITLE
Removing BaseComponent usage from a few more components

### DIFF
--- a/change/office-ui-fabric-react-2020-01-26-12-19-43-perf-improvements.json
+++ b/change/office-ui-fabric-react-2020-01-26-12-19-43-perf-improvements.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "PersonaCoin and related components: elliminating BaseComponent usage to reduce bundle size.",
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@hotmail.com",
+  "commit": "5ea4f4de7953f92965d5ded807f4f12dda08c9c4",
+  "dependentChangeType": "patch",
+  "date": "2020-01-26T20:19:43.641Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -8324,7 +8324,7 @@ export const PeoplePickerItemSuggestionBase: (props: IPeoplePickerItemSuggestion
 export const Persona: React.StatelessComponent<IPersonaProps>;
 
 // @public
-export class PersonaBase extends BaseComponent<IPersonaProps, {}> {
+export class PersonaBase extends React.Component<IPersonaProps, {}> {
     constructor(props: IPersonaProps);
     // (undocumented)
     static defaultProps: IPersonaProps;
@@ -8336,7 +8336,7 @@ export class PersonaBase extends BaseComponent<IPersonaProps, {}> {
 export const PersonaCoin: React.StatelessComponent<IPersonaCoinProps>;
 
 // @public
-export class PersonaCoinBase extends BaseComponent<IPersonaCoinProps, IPersonaState> {
+export class PersonaCoinBase extends React.Component<IPersonaCoinProps, IPersonaState> {
     constructor(props: IPersonaCoinProps);
     // (undocumented)
     static defaultProps: IPersonaCoinProps;
@@ -8501,7 +8501,7 @@ export namespace personaSize {
 export const Pivot: React.StatelessComponent<IPivotProps>;
 
 // @public
-export class PivotBase extends BaseComponent<IPivotProps, IPivotState> {
+export class PivotBase extends React.Component<IPivotProps, IPivotState> {
     constructor(props: IPivotProps);
     focus(): void;
     // (undocumented)
@@ -8997,7 +8997,7 @@ export class SpinButton extends React.Component<ISpinButtonProps, ISpinButtonSta
 export const Spinner: React.StatelessComponent<ISpinnerProps>;
 
 // @public (undocumented)
-export class SpinnerBase extends BaseComponent<ISpinnerProps, any> {
+export class SpinnerBase extends React.Component<ISpinnerProps, any> {
     // (undocumented)
     static defaultProps: ISpinnerProps;
     // (undocumented)

--- a/packages/office-ui-fabric-react/src/components/Persona/Persona.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/Persona.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, classNamesFunction, divProperties, getNativeProps, IRenderFunction } from '../../Utilities';
+import { warnDeprecations, classNamesFunction, divProperties, getNativeProps, IRenderFunction } from '../../Utilities';
 import { TooltipHost, TooltipOverflowMode, DirectionalHint } from '../../Tooltip';
 import { PersonaCoin } from './PersonaCoin/PersonaCoin';
 import {
@@ -17,7 +17,7 @@ const getClassNames = classNamesFunction<IPersonaStyleProps, IPersonaStyles>();
  * Persona with no default styles.
  * [Use the `styles` API to add your own styles.](https://github.com/OfficeDev/office-ui-fabric-react/wiki/Styling)
  */
-export class PersonaBase extends BaseComponent<IPersonaProps, {}> {
+export class PersonaBase extends React.Component<IPersonaProps, {}> {
   public static defaultProps: IPersonaProps = {
     size: PersonaSize.size48,
     presence: PersonaPresenceEnum.none,
@@ -27,7 +27,9 @@ export class PersonaBase extends BaseComponent<IPersonaProps, {}> {
   constructor(props: IPersonaProps) {
     super(props);
 
-    this._warnDeprecations({ primaryText: 'text' });
+    if (process.env.NODE_ENV !== 'production') {
+      warnDeprecations('Persona', props, { primaryText: 'text' });
+    }
   }
 
   public render(): JSX.Element {
@@ -116,8 +118,7 @@ export class PersonaBase extends BaseComponent<IPersonaProps, {}> {
     return (
       <div {...divProps} className={classNames.root} style={coinSize ? { height: coinSize, minWidth: coinSize } : undefined}>
         {onRenderPersonaCoin(personaCoinProps, this._onRenderPersonaCoin)}
-        {(!hidePersonaDetails || (size === PersonaSize.size8 || size === PersonaSize.size10 || size === PersonaSize.tiny)) &&
-          personaDetails}
+        {(!hidePersonaDetails || size === PersonaSize.size8 || size === PersonaSize.size10 || size === PersonaSize.tiny) && personaDetails}
       </div>
     );
   }

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/PersonaCoin.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, classNamesFunction, divProperties, getInitials, getNativeProps, getRTL } from '../../../Utilities';
+import { warnDeprecations, classNamesFunction, divProperties, getInitials, getNativeProps, getRTL } from '../../../Utilities';
 import { mergeStyles } from '../../../Styling';
 import { PersonaPresence } from '../PersonaPresence/index';
 import { Icon } from '../../../Icon';
@@ -26,7 +26,7 @@ export interface IPersonaState {
  * PersonaCoin with no default styles.
  * [Use the `getStyles` API to add your own styles.](https://github.com/OfficeDev/office-ui-fabric-react/wiki/Styling)
  */
-export class PersonaCoinBase extends BaseComponent<IPersonaCoinProps, IPersonaState> {
+export class PersonaCoinBase extends React.Component<IPersonaCoinProps, IPersonaState> {
   public static defaultProps: IPersonaCoinProps = {
     size: PersonaSize.size48,
     presence: PersonaPresenceEnum.none,
@@ -36,7 +36,9 @@ export class PersonaCoinBase extends BaseComponent<IPersonaCoinProps, IPersonaSt
   constructor(props: IPersonaCoinProps) {
     super(props);
 
-    this._warnDeprecations({ primaryText: 'text' });
+    if (process.env.NODE_ENV !== 'production') {
+      warnDeprecations('PersonaCoin', props, { primaryText: 'text' });
+    }
 
     this.state = {
       isImageLoaded: false,

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaPresence/PersonaPresence.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaPresence/PersonaPresence.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, classNamesFunction } from '../../../Utilities';
+import { classNamesFunction } from '../../../Utilities';
 import { Icon } from '../../../Icon';
 import {
   IPersonaPresenceProps,
@@ -21,7 +21,7 @@ const getClassNames = classNamesFunction<IPersonaPresenceStyleProps, IPersonaPre
  * PersonaPresence with no default styles.
  * [Use the `getStyles` API to add your own styles.](https://github.com/OfficeDev/office-ui-fabric-react/wiki/Styling)
  */
-export class PersonaPresenceBase extends BaseComponent<IPersonaPresenceProps, {}> {
+export class PersonaPresenceBase extends React.Component<IPersonaPresenceProps, {}> {
   constructor(props: IPersonaPresenceProps) {
     super(props);
   }

--- a/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Pivot/Pivot.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, KeyCodes, getId, getNativeProps, divProperties, classNamesFunction, warn } from '../../Utilities';
+import { warnDeprecations, KeyCodes, getId, getNativeProps, divProperties, classNamesFunction, warn } from '../../Utilities';
 import { CommandButton } from '../../Button';
 import { IPivotProps, IPivotStyleProps, IPivotStyles } from './Pivot.types';
 import { IPivotItemProps } from './PivotItem.types';
@@ -10,6 +10,7 @@ import { PivotLinkSize } from './Pivot.types';
 import { Icon } from '../../Icon';
 
 const getClassNames = classNamesFunction<IPivotStyleProps, IPivotStyles>();
+const PivotName = 'Pivot';
 
 export interface IPivotState {
   selectedKey: string | undefined;
@@ -36,7 +37,7 @@ type PivotLinkCollection = {
  *       </PivotItem>
  *     </Pivot>
  */
-export class PivotBase extends BaseComponent<IPivotProps, IPivotState> {
+export class PivotBase extends React.Component<IPivotProps, IPivotState> {
   private _pivotId: string;
   private _focusZone = React.createRef<FocusZone>();
   private _classNames: { [key in keyof IPivotStyles]: string };
@@ -44,12 +45,14 @@ export class PivotBase extends BaseComponent<IPivotProps, IPivotState> {
   constructor(props: IPivotProps) {
     super(props);
 
-    this._warnDeprecations({
-      initialSelectedKey: 'defaultSelectedKey',
-      initialSelectedIndex: 'defaultSelectedIndex'
-    });
+    if (process.env.NODE_ENV !== 'production') {
+      warnDeprecations(PivotName, props, {
+        initialSelectedKey: 'defaultSelectedKey',
+        initialSelectedIndex: 'defaultSelectedIndex'
+      });
+    }
 
-    this._pivotId = getId('Pivot');
+    this._pivotId = getId(PivotName);
     const links: IPivotItemProps[] = this._getPivotLinks(props).links;
 
     const { defaultSelectedKey = props.initialSelectedKey, defaultSelectedIndex = props.initialSelectedIndex } = props;

--- a/packages/office-ui-fabric-react/src/components/Spinner/Spinner.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Spinner/Spinner.base.tsx
@@ -1,10 +1,10 @@
 import * as React from 'react';
 import { ISpinnerProps, ISpinnerStyleProps, ISpinnerStyles, SpinnerType, SpinnerSize } from './Spinner.types';
-import { BaseComponent, classNamesFunction, DelayedRender, getNativeProps, divProperties } from '../../Utilities';
+import { classNamesFunction, DelayedRender, getNativeProps, divProperties } from '../../Utilities';
 
 const getClassNames = classNamesFunction<ISpinnerStyleProps, ISpinnerStyles>();
 
-export class SpinnerBase extends BaseComponent<ISpinnerProps, any> {
+export class SpinnerBase extends React.Component<ISpinnerProps, any> {
   public static defaultProps: ISpinnerProps = {
     size: SpinnerSize.medium,
     ariaLive: 'polite',


### PR DESCRIPTION
While evaluating bundle sizes, I noticed current Persona* components were still referencing BaseComponent. There are still quite a few references. This change removes a few more graph edges.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11804)