### PR TITLE
DateTime: fix broken test

### DIFF
--- a/change/@uifabric-date-time-2020-02-03-10-40-32-fix-datetime-test.json
+++ b/change/@uifabric-date-time-2020-02-03-10-40-32-fix-datetime-test.json
@@ -1,9 +1,9 @@
 {
-  "type": "patch",
+  "type": "none",
   "comment": "DateTime: fix broken test",
   "packageName": "@uifabric/date-time",
   "email": "joschect@microsoft.com",
   "commit": "65e124a96e3d37e81a0a9cadf5ad36ec36a2df60",
-  "dependentChangeType": "none",
+  "dependentChangeType": "patch",
   "date": "2020-02-03T18:40:29.830Z"
 }

--- a/change/@uifabric-date-time-2020-02-03-10-40-32-fix-datetime-test.json
+++ b/change/@uifabric-date-time-2020-02-03-10-40-32-fix-datetime-test.json
@@ -4,6 +4,6 @@
   "packageName": "@uifabric/date-time",
   "email": "joschect@microsoft.com",
   "commit": "65e124a96e3d37e81a0a9cadf5ad36ec36a2df60",
-  "dependentChangeType": "patch",
+  "dependentChangeType": "none",
   "date": "2020-02-03T18:40:29.830Z"
 }

--- a/change/@uifabric-date-time-2020-02-03-10-40-32-fix-datetime-test.json
+++ b/change/@uifabric-date-time-2020-02-03-10-40-32-fix-datetime-test.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "DateTime: fix broken test",
+  "packageName": "@uifabric/date-time",
+  "email": "joschect@microsoft.com",
+  "commit": "65e124a96e3d37e81a0a9cadf5ad36ec36a2df60",
+  "dependentChangeType": "patch",
+  "date": "2020-02-03T18:40:29.830Z"
+}

--- a/change/office-ui-fabric-react-2020-02-03-10-40-32-fix-datetime-test.json
+++ b/change/office-ui-fabric-react-2020-02-03-10-40-32-fix-datetime-test.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "DateTime: fix broken test",
+  "packageName": "office-ui-fabric-react",
+  "email": "joschect@microsoft.com",
+  "commit": "65e124a96e3d37e81a0a9cadf5ad36ec36a2df60",
+  "dependentChangeType": "patch",
+  "date": "2020-02-03T18:40:32.220Z"
+}

--- a/change/office-ui-fabric-react-2020-02-03-10-40-32-fix-datetime-test.json
+++ b/change/office-ui-fabric-react-2020-02-03-10-40-32-fix-datetime-test.json
@@ -1,9 +1,9 @@
 {
-  "type": "patch",
+  "type": "none",
   "comment": "DateTime: fix broken test",
   "packageName": "office-ui-fabric-react",
   "email": "joschect@microsoft.com",
   "commit": "65e124a96e3d37e81a0a9cadf5ad36ec36a2df60",
-  "dependentChangeType": "none",
+  "dependentChangeType": "patch",
   "date": "2020-02-03T18:40:32.220Z"
 }

--- a/change/office-ui-fabric-react-2020-02-03-10-40-32-fix-datetime-test.json
+++ b/change/office-ui-fabric-react-2020-02-03-10-40-32-fix-datetime-test.json
@@ -4,6 +4,6 @@
   "packageName": "office-ui-fabric-react",
   "email": "joschect@microsoft.com",
   "commit": "65e124a96e3d37e81a0a9cadf5ad36ec36a2df60",
-  "dependentChangeType": "patch",
+  "dependentChangeType": "none",
   "date": "2020-02-03T18:40:32.220Z"
 }

--- a/packages/date-time/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/date-time/src/components/DatePicker/DatePicker.test.tsx
@@ -157,7 +157,10 @@ describe('DatePicker', () => {
 
   it('should reflect the correct date in the input field when selecting a value', () => {
     const today = new Date('January 15, 2020');
-    const datePicker = mount(<DatePickerBase allowTextInput={true} today={today} />);
+    const initiallySelectedDate = new Date('January 10, 2020');
+    // initialPickerDate defaults to Date.now() if not provided so it must be given to ensure
+    // that the datepicker opens on the correct month
+    const datePicker = mount(<DatePickerBase allowTextInput={true} today={today} initialPickerDate={initiallySelectedDate} />);
 
     datePicker.setState({ isDatePickerShown: true });
     const todayButton = document.querySelector('[class^="dayIsToday"], [class*="dayIsToday"]') as HTMLButtonElement;
@@ -178,10 +181,15 @@ describe('DatePicker', () => {
 
   it('should reflect the correct date in the input field when selecting a value and a different format is given', () => {
     const today = new Date('January 15, 2020');
+    const initiallySelectedDate = new Date('January 10, 2020');
     const onFormatDate = (date: Date): string => {
       return date.getDate() + '/' + (date.getMonth() + 1) + '/' + (date.getFullYear() % 100);
     };
-    const datePicker = mount(<DatePickerBase allowTextInput={true} today={today} formatDate={onFormatDate} />);
+    // initialPickerDate defaults to Date.now() if not provided so it must be given to ensure
+    // that the datepicker opens on the correct month
+    const datePicker = mount(
+      <DatePickerBase allowTextInput={true} today={today} formatDate={onFormatDate} initialPickerDate={initiallySelectedDate} />
+    );
 
     datePicker.setState({ isDatePickerShown: true });
     const todayButton = document.querySelector('[class^="dayIsToday"], [class*="dayIsToday"]') as HTMLButtonElement;

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
@@ -221,7 +221,10 @@ describe('DatePicker', () => {
 
   it('should reflect the correct date in the input field when selecting a value', () => {
     const today = new Date('January 15, 2020');
-    const datePicker = mount(<DatePickerBase allowTextInput={true} today={today} />);
+    const initiallySelectedDate = new Date('January 10, 2020');
+    // initialPickerDate defaults to Date.now() if not provided so it must be given to ensure
+    // that the datepicker opens on the correct month
+    const datePicker = mount(<DatePickerBase allowTextInput={true} today={today} initialPickerDate={initiallySelectedDate} />);
 
     datePicker.setState({ isDatePickerShown: true });
     const todayButton = document.querySelector('.ms-DatePicker-day--today') as HTMLButtonElement;
@@ -242,10 +245,15 @@ describe('DatePicker', () => {
 
   it('should reflect the correct date in the input field when selecting a value and a different format is given', () => {
     const today = new Date('January 15, 2020');
+    const initiallySelectedDate = new Date('January 10, 2020');
     const onFormatDate = (date: Date): string => {
       return date.getDate() + '/' + (date.getMonth() + 1) + '/' + (date.getFullYear() % 100);
     };
-    const datePicker = mount(<DatePickerBase allowTextInput={true} today={today} formatDate={onFormatDate} />);
+    // initialPickerDate defaults to Date.now() if not provided so it must be given to ensure
+    // that the datepicker opens on the correct month
+    const datePicker = mount(
+      <DatePickerBase allowTextInput={true} today={today} formatDate={onFormatDate} initialPickerDate={initiallySelectedDate} />
+    );
 
     datePicker.setState({ isDatePickerShown: true });
     const todayButton = document.querySelector('.ms-DatePicker-day--today') as HTMLButtonElement;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Tests were broken because the date picker was opening to the incorrect month. This ensures that they will open on the right month.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11856)