### PR TITLE
Dialog: Fix DialogContentProps titleProps bugs

### DIFF
--- a/change/office-ui-fabric-react-2020-01-31-12-51-46-xgao-dialog-title-id.json
+++ b/change/office-ui-fabric-react-2020-01-31-12-51-46-xgao-dialog-title-id.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Dialog: Fix DialogContent titleProps",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "9e0dd8e0c13cba7a7dc0ba4bb636c837c17440e9",
+  "dependentChangeType": "patch",
+  "date": "2020-01-31T20:51:46.578Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.base.tsx
@@ -121,7 +121,11 @@ export class DialogBase extends React.Component<IDialogProps, {}> {
     const dialogContentProps: IDialogContentProps = {
       ...DefaultDialogContentProps,
       ...this.props.dialogContentProps,
-      draggableHeaderClassName: dialogDraggableClassName
+      draggableHeaderClassName: dialogDraggableClassName,
+      titleProps: {
+        id: this.props.dialogContentProps?.titleId || this._defaultTitleTextId,
+        ...this.props.dialogContentProps?.titleProps
+      }
     };
 
     const classNames = getClassNames(styles!, {
@@ -155,7 +159,6 @@ export class DialogBase extends React.Component<IDialogProps, {}> {
         <DialogContent
           subTextId={this._defaultSubTextId}
           title={title}
-          titleProps={{ id: this._defaultTitleTextId }}
           subText={subText}
           showCloseButton={isBlocking !== undefined ? !isBlocking : !mergedModalProps.isBlocking}
           topButtonsProps={topButtonsProps ? topButtonsProps : dialogContentProps!.topButtonsProps}

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.test.tsx
@@ -170,8 +170,7 @@ describe('Dialog', () => {
           dialogContentProps={{
             titleId,
             type: DialogType.normal,
-            title: 'sample title',
-            subText: 'Sample subtext'
+            title: 'sample title'
           }}
         />
       );
@@ -190,7 +189,6 @@ describe('Dialog', () => {
             titleId,
             type: DialogType.normal,
             title: 'sample title',
-            subText: 'Sample subtext',
             titleProps: { id: undefined }
           }}
         />
@@ -210,7 +208,6 @@ describe('Dialog', () => {
             titleId: `${titleId}_deprecated`,
             type: DialogType.normal,
             title: 'sample title',
-            subText: 'Sample subtext',
             titleProps: { id: titleId }
           }}
         />

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.test.tsx
@@ -5,6 +5,7 @@ import { mount } from 'enzyme';
 import { DialogBase } from './Dialog.base';
 import { DialogContent } from './DialogContent';
 import { DialogType } from './DialogContent.types'; // for express fluent assertions
+import { setWarningCallback } from '@uifabric/utilities';
 
 describe('Dialog', () => {
   afterEach(() => {
@@ -82,14 +83,19 @@ describe('Dialog', () => {
         dialogContentProps={{
           type: DialogType.normal,
           title: 'sample title',
-          subText: 'Sample subtext'
+          subText: 'Sample subtext',
+          titleProps: { 'aria-level': 3 }
         }}
       />
     );
 
     const dialogHTML = document.querySelector('[role="dialog"]');
     expect(dialogHTML).not.toBeNull();
-    expect(dialogHTML!.getAttribute('aria-labelledby')).toMatch(/Dialog[\d+]+-title/);
+
+    const labelledby = dialogHTML!.getAttribute('aria-labelledby');
+    expect(labelledby).toMatch(/Dialog[\d+]+-title/);
+    expect(document.getElementById(labelledby!)).not.toBeNull();
+
     expect(dialogHTML!.getAttribute('aria-describedby')).toMatch(/Dialog[\d+]+-subText/);
     wrapper.unmount();
   });
@@ -144,5 +150,75 @@ describe('Dialog', () => {
     expect(dialogHTML!.getAttribute('aria-labelledby')).toEqual(titleAriaId);
     expect(dialogHTML!.getAttribute('aria-describedby')).toMatch(/Dialog[\d+]+-subText/);
     wrapper.unmount();
+  });
+
+  describe('Dialog Title Id', () => {
+    beforeEach(() => {
+      // Prevent warn deprecations from failing test
+      setWarningCallback(() => {
+        /* no-op */
+      });
+    });
+
+    afterEach(() => setWarningCallback());
+
+    it('deprecated titleId prop should be set if titleProps.id is not passed', () => {
+      const titleId = 'title_id';
+      const wrapper = mount(
+        <DialogBase
+          hidden={false}
+          dialogContentProps={{
+            titleId,
+            type: DialogType.normal,
+            title: 'sample title',
+            subText: 'Sample subtext'
+          }}
+        />
+      );
+
+      const dialogTitle = document.getElementById(titleId);
+      expect(dialogTitle).not.toBeNull();
+      wrapper.unmount();
+    });
+
+    it('deprecated titleId prop should not be set if titleProps.id is undefined', () => {
+      const titleId = 'title_id';
+      const wrapper = mount(
+        <DialogBase
+          hidden={false}
+          dialogContentProps={{
+            titleId,
+            type: DialogType.normal,
+            title: 'sample title',
+            subText: 'Sample subtext',
+            titleProps: { id: undefined }
+          }}
+        />
+      );
+
+      const dialogTitle = document.getElementById(titleId);
+      expect(dialogTitle).toBeNull();
+      wrapper.unmount();
+    });
+
+    it('titleProps.id should be set if deprecated titleId is also passed', () => {
+      const titleId = 'title_id';
+      const wrapper = mount(
+        <DialogBase
+          hidden={false}
+          dialogContentProps={{
+            titleId: `${titleId}_deprecated`,
+            type: DialogType.normal,
+            title: 'sample title',
+            subText: 'Sample subtext',
+            titleProps: { id: titleId }
+          }}
+        />
+      );
+
+      const dialogTitle = document.getElementById(titleId);
+      expect(dialogTitle).not.toBeNull();
+      wrapper.unmount();
+    });
   });
 });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [X] Include a change request file using `$ yarn change`

#### Description of changes
Fixing couple issues with `dialogContentProps.titleProps` which were missed in [this change](https://github.com/OfficeDev/office-ui-fabric-react/pull/11798):
1. deprecated `titleId` field is not being honored regardless whether `titleProps` is passed. because `titleProps.id` is passed with default Id from `Dialog` and it overwrites `titleId` inside `DialogContent`
 2. when `titleProps` is passed, it overwrites `titleProps={{ id: this._defaultTitleTextId }}` completely regardless if `titleProps` contains `id` or not


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11848)