### PR TITLE
Website: Fixing Card API reference tables not appearing on the component docs page

### DIFF
--- a/apps/fabric-website/src/pages/Controls/ControlsAreaPage.tsx
+++ b/apps/fabric-website/src/pages/Controls/ControlsAreaPage.tsx
@@ -6,21 +6,16 @@ import { IPageJson } from 'office-ui-fabric-react/lib/common/DocPage.types';
 
 export interface IControlsPageProps extends IPageProps<Platforms> {}
 
-const apiRequireContext = [
-  require.context('@uifabric/api-docs/lib/pages/office-ui-fabric-react'),
-  require.context('@uifabric/api-docs/lib/pages/react-cards')
-];
+const apiRequireContext = require.context('@uifabric/api-docs/lib/pages/', true, /^(?!references).*/);
 
 const ControlsAreaPageBase: React.StatelessComponent<IControlsPageProps> = props => {
   let jsonDocs: IPageJson;
   if (props.platform === 'web' && !props.jsonDocs) {
     // Get the control's .page.json file for API docs if it exists
-    for (const context of apiRequireContext) {
-      for (const path of context.keys()) {
-        if (path.indexOf(`/${props.title}.page.json`) !== -1) {
-          jsonDocs = context<IPageJson>(path);
-          break;
-        }
+    for (const path of apiRequireContext.keys()) {
+      if (path.indexOf(`/${props.title}.page.json`) !== -1) {
+        jsonDocs = apiRequireContext<IPageJson>(path);
+        break;
       }
     }
   }

--- a/apps/fabric-website/src/pages/Controls/ControlsAreaPage.tsx
+++ b/apps/fabric-website/src/pages/Controls/ControlsAreaPage.tsx
@@ -6,16 +6,21 @@ import { IPageJson } from 'office-ui-fabric-react/lib/common/DocPage.types';
 
 export interface IControlsPageProps extends IPageProps<Platforms> {}
 
-const apiRequireContext = require.context('@uifabric/api-docs/lib/pages/office-ui-fabric-react');
+const apiRequireContext = [
+  require.context('@uifabric/api-docs/lib/pages/office-ui-fabric-react'),
+  require.context('@uifabric/api-docs/lib/pages/react-cards')
+];
 
 const ControlsAreaPageBase: React.StatelessComponent<IControlsPageProps> = props => {
   let jsonDocs: IPageJson;
   if (props.platform === 'web' && !props.jsonDocs) {
     // Get the control's .page.json file for API docs if it exists
-    for (const path of apiRequireContext.keys()) {
-      if (path.indexOf(`/${props.title}.page.json`) !== -1) {
-        jsonDocs = apiRequireContext<IPageJson>(path);
-        break;
+    for (const context of apiRequireContext) {
+      for (const path of context.keys()) {
+        if (path.indexOf(`/${props.title}.page.json`) !== -1) {
+          jsonDocs = context<IPageJson>(path);
+          break;
+        }
       }
     }
   }

--- a/change/@uifabric-fabric-website-2020-01-30-16-12-29-master.json
+++ b/change/@uifabric-fabric-website-2020-01-30-16-12-29-master.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Website: Fixing Card API reference tables not appearing on the component docs page.",
+  "packageName": "@uifabric/fabric-website",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "f5298bd0b9ddcbe8e4257c2092a95ebd81500f7c",
+  "dependentChangeType": "patch",
+  "date": "2020-01-31T00:12:29.806Z"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11843
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The API reference tables for the `Card` component weren't appearing on the website because it was looking only at pages generated from the `office-ui-fabric-react` package whereas the `Card` component is in the `@uifabric/react-cards` package. This PR fixes this issue by making the website look in both places for components.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11844)