### PR TITLE
TagItem title fix

### DIFF
--- a/change/office-ui-fabric-react-2020-02-02-15-45-47-tag-item-title-fix.json
+++ b/change/office-ui-fabric-react-2020-02-02-15-45-47-tag-item-title-fix.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "TagItem accepts title and defaults to item name (#11845)",
+  "packageName": "office-ui-fabric-react",
+  "email": "yann.normand@gmail.com",
+  "commit": "f52414de3b9e691f456b0276a81039ed641fd561",
+  "dependentChangeType": "patch",
+  "date": "2020-02-02T05:45:47.168Z"
+}

--- a/change/office-ui-fabric-react-2020-02-02-15-45-47-tag-item-title-fix.json
+++ b/change/office-ui-fabric-react-2020-02-02-15-45-47-tag-item-title-fix.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "TagItem accepts title and defaults to item name (#11845)",
+  "comment": "TagItem accepts title and defaults either children or item name (#11845)",
   "packageName": "office-ui-fabric-react",
   "email": "yann.normand@gmail.com",
   "commit": "f52414de3b9e691f456b0276a81039ed641fd561",

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -7522,6 +7522,7 @@ export interface ITagItemProps extends IPickerItemProps<ITag> {
     enableTagFocusInDisabledPicker?: boolean;
     styles?: IStyleFunctionOrObject<ITagItemStyleProps, ITagItemStyles>;
     theme?: ITheme;
+    title?: string;
 }
 
 // @public

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.test.tsx
@@ -1,0 +1,41 @@
+import * as React from 'react';
+import * as renderer from 'react-test-renderer';
+
+import { TagItem } from './TagItem';
+import { resetIds } from '@uifabric/utilities';
+
+describe('TagItem', () => {
+  beforeEach(() => {
+    resetIds();
+  });
+
+  it('renders correctly', () => {
+    const component = renderer.create(
+      <TagItem item={{ name: 'Red', key: 'red' }} index={0}>
+        Red
+      </TagItem>
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('renders custom children correctly', () => {
+    const component = renderer.create(
+      <TagItem item={{ name: 'Red', key: 'red' }} index={0}>
+        <span>Red</span>
+      </TagItem>
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
+  it('accepts title override', () => {
+    const component = renderer.create(
+      <TagItem item={{ name: 'Red', key: 'red' }} title="Red color" index={0}>
+        Red color
+      </TagItem>
+    );
+    const tree = component.toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.test.tsx
@@ -3,6 +3,7 @@ import * as renderer from 'react-test-renderer';
 
 import { TagItem } from './TagItem';
 import { resetIds } from '@uifabric/utilities';
+import { FontIcon } from '../../Icon';
 
 describe('TagItem', () => {
   beforeEach(() => {
@@ -12,17 +13,17 @@ describe('TagItem', () => {
   it('renders correctly', () => {
     const component = renderer.create(
       <TagItem item={{ name: 'Red', key: 'red' }} index={0}>
-        Red
+        Red color
       </TagItem>
     );
     const tree = component.toJSON();
     expect(tree).toMatchSnapshot();
   });
 
-  it('renders custom children correctly', () => {
+  it('defaults title to item name for non string children', () => {
     const component = renderer.create(
       <TagItem item={{ name: 'Red', key: 'red' }} index={0}>
-        <span>Red</span>
+        <FontIcon iconName="SquareShapeSolid" style={{ color: 'red' }} />
       </TagItem>
     );
     const tree = component.toJSON();
@@ -32,7 +33,7 @@ describe('TagItem', () => {
   it('accepts title override', () => {
     const component = renderer.create(
       <TagItem item={{ name: 'Red', key: 'red' }} title="Red color" index={0}>
-        Red color
+        Red
       </TagItem>
     );
     const tree = component.toJSON();

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.tsx
@@ -23,7 +23,7 @@ export const TagItemBase = (props: ITagItemProps) => {
     index,
     onRemoveItem,
     removeButtonAriaLabel,
-    title = props.item.name
+    title = typeof props.children === 'string' ? props.children : props.item.name
   } = props;
 
   const classNames = getClassNames(styles, {

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagItem.tsx
@@ -22,7 +22,8 @@ export const TagItemBase = (props: ITagItemProps) => {
     className,
     index,
     onRemoveItem,
-    removeButtonAriaLabel
+    removeButtonAriaLabel,
+    title = props.item.name
   } = props;
 
   const classNames = getClassNames(styles, {
@@ -40,7 +41,7 @@ export const TagItemBase = (props: ITagItemProps) => {
       data-selection-index={index}
       data-is-focusable={(enableTagFocusInDisabledPicker || !disabled) && true}
     >
-      <span className={classNames.text} aria-label={children as string} title={children as string}>
+      <span className={classNames.text} aria-label={title} title={title}>
         {children}
       </span>
       <IconButton

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagPicker.types.ts
@@ -37,6 +37,10 @@ export interface ITagItemProps extends IPickerItemProps<ITag> {
    */
   enableTagFocusInDisabledPicker?: boolean;
 
+  /**
+   * The title (and aria-label) attribute used by the TagItem text element.
+   * @defaultvalue item.name
+   */
   title?: string;
 
   /** Call to provide customized styling that will layer on top of the variant rules. */

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagPicker.types.ts
@@ -39,7 +39,7 @@ export interface ITagItemProps extends IPickerItemProps<ITag> {
 
   /**
    * The title (and aria-label) attribute used by the TagItem text element.
-   * @defaultvalue item.name
+   * @defaultvalue children if of type string or item.name
    */
   title?: string;
 

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagPicker.types.ts
@@ -37,6 +37,8 @@ export interface ITagItemProps extends IPickerItemProps<ITag> {
    */
   enableTagFocusInDisabledPicker?: boolean;
 
+  title?: string;
+
   /** Call to provide customized styling that will layer on top of the variant rules. */
   styles?: IStyleFunctionOrObject<ITagItemStyleProps, ITagItemStyles>;
 

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/__snapshots__/TagItem.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/__snapshots__/TagItem.test.tsx.snap
@@ -74,7 +74,233 @@ exports[`TagItem accepts title override 1`] = `
         }
     title="Red color"
   >
-    Red color
+    Red
+  </span>
+  <button
+    className=
+        ms-Button
+        ms-Button--icon
+        ms-TagItem-close
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: transparent;
+          border-radius: 0 2px 2px 0;
+          border: none;
+          box-sizing: border-box;
+          color: #605e5c;
+          cursor: pointer;
+          display: inline-block;
+          flex: 0 0 auto;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 100%;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 4px;
+          padding-right: 4px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+          width: 30px;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid transparent;
+          bottom: 2px;
+          content: "";
+          left: 2px;
+          outline: 1px solid #605e5c;
+          position: absolute;
+          right: 2px;
+          top: 2px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:active > * {
+          left: 0px;
+          position: relative;
+          top: 0px;
+        }
+        &:hover {
+          background-color: #f3f2f1;
+          background: #e1dfdd;
+          color: #323130;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #005a9e;
+          color: #ffffff;
+        }
+    data-is-focusable={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    onKeyPress={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
+    type="button"
+  >
+    <span
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
+      data-automationid="splitbuttonprimary"
+    >
+      <i
+        aria-hidden={true}
+        className=
+            ms-Button-icon
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              flex-shrink: 0;
+              font-family: "FabricMDL2Icons";
+              font-size: 12px;
+              font-style: normal;
+              font-weight: normal;
+              height: 16px;
+              line-height: 16px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              speak: none;
+              text-align: center;
+              vertical-align: middle;
+            }
+        data-icon-name="Cancel"
+      >
+        
+      </i>
+    </span>
+  </button>
+</div>
+`;
+
+exports[`TagItem defaults title to item name for non string children 1`] = `
+<div
+  className=
+      ms-TagItem
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background: #f3f2f1;
+        border-radius: 2px;
+        box-sizing: content-box;
+        color: #323130;
+        cursor: default;
+        display: flex;
+        flex-shrink: 1;
+        flex-wrap: nowrap;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 26px;
+        line-height: 26px;
+        margin-bottom: 2px;
+        margin-left: 2px;
+        margin-right: 2px;
+        margin-top: 2px;
+        max-width: 300px;
+        min-width: 0px;
+        outline: transparent;
+        position: relative;
+        user-select: none;
+      }
+      &::-moz-focus-inner {
+        border: 0;
+      }
+      .ms-Fabric--isFocusVisible &:focus:after {
+        border: 1px solid #ffffff;
+        bottom: 1px;
+        content: "";
+        left: 1px;
+        outline: 1px solid #605e5c;
+        position: absolute;
+        right: 1px;
+        top: 1px;
+        z-index: 1;
+      }
+      &:hover {
+        background: #edebe9;
+        color: #201f1e;
+      }
+      &:hover .ms-TagItem-close {
+        color: #323130;
+      }
+      @media screen and (-ms-high-contrast: active){& {
+        border: 1px solid WindowText;
+      }
+  data-is-focusable={true}
+  data-selection-index={0}
+  role="listitem"
+>
+  <span
+    aria-label="Red"
+    className=
+        ms-TagItem-text
+        {
+          margin-bottom: 0;
+          margin-left: 8px;
+          margin-right: 8px;
+          margin-top: 0;
+          min-width: 30px;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+    title="Red"
+  >
+    <i
+      aria-hidden={true}
+      className=
+          ms-Icon
+          {
+            display: inline-block;
+          }
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: "FabricMDL2Icons-15";
+            font-style: normal;
+            font-weight: normal;
+            speak: none;
+          }
+      data-icon-name="SquareShapeSolid"
+      role="presentation"
+      style={
+        Object {
+          "color": "red",
+          "fontFamily": "\\"FabricMDL2Icons-15\\"",
+        }
+      }
+    >
+      
+    </i>
   </span>
   <button
     className=
@@ -260,7 +486,7 @@ exports[`TagItem renders correctly 1`] = `
   role="listitem"
 >
   <span
-    aria-label="Red"
+    aria-label="Red color"
     className=
         ms-TagItem-text
         {
@@ -273,212 +499,9 @@ exports[`TagItem renders correctly 1`] = `
           text-overflow: ellipsis;
           white-space: nowrap;
         }
-    title="Red"
+    title="Red color"
   >
-    Red
-  </span>
-  <button
-    className=
-        ms-Button
-        ms-Button--icon
-        ms-TagItem-close
-        {
-          -moz-osx-font-smoothing: grayscale;
-          -webkit-font-smoothing: antialiased;
-          background-color: transparent;
-          border-radius: 0 2px 2px 0;
-          border: none;
-          box-sizing: border-box;
-          color: #605e5c;
-          cursor: pointer;
-          display: inline-block;
-          flex: 0 0 auto;
-          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-          font-size: 14px;
-          font-weight: 400;
-          height: 100%;
-          outline: transparent;
-          padding-bottom: 0;
-          padding-left: 4px;
-          padding-right: 4px;
-          padding-top: 0;
-          position: relative;
-          text-align: center;
-          text-decoration: none;
-          user-select: none;
-          vertical-align: top;
-          width: 30px;
-        }
-        &::-moz-focus-inner {
-          border: 0;
-        }
-        .ms-Fabric--isFocusVisible &:focus:after {
-          border: 1px solid transparent;
-          bottom: 2px;
-          content: "";
-          left: 2px;
-          outline: 1px solid #605e5c;
-          position: absolute;
-          right: 2px;
-          top: 2px;
-          z-index: 1;
-        }
-        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
-          border: none;
-          bottom: -2px;
-          left: -2px;
-          outline-color: ButtonText;
-          right: -2px;
-          top: -2px;
-        }
-        &:active > * {
-          left: 0px;
-          position: relative;
-          top: 0px;
-        }
-        &:hover {
-          background-color: #f3f2f1;
-          background: #e1dfdd;
-          color: #323130;
-        }
-        @media screen and (-ms-high-contrast: active){&:hover {
-          border-color: Highlight;
-          color: Highlight;
-        }
-        &:active {
-          background-color: #005a9e;
-          color: #ffffff;
-        }
-    data-is-focusable={true}
-    onClick={[Function]}
-    onKeyDown={[Function]}
-    onKeyPress={[Function]}
-    onKeyUp={[Function]}
-    onMouseDown={[Function]}
-    onMouseUp={[Function]}
-    type="button"
-  >
-    <span
-      className=
-          ms-Button-flexContainer
-          {
-            align-items: center;
-            display: flex;
-            flex-wrap: nowrap;
-            height: 100%;
-            justify-content: center;
-          }
-      data-automationid="splitbuttonprimary"
-    >
-      <i
-        aria-hidden={true}
-        className=
-            ms-Button-icon
-            {
-              -moz-osx-font-smoothing: grayscale;
-              -webkit-font-smoothing: antialiased;
-              display: inline-block;
-              flex-shrink: 0;
-              font-family: "FabricMDL2Icons";
-              font-size: 12px;
-              font-style: normal;
-              font-weight: normal;
-              height: 16px;
-              line-height: 16px;
-              margin-bottom: 0;
-              margin-left: 4px;
-              margin-right: 4px;
-              margin-top: 0;
-              speak: none;
-              text-align: center;
-              vertical-align: middle;
-            }
-        data-icon-name="Cancel"
-      >
-        
-      </i>
-    </span>
-  </button>
-</div>
-`;
-
-exports[`TagItem renders custom children correctly 1`] = `
-<div
-  className=
-      ms-TagItem
-      {
-        -moz-osx-font-smoothing: grayscale;
-        -webkit-font-smoothing: antialiased;
-        background: #f3f2f1;
-        border-radius: 2px;
-        box-sizing: content-box;
-        color: #323130;
-        cursor: default;
-        display: flex;
-        flex-shrink: 1;
-        flex-wrap: nowrap;
-        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-        font-size: 14px;
-        font-weight: 400;
-        height: 26px;
-        line-height: 26px;
-        margin-bottom: 2px;
-        margin-left: 2px;
-        margin-right: 2px;
-        margin-top: 2px;
-        max-width: 300px;
-        min-width: 0px;
-        outline: transparent;
-        position: relative;
-        user-select: none;
-      }
-      &::-moz-focus-inner {
-        border: 0;
-      }
-      .ms-Fabric--isFocusVisible &:focus:after {
-        border: 1px solid #ffffff;
-        bottom: 1px;
-        content: "";
-        left: 1px;
-        outline: 1px solid #605e5c;
-        position: absolute;
-        right: 1px;
-        top: 1px;
-        z-index: 1;
-      }
-      &:hover {
-        background: #edebe9;
-        color: #201f1e;
-      }
-      &:hover .ms-TagItem-close {
-        color: #323130;
-      }
-      @media screen and (-ms-high-contrast: active){& {
-        border: 1px solid WindowText;
-      }
-  data-is-focusable={true}
-  data-selection-index={0}
-  role="listitem"
->
-  <span
-    aria-label="Red"
-    className=
-        ms-TagItem-text
-        {
-          margin-bottom: 0;
-          margin-left: 8px;
-          margin-right: 8px;
-          margin-top: 0;
-          min-width: 30px;
-          overflow: hidden;
-          text-overflow: ellipsis;
-          white-space: nowrap;
-        }
-    title="Red"
-  >
-    <span>
-      Red
-    </span>
+    Red color
   </span>
   <button
     className=

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/__snapshots__/TagItem.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/__snapshots__/TagItem.test.tsx.snap
@@ -1,0 +1,606 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TagItem accepts title override 1`] = `
+<div
+  className=
+      ms-TagItem
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background: #f3f2f1;
+        border-radius: 2px;
+        box-sizing: content-box;
+        color: #323130;
+        cursor: default;
+        display: flex;
+        flex-shrink: 1;
+        flex-wrap: nowrap;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 26px;
+        line-height: 26px;
+        margin-bottom: 2px;
+        margin-left: 2px;
+        margin-right: 2px;
+        margin-top: 2px;
+        max-width: 300px;
+        min-width: 0px;
+        outline: transparent;
+        position: relative;
+        user-select: none;
+      }
+      &::-moz-focus-inner {
+        border: 0;
+      }
+      .ms-Fabric--isFocusVisible &:focus:after {
+        border: 1px solid #ffffff;
+        bottom: 1px;
+        content: "";
+        left: 1px;
+        outline: 1px solid #605e5c;
+        position: absolute;
+        right: 1px;
+        top: 1px;
+        z-index: 1;
+      }
+      &:hover {
+        background: #edebe9;
+        color: #201f1e;
+      }
+      &:hover .ms-TagItem-close {
+        color: #323130;
+      }
+      @media screen and (-ms-high-contrast: active){& {
+        border: 1px solid WindowText;
+      }
+  data-is-focusable={true}
+  data-selection-index={0}
+  role="listitem"
+>
+  <span
+    aria-label="Red color"
+    className=
+        ms-TagItem-text
+        {
+          margin-bottom: 0;
+          margin-left: 8px;
+          margin-right: 8px;
+          margin-top: 0;
+          min-width: 30px;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+    title="Red color"
+  >
+    Red color
+  </span>
+  <button
+    className=
+        ms-Button
+        ms-Button--icon
+        ms-TagItem-close
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: transparent;
+          border-radius: 0 2px 2px 0;
+          border: none;
+          box-sizing: border-box;
+          color: #605e5c;
+          cursor: pointer;
+          display: inline-block;
+          flex: 0 0 auto;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 100%;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 4px;
+          padding-right: 4px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+          width: 30px;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid transparent;
+          bottom: 2px;
+          content: "";
+          left: 2px;
+          outline: 1px solid #605e5c;
+          position: absolute;
+          right: 2px;
+          top: 2px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:active > * {
+          left: 0px;
+          position: relative;
+          top: 0px;
+        }
+        &:hover {
+          background-color: #f3f2f1;
+          background: #e1dfdd;
+          color: #323130;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #005a9e;
+          color: #ffffff;
+        }
+    data-is-focusable={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    onKeyPress={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
+    type="button"
+  >
+    <span
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
+      data-automationid="splitbuttonprimary"
+    >
+      <i
+        aria-hidden={true}
+        className=
+            ms-Button-icon
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              flex-shrink: 0;
+              font-family: "FabricMDL2Icons";
+              font-size: 12px;
+              font-style: normal;
+              font-weight: normal;
+              height: 16px;
+              line-height: 16px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              speak: none;
+              text-align: center;
+              vertical-align: middle;
+            }
+        data-icon-name="Cancel"
+      >
+        
+      </i>
+    </span>
+  </button>
+</div>
+`;
+
+exports[`TagItem renders correctly 1`] = `
+<div
+  className=
+      ms-TagItem
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background: #f3f2f1;
+        border-radius: 2px;
+        box-sizing: content-box;
+        color: #323130;
+        cursor: default;
+        display: flex;
+        flex-shrink: 1;
+        flex-wrap: nowrap;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 26px;
+        line-height: 26px;
+        margin-bottom: 2px;
+        margin-left: 2px;
+        margin-right: 2px;
+        margin-top: 2px;
+        max-width: 300px;
+        min-width: 0px;
+        outline: transparent;
+        position: relative;
+        user-select: none;
+      }
+      &::-moz-focus-inner {
+        border: 0;
+      }
+      .ms-Fabric--isFocusVisible &:focus:after {
+        border: 1px solid #ffffff;
+        bottom: 1px;
+        content: "";
+        left: 1px;
+        outline: 1px solid #605e5c;
+        position: absolute;
+        right: 1px;
+        top: 1px;
+        z-index: 1;
+      }
+      &:hover {
+        background: #edebe9;
+        color: #201f1e;
+      }
+      &:hover .ms-TagItem-close {
+        color: #323130;
+      }
+      @media screen and (-ms-high-contrast: active){& {
+        border: 1px solid WindowText;
+      }
+  data-is-focusable={true}
+  data-selection-index={0}
+  role="listitem"
+>
+  <span
+    aria-label="Red"
+    className=
+        ms-TagItem-text
+        {
+          margin-bottom: 0;
+          margin-left: 8px;
+          margin-right: 8px;
+          margin-top: 0;
+          min-width: 30px;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+    title="Red"
+  >
+    Red
+  </span>
+  <button
+    className=
+        ms-Button
+        ms-Button--icon
+        ms-TagItem-close
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: transparent;
+          border-radius: 0 2px 2px 0;
+          border: none;
+          box-sizing: border-box;
+          color: #605e5c;
+          cursor: pointer;
+          display: inline-block;
+          flex: 0 0 auto;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 100%;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 4px;
+          padding-right: 4px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+          width: 30px;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid transparent;
+          bottom: 2px;
+          content: "";
+          left: 2px;
+          outline: 1px solid #605e5c;
+          position: absolute;
+          right: 2px;
+          top: 2px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:active > * {
+          left: 0px;
+          position: relative;
+          top: 0px;
+        }
+        &:hover {
+          background-color: #f3f2f1;
+          background: #e1dfdd;
+          color: #323130;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #005a9e;
+          color: #ffffff;
+        }
+    data-is-focusable={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    onKeyPress={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
+    type="button"
+  >
+    <span
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
+      data-automationid="splitbuttonprimary"
+    >
+      <i
+        aria-hidden={true}
+        className=
+            ms-Button-icon
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              flex-shrink: 0;
+              font-family: "FabricMDL2Icons";
+              font-size: 12px;
+              font-style: normal;
+              font-weight: normal;
+              height: 16px;
+              line-height: 16px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              speak: none;
+              text-align: center;
+              vertical-align: middle;
+            }
+        data-icon-name="Cancel"
+      >
+        
+      </i>
+    </span>
+  </button>
+</div>
+`;
+
+exports[`TagItem renders custom children correctly 1`] = `
+<div
+  className=
+      ms-TagItem
+      {
+        -moz-osx-font-smoothing: grayscale;
+        -webkit-font-smoothing: antialiased;
+        background: #f3f2f1;
+        border-radius: 2px;
+        box-sizing: content-box;
+        color: #323130;
+        cursor: default;
+        display: flex;
+        flex-shrink: 1;
+        flex-wrap: nowrap;
+        font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+        font-size: 14px;
+        font-weight: 400;
+        height: 26px;
+        line-height: 26px;
+        margin-bottom: 2px;
+        margin-left: 2px;
+        margin-right: 2px;
+        margin-top: 2px;
+        max-width: 300px;
+        min-width: 0px;
+        outline: transparent;
+        position: relative;
+        user-select: none;
+      }
+      &::-moz-focus-inner {
+        border: 0;
+      }
+      .ms-Fabric--isFocusVisible &:focus:after {
+        border: 1px solid #ffffff;
+        bottom: 1px;
+        content: "";
+        left: 1px;
+        outline: 1px solid #605e5c;
+        position: absolute;
+        right: 1px;
+        top: 1px;
+        z-index: 1;
+      }
+      &:hover {
+        background: #edebe9;
+        color: #201f1e;
+      }
+      &:hover .ms-TagItem-close {
+        color: #323130;
+      }
+      @media screen and (-ms-high-contrast: active){& {
+        border: 1px solid WindowText;
+      }
+  data-is-focusable={true}
+  data-selection-index={0}
+  role="listitem"
+>
+  <span
+    aria-label="Red"
+    className=
+        ms-TagItem-text
+        {
+          margin-bottom: 0;
+          margin-left: 8px;
+          margin-right: 8px;
+          margin-top: 0;
+          min-width: 30px;
+          overflow: hidden;
+          text-overflow: ellipsis;
+          white-space: nowrap;
+        }
+    title="Red"
+  >
+    <span>
+      Red
+    </span>
+  </span>
+  <button
+    className=
+        ms-Button
+        ms-Button--icon
+        ms-TagItem-close
+        {
+          -moz-osx-font-smoothing: grayscale;
+          -webkit-font-smoothing: antialiased;
+          background-color: transparent;
+          border-radius: 0 2px 2px 0;
+          border: none;
+          box-sizing: border-box;
+          color: #605e5c;
+          cursor: pointer;
+          display: inline-block;
+          flex: 0 0 auto;
+          font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+          font-size: 14px;
+          font-weight: 400;
+          height: 100%;
+          outline: transparent;
+          padding-bottom: 0;
+          padding-left: 4px;
+          padding-right: 4px;
+          padding-top: 0;
+          position: relative;
+          text-align: center;
+          text-decoration: none;
+          user-select: none;
+          vertical-align: top;
+          width: 30px;
+        }
+        &::-moz-focus-inner {
+          border: 0;
+        }
+        .ms-Fabric--isFocusVisible &:focus:after {
+          border: 1px solid transparent;
+          bottom: 2px;
+          content: "";
+          left: 2px;
+          outline: 1px solid #605e5c;
+          position: absolute;
+          right: 2px;
+          top: 2px;
+          z-index: 1;
+        }
+        @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
+          border: none;
+          bottom: -2px;
+          left: -2px;
+          outline-color: ButtonText;
+          right: -2px;
+          top: -2px;
+        }
+        &:active > * {
+          left: 0px;
+          position: relative;
+          top: 0px;
+        }
+        &:hover {
+          background-color: #f3f2f1;
+          background: #e1dfdd;
+          color: #323130;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover {
+          border-color: Highlight;
+          color: Highlight;
+        }
+        &:active {
+          background-color: #005a9e;
+          color: #ffffff;
+        }
+    data-is-focusable={true}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    onKeyPress={[Function]}
+    onKeyUp={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
+    type="button"
+  >
+    <span
+      className=
+          ms-Button-flexContainer
+          {
+            align-items: center;
+            display: flex;
+            flex-wrap: nowrap;
+            height: 100%;
+            justify-content: center;
+          }
+      data-automationid="splitbuttonprimary"
+    >
+      <i
+        aria-hidden={true}
+        className=
+            ms-Button-icon
+            {
+              -moz-osx-font-smoothing: grayscale;
+              -webkit-font-smoothing: antialiased;
+              display: inline-block;
+              flex-shrink: 0;
+              font-family: "FabricMDL2Icons";
+              font-size: 12px;
+              font-style: normal;
+              font-weight: normal;
+              height: 16px;
+              line-height: 16px;
+              margin-bottom: 0;
+              margin-left: 4px;
+              margin-right: 4px;
+              margin-top: 0;
+              speak: none;
+              text-align: center;
+              vertical-align: middle;
+            }
+        data-icon-name="Cancel"
+      >
+        
+      </i>
+    </span>
+  </button>
+</div>
+`;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11845 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The TagItem component uses the `item.name` as the title and aria-label value instead of the `children` prop given it is not guaranteed to be a string.
`title` prop is now exposed to allow custom title / label.

#### Focus areas to test

TagPicker when `onResolveItem` uses the `TagItem` with a non string `children` prop. 


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11853)