### PR TITLE
GroupedList: Adding aria-level to indicate nested level of groups

### DIFF
--- a/change/office-ui-fabric-react-2020-01-29-17-36-36-groupedListLevel.json
+++ b/change/office-ui-fabric-react-2020-01-29-17-36-36-groupedListLevel.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "GroupedList: Adding aria-level to indicate nested level of groups.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "ee88c9473cd7cb6eac5709883930a7bd798951af",
+  "dependentChangeType": "patch",
+  "date": "2020-01-30T01:36:36.884Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Grouped.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Grouped.Example.tsx
@@ -54,9 +54,9 @@ export class DetailsListGroupedExample extends React.Component<{}, IDetailsListG
       ],
       // This is based on the definition of items
       groups: [
-        { key: 'groupred0', name: 'Color: "red"', startIndex: 0, count: 2 },
-        { key: 'groupgreen2', name: 'Color: "green"', startIndex: 2, count: 0 },
-        { key: 'groupblue2', name: 'Color: "blue"', startIndex: 2, count: 3 }
+        { key: 'groupred0', name: 'Color: "red"', startIndex: 0, count: 2, level: 0 },
+        { key: 'groupgreen2', name: 'Color: "green"', startIndex: 2, count: 0, level: 0 },
+        { key: 'groupblue2', name: 'Color: "blue"', startIndex: 2, count: 3, level: 0 }
       ],
       showItemIndexInView: false,
       isCompactMode: false

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Grouped.Large.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.Grouped.Large.Example.tsx
@@ -30,7 +30,8 @@ export class DetailsListGroupedLargeExample extends React.Component<{}, {}> {
         key: i.toString(),
         name: i.toString(),
         startIndex: i * 100,
-        count: 100
+        count: 100,
+        level: 0
       });
     }
 

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
@@ -91,6 +91,7 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
         style={viewport ? { minWidth: viewport.width } : {}}
         onClick={this._onHeaderClick}
         aria-label={group.ariaLabel || group.name}
+        aria-level={groupLevel !== undefined ? groupLevel + 1 : undefined}
         data-is-focusable={true}
       >
         <FocusZone className={this._classNames.groupHeaderContainer} direction={FocusZoneDirection.horizontal}>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -1257,6 +1257,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                         >
                           <div
                             aria-label="Color: \\"red\\""
+                            aria-level={1}
                             className=
                                 ms-GroupHeader
                                 {
@@ -2631,6 +2632,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                         >
                           <div
                             aria-label="Color: \\"green\\""
+                            aria-level={1}
                             className=
                                 ms-GroupHeader
                                 {
@@ -3039,6 +3041,7 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                         >
                           <div
                             aria-label="Color: \\"blue\\""
+                            aria-level={1}
                             className=
                                 ms-GroupHeader
                                 {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -912,6 +912,7 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                       >
                         <div
                           aria-label="0"
+                          aria-level={1}
                           className=
                               ms-GroupHeader
                               {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11820
- [x] Include a change request file using `$ yarn change`

#### Description of changes

There was no way to indicate the nested level of groups to screen reader users in `GroupedLists`. This PR adds this ability by making use of `aria-level`.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11834)