### PR TITLE
GroupedList: Announcing position in set

### DIFF
--- a/change/office-ui-fabric-react-2020-01-31-15-24-29-groupedListPosInSet.json
+++ b/change/office-ui-fabric-react-2020-01-31-15-24-29-groupedListPosInSet.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "GroupedList: Announcing position in set.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "666329aad1b362ee3d57ed8134f8398bab2347aa",
+  "dependentChangeType": "patch",
+  "date": "2020-01-31T23:24:29.313Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -4904,6 +4904,8 @@ export interface IGroupFooterStyles {
 
 // @public (undocumented)
 export interface IGroupHeaderProps extends IGroupDividerProps {
+    ariaPosInSet?: number;
+    ariaSetSize?: number;
     expandButtonProps?: React.HTMLAttributes<HTMLButtonElement>;
     groupedListId?: string;
     selectAllButtonProps?: React.HTMLAttributes<HTMLButtonElement>;

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/DetailsList.test.tsx.snap
@@ -5127,6 +5127,8 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                         <div
                           aria-expanded={true}
                           aria-label="Group 0"
+                          aria-posinset={1}
+                          aria-setsize={2}
                           className=
                               ms-GroupHeader
                               {
@@ -5741,6 +5743,8 @@ exports[`DetailsList renders List with hidden checkboxes correctly 1`] = `
                         <div
                           aria-expanded={true}
                           aria-label="Group 1"
+                          aria-posinset={2}
+                          aria-setsize={2}
                           className=
                               ms-GroupHeader
                               {

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.base.tsx
@@ -63,7 +63,9 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
       styles,
       className,
       groupedListId,
-      compact
+      compact,
+      ariaPosInSet,
+      ariaSetSize
     } = this.props;
 
     const { isCollapsed, isLoadingVisible } = this.state;
@@ -93,6 +95,8 @@ export class GroupHeaderBase extends React.Component<IGroupHeaderProps, IGroupHe
         aria-expanded={!group.isCollapsed}
         aria-label={group.ariaLabel || group.name}
         aria-level={groupLevel !== undefined ? groupLevel + 1 : undefined}
+        aria-setsize={ariaSetSize}
+        aria-posinset={ariaPosInSet}
         data-is-focusable={true}
       >
         <FocusZone className={this._classNames.groupHeaderContainer} direction={FocusZoneDirection.horizontal}>

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.types.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupHeader.types.ts
@@ -7,14 +7,10 @@ import { IStyle } from '../../Styling';
  * {@docCategory GroupedList}
  */
 export interface IGroupHeaderProps extends IGroupDividerProps {
-  /**
-   * Style function to be passed in to override the themed or default styles
-   */
+  /** Style function to be passed in to override the themed or default styles */
   styles?: IStyleFunctionOrObject<IGroupHeaderStyleProps, IGroupHeaderStyles>;
 
-  /**
-   * GroupedList id for aria-controls
-   */
+  /** GroupedList id for aria-controls */
   groupedListId?: string;
 
   /** Native props for the GroupHeader expand and collapse button */
@@ -22,6 +18,12 @@ export interface IGroupHeaderProps extends IGroupDividerProps {
 
   /** Native props for the GroupHeader select all button */
   selectAllButtonProps?: React.HTMLAttributes<HTMLButtonElement>;
+
+  /** Defines the number of items in the current set of listitems or treeitems */
+  ariaSetSize?: number;
+
+  /** Defines an element's number or position in the current set of listitems or treeitems */
+  ariaPosInSet?: number;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
@@ -212,7 +212,9 @@ export class GroupedListSection extends React.Component<IGroupedListSectionProps
     };
 
     const ariaControlsProps: IGroupHeaderProps = {
-      groupedListId: this._id
+      groupedListId: this._id,
+      ariaSetSize: groups ? groups.length : undefined,
+      ariaPosInSet: groupIndex !== undefined ? groupIndex + 1 : undefined
     };
 
     const groupHeaderProps: IGroupHeaderProps = { ...headerProps, ...dividerProps, ...ariaControlsProps };

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -1259,6 +1259,8 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                             aria-expanded={true}
                             aria-label="Color: \\"red\\""
                             aria-level={1}
+                            aria-posinset={1}
+                            aria-setsize={3}
                             className=
                                 ms-GroupHeader
                                 {
@@ -2635,6 +2637,8 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                             aria-expanded={true}
                             aria-label="Color: \\"green\\""
                             aria-level={1}
+                            aria-posinset={2}
+                            aria-setsize={3}
                             className=
                                 ms-GroupHeader
                                 {
@@ -3045,6 +3049,8 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
                             aria-expanded={true}
                             aria-label="Color: \\"blue\\""
                             aria-level={1}
+                            aria-posinset={3}
+                            aria-setsize={3}
                             className=
                                 ms-GroupHeader
                                 {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Large.Example.tsx.shot
@@ -914,6 +914,8 @@ exports[`Component Examples renders DetailsList.Grouped.Large.Example.tsx correc
                           aria-expanded={true}
                           aria-label="0"
                           aria-level={1}
+                          aria-posinset={1}
+                          aria-setsize={10}
                           className=
                               ms-GroupHeader
                               {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11818
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Group headers in `GroupedLists` were not announcing their position relative to other groups at the same level. This PR adds the corresponding logic to do this, now announcing their position.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11850)