### PR TITLE
Text: Updating docs and style logic to remove 'inherit' by default behavior

### DIFF
--- a/change/@uifabric-experiments-2020-01-29-15-00-12-textDocumentation.json
+++ b/change/@uifabric-experiments-2020-01-29-15-00-12-textDocumentation.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Updating snapshots in experiments package.",
+  "packageName": "@uifabric/experiments",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "1be065b85f29c28ee7a316ab93a263f09e32f1db",
+  "dependentChangeType": "patch",
+  "date": "2020-01-29T23:00:12.530Z"
+}

--- a/change/office-ui-fabric-react-2020-01-29-13-52-30-textDocumentation.json
+++ b/change/office-ui-fabric-react-2020-01-29-13-52-30-textDocumentation.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Text: Updating docs and style logic to remove 'inherit' by default behavior.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "ef797d1a598395ea8fddf5c275b01bf043c5840f",
+  "dependentChangeType": "patch",
+  "date": "2020-01-29T21:52:30.492Z"
+}

--- a/packages/experiments/src/components/Button/ButtonVariants/__snapshots__/ButtonVariants.test.tsx.snap
+++ b/packages/experiments/src/components/Button/ButtonVariants/__snapshots__/ButtonVariants.test.tsx.snap
@@ -102,7 +102,6 @@ exports[`Button Variants renders a CommandBarButton correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
@@ -225,7 +224,6 @@ exports[`Button Variants renders a DefaultButton correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: inherit;
           font-size: 14px;
@@ -350,7 +348,6 @@ exports[`Button Variants renders a PrimaryButton correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: inherit;
           font-size: 14px;
@@ -613,7 +610,6 @@ exports[`Button Variants renders a default MessageBarButton correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: inherit;
           font-size: 14px;
@@ -891,7 +887,6 @@ exports[`Button Variants renders a default disabled MessageBarButton correctly 1
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: inherit;
           font-size: 14px;
@@ -1014,7 +1009,6 @@ exports[`Button Variants renders a disabled ActionButton correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
@@ -1133,7 +1127,6 @@ exports[`Button Variants renders a disabled CommandBarButton correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
@@ -1262,7 +1255,6 @@ exports[`Button Variants renders a disabled DefaultButton correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: inherit;
           font-size: 14px;
@@ -1387,7 +1379,6 @@ exports[`Button Variants renders a disabled IconButton correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: inherit;
           font-size: 14px;
@@ -1519,7 +1510,6 @@ exports[`Button Variants renders a disabled PrimaryButton correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: inherit;
           font-size: 14px;
@@ -1799,7 +1789,6 @@ exports[`Button Variants renders a primary MessageBarButton correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: inherit;
           font-size: 14px;
@@ -2083,7 +2072,6 @@ exports[`Button Variants renders a primary disabled MessageBarButton correctly 1
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: inherit;
           font-size: 14px;
@@ -2204,7 +2192,6 @@ exports[`Button Variants renders an ActionButton correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
@@ -2328,7 +2315,6 @@ exports[`Button Variants renders an IconButton correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: inherit;
           font-size: 14px;

--- a/packages/experiments/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/experiments/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -108,7 +108,6 @@ exports[`Button renders a default Button with content correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: inherit;
           font-size: 14px;

--- a/packages/experiments/src/components/Persona/Vertical/__snapshots__/VerticalPersona.test.tsx.snap
+++ b/packages/experiments/src/components/Persona/Vertical/__snapshots__/VerticalPersona.test.tsx.snap
@@ -38,7 +38,6 @@ exports[`VerticalPersona renders correctly with a text and secondary text 1`] = 
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            color: inherit;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 19.2px;
@@ -138,7 +137,6 @@ exports[`VerticalPersona renders correctly with only a text 1`] = `
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            color: inherit;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 19.2px;
@@ -214,7 +212,6 @@ exports[`VerticalPersona renders the coin with the passed coinProps 1`] = `
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            color: inherit;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 19.2px;

--- a/packages/experiments/src/components/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/experiments/src/components/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -96,7 +96,6 @@ exports[`PersonaCoin renders a coin with the initials JB 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 19.2px;
@@ -132,7 +131,6 @@ exports[`PersonaCoin renders a correct persona 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 19.2px;
@@ -168,7 +166,6 @@ exports[`PersonaCoin renders a red coin 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 19.2px;
@@ -400,7 +397,6 @@ exports[`PersonaCoin renders the coin with the provided image 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 19.2px;

--- a/packages/office-ui-fabric-react/src/components/Text/Text.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Text/Text.styles.ts
@@ -12,12 +12,12 @@ export const TextStyles: ITextComponent['styles'] = (props: ITextProps, theme: I
       theme.fonts.medium,
       {
         display: block ? (as === 'td' ? 'table-cell' : 'block') : 'inline',
-        fontFamily: (variantObject && variantObject.fontFamily) || 'inherit',
-        fontSize: (variantObject && variantObject.fontSize) || 'inherit',
-        fontWeight: (variantObject && variantObject.fontWeight) || 'inherit',
-        color: (variantObject && variantObject.color) || 'inherit',
-        mozOsxFontSmoothing: variantObject && variantObject.MozOsxFontSmoothing,
-        webkitFontSmoothing: variantObject && variantObject.WebkitFontSmoothing
+        fontFamily: variantObject.fontFamily,
+        fontSize: variantObject.fontSize,
+        fontWeight: variantObject.fontWeight,
+        color: variantObject.color,
+        mozOsxFontSmoothing: variantObject.MozOsxFontSmoothing,
+        webkitFontSmoothing: variantObject.WebkitFontSmoothing
       },
       nowrap && {
         whiteSpace: 'nowrap',

--- a/packages/office-ui-fabric-react/src/components/Text/__snapshots__/Text.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Text/__snapshots__/Text.test.tsx.snap
@@ -7,7 +7,6 @@ exports[`Text renders Text with {0} as its children correctly 1`] = `
       {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;
-        color: inherit;
         display: inline;
         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
         font-size: 14px;
@@ -27,7 +26,6 @@ exports[`Text renders default Text correctly 1`] = `
       {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;
-        color: inherit;
         display: inline;
         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
         font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/Text/docs/TextOverview.md
+++ b/packages/office-ui-fabric-react/src/components/Text/docs/TextOverview.md
@@ -3,7 +3,7 @@ You can use Text to standardize text across your web app.
 
 You can specify the `variant` prop to apply font styles to Text.
 This variant pulls from the Fabric theme loaded on the page.
-If you do not specify the `variant` prop, by default, Text inherits font family, font size, font weight, and color from its parent element.
+If you do not specify the `variant` prop, by default, Text applies the styling from specifying the `variant` value to `medium`.
 
 The Text control is inline wrap by default.
 You can specify `block` to enable block and `nowrap` to enable `nowrap`.

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.BulkOperations.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.BulkOperations.Example.tsx.shot
@@ -28,7 +28,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
@@ -45,7 +44,6 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.LazyLoading.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.LazyLoading.Example.tsx.shot
@@ -28,7 +28,6 @@ exports[`Component Examples renders Announced.LazyLoading.Example.tsx correctly 
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.SearchResults.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.SearchResults.Example.tsx.shot
@@ -28,7 +28,6 @@ exports[`Component Examples renders Announced.SearchResults.Example.tsx correctl
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -42,7 +42,6 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            color: inherit;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -42,7 +42,6 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            color: inherit;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Separator.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Separator.Basic.Example.tsx.shot
@@ -49,7 +49,6 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            color: inherit;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
@@ -135,7 +134,6 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            color: inherit;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
@@ -221,7 +219,6 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            color: inherit;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
@@ -307,7 +304,6 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            color: inherit;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
@@ -414,7 +410,6 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              color: inherit;
               display: inline;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
@@ -520,7 +515,6 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              color: inherit;
               display: inline;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
@@ -626,7 +620,6 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              color: inherit;
               display: inline;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
@@ -732,7 +725,6 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
-              color: inherit;
               display: inline;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Separator.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Separator.Icon.Example.tsx.shot
@@ -28,7 +28,6 @@ exports[`Component Examples renders Separator.Icon.Example.tsx correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Separator.Theming.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Separator.Theming.Example.tsx.shot
@@ -28,7 +28,6 @@ exports[`Component Examples renders Separator.Theming.Example.tsx correctly 1`] 
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Block.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Block.Example.tsx.shot
@@ -8,7 +8,6 @@ Array [
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: block;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
@@ -25,7 +24,6 @@ Array [
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: block;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
@@ -42,7 +40,6 @@ Array [
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: block;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
@@ -59,7 +56,6 @@ Array [
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: block;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Ramp.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Ramp.Example.tsx.shot
@@ -740,7 +740,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
-                                  color: inherit;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 10px;
@@ -987,7 +986,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
-                                  color: inherit;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 10px;
@@ -1234,7 +1232,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
-                                  color: inherit;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 12px;
@@ -1481,7 +1478,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
-                                  color: inherit;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 12px;
@@ -1728,7 +1724,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
-                                  color: inherit;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 14px;
@@ -1975,7 +1970,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
-                                  color: inherit;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 16px;
@@ -2222,7 +2216,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
-                                  color: inherit;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 18px;
@@ -2469,7 +2462,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
-                                  color: inherit;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 20px;
@@ -2716,7 +2708,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
-                                  color: inherit;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 28px;
@@ -2963,7 +2954,6 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
-                                  color: inherit;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 68px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Wrap.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Wrap.Example.tsx.shot
@@ -49,7 +49,6 @@ exports[`Component Examples renders Text.Wrap.Example.tsx correctly 1`] = `
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            color: inherit;
             display: block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 18px;
@@ -66,7 +65,6 @@ exports[`Component Examples renders Text.Wrap.Example.tsx correctly 1`] = `
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            color: inherit;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
@@ -105,7 +103,6 @@ exports[`Component Examples renders Text.Wrap.Example.tsx correctly 1`] = `
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            color: inherit;
             display: block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 18px;
@@ -122,7 +119,6 @@ exports[`Component Examples renders Text.Wrap.Example.tsx correctly 1`] = `
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
-            color: inherit;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Styled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Styled.Example.tsx.shot
@@ -28,7 +28,6 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: inherit;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11801
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The `Text` component had some outdated documentation about the component inheriting its parent font styles while this is no longer the case. This PR updates this documentation and fixes some logic in the styles that still accounted for this old behavior.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11831)