### PR TITLE
Adding istrusted !== false check in the dismiss on scroll handler

### DIFF
--- a/change/office-ui-fabric-react-2020-01-28-12-15-29-sabans-dismissonscrollbugfix.json
+++ b/change/office-ui-fabric-react-2020-01-28-12-15-29-sabans-dismissonscrollbugfix.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Adding ev.isTrusted == false check for the diss dropdown callout handler.",
+  "packageName": "office-ui-fabric-react",
+  "email": "sabans@microsoft.com",
+  "commit": "a727628ea9e1ff750da418ab57b8c39c0c763c68",
+  "dependentChangeType": "patch",
+  "date": "2020-01-28T06:45:29.628Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -269,7 +269,7 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
 
   protected _dismissOnScroll = (ev: Event) => {
     const { preventDismissOnScroll } = this.props;
-    if (this.state.positions && !preventDismissOnScroll && ev.isTrusted == false) {
+    if (this.state.positions && !preventDismissOnScroll && ev.isTrusted !== false) {
       this._dismissOnClickOrScroll(ev);
     }
   };

--- a/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Callout/CalloutContent.base.tsx
@@ -269,7 +269,7 @@ export class CalloutContentBase extends React.Component<ICalloutProps, ICalloutS
 
   protected _dismissOnScroll = (ev: Event) => {
     const { preventDismissOnScroll } = this.props;
-    if (this.state.positions && !preventDismissOnScroll) {
+    if (this.state.positions && !preventDismissOnScroll && ev.isTrusted == false) {
       this._dismissOnClickOrScroll(ev);
     }
   };


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11800
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Users in word online have been experiencing this behavior where when multiple author on a document are typing and one of those users had a drop down open from the simplified ribbon and another co-author writes something and enters a new line the drop down for the co-author gets closed automatically. Now this on investigation was found due to the adjustment word online has to do to make sure the co-authors do not get a scrolling experience from the fact that new text got added and the IP moves. In order to achieve this the auto scroll event is fired when the changes from co-authors are merged in the session. This event is handled by the office-ui code that makes sure all the drop downs get closed when scroll happens. i added a fix on that side of code to ensure this is not done via a flag check but that looked like a hack and this was suggested that this information to be given via the office-fabric code. Hence this change.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11813)