### PR TITLE
Fix key up causing scrolling issue of whole page

### DIFF
--- a/change/office-ui-fabric-react-2020-01-28-13-42-15-fixKeyUpCausingScrollingIssue.json
+++ b/change/office-ui-fabric-react-2020-01-28-13-42-15-fixKeyUpCausingScrollingIssue.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Fix an issue where pressing the key up can cause scrolling of the whole page.",
+  "packageName": "office-ui-fabric-react",
+  "email": "jehawley@microsoft.com",
+  "commit": "ec4f9e60183ddd572046820cea04c0f29c508a68",
+  "dependentChangeType": "patch",
+  "date": "2020-01-28T21:42:15.529Z"
+}

--- a/change/office-ui-fabric-react-2020-01-28-13-42-15-fixKeyUpCausingScrollingIssue.json
+++ b/change/office-ui-fabric-react-2020-01-28-13-42-15-fixKeyUpCausingScrollingIssue.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix an issue where pressing the key up can cause scrolling of the whole page.",
+  "comment": "Dropdown: Fix issue where pressing key up can cause scrolling of the whole page.",
   "packageName": "office-ui-fabric-react",
   "email": "jehawley@microsoft.com",
   "commit": "ec4f9e60183ddd572046820cea04c0f29c508a68",

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -420,18 +420,20 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
       return selectedIndex;
     }
 
-    // Set starting index to 0 if index is < 0
-    if (index < 0) {
-      index = 0;
-    }
-    // Set starting index to the first option index if greater than options.length.
-    // The reason is that as the user is pressing the down key without opening
-    // the dropdown, the dropdown will cycle through the options. If
-    // the index is set as the last option, then pressing the down key will
-    // cause the whole window to scroll, if the window can be scrolled.
+    // If the user is pressing the up or down key we want to make
+    // sure that the dropdown cycles through the options without
+    // causing the screen to scroll. In _onDropdownKeyDown
+    // at the very end is a check to see if newIndex !== selectedIndex.
+    // If the index is less than 0 and we set it back to 0, then
+    // newIndex will equal selectedIndex and not stop the action
+    // of the key press happening and vic versa for index greater
+    // than or equal to the options length.
     if (index >= options.length) {
       index = 0;
+    } else if (index < 0) {
+      index = options.length - 1;
     }
+
     let stepCounter = 0;
     // If current index is a header or divider, or disabled, increment by step
     while (

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -426,7 +426,7 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
     // at the very end is a check to see if newIndex !== selectedIndex.
     // If the index is less than 0 and we set it back to 0, then
     // newIndex will equal selectedIndex and not stop the action
-    // of the key press happening and vic versa for index greater
+    // of the key press happening and vice versa for index greater
     // than or equal to the options length.
     if (index >= options.length) {
       index = 0;

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -426,7 +426,7 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
     // at the very end is a check to see if newIndex !== selectedIndex.
     // If the index is less than 0 and we set it back to 0, then
     // newIndex will equal selectedIndex and not stop the action
-    // of the key press happening and vice versa for index greater
+    // of the key press happening and vice versa for indexes greater
     // than or equal to the options length.
     if (index >= options.length) {
       index = 0;


### PR DESCRIPTION

#### Pull request checklist

- [X] Addresses an existing issue: Fixes #11821
- [X] Include a change request file using `$ yarn change`

#### Description of changes

// If the user is pressing the up or down key we want to make
    // sure that the dropdown cycles through the options without
    // causing the screen to scroll. In _onDropdownKeyDown
    // at the very end is a check to see if newIndex !== selectedIndex.
    // If the index is less than 0 and we set it back to 0, then
    // newIndex will equal selectedIndex and not stop the action
    // of the key press happening and vic versa for index greater
    // than or equal to the options length.

#### Focus areas to test

Dropdowns.  Please see existing issue for how to reproduce the issue.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11822)