### PR TITLE
Fix SearchBoxBase leak by disposing EventGroup instance on unmount

### DIFF
--- a/change/office-ui-fabric-react-2020-01-25-13-53-38-keco-searchbox-leak.json
+++ b/change/office-ui-fabric-react-2020-01-25-13-53-38-keco-searchbox-leak.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "SearchBox: Dispose of EventGroup on unmount",
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com",
+  "commit": "ee1a499fe789b25ec465e2aafda5bd3ad6573f2e",
+  "date": "2020-01-25T21:53:38.303Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -8759,13 +8759,13 @@ export const SearchBox: React.StatelessComponent<ISearchBoxProps>;
 export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxState> {
     constructor(props: ISearchBoxProps);
     // (undocumented)
+    componentWillUnmount(): void;
+    // (undocumented)
     static defaultProps: Pick<ISearchBoxProps, 'disableAnimation' | 'clearButtonProps'>;
     focus(): void;
     hasFocus(): boolean;
     // (undocumented)
     render(): JSX.Element;
-    // (undocumented)
-    UNSAFE_componentWillMount(): void;
     // (undocumented)
     UNSAFE_componentWillReceiveProps(newProps: ISearchBoxProps): void;
 }

--- a/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/SearchBox/SearchBox.base.tsx
@@ -65,8 +65,7 @@ export class SearchBoxBase extends React.Component<ISearchBoxProps, ISearchBoxSt
     }
   }
 
-  // tslint:disable-next-line function-name
-  public UNSAFE_componentWillMount() {
+  public componentWillUnmount() {
     if (this._events) {
       this._events.dispose();
     }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Fix memory leak of `SearchBoxBase` by disposing of `EventGroup` instance in `componentWillUnmount`.

![image](https://user-images.githubusercontent.com/706967/73141568-654c4700-403a-11ea-9b40-6e43b3bdeff5.png)

Relevant lines for EventGroup `parent` retainer:

https://github.com/OfficeDev/office-ui-fabric-react/blob/9e7b65719ad144fcbce97850140b0c703378d26e/packages/utilities/src/EventGroup.ts#L163

https://github.com/OfficeDev/office-ui-fabric-react/blob/9e7b65719ad144fcbce97850140b0c703378d26e/packages/utilities/src/EventGroup.ts#L172

#### Focus areas to test

- CI should pass.
- To verify, conditionally render the control and capture comparison heap snapshots.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11806)