### PR TITLE
Prevent ComponentExamples test from eating errors

### DIFF
--- a/change/office-ui-fabric-react-2020-01-31-12-45-47-errors-plz.json
+++ b/change/office-ui-fabric-react-2020-01-31-12-45-47-errors-plz.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Prevent the ComponentExamples test from eating errors",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "commit": "f6fdd3eefc61817a53077b45f37dd3d7da8d3420",
+  "dependentChangeType": "patch",
+  "date": "2020-01-31T20:45:47.571Z"
+}

--- a/scripts/jest/jest-setup.js
+++ b/scripts/jest/jest-setup.js
@@ -18,6 +18,6 @@ function customError(type, ...args) {
     // If the "message" was an exception, re-throw it to get the full stack trace
     throw args[0];
   } else {
-    throw new Error(`[console ${type}] ${args.join(' ')}`);
+    throw new Error(`[console.${type}] ${args.join(' ')}`);
   }
 }

--- a/scripts/jest/jest-setup.js
+++ b/scripts/jest/jest-setup.js
@@ -1,13 +1,23 @@
+// @ts-check
+
 // Fail on warnings.
+const consoleWarn = console.warn;
 const consoleError = console.error;
 
-console.error = console.warn = message => {
-  consoleError(message);
+console.error = customError.bind(null, 'error');
+console.warn = customError.bind(null, 'warn');
 
-  if (typeof message === 'object' && message.stack) {
-    // If the "message" was an exception, re-throw it to get the full stack trace
-    throw message;
+function customError(type, ...args) {
+  if (type === 'warn') {
+    consoleWarn(...args);
   } else {
-    throw new Error('Caught: ' + message);
+    consoleError(...args);
   }
-};
+
+  if (args.length === 1 && typeof args[0] === 'object' && args[0].stack) {
+    // If the "message" was an exception, re-throw it to get the full stack trace
+    throw args[0];
+  } else {
+    throw new Error(`[console ${type}] ${args.join(' ')}`);
+  }
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

ComponentExamples.test.tsx had some custom error logging which ate the actual error stacks/info and made failures really hard to debug. This PR substantially improves the test's logging approach, as well as updating the global warn/error overrides to have better handling of more cases.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11849)