### PR TITLE
GroupedList: Adding aria-expanded state to the focus target of groups

### DIFF
--- a/change/office-ui-fabric-react-2020-01-29-16-53-39-groupedListExpandedState.json
+++ b/change/office-ui-fabric-react-2020-01-29-16-53-39-groupedListExpandedState.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "GroupedList: Adding aria-expanded state to the focus target of groups so that the collapsed/expanded state of the group is announced.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "e3b68f4911328f99831f98840231c26d1d68da4c",
+  "dependentChangeType": "patch",
+  "date": "2020-01-30T00:53:39.300Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -5125,6 +5125,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                         role="presentation"
                       >
                         <div
+                          aria-expanded={true}
                           aria-label="Group 0"
                           className=
                               ms-GroupHeader
@@ -5738,6 +5739,7 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                         role="presentation"
                       >
                         <div
+                          aria-expanded={true}
                           aria-label="Group 1"
                           className=
                               ms-GroupHeader

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
@@ -90,7 +90,7 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
         className={this._classNames.root}
         style={viewport ? { minWidth: viewport.width } : {}}
         onClick={this._onHeaderClick}
-        aria-expanded={group ? !group.isCollapsed : undefined}
+        aria-expanded={!group.isCollapsed}
         aria-label={group.ariaLabel || group.name}
         data-is-focusable={true}
       >
@@ -120,7 +120,7 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
             type="button"
             className={this._classNames.expand}
             onClick={this._onToggleCollapse}
-            aria-expanded={group ? !group.isCollapsed : undefined}
+            aria-expanded={!group.isCollapsed}
             aria-controls={group && !group.isCollapsed ? groupedListId : undefined}
             {...expandButtonProps}
           >

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
@@ -90,6 +90,7 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
         className={this._classNames.root}
         style={viewport ? { minWidth: viewport.width } : {}}
         onClick={this._onHeaderClick}
+        aria-expanded={group ? !group.isCollapsed : undefined}
         aria-label={group.ariaLabel || group.name}
         data-is-focusable={true}
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -1256,6 +1256,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                           role="presentation"
                         >
                           <div
+                            aria-expanded={true}
                             aria-label="Color: \\"red\\""
                             className=
                                 ms-GroupHeader
@@ -2630,6 +2631,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                           role="presentation"
                         >
                           <div
+                            aria-expanded={true}
                             aria-label="Color: \\"green\\""
                             className=
                                 ms-GroupHeader
@@ -3038,6 +3040,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                           role="presentation"
                         >
                           <div
+                            aria-expanded={true}
                             aria-label="Color: \\"blue\\""
                             className=
                                 ms-GroupHeader

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -911,6 +911,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                         role="presentation"
                       >
                         <div
+                          aria-expanded={true}
                           aria-label="0"
                           className=
                               ms-GroupHeader


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11816
- [x] Include a change request file using `$ yarn change`

#### Description of changes

When using keyboard navigation on the `GroupedList` and arriving on a group, the tab stop was on the entire group itself, which was not announcing the collapsed/expanded state of the group because this information was only being added to the chevron button. This PR adds this information on the top-level tab stop so that screen reader users can know this when navigating through `GroupedLists`.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11833)