### PR TITLE
Add support to customize DetailsList tooltips based on column data

### DIFF
--- a/change/office-ui-fabric-react-2020-01-30-16-43-16-list-accessibility.json
+++ b/change/office-ui-fabric-react-2020-01-30-16-43-16-list-accessibility.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Add ability to customize DetailsHeader tooltip based on column data",
+  "packageName": "office-ui-fabric-react",
+  "email": "tmichon@microsoft.com",
+  "commit": "2abe8243a70877dcdfa0b7417f27bac812326b46",
+  "dependentChangeType": "patch",
+  "date": "2020-01-31T00:43:16.062Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -3275,7 +3275,7 @@ export interface IDetailsColumnProps extends React.ClassAttributes<DetailsColumn
     isDropped?: boolean;
     onColumnClick?: (ev: React.MouseEvent<HTMLElement>, column: IColumn) => void;
     onColumnContextMenu?: (column: IColumn, ev: React.MouseEvent<HTMLElement>) => void;
-    onRenderColumnHeaderTooltip?: IRenderFunction<ITooltipHostProps>;
+    onRenderColumnHeaderTooltip?: IRenderFunction<IDetailsColumnRenderTooltipProps>;
     parentId?: string;
     // @deprecated (undocumented)
     setDraggedItemIndex?: (itemIndex: number) => void;
@@ -3285,6 +3285,11 @@ export interface IDetailsColumnProps extends React.ClassAttributes<DetailsColumn
         itemIndex: number;
     }, event?: MouseEvent) => void;
     useFastIcons?: boolean;
+}
+
+// @public (undocumented)
+export interface IDetailsColumnRenderTooltipProps extends ITooltipHostProps {
+    column?: IColumn;
 }
 
 // @public (undocumented)
@@ -3365,7 +3370,7 @@ export interface IDetailsHeaderBaseProps extends React.ClassAttributes<DetailsHe
     onColumnContextMenu?: (column: IColumn, ev: React.MouseEvent<HTMLElement>) => void;
     onColumnIsSizingChanged?: (column: IColumn, isSizing: boolean) => void;
     onColumnResized?: (column: IColumn, newWidth: number, columnIndex: number) => void;
-    onRenderColumnHeaderTooltip?: IRenderFunction<ITooltipHostProps>;
+    onRenderColumnHeaderTooltip?: IRenderFunction<IDetailsColumnRenderTooltipProps>;
     onRenderDetailsCheckbox?: IRenderFunction<IDetailsCheckboxProps>;
     onToggleCollapseAll?: (isAllCollapsed: boolean) => void;
     selectAllVisibility?: SelectAllVisibility;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.base.tsx
@@ -2,11 +2,14 @@ import * as React from 'react';
 import { Icon, FontIcon } from '../../Icon';
 import { initializeComponentRef, EventGroup, Async, IDisposable, classNamesFunction, IClassNames } from '../../Utilities';
 import { ColumnActionsMode } from './DetailsList.types';
-
-import { ITooltipHostProps } from '../../Tooltip';
 import { IDragDropOptions } from './../../utilities/dragdrop/interfaces';
 import { DEFAULT_CELL_STYLE_PROPS } from './DetailsRow.styles';
-import { IDetailsColumnStyleProps, IDetailsColumnProps, IDetailsColumnStyles } from './DetailsColumn.types';
+import {
+  IDetailsColumnStyleProps,
+  IDetailsColumnProps,
+  IDetailsColumnStyles,
+  IDetailsColumnRenderTooltipProps
+} from './DetailsColumn.types';
 
 const MOUSEDOWN_PRIMARY_BUTTON = 0; // for mouse down event we are using ev.button property, 0 means left button
 
@@ -91,6 +94,7 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
               hostClassName: classNames.cellTooltip,
               id: `${parentId}-${column.key}-tooltip`,
               setAriaDescribedBy: false,
+              column,
               content: column.columnActionsMode !== ColumnActionsMode.disabled ? column.ariaLabel : '',
               children: (
                 <span
@@ -191,7 +195,7 @@ export class DetailsColumnBase extends React.Component<IDetailsColumnProps> {
     }
   }
 
-  private _onRenderColumnHeaderTooltip = (tooltipHostProps: ITooltipHostProps): JSX.Element => {
+  private _onRenderColumnHeaderTooltip = (tooltipHostProps: IDetailsColumnRenderTooltipProps): JSX.Element => {
     return <span className={tooltipHostProps.hostClassName}>{tooltipHostProps.children}</span>;
   };
 

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsColumn.types.ts
@@ -8,6 +8,17 @@ import { ICellStyleProps } from './DetailsRow.types';
 import { ITheme, IStyle } from '../../Styling';
 
 /**
+ * {@docgategory DetailsList}
+ */
+export interface IDetailsColumnRenderTooltipProps extends ITooltipHostProps {
+  /**
+   * Information about the column for which the tooltip is being rendered.
+   * Use this to format status information about the column, such as its filter or sort state.
+   */
+  column?: IColumn;
+}
+
+/**
  * {@docCategory DetailsList}
  */
 export interface IDetailsColumnProps extends React.ClassAttributes<DetailsColumnBase> {
@@ -38,7 +49,7 @@ export interface IDetailsColumnProps extends React.ClassAttributes<DetailsColumn
   /**
    * Render function for providing a column header tooltip.
    */
-  onRenderColumnHeaderTooltip?: IRenderFunction<ITooltipHostProps>;
+  onRenderColumnHeaderTooltip?: IRenderFunction<IDetailsColumnRenderTooltipProps>;
   /**
    * Callback fired when click event occurs.
    */

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.types.ts
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsHeader.types.ts
@@ -1,13 +1,13 @@
 import * as React from 'react';
 import { IRefObject, IRenderFunction, IStyleFunctionOrObject } from '../../Utilities';
 import { CollapseAllVisibility } from '../../GroupedList';
-import { ITooltipHostProps } from '../../Tooltip';
 import { ITheme, IStyle } from '../../Styling';
 import { DetailsHeaderBase } from './DetailsHeader.base';
 import { IColumn, DetailsListLayoutMode, IColumnReorderOptions, ColumnDragEndLocation } from './DetailsList.types';
 import { ICellStyleProps, IDetailsItemProps } from './DetailsRow.types';
 import { ISelection, SelectionMode } from '../../utilities/selection/index';
 import { IDetailsCheckboxProps } from './DetailsRowCheck.types';
+import { IDetailsColumnRenderTooltipProps } from './DetailsColumn.types';
 
 /**
  * {@docCategory DetailsList}
@@ -49,7 +49,7 @@ export interface IDetailsHeaderBaseProps extends React.ClassAttributes<DetailsHe
   onColumnContextMenu?: (column: IColumn, ev: React.MouseEvent<HTMLElement>) => void;
 
   /** Callback to render a tooltip for the column header */
-  onRenderColumnHeaderTooltip?: IRenderFunction<ITooltipHostProps>;
+  onRenderColumnHeaderTooltip?: IRenderFunction<IDetailsColumnRenderTooltipProps>;
 
   /** Whether to collapse for all visibility */
   collapseAllVisibility?: CollapseAllVisibility;


### PR DESCRIPTION
Updated the interface for `onRenderColumnHeaderTooltip` so the implementation passes `column` alongside the current `TooltipHost` props. This way, a downstream override can customize the result based on which column is being rendered.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11846)