### PR TITLE
Fix Codepen Fabric component renaming

### DIFF
--- a/change/@uifabric-tsx-editor-2020-01-28-16-14-33-xgao-fix-aria-level.json
+++ b/change/@uifabric-tsx-editor-2020-01-28-16-14-33-xgao-fix-aria-level.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Fix DetailsList export to codepen/live code editing",
+  "packageName": "@uifabric/tsx-editor",
+  "email": "xgao@microsoft.com",
+  "commit": "5d1bfca15b9979483e65953ecc872fb809a10875",
+  "dependentChangeType": "patch",
+  "date": "2020-01-29T00:14:33.899Z"
+}

--- a/packages/tsx-editor/src/transpiler/__snapshots__/exampleTransform.test.ts.snap
+++ b/packages/tsx-editor/src/transpiler/__snapshots__/exampleTransform.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`example transform can return component 1`] = `
 Object {
   "output": "(function(React) {
-const { Label, Fabric: FabricComponent, initializeIcons } = window.Fabric;
+const { Label, Fabric, initializeIcons } = window.Fabric;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -16,7 +16,7 @@ const LabelBasicExample = () => {
   );
 };
 
-const LabelBasicExampleWrapper = () => React.createElement(FabricComponent, null, React.createElement(LabelBasicExample, null));
+const LabelBasicExampleWrapper = () => React.createElement(Fabric, null, React.createElement(LabelBasicExample, null));
 return LabelBasicExampleWrapper;
 })",
 }
@@ -25,7 +25,7 @@ return LabelBasicExampleWrapper;
 exports[`example transform can return component with transpiled example 1`] = `
 Object {
   "output": "(function(React) {
-const { Label, Fabric: FabricComponent, initializeIcons } = window.Fabric;
+const { Label, Fabric, initializeIcons } = window.Fabric;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -35,7 +35,7 @@ var LabelBasicExample = function () {
         React.createElement(Label, null, \\"I'm a Label\\")));
 };
 
-const LabelBasicExampleWrapper = () => React.createElement(FabricComponent, null, React.createElement(LabelBasicExample, null));
+const LabelBasicExampleWrapper = () => React.createElement(Fabric, null, React.createElement(LabelBasicExample, null));
 return LabelBasicExampleWrapper;
 })",
 }
@@ -43,7 +43,7 @@ return LabelBasicExampleWrapper;
 
 exports[`example transform handles examples with class components 1`] = `
 Object {
-  "output": "const { SpinButton, Fabric: FabricComponent, initializeIcons } = window.Fabric;
+  "output": "const { SpinButton, Fabric, initializeIcons } = window.Fabric;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -67,7 +67,7 @@ class SpinButtonBasicExample extends React.Component<any, any> {
   }
 }
 
-const SpinButtonBasicExampleWrapper = () => <FabricComponent><SpinButtonBasicExample /></FabricComponent>;
+const SpinButtonBasicExampleWrapper = () => <Fabric><SpinButtonBasicExample /></Fabric>;
 ReactDOM.render(<SpinButtonBasicExampleWrapper />, document.getElementById('fake'))",
 }
 `;
