### PR TITLE
ContextualMenu: fix role for checkable split button menu item

### DIFF
--- a/change/office-ui-fabric-react-2020-01-29-12-33-04-xgao-a11y-menu.json
+++ b/change/office-ui-fabric-react-2020-01-29-12-33-04-xgao-a11y-menu.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "ContextualMenu: fix role for checkable split button menu item",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "23cb06c1bbe4bdb2b7d756c499c1314474a78de7",
+  "dependentChangeType": "patch",
+  "date": "2020-01-29T20:33:04.046Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuButton.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { buttonProperties, getNativeProps, memoizeFunction } from '../../../Utilities';
 import { ContextualMenuItemWrapper } from './ContextualMenuItemWrapper';
 import { KeytipData } from '../../../KeytipData';
-import { getIsChecked, isItemDisabled, hasSubmenu } from '../../../utilities/contextualMenu/index';
+import { getIsChecked, isItemDisabled, hasSubmenu, getMenuItemAriaRole } from '../../../utilities/contextualMenu/index';
 import { ContextualMenuItem } from '../ContextualMenuItem';
 import { IKeytipDataProps } from '../../KeytipData/KeytipData.types';
 import { IKeytipProps } from '../../Keytip/Keytip.types';
@@ -39,7 +39,7 @@ export class ContextualMenuButton extends ContextualMenuItemWrapper {
 
     const isChecked: boolean | null | undefined = getIsChecked(item);
     const canCheck: boolean = isChecked !== null;
-    const defaultRole = canCheck ? 'menuitemcheckbox' : 'menuitem';
+    const defaultRole = getMenuItemAriaRole(item);
     const itemHasSubmenu = hasSubmenu(item);
     const { itemProps, ariaLabel } = item;
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
@@ -4,7 +4,7 @@ import { ContextualMenuItem } from '../ContextualMenuItem';
 import { IContextualMenuItem } from '../ContextualMenu.types';
 import { IMenuItemClassNames, getSplitButtonVerticalDividerClassNames } from '../ContextualMenu.classNames';
 import { KeytipData } from '../../../KeytipData';
-import { isItemDisabled, hasSubmenu } from '../../../utilities/contextualMenu/index';
+import { isItemDisabled, hasSubmenu, getMenuItemAriaRole } from '../../../utilities/contextualMenu/index';
 import { VerticalDivider } from '../../../Divider';
 import { ContextualMenuItemWrapper } from './ContextualMenuItemWrapper';
 import { IKeytipProps } from '../../Keytip/Keytip.types';
@@ -57,7 +57,7 @@ export class ContextualMenuSplitButton extends ContextualMenuItemWrapper {
           <div
             data-ktp-target={keytipAttributes['data-ktp-target']}
             ref={(splitButton: HTMLDivElement) => (this._splitButton = splitButton)}
-            role={'menuitem'}
+            role={getMenuItemAriaRole(item)}
             aria-label={item.ariaLabel}
             className={classNames.splitContainer}
             aria-disabled={isItemDisabled(item)}

--- a/packages/office-ui-fabric-react/src/utilities/contextualMenu/contextualMenuUtility.test.ts
+++ b/packages/office-ui-fabric-react/src/utilities/contextualMenu/contextualMenuUtility.test.ts
@@ -1,4 +1,4 @@
-import { getIsChecked, hasSubmenu } from './contextualMenuUtility';
+import { getIsChecked, hasSubmenu, getMenuItemAriaRole } from './contextualMenuUtility';
 import { IContextualMenuItem } from '../../index';
 
 describe('getIsChecked', () => {
@@ -18,6 +18,14 @@ describe('getIsChecked', () => {
       menuItem.checked = true;
       expect(getIsChecked(menuItem)).toBe(true);
     });
+  });
+
+  it('when item cannot be checked', () => {
+    const menuItem: IContextualMenuItem = {
+      key: '123',
+      canCheck: false
+    };
+    expect(getIsChecked(menuItem)).toBe(null);
   });
 
   describe('when item isChecked', () => {
@@ -54,6 +62,18 @@ describe('getIsChecked', () => {
     it('returns false', () => {
       expect(getIsChecked(menuItem)).toBeFalsy();
     });
+  });
+});
+
+describe('getMenuItemAriaRole', () => {
+  it('menu item is checkbox', () => {
+    const menuItem: IContextualMenuItem = { key: '123', canCheck: true, checked: false };
+    expect(getMenuItemAriaRole(menuItem)).toBe('menuitemcheckbox');
+  });
+
+  it('menu item is not checkbox', () => {
+    const menuItem: IContextualMenuItem = { key: '123', canCheck: false };
+    expect(getMenuItemAriaRole(menuItem)).toBe('menuitem');
   });
 });
 

--- a/packages/office-ui-fabric-react/src/utilities/contextualMenu/contextualMenuUtility.ts
+++ b/packages/office-ui-fabric-react/src/utilities/contextualMenu/contextualMenuUtility.ts
@@ -32,3 +32,9 @@ export function hasSubmenu(item: IContextualMenuItem): boolean {
 export function isItemDisabled(item: IContextualMenuItem): boolean {
   return !!(item.isDisabled || item.disabled);
 }
+
+export function getMenuItemAriaRole(item: IContextualMenuItem): string {
+  const isChecked = getIsChecked(item);
+  const canCheck: boolean = isChecked !== null;
+  return canCheck ? 'menuitemcheckbox' : 'menuitem';
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10830
- [x] Include a change request file using `$ yarn change`

#### Description of changes
The checked/unchecked state of a checkable split button menu item is not announced. The reason is the `ContextualMenuSplitButton` always set to be `role=menuitem`


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11830)