@@ -89,7 +89,7 @@ ReactDOM.render(<FooExample />, document.getElementById('fake'))",
 
 exports[`example transform handles examples with custom supportedPackages and Fabric 1`] = `
 Object {
-  "output": "const { Stack, Fabric: FabricComponent, initializeIcons } = window.Fabric;
+  "output": "const { Stack, Fabric, initializeIcons } = window.Fabric;
 const { FooLabel } = window.Foo;
 
 // Initialize icons in case this example uses them
@@ -103,14 +103,14 @@ const FooExample = () => {
   );
 };
 
-const FooExampleWrapper = () => <FabricComponent><FooExample /></FabricComponent>;
+const FooExampleWrapper = () => <Fabric><FooExample /></Fabric>;
 ReactDOM.render(<FooExampleWrapper />, document.getElementById('fake'))",
 }
 `;
 
 exports[`example transform handles examples with function components 1`] = `
 Object {
-  "output": "const { Label, Fabric: FabricComponent, initializeIcons } = window.Fabric;
+  "output": "const { Label, Fabric, initializeIcons } = window.Fabric;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -123,14 +123,14 @@ const LabelBasicExample = () => {
   );
 };
 
-const LabelBasicExampleWrapper = () => <FabricComponent><LabelBasicExample /></FabricComponent>;
+const LabelBasicExampleWrapper = () => <Fabric><LabelBasicExample /></Fabric>;
 ReactDOM.render(<LabelBasicExampleWrapper />, document.getElementById('fake'))",
 }
 `;
 
 exports[`example transform handles transpiled examples with class components 1`] = `
 Object {
-  "output": "const { SpinButton, Fabric: FabricComponent, initializeIcons } = window.Fabric;
+  "output": "const { SpinButton, Fabric, initializeIcons } = window.Fabric;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -163,14 +163,14 @@ var SpinButtonBasicExample = /** @class */ (function (_super) {
 }(React.Component));
 { SpinButtonBasicExample };
 
-const SpinButtonBasicExampleWrapper = () => <FabricComponent><SpinButtonBasicExample /></FabricComponent>;
+const SpinButtonBasicExampleWrapper = () => <Fabric><SpinButtonBasicExample /></Fabric>;
 ReactDOM.render(<SpinButtonBasicExampleWrapper />, document.getElementById('fake'))",
 }
 `;
 
 exports[`example transform handles transpiled examples with function components 1`] = `
 Object {
-  "output": "const { Label, Fabric: FabricComponent, initializeIcons } = window.Fabric;
+  "output": "const { Label, Fabric, initializeIcons } = window.Fabric;
 
 // Initialize icons in case this example uses them
 initializeIcons();
@@ -180,7 +180,7 @@ var LabelBasicExample = function () {
         React.createElement(Label, null, \\"I'm a Label\\")));
 };
 
-const LabelBasicExampleWrapper = () => <FabricComponent><LabelBasicExample /></FabricComponent>;
+const LabelBasicExampleWrapper = () => <Fabric><LabelBasicExample /></Fabric>;
 ReactDOM.render(<LabelBasicExampleWrapper />, document.getElementById('fake'))",
 }
 `;

--- a/packages/tsx-editor/src/transpiler/exampleTransform.ts
+++ b/packages/tsx-editor/src/transpiler/exampleTransform.ts
@@ -91,17 +91,14 @@ export function transformExample(params: ITransformExampleParams): ITransformedC
     // and initialize icons in case the example uses them.
     finalComponent = component + 'Wrapper';
 
-    // rename to avoid conflict with window.Fabric
-    const renamedFabricComponent = 'FabricComponent';
-
     // If eval-ing the code, the component can't use JSX format
     const wrapperCode = returnFunction
-      ? `React.createElement(${renamedFabricComponent}, null, React.createElement(${component}, null))`
-      : `<${renamedFabricComponent}><${component} /></${renamedFabricComponent}>`;
+      ? `React.createElement(Fabric, null, React.createElement(${component}, null))`
+      : `<Fabric><${component} /></Fabric>`;
     lines.push('', `const ${finalComponent} = () => ${wrapperCode};`);
 
     if (identifiersByGlobal.Fabric.indexOf('Fabric') === -1) {
-      identifiersByGlobal.Fabric.push(`Fabric: ${renamedFabricComponent}`);
+      identifiersByGlobal.Fabric.push('Fabric');
     }
 
     if (identifiersByGlobal.Fabric.indexOf('initializeIcons') === -1) {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ yarn change`

#### Description of changes
In my [previous change](https://github.com/OfficeDev/office-ui-fabric-react/pull/11771) to fix codepen, i missed the case of:
```
 if (identifiersByGlobal.Fabric.indexOf('Fabric') === -1) {
      identifiersByGlobal.Fabric.push(`Fabric: ${renamedFabricComponent}`);
 } else {
 // NOTE: this is the missed case, we need to rename fabric here as well
}
```
As a result, DetailLists and potentially more components failed to export pen: https://developer.microsoft.com/en-us/fabric#/controls/web/detailslist

But since codepen team has fixed the bug on their side [here](https://github.com/OfficeDev/office-ui-fabric-react/issues/11773), we no longer need to rename the Fabric component. I am simply going to revert the renaming change.

#### Focus areas to test
- Export to codepen
- Live code editor


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11823)