### PR TITLE
Fix high contrast in new Edge: TextField, Checkbox, Shimmer

### DIFF
--- a/change/@uifabric-date-time-2020-02-03-14-31-04-xgao-fix-new-edge-HC.json
+++ b/change/@uifabric-date-time-2020-02-03-14-31-04-xgao-fix-new-edge-HC.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Fix High Contrast in Edge Chromium: TextField and Checkbox",
+  "packageName": "@uifabric/date-time",
+  "email": "xgao@microsoft.com",
+  "commit": "09d7f66b6e6d4ef6aa853b5f378e77745bd6f696",
+  "dependentChangeType": "patch",
+  "date": "2020-02-03T22:30:51.896Z"
+}

--- a/change/@uifabric-experiments-2020-02-03-14-31-04-xgao-fix-new-edge-HC.json
+++ b/change/@uifabric-experiments-2020-02-03-14-31-04-xgao-fix-new-edge-HC.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Fix High Contrast in Edge Chromium: TextField and Checkbox",
+  "packageName": "@uifabric/experiments",
+  "email": "xgao@microsoft.com",
+  "commit": "09d7f66b6e6d4ef6aa853b5f378e77745bd6f696",
+  "dependentChangeType": "patch",
+  "date": "2020-02-03T22:31:04.263Z"
+}

--- a/change/@uifabric-merge-styles-2020-01-22-17-23-40-xgao-fix-new-edge-HC.json
+++ b/change/@uifabric-merge-styles-2020-01-22-17-23-40-xgao-fix-new-edge-HC.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Support forced-color-adjust style",
+  "packageName": "@uifabric/merge-styles",
+  "email": "xgao@microsoft.com",
+  "commit": "5de7b877ca1f1038f0e978cb2a8ee3ac7375ad16",
+  "date": "2020-01-23T01:22:15.109Z"
+}

--- a/change/@uifabric-styling-2020-01-22-17-23-40-xgao-fix-new-edge-HC.json
+++ b/change/@uifabric-styling-2020-01-22-17-23-40-xgao-fix-new-edge-HC.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "add high contrast common style to turn off forced color adjust in Edge Chromium ",
+  "packageName": "@uifabric/styling",
+  "email": "xgao@microsoft.com",
+  "commit": "5de7b877ca1f1038f0e978cb2a8ee3ac7375ad16",
+  "date": "2020-01-23T01:23:40.689Z"
+}

--- a/change/office-ui-fabric-react-2020-01-22-17-23-40-xgao-fix-new-edge-HC.json
+++ b/change/office-ui-fabric-react-2020-01-22-17-23-40-xgao-fix-new-edge-HC.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix High Contrast in Edge Chromium: TextField and Checkbox",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "5de7b877ca1f1038f0e978cb2a8ee3ac7375ad16",
+  "date": "2020-01-23T01:22:52.482Z"
+}

--- a/packages/date-time/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/date-time/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -88,6 +88,9 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
               }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
+              }
         >
           <input
             aria-expanded={false}
@@ -132,6 +135,10 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -140,6 +147,9 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -150,6 +160,9 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -158,6 +171,9 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="DatePicker0-label"
             onBlur={[Function]}

--- a/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -1521,6 +1521,9 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
             right: 0px;
             top: 0px;
           }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:focus:after {
+            forced-color-adjust: none;
+          }
       id="ComboBox6wrapper"
     >
       <input

--- a/packages/experiments/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/packages/experiments/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -39,6 +39,13 @@ exports[`Slider renders correctly 1`] = `
           padding-top: 0px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
     htmlFor="Slider2"
   >
     I am a slider
@@ -70,6 +77,13 @@ exports[`Slider renders correctly 1`] = `
           padding-top: 5px;
           white-space: nowrap;
           word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
   >
     : 0

--- a/packages/experiments/src/components/Toggle/__snapshots__/Toggle.view.test.tsx.snap
+++ b/packages/experiments/src/components/Toggle/__snapshots__/Toggle.view.test.tsx.snap
@@ -39,6 +39,13 @@ exports[`ToggleView renders toggle correctly 1`] = `
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
   >
     Label
   </label>

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -209,6 +209,8 @@ export interface IRawStyleBase extends IRawFontStyle {
     flexWrap?: ICSSRule | 'nowrap' | 'wrap' | 'wrap-reverse';
     float?: ICSSRule | string;
     flowFrom?: ICSSRule | string;
+    // (undocumented)
+    forcedColorAdjust?: 'auto' | 'none';
     gridArea?: ICSSRule | string;
     gridAutoColumns?: ICSSRule | string;
     gridAutoFlow?: ICSSRule | string;

--- a/packages/merge-styles/etc/merge-styles.api.md
+++ b/packages/merge-styles/etc/merge-styles.api.md
@@ -209,7 +209,6 @@ export interface IRawStyleBase extends IRawFontStyle {
     flexWrap?: ICSSRule | 'nowrap' | 'wrap' | 'wrap-reverse';
     float?: ICSSRule | string;
     flowFrom?: ICSSRule | string;
-    // (undocumented)
     forcedColorAdjust?: 'auto' | 'none';
     gridArea?: ICSSRule | string;
     gridAutoColumns?: ICSSRule | string;

--- a/packages/merge-styles/src/IRawStyleBase.ts
+++ b/packages/merge-styles/src/IRawStyleBase.ts
@@ -277,6 +277,7 @@ export interface IFontFace extends IRawFontStyle {
  * {@docCategory IRawStyleBase}
  */
 export interface IRawStyleBase extends IRawFontStyle {
+  forcedColorAdjust?: 'auto' | 'none';
   /**
    * (Ms specific) constrast adjust rule.
    */

--- a/packages/merge-styles/src/IRawStyleBase.ts
+++ b/packages/merge-styles/src/IRawStyleBase.ts
@@ -277,7 +277,12 @@ export interface IFontFace extends IRawFontStyle {
  * {@docCategory IRawStyleBase}
  */
 export interface IRawStyleBase extends IRawFontStyle {
+  /**
+   * The property which allows authors to opt particular elements out of forced colors mode, restoring full control over the colors to CSS.
+   * Currently it's only supported in Edge Chromium.
+   */
   forcedColorAdjust?: 'auto' | 'none';
+
   /**
    * (Ms specific) constrast adjust rule.
    */

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
@@ -1,7 +1,7 @@
 import { ICheckboxStyleProps, ICheckboxStyles } from './Checkbox.types';
 import { HighContrastSelector, getGlobalClassNames, IStyle } from '../../Styling';
 import { IsFocusVisibleClassName } from '../../Utilities';
-import { getEdgeChromiumForcedStylesOffSelector } from '@uifabric/styling';
+import { getEdgeChromiumNoHighContrastAdjustSelector } from '@uifabric/styling';
 
 const GlobalClassNames = {
   root: 'ms-Checkbox',
@@ -234,7 +234,7 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
           [HighContrastSelector]: {
             borderColor: 'WindowText'
           },
-          ...getEdgeChromiumForcedStylesOffSelector()
+          ...getEdgeChromiumNoHighContrastAdjustSelector()
         }
       },
       indeterminate && {

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
@@ -1,6 +1,7 @@
 import { ICheckboxStyleProps, ICheckboxStyles } from './Checkbox.types';
 import { HighContrastSelector, getGlobalClassNames, IStyle } from '../../Styling';
 import { IsFocusVisibleClassName } from '../../Utilities';
+import { getEdgeChromiumForcedStylesOffSelector } from '@uifabric/styling';
 
 const GlobalClassNames = {
   root: 'ms-Checkbox',
@@ -54,7 +55,12 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
       borderColor: disabled ? checkboxBorderColorDisabled : checkboxBorderIndeterminateColor,
       transitionProperty: 'border-width, border, border-color',
       transitionDuration: MS_CHECKBOX_TRANSITION_DURATION,
-      transitionTimingFunction: MS_CHECKBOX_TRANSITION_TIMING
+      transitionTimingFunction: MS_CHECKBOX_TRANSITION_TIMING,
+      selectors: {
+        [HighContrastSelector]: {
+          borderColor: 'WindowText'
+        }
+      }
     }
   ];
 
@@ -103,10 +109,6 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
                 background: checkboxBackgroundCheckedHovered,
                 borderColor: checkboxBorderColorCheckedHovered
               },
-              [`.${classNames.checkbox}`]: {
-                background: checkboxBorderColorChecked,
-                borderColor: checkboxBorderColorChecked
-              },
               [HighContrastSelector]: {
                 selectors: {
                   [`:hover .${classNames.checkbox}`]: {
@@ -132,7 +134,12 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         indeterminate && {
           selectors: {
             [`:hover .${classNames.checkbox}, :hover .${classNames.checkbox}:after`]: {
-              borderColor: checkboxBorderIndeterminateHoveredColor
+              borderColor: checkboxBorderIndeterminateHoveredColor,
+              selectors: {
+                [HighContrastSelector]: {
+                  borderColor: 'WindowText'
+                }
+              }
             },
             [`:focus .${classNames.checkbox}`]: {
               borderColor: checkboxBorderIndeterminateHoveredColor
@@ -144,8 +151,14 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         },
         {
           selectors: {
-            [`:hover .${classNames.text}`]: { color: checkboxHoveredTextColor },
-            [`:focus .${classNames.text}`]: { color: checkboxHoveredTextColor }
+            [`:hover .${classNames.text}, :focus .${classNames.text}`]: {
+              color: checkboxHoveredTextColor,
+              selectors: {
+                [HighContrastSelector]: {
+                  color: disabled ? 'GrayText' : 'WindowText'
+                }
+              }
+            }
           }
         }
       ],
@@ -217,7 +230,11 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         /* in case the icon is bigger than the box */
         overflow: 'hidden',
         selectors: {
-          ':after': indeterminate ? indeterminateDotStyles : null
+          ':after': indeterminate ? indeterminateDotStyles : null,
+          [HighContrastSelector]: {
+            borderColor: 'WindowText'
+          },
+          ...getEdgeChromiumForcedStylesOffSelector()
         }
       },
       indeterminate && {
@@ -250,14 +267,19 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         borderColor: checkboxBorderColorDisabled,
         selectors: {
           [HighContrastSelector]: {
-            borderColor: 'InactiveBorder'
+            borderColor: 'GrayText'
           }
         }
       },
       checked &&
         disabled && {
           background: checkboxBackgroundDisabledChecked,
-          borderColor: checkboxBorderColorDisabled
+          borderColor: checkboxBorderColorDisabled,
+          selectors: {
+            [HighContrastSelector]: {
+              background: 'Window'
+            }
+          }
         }
     ],
     checkmark: [
@@ -267,7 +289,7 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         color: checkmarkFontColor,
         selectors: {
           [HighContrastSelector]: {
-            color: disabled ? 'InactiveBorder' : 'Window',
+            color: disabled ? 'GrayText' : 'Window',
             MsHighContrastAdjust: 'none'
           }
         }
@@ -278,7 +300,12 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
       {
         color: disabled ? checkboxTextColorDisabled : checkboxTextColor,
         fontSize: fonts.medium.fontSize,
-        lineHeight: '20px'
+        lineHeight: '20px',
+        selectors: {
+          [HighContrastSelector]: {
+            color: disabled ? 'GrayText' : 'WindowText'
+          }
+        }
       },
       !reversed
         ? {
@@ -286,16 +313,7 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
           }
         : {
             marginRight: 4
-          },
-      disabled && {
-        selectors: {
-          [HighContrastSelector]: {
-            // backwards compat for the color of the text when the checkbox was rendered
-            // using a Button.
-            color: 'InactiveBorder'
           }
-        }
-      }
     ]
   };
 };

--- a/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/Checkbox.styles.ts
@@ -1,7 +1,6 @@
 import { ICheckboxStyleProps, ICheckboxStyles } from './Checkbox.types';
-import { HighContrastSelector, getGlobalClassNames, IStyle } from '../../Styling';
+import { HighContrastSelector, getGlobalClassNames, getEdgeChromiumNoHighContrastAdjustSelector, IStyle } from '../../Styling';
 import { IsFocusVisibleClassName } from '../../Utilities';
-import { getEdgeChromiumNoHighContrastAdjustSelector } from '@uifabric/styling';
 
 const GlobalClassNames = {
   root: 'ms-Checkbox',
@@ -304,7 +303,8 @@ export const getStyles = (props: ICheckboxStyleProps): ICheckboxStyles => {
         selectors: {
           [HighContrastSelector]: {
             color: disabled ? 'GrayText' : 'WindowText'
-          }
+          },
+          ...getEdgeChromiumNoHighContrastAdjustSelector()
         }
       },
       !reversed

--- a/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -18,10 +18,6 @@ exports[`Checkbox renders checked correctly 1`] = `
         background: #005a9e;
         border-color: #005a9e;
       }
-      & .ms-Checkbox-checkbox {
-        background: #0078d4;
-        border-color: #0078d4;
-      }
       @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
         background: Window;
         border-color: Highlight;
@@ -41,8 +37,14 @@ exports[`Checkbox renders checked correctly 1`] = `
       &:hover .ms-Checkbox-text {
         color: #201f1e;
       }
+      @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+        color: WindowText;
+      }
       &:focus .ms-Checkbox-text {
         color: #201f1e;
+      }
+      @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+        color: WindowText;
       }
 >
   <input
@@ -122,6 +124,9 @@ exports[`Checkbox renders checked correctly 1`] = `
             background: Highlight;
             border-color: Highlight;
           }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
     >
       <i
         aria-hidden={true}
@@ -157,6 +162,12 @@ exports[`Checkbox renders checked correctly 1`] = `
             line-height: 20px;
             margin-left: 4px;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
     >
       Standard checkbox
     </span>
@@ -177,7 +188,7 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
         border-color: #005a9e;
       }
       @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-        border-color: Highlight;
+        border-color: WindowText;
       }
       &:focus .ms-Checkbox-checkbox {
         border-color: #005a9e;
@@ -192,11 +203,20 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
       &:hover .ms-Checkbox-checkbox:after {
         border-color: #005a9e;
       }
+      @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox:after {
+        border-color: WindowText;
+      }
       &:hover .ms-Checkbox-text {
         color: #201f1e;
       }
+      @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+        color: WindowText;
+      }
       &:focus .ms-Checkbox-text {
         color: #201f1e;
+      }
+      @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+        color: WindowText;
       }
 >
   <input
@@ -287,6 +307,15 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
             transition-timing-function: cubic-bezier(.4, 0, .23, 1);
             width: 10px;
           }
+          @media screen and (-ms-high-contrast: active){&:after {
+            border-color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            border-color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
     >
       <i
         aria-hidden={true}
@@ -321,6 +350,12 @@ exports[`Checkbox renders indeterminate correctly 1`] = `
             font-size: 14px;
             line-height: 20px;
             margin-left: 4px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
     >
       Standard checkbox
@@ -357,8 +392,14 @@ exports[`Checkbox renders unchecked correctly 1`] = `
       &:hover .ms-Checkbox-text {
         color: #201f1e;
       }
+      @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+        color: WindowText;
+      }
       &:focus .ms-Checkbox-text {
         color: #201f1e;
+      }
+      @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+        color: WindowText;
       }
 >
   <input
@@ -432,6 +473,12 @@ exports[`Checkbox renders unchecked correctly 1`] = `
             transition-timing-function: cubic-bezier(.4, 0, .23, 1);
             width: 20px;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            border-color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
     >
       <i
         aria-hidden={true}
@@ -466,6 +513,12 @@ exports[`Checkbox renders unchecked correctly 1`] = `
             font-size: 14px;
             line-height: 20px;
             margin-left: 4px;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
     >
       Standard checkbox

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/__snapshots__/ChoiceGroup.test.tsx.snap
@@ -486,10 +486,20 @@ exports[`ChoiceGroup renders ChoiceGroup with label correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
           &::after {
             color: #a4262c;
             content: ' *';
             padding-right: 12px;
+          }
+          @media screen and (-ms-high-contrast: active){&::after {
+            color: WindowText;
           }
       id="ChoiceGroup0-label"
     >

--- a/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ColorPicker/__snapshots__/ColorPicker.test.tsx.snap
@@ -401,6 +401,9 @@ exports[`ColorPicker renders correctly 1`] = `
                       @media screen and (-ms-high-contrast: active){&:hover {
                         border-color: Highlight;
                       }
+                      @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                        forced-color-adjust: none;
+                      }
                 >
                   <input
                     aria-invalid={false}
@@ -446,6 +449,10 @@ exports[`ColorPicker renders correctly 1`] = `
                         &::-ms-clear {
                           display: none;
                         }
+                        @media screen and (-ms-high-contrast: active){& {
+                          background: Window;
+                          color: WindowText;
+                        }
                         &::placeholder {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
@@ -454,6 +461,9 @@ exports[`ColorPicker renders correctly 1`] = `
                           font-size: 14px;
                           font-weight: 400;
                           opacity: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active){&::placeholder {
+                          color: GrayText;
                         }
                         &:-ms-input-placeholder {
                           -moz-osx-font-smoothing: grayscale;
@@ -464,6 +474,9 @@ exports[`ColorPicker renders correctly 1`] = `
                           font-weight: 400;
                           opacity: 1;
                         }
+                        @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                          color: GrayText;
+                        }
                         &::-ms-input-placeholder {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
@@ -472,6 +485,9 @@ exports[`ColorPicker renders correctly 1`] = `
                           font-size: 14px;
                           font-weight: 400;
                           opacity: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                          color: GrayText;
                         }
                     id="TextField1"
                     onBlur={[Function]}
@@ -565,6 +581,9 @@ exports[`ColorPicker renders correctly 1`] = `
                       @media screen and (-ms-high-contrast: active){&:hover {
                         border-color: Highlight;
                       }
+                      @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                        forced-color-adjust: none;
+                      }
                 >
                   <input
                     aria-invalid={false}
@@ -610,6 +629,10 @@ exports[`ColorPicker renders correctly 1`] = `
                         &::-ms-clear {
                           display: none;
                         }
+                        @media screen and (-ms-high-contrast: active){& {
+                          background: Window;
+                          color: WindowText;
+                        }
                         &::placeholder {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
@@ -618,6 +641,9 @@ exports[`ColorPicker renders correctly 1`] = `
                           font-size: 14px;
                           font-weight: 400;
                           opacity: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active){&::placeholder {
+                          color: GrayText;
                         }
                         &:-ms-input-placeholder {
                           -moz-osx-font-smoothing: grayscale;
@@ -628,6 +654,9 @@ exports[`ColorPicker renders correctly 1`] = `
                           font-weight: 400;
                           opacity: 1;
                         }
+                        @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                          color: GrayText;
+                        }
                         &::-ms-input-placeholder {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
@@ -636,6 +665,9 @@ exports[`ColorPicker renders correctly 1`] = `
                           font-size: 14px;
                           font-weight: 400;
                           opacity: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                          color: GrayText;
                         }
                     id="TextField4"
                     onBlur={[Function]}
@@ -729,6 +761,9 @@ exports[`ColorPicker renders correctly 1`] = `
                       @media screen and (-ms-high-contrast: active){&:hover {
                         border-color: Highlight;
                       }
+                      @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                        forced-color-adjust: none;
+                      }
                 >
                   <input
                     aria-invalid={false}
@@ -774,6 +809,10 @@ exports[`ColorPicker renders correctly 1`] = `
                         &::-ms-clear {
                           display: none;
                         }
+                        @media screen and (-ms-high-contrast: active){& {
+                          background: Window;
+                          color: WindowText;
+                        }
                         &::placeholder {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
@@ -782,6 +821,9 @@ exports[`ColorPicker renders correctly 1`] = `
                           font-size: 14px;
                           font-weight: 400;
                           opacity: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active){&::placeholder {
+                          color: GrayText;
                         }
                         &:-ms-input-placeholder {
                           -moz-osx-font-smoothing: grayscale;
@@ -792,6 +834,9 @@ exports[`ColorPicker renders correctly 1`] = `
                           font-weight: 400;
                           opacity: 1;
                         }
+                        @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                          color: GrayText;
+                        }
                         &::-ms-input-placeholder {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
@@ -800,6 +845,9 @@ exports[`ColorPicker renders correctly 1`] = `
                           font-size: 14px;
                           font-weight: 400;
                           opacity: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                          color: GrayText;
                         }
                     id="TextField7"
                     onBlur={[Function]}
@@ -893,6 +941,9 @@ exports[`ColorPicker renders correctly 1`] = `
                       @media screen and (-ms-high-contrast: active){&:hover {
                         border-color: Highlight;
                       }
+                      @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                        forced-color-adjust: none;
+                      }
                 >
                   <input
                     aria-invalid={false}
@@ -938,6 +989,10 @@ exports[`ColorPicker renders correctly 1`] = `
                         &::-ms-clear {
                           display: none;
                         }
+                        @media screen and (-ms-high-contrast: active){& {
+                          background: Window;
+                          color: WindowText;
+                        }
                         &::placeholder {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
@@ -946,6 +1001,9 @@ exports[`ColorPicker renders correctly 1`] = `
                           font-size: 14px;
                           font-weight: 400;
                           opacity: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active){&::placeholder {
+                          color: GrayText;
                         }
                         &:-ms-input-placeholder {
                           -moz-osx-font-smoothing: grayscale;
@@ -956,6 +1014,9 @@ exports[`ColorPicker renders correctly 1`] = `
                           font-weight: 400;
                           opacity: 1;
                         }
+                        @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                          color: GrayText;
+                        }
                         &::-ms-input-placeholder {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
@@ -964,6 +1025,9 @@ exports[`ColorPicker renders correctly 1`] = `
                           font-size: 14px;
                           font-weight: 400;
                           opacity: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                          color: GrayText;
                         }
                     id="TextField10"
                     onBlur={[Function]}
@@ -1057,6 +1121,9 @@ exports[`ColorPicker renders correctly 1`] = `
                       @media screen and (-ms-high-contrast: active){&:hover {
                         border-color: Highlight;
                       }
+                      @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                        forced-color-adjust: none;
+                      }
                 >
                   <input
                     aria-invalid={false}
@@ -1102,6 +1169,10 @@ exports[`ColorPicker renders correctly 1`] = `
                         &::-ms-clear {
                           display: none;
                         }
+                        @media screen and (-ms-high-contrast: active){& {
+                          background: Window;
+                          color: WindowText;
+                        }
                         &::placeholder {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
@@ -1110,6 +1181,9 @@ exports[`ColorPicker renders correctly 1`] = `
                           font-size: 14px;
                           font-weight: 400;
                           opacity: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active){&::placeholder {
+                          color: GrayText;
                         }
                         &:-ms-input-placeholder {
                           -moz-osx-font-smoothing: grayscale;
@@ -1120,6 +1194,9 @@ exports[`ColorPicker renders correctly 1`] = `
                           font-weight: 400;
                           opacity: 1;
                         }
+                        @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                          color: GrayText;
+                        }
                         &::-ms-input-placeholder {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
@@ -1128,6 +1205,9 @@ exports[`ColorPicker renders correctly 1`] = `
                           font-size: 14px;
                           font-weight: 400;
                           opacity: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                          color: GrayText;
                         }
                     id="TextField13"
                     onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -132,6 +132,9 @@ exports[`ComboBox Renders correctly 1`] = `
           right: 0px;
           top: 0px;
         }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:focus:after {
+          forced-color-adjust: none;
+        }
     id="ComboBox0wrapper"
   >
     <input
@@ -498,6 +501,9 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
           position: absolute;
           right: 0px;
           top: 0px;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:focus:after {
+          forced-color-adjust: none;
         }
     data-ktp-target="ktp-a"
     id="ComboBox4wrapper"

--- a/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/__snapshots__/DatePicker.test.tsx.snap
@@ -88,6 +88,9 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
               }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
+              }
         >
           <input
             aria-expanded={false}
@@ -132,6 +135,10 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -140,6 +147,9 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -150,6 +160,9 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -158,6 +171,9 @@ exports[`DatePicker renders default DatePicker correctly 1`] = `
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="DatePicker0-label"
             onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
@@ -441,6 +441,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                     0 0 / 90% 100%
                                                     no-repeat;
                             }
+                            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                              forced-color-adjust: none;
+                            }
                         style={
                           Object {
                             "width": "100%",
@@ -624,6 +627,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                       transparent 100%)
                                                     0 0 / 90% 100%
                                                     no-repeat;
+                            }
+                            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                              forced-color-adjust: none;
                             }
                         style={
                           Object {
@@ -809,6 +815,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                     0 0 / 90% 100%
                                                     no-repeat;
                             }
+                            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                              forced-color-adjust: none;
+                            }
                         style={
                           Object {
                             "width": "100%",
@@ -992,6 +1001,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                       transparent 100%)
                                                     0 0 / 90% 100%
                                                     no-repeat;
+                            }
+                            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                              forced-color-adjust: none;
                             }
                         style={
                           Object {
@@ -1177,6 +1189,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                     0 0 / 90% 100%
                                                     no-repeat;
                             }
+                            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                              forced-color-adjust: none;
+                            }
                         style={
                           Object {
                             "width": "100%",
@@ -1360,6 +1375,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                       transparent 100%)
                                                     0 0 / 90% 100%
                                                     no-repeat;
+                            }
+                            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                              forced-color-adjust: none;
                             }
                         style={
                           Object {
@@ -1545,6 +1563,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                     0 0 / 90% 100%
                                                     no-repeat;
                             }
+                            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                              forced-color-adjust: none;
+                            }
                         style={
                           Object {
                             "width": "100%",
@@ -1728,6 +1749,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                       transparent 100%)
                                                     0 0 / 90% 100%
                                                     no-repeat;
+                            }
+                            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                              forced-color-adjust: none;
                             }
                         style={
                           Object {
@@ -1913,6 +1937,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                     0 0 / 90% 100%
                                                     no-repeat;
                             }
+                            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                              forced-color-adjust: none;
+                            }
                         style={
                           Object {
                             "width": "100%",
@@ -2096,6 +2123,9 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
                                                       transparent 100%)
                                                     0 0 / 90% 100%
                                                     no-repeat;
+                            }
+                            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                              forced-color-adjust: none;
                             }
                         style={
                           Object {

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/__snapshots__/DocumentCard.test.tsx.snap
@@ -33,6 +33,9 @@ exports[`DocumentCard renders DocumentCard correctly 1`] = `
       @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
         border-color: Highlight;
       }
+      @media screen and (-ms-high-contrast: active) and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+        forced-color-adjust: none;
+      }
       & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
         padding-top: 4px;
       }

--- a/packages/office-ui-fabric-react/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Fabric/__snapshots__/Fabric.test.tsx.snap
@@ -82,8 +82,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -157,6 +163,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -191,6 +203,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                 font-size: 14px;
                 line-height: 20px;
                 margin-left: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           I am in ltr
@@ -248,8 +266,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
             &:hover .ms-Checkbox-text {
               color: #201f1e;
             }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+              color: WindowText;
+            }
             &:focus .ms-Checkbox-text {
               color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+              color: WindowText;
             }
       >
         <input
@@ -323,6 +347,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                   transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                   width: 20px;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             <i
               aria-hidden={true}
@@ -357,6 +387,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                   font-size: 14px;
                   line-height: 20px;
                   margin-right: 4px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
           >
             I am in rtl, inside of ltr
@@ -414,8 +450,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
               &:hover .ms-Checkbox-text {
                 color: #201f1e;
               }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                color: WindowText;
+              }
               &:focus .ms-Checkbox-text {
                 color: #201f1e;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                color: WindowText;
               }
         >
           <input
@@ -489,6 +531,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                     transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                     width: 20px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               <i
                 aria-hidden={true}
@@ -523,6 +571,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                     font-size: 14px;
                     line-height: 20px;
                     margin-left: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
             >
               I am in ltr, inside of rtl, inside of ltr
@@ -583,8 +637,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -658,6 +718,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -692,6 +758,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                 font-size: 14px;
                 line-height: 20px;
                 margin-right: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           I am in rtl
@@ -749,8 +821,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
             &:hover .ms-Checkbox-text {
               color: #201f1e;
             }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+              color: WindowText;
+            }
             &:focus .ms-Checkbox-text {
               color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+              color: WindowText;
             }
       >
         <input
@@ -824,6 +902,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                   transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                   width: 20px;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             <i
               aria-hidden={true}
@@ -858,6 +942,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                   font-size: 14px;
                   line-height: 20px;
                   margin-left: 4px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
           >
             I am in ltr, inside of rtl
@@ -915,8 +1005,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
               &:hover .ms-Checkbox-text {
                 color: #201f1e;
               }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                color: WindowText;
+              }
               &:focus .ms-Checkbox-text {
                 color: #201f1e;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                color: WindowText;
               }
         >
           <input
@@ -990,6 +1086,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                     transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                     width: 20px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               <i
                 aria-hidden={true}
@@ -1024,6 +1126,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 1`] = `
                     font-size: 14px;
                     line-height: 20px;
                     margin-right: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
             >
               I am in rtl, inside of rtl, inside of rtl
@@ -1089,8 +1197,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -1164,6 +1278,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -1198,6 +1318,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                 font-size: 14px;
                 line-height: 20px;
                 margin-left: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           I am in ltr
@@ -1255,8 +1381,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
             &:hover .ms-Checkbox-text {
               color: #201f1e;
             }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+              color: WindowText;
+            }
             &:focus .ms-Checkbox-text {
               color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+              color: WindowText;
             }
       >
         <input
@@ -1330,6 +1462,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                   transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                   width: 20px;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             <i
               aria-hidden={true}
@@ -1364,6 +1502,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                   font-size: 14px;
                   line-height: 20px;
                   margin-right: 4px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
           >
             I am in rtl, inside of ltr
@@ -1421,8 +1565,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
               &:hover .ms-Checkbox-text {
                 color: #201f1e;
               }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                color: WindowText;
+              }
               &:focus .ms-Checkbox-text {
                 color: #201f1e;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                color: WindowText;
               }
         >
           <input
@@ -1496,6 +1646,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                     transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                     width: 20px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               <i
                 aria-hidden={true}
@@ -1530,6 +1686,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                     font-size: 14px;
                     line-height: 20px;
                     margin-left: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
             >
               I am in ltr, inside of rtl, inside of ltr
@@ -1590,8 +1752,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -1665,6 +1833,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -1699,6 +1873,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                 font-size: 14px;
                 line-height: 20px;
                 margin-right: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           I am in rtl
@@ -1756,8 +1936,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
             &:hover .ms-Checkbox-text {
               color: #201f1e;
             }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+              color: WindowText;
+            }
             &:focus .ms-Checkbox-text {
               color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+              color: WindowText;
             }
       >
         <input
@@ -1831,6 +2017,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                   transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                   width: 20px;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             <i
               aria-hidden={true}
@@ -1865,6 +2057,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                   font-size: 14px;
                   line-height: 20px;
                   margin-left: 4px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
           >
             I am in ltr, inside of rtl
@@ -1922,8 +2120,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
               &:hover .ms-Checkbox-text {
                 color: #201f1e;
               }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                color: WindowText;
+              }
               &:focus .ms-Checkbox-text {
                 color: #201f1e;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                color: WindowText;
               }
         >
           <input
@@ -1997,6 +2201,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                     transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                     width: 20px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               <i
                 aria-hidden={true}
@@ -2031,6 +2241,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 2`] = `
                     font-size: 14px;
                     line-height: 20px;
                     margin-right: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
             >
               I am in rtl, inside of rtl, inside of rtl
@@ -2096,8 +2312,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -2171,6 +2393,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -2205,6 +2433,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                 font-size: 14px;
                 line-height: 20px;
                 margin-left: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           I am in ltr
@@ -2262,8 +2496,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
             &:hover .ms-Checkbox-text {
               color: #201f1e;
             }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+              color: WindowText;
+            }
             &:focus .ms-Checkbox-text {
               color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+              color: WindowText;
             }
       >
         <input
@@ -2337,6 +2577,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                   transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                   width: 20px;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             <i
               aria-hidden={true}
@@ -2371,6 +2617,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                   font-size: 14px;
                   line-height: 20px;
                   margin-right: 4px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
           >
             I am in rtl, inside of ltr
@@ -2428,8 +2680,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
               &:hover .ms-Checkbox-text {
                 color: #201f1e;
               }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                color: WindowText;
+              }
               &:focus .ms-Checkbox-text {
                 color: #201f1e;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                color: WindowText;
               }
         >
           <input
@@ -2503,6 +2761,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                     transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                     width: 20px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               <i
                 aria-hidden={true}
@@ -2537,6 +2801,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                     font-size: 14px;
                     line-height: 20px;
                     margin-left: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
             >
               I am in ltr, inside of rtl, inside of ltr
@@ -2597,8 +2867,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -2672,6 +2948,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -2706,6 +2988,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                 font-size: 14px;
                 line-height: 20px;
                 margin-right: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           I am in rtl
@@ -2763,8 +3051,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
             &:hover .ms-Checkbox-text {
               color: #201f1e;
             }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+              color: WindowText;
+            }
             &:focus .ms-Checkbox-text {
               color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+              color: WindowText;
             }
       >
         <input
@@ -2838,6 +3132,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                   transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                   width: 20px;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             <i
               aria-hidden={true}
@@ -2872,6 +3172,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                   font-size: 14px;
                   line-height: 20px;
                   margin-left: 4px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
           >
             I am in ltr, inside of rtl
@@ -2929,8 +3235,14 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
               &:hover .ms-Checkbox-text {
                 color: #201f1e;
               }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                color: WindowText;
+              }
               &:focus .ms-Checkbox-text {
                 color: #201f1e;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                color: WindowText;
               }
         >
           <input
@@ -3004,6 +3316,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                     transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                     width: 20px;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    border-color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               <i
                 aria-hidden={true}
@@ -3038,6 +3356,12 @@ exports[`Fabric renders a Fabric component in RTL and LTR theme 3`] = `
                     font-size: 14px;
                     line-height: 20px;
                     margin-right: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
             >
               I am in rtl, inside of rtl, inside of rtl

--- a/packages/office-ui-fabric-react/src/components/Label/Label.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Label/Label.styles.ts
@@ -1,4 +1,4 @@
-import { HighContrastSelector, FontWeights } from '../../Styling';
+import { HighContrastSelector, FontWeights, getEdgeChromiumForcedStylesOffSelector } from '../../Styling';
 import { ILabelStyleProps, ILabelStyles } from './Label.types';
 
 export const getStyles = (props: ILabelStyleProps): ILabelStyles => {
@@ -24,22 +24,29 @@ export const getStyles = (props: ILabelStyleProps): ILabelStyles => {
         display: 'block',
         padding: '5px 0',
         wordWrap: 'break-word',
-        overflowWrap: 'break-word'
-      },
-      disabled && {
-        color: labelDisabledColor,
+        overflowWrap: 'break-word',
         selectors: {
           [HighContrastSelector]: {
-            color: 'GrayText'
-          }
+            background: 'Window',
+            color: disabled ? 'GrayText' : 'WindowText'
+          },
+          ...getEdgeChromiumForcedStylesOffSelector()
         }
+      },
+      disabled && {
+        color: labelDisabledColor
       },
       required && {
         selectors: {
           '::after': {
             content: `' *'`,
             color: labelRequiredStarColor,
-            paddingRight: 12
+            paddingRight: 12,
+            selectors: {
+              [HighContrastSelector]: {
+                color: 'WindowText'
+              }
+            }
           }
         }
       },

--- a/packages/office-ui-fabric-react/src/components/Label/Label.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Label/Label.styles.ts
@@ -1,4 +1,4 @@
-import { HighContrastSelector, FontWeights, getEdgeChromiumForcedStylesOffSelector } from '../../Styling';
+import { HighContrastSelector, FontWeights, getEdgeChromiumNoHighContrastAdjustSelector } from '../../Styling';
 import { ILabelStyleProps, ILabelStyles } from './Label.types';
 
 export const getStyles = (props: ILabelStyleProps): ILabelStyles => {
@@ -30,7 +30,7 @@ export const getStyles = (props: ILabelStyleProps): ILabelStyles => {
             background: 'Window',
             color: disabled ? 'GrayText' : 'WindowText'
           },
-          ...getEdgeChromiumForcedStylesOffSelector()
+          ...getEdgeChromiumNoHighContrastAdjustSelector()
         }
       },
       disabled && {

--- a/packages/office-ui-fabric-react/src/components/Label/__snapshots__/Label.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Label/__snapshots__/Label.test.tsx.snap
@@ -25,6 +25,13 @@ exports[`Label renders label correctly 1`] = `
         padding-top: 5px;
         word-wrap: break-word;
       }
+      @media screen and (-ms-high-contrast: active){& {
+        background: Window;
+        color: WindowText;
+      }
+      @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+        forced-color-adjust: none;
+      }
 >
   test
 </label>

--- a/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/Shimmer.styles.ts
@@ -1,6 +1,7 @@
 import { IShimmerStyleProps, IShimmerStyles } from './Shimmer.types';
 import { keyframes, getGlobalClassNames, hiddenContentStyle, HighContrastSelector } from '../../Styling';
 import { getRTL } from '../../Utilities';
+import { getEdgeChromiumNoHighContrastAdjustSelector } from '@uifabric/styling';
 
 const GlobalClassNames = {
   root: 'ms-Shimmer-container',
@@ -68,7 +69,8 @@ export function getStyles(props: IShimmerStyleProps): IShimmerStyles {
                           transparent 100%)
                         0 0 / 90% 100%
                         no-repeat`
-          }
+          },
+          ...getEdgeChromiumNoHighContrastAdjustSelector()
         }
       },
       isDataLoaded && {

--- a/packages/office-ui-fabric-react/src/components/Shimmer/__snapshots__/Shimmer.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Shimmer/__snapshots__/Shimmer.test.tsx.snap
@@ -37,6 +37,9 @@ exports[`Shimmer renders Shimmer correctly 1`] = `
                                 0 0 / 90% 100%
                                 no-repeat;
         }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
     style={
       Object {
         "width": "50%",
@@ -297,6 +300,9 @@ exports[`Shimmer renders Shimmer with custom elements correctly 1`] = `
                                   transparent 100%)
                                 0 0 / 90% 100%
                                 no-repeat;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
     style={
       Object {

--- a/packages/office-ui-fabric-react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Slider/__snapshots__/Slider.test.tsx.snap
@@ -39,6 +39,13 @@ exports[`Slider renders correctly 1`] = `
           padding-top: 0px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
     htmlFor="Slider0"
   >
     I am a slider
@@ -256,6 +263,13 @@ exports[`Slider renders correctly 1`] = `
             white-space: nowrap;
             width: 40px;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
     >
       0

--- a/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
@@ -48,6 +48,13 @@ exports[`SpinButton renders SpinButton correctly 1`] = `
             pointer-events: none;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       htmlFor="input1"
       id="Label0"
     >
@@ -478,6 +485,13 @@ exports[`SpinButton renders SpinButton correctly with values that the user passe
             padding-top: 5px;
             pointer-events: none;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="input1"
       id="Label0"

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/__snapshots__/MaskedTextField.test.tsx.snap
@@ -52,6 +52,13 @@ exports[`MaskedTextField renders correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       htmlFor="TextField0"
       id="TextFieldLabel2"
     >
@@ -86,6 +93,9 @@ exports[`MaskedTextField renders correctly 1`] = `
           }
           @media screen and (-ms-high-contrast: active){&:hover {
             border-color: Highlight;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+            forced-color-adjust: none;
           }
     >
       <input
@@ -131,6 +141,10 @@ exports[`MaskedTextField renders correctly 1`] = `
             &::-ms-clear {
               display: none;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
             &::placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
@@ -139,6 +153,9 @@ exports[`MaskedTextField renders correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
               opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::placeholder {
+              color: GrayText;
             }
             &:-ms-input-placeholder {
               -moz-osx-font-smoothing: grayscale;
@@ -149,6 +166,9 @@ exports[`MaskedTextField renders correctly 1`] = `
               font-weight: 400;
               opacity: 1;
             }
+            @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+              color: GrayText;
+            }
             &::-ms-input-placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
@@ -157,6 +177,9 @@ exports[`MaskedTextField renders correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
               opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+              color: GrayText;
             }
         id="TextField0"
         onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -7,7 +7,7 @@ import {
   normalize,
   getPlaceholderStyles,
   IconFontSizes,
-  getEdgeChromiumForcedStylesOffSelector
+  getEdgeChromiumNoHighContrastAdjustSelector
 } from '../../Styling';
 import { ILabelStyles, ILabelStyleProps } from '../../Label';
 import { ITextFieldStyleProps, ITextFieldStyles } from './TextField.types';
@@ -156,7 +156,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
             [HighContrastSelector]: {
               borderColor: 'GrayText'
             },
-            ...getEdgeChromiumForcedStylesOffSelector()
+            ...getEdgeChromiumNoHighContrastAdjustSelector()
           }
         },
         !disabled && {
@@ -167,7 +167,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
                 [HighContrastSelector]: {
                   borderBottomColor: 'Highlight'
                 },
-                ...getEdgeChromiumForcedStylesOffSelector()
+                ...getEdgeChromiumNoHighContrastAdjustSelector()
               }
             }
           }
@@ -209,7 +209,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
                 [HighContrastSelector]: {
                   borderColor: 'Highlight'
                 },
-                ...getEdgeChromiumForcedStylesOffSelector()
+                ...getEdgeChromiumNoHighContrastAdjustSelector()
               }
             }
           }
@@ -224,7 +224,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
           [HighContrastSelector]: {
             borderColor: 'GrayText'
           },
-          ...getEdgeChromiumForcedStylesOffSelector()
+          ...getEdgeChromiumNoHighContrastAdjustSelector()
         },
 
         cursor: 'default'

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -6,7 +6,8 @@ import {
   IStyle,
   normalize,
   getPlaceholderStyles,
-  IconFontSizes
+  IconFontSizes,
+  getEdgeChromiumForcedStylesOffSelector
 } from '../../Styling';
 import { ILabelStyles, ILabelStyleProps } from '../../Label';
 import { ITextFieldStyleProps, ITextFieldStyles } from './TextField.types';
@@ -38,6 +39,14 @@ function getLabelStyles(props: ITextFieldStyleProps): IStyleFunctionOrObject<ILa
 
   return () => ({
     root: [
+      // {
+      //   selectors: {
+      //     [HighContrastSelector]: {
+      //       background: 'Window',
+      //       color: disabled ? 'GrayText' : 'WindowText'
+      //     }
+      //   }
+      // },
       underlined &&
         disabled && {
           color: palette.neutralTertiary
@@ -92,7 +101,13 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
     padding: '0 10px',
     lineHeight: 1,
     whiteSpace: 'nowrap',
-    flexShrink: 0
+    flexShrink: 0,
+    selectors: {
+      [HighContrastSelector]: {
+        background: 'Window',
+        color: disabled ? 'GrayText' : 'WindowText'
+      }
+    }
   };
 
   // placeholder style constants
@@ -100,12 +115,22 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
     fonts.medium,
     {
       color: semanticColors.inputPlaceholderText,
-      opacity: 1
+      opacity: 1,
+      selectors: {
+        [HighContrastSelector]: {
+          color: 'GrayText'
+        }
+      }
     }
   ];
 
   const disabledPlaceholderStyles: IStyle = {
-    color: semanticColors.disabledText
+    color: semanticColors.disabledText,
+    selectors: {
+      [HighContrastSelector]: {
+        color: 'GrayText'
+      }
+    }
   };
 
   return {
@@ -138,7 +163,8 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
           selectors: {
             [HighContrastSelector]: {
               borderColor: 'GrayText'
-            }
+            },
+            ...getEdgeChromiumForcedStylesOffSelector()
           }
         },
         !disabled && {
@@ -148,7 +174,8 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
               selectors: {
                 [HighContrastSelector]: {
                   borderBottomColor: 'Highlight'
-                }
+                },
+                ...getEdgeChromiumForcedStylesOffSelector()
               }
             }
           }
@@ -189,7 +216,8 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
               selectors: {
                 [HighContrastSelector]: {
                   borderColor: 'Highlight'
-                }
+                },
+                ...getEdgeChromiumForcedStylesOffSelector()
               }
             }
           }
@@ -203,7 +231,8 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
         selectors: {
           [HighContrastSelector]: {
             borderColor: 'GrayText'
-          }
+          },
+          ...getEdgeChromiumForcedStylesOffSelector()
         },
 
         cursor: 'default'
@@ -252,6 +281,7 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
             [HighContrastSelector]: {
               selectors: {
                 ':before': {
+                  color: 'WindowText',
                   right: -14 // moving the * 4 pixel to right to alleviate border clipping in HC mode.
                 }
               }
@@ -278,6 +308,10 @@ export function getStyles(props: ITextFieldStyleProps): ITextFieldStyles {
           '&:active, &:focus, &:hover': { outline: 0 },
           '::-ms-clear': {
             display: 'none'
+          },
+          [HighContrastSelector]: {
+            background: 'Window',
+            color: disabled ? 'GrayText' : 'WindowText'
           }
         }
       },

--- a/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/TextField.styles.tsx
@@ -39,14 +39,6 @@ function getLabelStyles(props: ITextFieldStyleProps): IStyleFunctionOrObject<ILa
 
   return () => ({
     root: [
-      // {
-      //   selectors: {
-      //     [HighContrastSelector]: {
-      //       background: 'Window',
-      //       color: disabled ? 'GrayText' : 'WindowText'
-      //     }
-      //   }
-      // },
       underlined &&
         disabled && {
           color: palette.neutralTertiary

--- a/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TextField/__snapshots__/TextField.test.tsx.snap
@@ -53,6 +53,13 @@ exports[`TextField snapshots renders correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       htmlFor="TextField0"
       id="TextFieldLabel2"
     >
@@ -87,6 +94,9 @@ exports[`TextField snapshots renders correctly 1`] = `
           }
           @media screen and (-ms-high-contrast: active){&:hover {
             border-color: Highlight;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+            forced-color-adjust: none;
           }
     >
       <input
@@ -133,6 +143,10 @@ exports[`TextField snapshots renders correctly 1`] = `
             &::-ms-clear {
               display: none;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
             &::placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
@@ -141,6 +155,9 @@ exports[`TextField snapshots renders correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
               opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::placeholder {
+              color: GrayText;
             }
             &:-ms-input-placeholder {
               -moz-osx-font-smoothing: grayscale;
@@ -151,6 +168,9 @@ exports[`TextField snapshots renders correctly 1`] = `
               font-weight: 400;
               opacity: 1;
             }
+            @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+              color: GrayText;
+            }
             &::-ms-input-placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
@@ -159,6 +179,9 @@ exports[`TextField snapshots renders correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
               opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+              color: GrayText;
             }
         id="TextField0"
         onBlur={[Function]}
@@ -211,6 +234,9 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
         @media screen and (-ms-high-contrast: active){&:hover {
           border-bottom-color: Highlight;
         }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+          forced-color-adjust: none;
+        }
   >
     <label
       className=
@@ -237,6 +263,13 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
             padding-right: 0px;
             padding-top: 5px;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="TextField0"
       id="TextFieldLabel2"
@@ -275,6 +308,9 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
           @media screen and (-ms-high-contrast: active){&:hover {
             border-color: Highlight;
           }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+            forced-color-adjust: none;
+          }
     >
       <div
         className=
@@ -291,6 +327,10 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
               padding-right: 10px;
               padding-top: 0;
               white-space: nowrap;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
             }
       >
         <span
@@ -348,6 +388,10 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
             &::-ms-clear {
               display: none;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
             &::placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
@@ -356,6 +400,9 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
               font-size: 14px;
               font-weight: 400;
               opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::placeholder {
+              color: GrayText;
             }
             &:-ms-input-placeholder {
               -moz-osx-font-smoothing: grayscale;
@@ -366,6 +413,9 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
               font-weight: 400;
               opacity: 1;
             }
+            @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+              color: GrayText;
+            }
             &::-ms-input-placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
@@ -374,6 +424,9 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
               font-size: 14px;
               font-weight: 400;
               opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+              color: GrayText;
             }
         id="TextField0"
         onBlur={[Function]}
@@ -398,6 +451,10 @@ exports[`TextField snapshots renders multiline correctly with errorMessage 1`] =
               padding-right: 10px;
               padding-top: 0;
               white-space: nowrap;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
             }
       >
         <span
@@ -460,6 +517,9 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
         @media screen and (-ms-high-contrast: active){&:hover {
           border-bottom-color: Highlight;
         }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+          forced-color-adjust: none;
+        }
   >
     <label
       className=
@@ -486,6 +546,13 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
             padding-right: 0px;
             padding-top: 5px;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="TextField0"
       id="TextFieldLabel2"
@@ -524,6 +591,9 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
           @media screen and (-ms-high-contrast: active){&:hover {
             border-color: Highlight;
           }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+            forced-color-adjust: none;
+          }
     >
       <div
         className=
@@ -540,6 +610,10 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
               padding-right: 10px;
               padding-top: 0;
               white-space: nowrap;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
             }
       >
         <span
@@ -597,6 +671,10 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
             &::-ms-clear {
               display: none;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
             &::placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
@@ -605,6 +683,9 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
               font-size: 14px;
               font-weight: 400;
               opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::placeholder {
+              color: GrayText;
             }
             &:-ms-input-placeholder {
               -moz-osx-font-smoothing: grayscale;
@@ -615,6 +696,9 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
               font-weight: 400;
               opacity: 1;
             }
+            @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+              color: GrayText;
+            }
             &::-ms-input-placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
@@ -623,6 +707,9 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
               font-size: 14px;
               font-weight: 400;
               opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+              color: GrayText;
             }
         id="TextField0"
         onBlur={[Function]}
@@ -647,6 +734,10 @@ exports[`TextField snapshots renders multiline correctly with props affecting st
               padding-right: 10px;
               padding-top: 0;
               white-space: nowrap;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
             }
       >
         <span
@@ -724,6 +815,13 @@ exports[`TextField snapshots renders multiline resizable correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       htmlFor="TextField0"
       id="TextFieldLabel2"
     >
@@ -759,6 +857,9 @@ exports[`TextField snapshots renders multiline resizable correctly 1`] = `
           }
           @media screen and (-ms-high-contrast: active){&:hover {
             border-color: Highlight;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+            forced-color-adjust: none;
           }
     >
       <textarea
@@ -808,6 +909,10 @@ exports[`TextField snapshots renders multiline resizable correctly 1`] = `
             &::-ms-clear {
               display: none;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
             &::placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
@@ -816,6 +921,9 @@ exports[`TextField snapshots renders multiline resizable correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
               opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::placeholder {
+              color: GrayText;
             }
             &:-ms-input-placeholder {
               -moz-osx-font-smoothing: grayscale;
@@ -826,6 +934,9 @@ exports[`TextField snapshots renders multiline resizable correctly 1`] = `
               font-weight: 400;
               opacity: 1;
             }
+            @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+              color: GrayText;
+            }
             &::-ms-input-placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
@@ -834,6 +945,9 @@ exports[`TextField snapshots renders multiline resizable correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
               opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+              color: GrayText;
             }
         id="TextField0"
         onBlur={[Function]}
@@ -900,6 +1014,13 @@ exports[`TextField snapshots renders multiline unresizable correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       htmlFor="TextField0"
       id="TextFieldLabel2"
     >
@@ -935,6 +1056,9 @@ exports[`TextField snapshots renders multiline unresizable correctly 1`] = `
           }
           @media screen and (-ms-high-contrast: active){&:hover {
             border-color: Highlight;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+            forced-color-adjust: none;
           }
     >
       <textarea
@@ -986,6 +1110,10 @@ exports[`TextField snapshots renders multiline unresizable correctly 1`] = `
             &::-ms-clear {
               display: none;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
             &::placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
@@ -994,6 +1122,9 @@ exports[`TextField snapshots renders multiline unresizable correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
               opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::placeholder {
+              color: GrayText;
             }
             &:-ms-input-placeholder {
               -moz-osx-font-smoothing: grayscale;
@@ -1004,6 +1135,9 @@ exports[`TextField snapshots renders multiline unresizable correctly 1`] = `
               font-weight: 400;
               opacity: 1;
             }
+            @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+              color: GrayText;
+            }
             &::-ms-input-placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
@@ -1012,6 +1146,9 @@ exports[`TextField snapshots renders multiline unresizable correctly 1`] = `
               font-size: 14px;
               font-weight: 400;
               opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+              color: GrayText;
             }
         id="TextField0"
         onBlur={[Function]}
@@ -1078,6 +1215,13 @@ exports[`TextField snapshots renders multiline with placeholder correctly 1`] = 
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       htmlFor="TextField0"
       id="TextFieldLabel2"
     >
@@ -1113,6 +1257,9 @@ exports[`TextField snapshots renders multiline with placeholder correctly 1`] = 
           }
           @media screen and (-ms-high-contrast: active){&:hover {
             border-color: Highlight;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+            forced-color-adjust: none;
           }
     >
       <textarea
@@ -1162,6 +1309,10 @@ exports[`TextField snapshots renders multiline with placeholder correctly 1`] = 
             &::-ms-clear {
               display: none;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
             &::placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
@@ -1170,6 +1321,9 @@ exports[`TextField snapshots renders multiline with placeholder correctly 1`] = 
               font-size: 14px;
               font-weight: 400;
               opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::placeholder {
+              color: GrayText;
             }
             &:-ms-input-placeholder {
               -moz-osx-font-smoothing: grayscale;
@@ -1180,6 +1334,9 @@ exports[`TextField snapshots renders multiline with placeholder correctly 1`] = 
               font-weight: 400;
               opacity: 1;
             }
+            @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+              color: GrayText;
+            }
             &::-ms-input-placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
@@ -1188,6 +1345,9 @@ exports[`TextField snapshots renders multiline with placeholder correctly 1`] = 
               font-size: 14px;
               font-weight: 400;
               opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+              color: GrayText;
             }
         id="TextField0"
         onBlur={[Function]}
@@ -1241,6 +1401,9 @@ exports[`TextField snapshots should resepect user component and subcomponent sty
         @media screen and (-ms-high-contrast: active){&:hover {
           border-bottom-color: Highlight;
         }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+          forced-color-adjust: none;
+        }
   >
     <label
       className=
@@ -1268,6 +1431,13 @@ exports[`TextField snapshots should resepect user component and subcomponent sty
             padding-right: 0px;
             padding-top: 5px;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="TextField0"
       id="TextFieldLabel2"
@@ -1306,6 +1476,9 @@ exports[`TextField snapshots should resepect user component and subcomponent sty
           @media screen and (-ms-high-contrast: active){&:hover {
             border-color: Highlight;
           }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+            forced-color-adjust: none;
+          }
     >
       <div
         className=
@@ -1322,6 +1495,10 @@ exports[`TextField snapshots should resepect user component and subcomponent sty
               padding-right: 10px;
               padding-top: 0;
               white-space: nowrap;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
             }
       >
         <span
@@ -1379,6 +1556,10 @@ exports[`TextField snapshots should resepect user component and subcomponent sty
             &::-ms-clear {
               display: none;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
             &::placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
@@ -1387,6 +1568,9 @@ exports[`TextField snapshots should resepect user component and subcomponent sty
               font-size: 14px;
               font-weight: 400;
               opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::placeholder {
+              color: GrayText;
             }
             &:-ms-input-placeholder {
               -moz-osx-font-smoothing: grayscale;
@@ -1397,6 +1581,9 @@ exports[`TextField snapshots should resepect user component and subcomponent sty
               font-weight: 400;
               opacity: 1;
             }
+            @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+              color: GrayText;
+            }
             &::-ms-input-placeholder {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
@@ -1405,6 +1592,9 @@ exports[`TextField snapshots should resepect user component and subcomponent sty
               font-size: 14px;
               font-weight: 400;
               opacity: 1;
+            }
+            @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+              color: GrayText;
             }
         id="TextField0"
         onBlur={[Function]}
@@ -1429,6 +1619,10 @@ exports[`TextField snapshots should resepect user component and subcomponent sty
               padding-right: 10px;
               padding-top: 0;
               white-space: nowrap;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
             }
       >
         <span

--- a/packages/office-ui-fabric-react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Toggle/__snapshots__/Toggle.test.tsx.snap
@@ -140,6 +140,13 @@ exports[`Toggle renders toggle correctly 1`] = `
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
     htmlFor="Toggle1"
     id="Toggle1-label"
   >
@@ -273,6 +280,13 @@ exports[`Toggle renders toggle correctly with inline label (JSX Element) 1`] = `
           padding-top: 5px;
           word-break: break-all;
           word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
     htmlFor="Toggle3"
     id="Toggle3-label"
@@ -410,6 +424,13 @@ exports[`Toggle renders toggle correctly with inline label (string) 1`] = `
           word-break: break-all;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
     htmlFor="Toggle2"
     id="Toggle2-label"
   >
@@ -543,6 +564,13 @@ exports[`Toggle renders toggle correctly with inline label and on/off text provi
           word-break: break-all;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
     htmlFor="Toggle4"
     id="Toggle4-label"
   >
@@ -654,6 +682,13 @@ exports[`Toggle renders toggle correctly with inline label and on/off text provi
             padding-right: 0;
             padding-top: 5px;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
           && {
             font-weight: 400;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -26,6 +26,13 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
         &:not(:first-child) {
           margin-top: 24px;
         }
@@ -700,6 +707,13 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
         &:not(:first-child) {
           margin-top: 24px;
         }
@@ -1340,6 +1354,13 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
         &:not(:first-child) {
           margin-top: 24px;
         }
@@ -1816,6 +1837,13 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
           padding-right: 0;
           padding-top: 5px;
           word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
         &:not(:first-child) {
           margin-top: 24px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Collapsing.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Collapsing.Example.tsx.shot
@@ -26,6 +26,13 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
         &:not(:first-child) {
           margin-top: 24px;
         }
@@ -984,6 +991,13 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
         &:not(:first-child) {
           margin-top: 24px;
         }
@@ -1657,6 +1671,13 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
           padding-right: 0;
           padding-top: 5px;
           word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
         &:not(:first-child) {
           margin-top: 24px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CustomSplit.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CustomSplit.Example.tsx.shot
@@ -26,6 +26,13 @@ exports[`Component Examples renders Button.CustomSplit.Example.tsx correctly 1`]
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
   >
     Split button with icon and custom styles
   </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
@@ -40,6 +40,13 @@ Array [
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         id="Dropdown0-label"
       >
         Directional hint

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
@@ -31,10 +31,6 @@ Array [
             background: #005a9e;
             border-color: #005a9e;
           }
-          & .ms-Checkbox-checkbox {
-            background: #0078d4;
-            border-color: #0078d4;
-          }
           @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
             background: Window;
             border-color: Highlight;
@@ -54,8 +50,14 @@ Array [
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -135,6 +137,9 @@ Array [
                 background: Highlight;
                 border-color: Highlight;
               }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -169,6 +174,12 @@ Array [
                 font-size: 14px;
                 line-height: 20px;
                 margin-left: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           Show beak
@@ -212,6 +223,13 @@ Array [
               padding-right: 0px;
               padding-top: 0px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         htmlFor="Slider3"
       >
@@ -431,6 +449,13 @@ Array [
                 width: 40px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           0
         </label>
@@ -473,6 +498,13 @@ Array [
               padding-right: 0px;
               padding-top: 0px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         htmlFor="Slider4"
       >
@@ -692,6 +724,13 @@ Array [
                 width: 40px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           16
         </label>
@@ -726,6 +765,13 @@ Array [
               padding-right: 0;
               padding-top: 5px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         id="Dropdown5-label"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Basic.Example.tsx.shot
@@ -49,8 +49,14 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -124,6 +130,12 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -159,6 +171,12 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               line-height: 20px;
               margin-left: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Unchecked checkbox (uncontrolled)
       </span>
@@ -181,10 +199,6 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
           background: #005a9e;
           border-color: #005a9e;
         }
-        & .ms-Checkbox-checkbox {
-          background: #0078d4;
-          border-color: #0078d4;
-        }
         @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
           background: Window;
           border-color: Highlight;
@@ -204,8 +218,14 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -285,6 +305,9 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               background: Highlight;
               border-color: Highlight;
             }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -319,6 +342,12 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Checked checkbox (uncontrolled)
@@ -409,7 +438,10 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active){& {
-              border-color: InactiveBorder;
+              border-color: GrayText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         <i
@@ -429,7 +461,7 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               }
               @media screen and (-ms-high-contrast: active){& {
                 -ms-high-contrast-adjust: none;
-                color: InactiveBorder;
+                color: GrayText;
               }
           data-icon-name="CheckMark"
         >
@@ -447,7 +479,10 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active){& {
-              color: InactiveBorder;
+              color: GrayText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Disabled checkbox
@@ -540,7 +575,11 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               width: 20px;
             }
             @media screen and (-ms-high-contrast: active){& {
-              border-color: InactiveBorder;
+              background: Window;
+              border-color: GrayText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         <i
@@ -560,7 +599,7 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               }
               @media screen and (-ms-high-contrast: active){& {
                 -ms-high-contrast-adjust: none;
-                color: InactiveBorder;
+                color: GrayText;
               }
           data-icon-name="CheckMark"
         >
@@ -578,7 +617,10 @@ exports[`Component Examples renders Checkbox.Basic.Example.tsx correctly 1`] = `
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active){& {
-              color: InactiveBorder;
+              color: GrayText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Disabled checked checkbox

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Indeterminate.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Indeterminate.Example.tsx.shot
@@ -34,7 +34,7 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
           border-color: #005a9e;
         }
         @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-          border-color: Highlight;
+          border-color: WindowText;
         }
         &:focus .ms-Checkbox-checkbox {
           border-color: #005a9e;
@@ -49,11 +49,20 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
         &:hover .ms-Checkbox-checkbox:after {
           border-color: #005a9e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox:after {
+          border-color: WindowText;
+        }
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -144,6 +153,15 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 10px;
             }
+            @media screen and (-ms-high-contrast: active){&:after {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -179,6 +197,12 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               line-height: 20px;
               margin-left: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Indeterminate checkbox (uncontrolled)
       </span>
@@ -196,8 +220,14 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
         &:hover .ms-Checkbox-checkbox {
           border-color: #005a9e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
+          border-color: WindowText;
+        }
         &:hover .ms-Checkbox-checkbox:after {
           border-color: #005a9e;
+        }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox:after {
+          border-color: WindowText;
         }
         &:focus .ms-Checkbox-checkbox {
           border-color: #005a9e;
@@ -208,8 +238,14 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -300,6 +336,15 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 10px;
             }
+            @media screen and (-ms-high-contrast: active){&:after {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -334,6 +379,12 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Indeterminate checkbox which defaults to true when clicked (uncontrolled)
@@ -439,8 +490,14 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 10px;
             }
+            @media screen and (-ms-high-contrast: active){&:after {
+              border-color: WindowText;
+            }
             @media screen and (-ms-high-contrast: active){& {
-              border-color: InactiveBorder;
+              border-color: GrayText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         <i
@@ -460,7 +517,7 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               }
               @media screen and (-ms-high-contrast: active){& {
                 -ms-high-contrast-adjust: none;
-                color: InactiveBorder;
+                color: GrayText;
               }
           data-icon-name="CheckMark"
         >
@@ -478,7 +535,10 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               margin-left: 4px;
             }
             @media screen and (-ms-high-contrast: active){& {
-              color: InactiveBorder;
+              color: GrayText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Disabled indeterminate checkbox
@@ -497,7 +557,7 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
           border-color: #005a9e;
         }
         @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
-          border-color: Highlight;
+          border-color: WindowText;
         }
         &:focus .ms-Checkbox-checkbox {
           border-color: #005a9e;
@@ -512,11 +572,20 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
         &:hover .ms-Checkbox-checkbox:after {
           border-color: #005a9e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox:after {
+          border-color: WindowText;
+        }
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -607,6 +676,15 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 10px;
             }
+            @media screen and (-ms-high-contrast: active){&:after {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -641,6 +719,12 @@ exports[`Component Examples renders Checkbox.Indeterminate.Example.tsx correctly
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Indeterminate checkbox (controlled)

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Other.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Other.Example.tsx.shot
@@ -39,10 +39,6 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
           background: #005a9e;
           border-color: #005a9e;
         }
-        & .ms-Checkbox-checkbox {
-          background: #0078d4;
-          border-color: #0078d4;
-        }
         @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
           background: Window;
           border-color: Highlight;
@@ -62,8 +58,14 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -143,6 +145,9 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
               background: Highlight;
               border-color: Highlight;
             }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -178,6 +183,12 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
               line-height: 20px;
               margin-left: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Controlled checkbox
       </span>
@@ -211,8 +222,14 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -288,6 +305,12 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -323,6 +346,12 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
               line-height: 20px;
               margin-right: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Checkbox rendered with boxSide "end"
       </span>
@@ -355,8 +384,14 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -430,6 +465,12 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -465,6 +506,12 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
               line-height: 20px;
               margin-left: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Checkbox with extra props for the input
       </span>
@@ -497,8 +544,14 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -571,6 +624,12 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
               transition-property: background, border, border-color;
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         <i

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Basic.Example.tsx.shot
@@ -44,10 +44,20 @@ exports[`Component Examples renders ChoiceGroup.Basic.Example.tsx correctly 1`] 
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
           &::after {
             color: #a4262c;
             content: ' *';
             padding-right: 12px;
+          }
+          @media screen and (-ms-high-contrast: active){&::after {
+            color: WindowText;
           }
       id="ChoiceGroup0-label"
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Controlled.Example.tsx.shot
@@ -44,6 +44,13 @@ exports[`Component Examples renders ChoiceGroup.Controlled.Example.tsx correctly
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       id="ChoiceGroup0-label"
     >
       Pick one

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Custom.Example.tsx.shot
@@ -44,6 +44,13 @@ exports[`Component Examples renders ChoiceGroup.Custom.Example.tsx correctly 1`]
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       id="ChoiceGroup0-label"
     >
       Pick one

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
@@ -44,6 +44,13 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       id="ChoiceGroup0-label"
     >
       Pick one icon

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
@@ -44,6 +44,13 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       id="ChoiceGroup0-label"
     >
       Pick one image

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Label.Example.tsx.shot
@@ -26,6 +26,13 @@ exports[`Component Examples renders ChoiceGroup.Label.Example.tsx correctly 1`] 
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
     id="labelElement0"
   >
     <div

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
@@ -39,6 +39,13 @@ exports[`Component Examples renders Coachmark.Basic.Example.tsx correctly 1`] = 
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         id="Dropdown0-label"
       >
         Coachmark position

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ColorPicker.Basic.Example.tsx.shot
@@ -437,6 +437,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                         @media screen and (-ms-high-contrast: active){&:hover {
                           border-color: Highlight;
                         }
+                        @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                          forced-color-adjust: none;
+                        }
                   >
                     <input
                       aria-invalid={false}
@@ -482,6 +485,10 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                           &::-ms-clear {
                             display: none;
                           }
+                          @media screen and (-ms-high-contrast: active){& {
+                            background: Window;
+                            color: WindowText;
+                          }
                           &::placeholder {
                             -moz-osx-font-smoothing: grayscale;
                             -webkit-font-smoothing: antialiased;
@@ -490,6 +497,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             font-size: 14px;
                             font-weight: 400;
                             opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active){&::placeholder {
+                            color: GrayText;
                           }
                           &:-ms-input-placeholder {
                             -moz-osx-font-smoothing: grayscale;
@@ -500,6 +510,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             font-weight: 400;
                             opacity: 1;
                           }
+                          @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                            color: GrayText;
+                          }
                           &::-ms-input-placeholder {
                             -moz-osx-font-smoothing: grayscale;
                             -webkit-font-smoothing: antialiased;
@@ -508,6 +521,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             font-size: 14px;
                             font-weight: 400;
                             opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                            color: GrayText;
                           }
                       id="TextField1"
                       onBlur={[Function]}
@@ -601,6 +617,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                         @media screen and (-ms-high-contrast: active){&:hover {
                           border-color: Highlight;
                         }
+                        @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                          forced-color-adjust: none;
+                        }
                   >
                     <input
                       aria-invalid={false}
@@ -646,6 +665,10 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                           &::-ms-clear {
                             display: none;
                           }
+                          @media screen and (-ms-high-contrast: active){& {
+                            background: Window;
+                            color: WindowText;
+                          }
                           &::placeholder {
                             -moz-osx-font-smoothing: grayscale;
                             -webkit-font-smoothing: antialiased;
@@ -654,6 +677,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             font-size: 14px;
                             font-weight: 400;
                             opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active){&::placeholder {
+                            color: GrayText;
                           }
                           &:-ms-input-placeholder {
                             -moz-osx-font-smoothing: grayscale;
@@ -664,6 +690,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             font-weight: 400;
                             opacity: 1;
                           }
+                          @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                            color: GrayText;
+                          }
                           &::-ms-input-placeholder {
                             -moz-osx-font-smoothing: grayscale;
                             -webkit-font-smoothing: antialiased;
@@ -672,6 +701,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             font-size: 14px;
                             font-weight: 400;
                             opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                            color: GrayText;
                           }
                       id="TextField4"
                       onBlur={[Function]}
@@ -765,6 +797,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                         @media screen and (-ms-high-contrast: active){&:hover {
                           border-color: Highlight;
                         }
+                        @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                          forced-color-adjust: none;
+                        }
                   >
                     <input
                       aria-invalid={false}
@@ -810,6 +845,10 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                           &::-ms-clear {
                             display: none;
                           }
+                          @media screen and (-ms-high-contrast: active){& {
+                            background: Window;
+                            color: WindowText;
+                          }
                           &::placeholder {
                             -moz-osx-font-smoothing: grayscale;
                             -webkit-font-smoothing: antialiased;
@@ -818,6 +857,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             font-size: 14px;
                             font-weight: 400;
                             opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active){&::placeholder {
+                            color: GrayText;
                           }
                           &:-ms-input-placeholder {
                             -moz-osx-font-smoothing: grayscale;
@@ -828,6 +870,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             font-weight: 400;
                             opacity: 1;
                           }
+                          @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                            color: GrayText;
+                          }
                           &::-ms-input-placeholder {
                             -moz-osx-font-smoothing: grayscale;
                             -webkit-font-smoothing: antialiased;
@@ -836,6 +881,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             font-size: 14px;
                             font-weight: 400;
                             opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                            color: GrayText;
                           }
                       id="TextField7"
                       onBlur={[Function]}
@@ -929,6 +977,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                         @media screen and (-ms-high-contrast: active){&:hover {
                           border-color: Highlight;
                         }
+                        @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                          forced-color-adjust: none;
+                        }
                   >
                     <input
                       aria-invalid={false}
@@ -974,6 +1025,10 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                           &::-ms-clear {
                             display: none;
                           }
+                          @media screen and (-ms-high-contrast: active){& {
+                            background: Window;
+                            color: WindowText;
+                          }
                           &::placeholder {
                             -moz-osx-font-smoothing: grayscale;
                             -webkit-font-smoothing: antialiased;
@@ -982,6 +1037,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             font-size: 14px;
                             font-weight: 400;
                             opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active){&::placeholder {
+                            color: GrayText;
                           }
                           &:-ms-input-placeholder {
                             -moz-osx-font-smoothing: grayscale;
@@ -992,6 +1050,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             font-weight: 400;
                             opacity: 1;
                           }
+                          @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                            color: GrayText;
+                          }
                           &::-ms-input-placeholder {
                             -moz-osx-font-smoothing: grayscale;
                             -webkit-font-smoothing: antialiased;
@@ -1000,6 +1061,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             font-size: 14px;
                             font-weight: 400;
                             opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                            color: GrayText;
                           }
                       id="TextField10"
                       onBlur={[Function]}
@@ -1093,6 +1157,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                         @media screen and (-ms-high-contrast: active){&:hover {
                           border-color: Highlight;
                         }
+                        @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                          forced-color-adjust: none;
+                        }
                   >
                     <input
                       aria-invalid={false}
@@ -1138,6 +1205,10 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                           &::-ms-clear {
                             display: none;
                           }
+                          @media screen and (-ms-high-contrast: active){& {
+                            background: Window;
+                            color: WindowText;
+                          }
                           &::placeholder {
                             -moz-osx-font-smoothing: grayscale;
                             -webkit-font-smoothing: antialiased;
@@ -1146,6 +1217,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             font-size: 14px;
                             font-weight: 400;
                             opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active){&::placeholder {
+                            color: GrayText;
                           }
                           &:-ms-input-placeholder {
                             -moz-osx-font-smoothing: grayscale;
@@ -1156,6 +1230,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             font-weight: 400;
                             opacity: 1;
                           }
+                          @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                            color: GrayText;
+                          }
                           &::-ms-input-placeholder {
                             -moz-osx-font-smoothing: grayscale;
                             -webkit-font-smoothing: antialiased;
@@ -1164,6 +1241,9 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
                             font-size: 14px;
                             font-weight: 400;
                             opacity: 1;
+                          }
+                          @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                            color: GrayText;
                           }
                       id="TextField13"
                       onBlur={[Function]}
@@ -1227,6 +1307,13 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
               padding-right: 0;
               padding-top: 5px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         htmlFor="Toggle16"
         id="Toggle16-label"
@@ -1356,6 +1443,13 @@ exports[`Component Examples renders ColorPicker.Basic.Example.tsx correctly 1`] 
               padding-right: 0;
               padding-top: 5px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         htmlFor="Toggle17"
         id="Toggle17-label"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -61,6 +61,13 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         id="ComboBox0-label"
       >
         Single-select ComboBox (uncontrolled, allowFreeform: T, autoComplete: T)
@@ -192,6 +199,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               position: absolute;
               right: 0px;
               top: 0px;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:focus:after {
+              forced-color-adjust: none;
             }
         id="ComboBox0wrapper"
       >
@@ -594,6 +604,13 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       id="ComboBox7-label"
     >
       Multi-select ComboBox (uncontrolled)
@@ -746,6 +763,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             position: absolute;
             right: 0px;
             top: 0px;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:focus:after {
+            forced-color-adjust: none;
           }
       id="ComboBox7wrapper"
     >
@@ -1008,6 +1028,13 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       id="ComboBox11-label"
     >
       ComboBox with placeholder text
@@ -1139,6 +1166,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             position: absolute;
             right: 0px;
             top: 0px;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:focus:after {
+            forced-color-adjust: none;
           }
       id="ComboBox11wrapper"
     >
@@ -1402,6 +1432,13 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       id="ComboBox15-label"
     >
       ComboBox with persisted menu
@@ -1533,6 +1570,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             position: absolute;
             right: 0px;
             top: 0px;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:focus:after {
+            forced-color-adjust: none;
           }
       id="ComboBox15wrapper"
     >
@@ -3597,6 +3637,13 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       id="ComboBox19-label"
     >
       ComboBox with static error message
@@ -3942,6 +3989,13 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       id="ComboBox23-label"
     >
       ComboBox with dynamic error message
@@ -4073,6 +4127,9 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             position: absolute;
             right: 0px;
             top: 0px;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:focus:after {
+            forced-color-adjust: none;
           }
       id="ComboBox23wrapper"
     >
@@ -4337,7 +4394,11 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             word-wrap: break-word;
           }
           @media screen and (-ms-high-contrast: active){& {
+            background: Window;
             color: GrayText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       id="ComboBox27-label"
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
@@ -58,6 +58,13 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       id="ComboBox0-label"
     >
       Controlled single-select ComboBox (allowFreeform: T)
@@ -189,6 +196,9 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
             position: absolute;
             right: 0px;
             top: 0px;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:focus:after {
+            forced-color-adjust: none;
           }
       id="ComboBox0wrapper"
     >
@@ -451,6 +461,13 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       id="ComboBox4-label"
     >
       Controlled multi-select ComboBox (allowFreeform: T)
@@ -583,6 +600,9 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
             position: absolute;
             right: 0px;
             top: 0px;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:focus:after {
+            forced-color-adjust: none;
           }
       id="ComboBox4wrapper"
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
@@ -62,6 +62,13 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       id="ComboBox0-label"
     >
       Custom styled ComboBox
@@ -193,6 +200,9 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
             position: absolute;
             right: 0px;
             top: 0px;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:focus:after {
+            forced-color-adjust: none;
           }
       id="ComboBox0wrapper"
     >
@@ -455,6 +465,13 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       id="ComboBox4-label"
     >
       ComboBox with custom option rendering (type the name of a font and the option will render in that font)
@@ -586,6 +603,9 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
             position: absolute;
             right: 0px;
             top: 0px;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:focus:after {
+            forced-color-adjust: none;
           }
       id="ComboBox4wrapper"
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -59,6 +59,13 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       id="ComboBox0-label"
     >
       ComboBox with toggleable freeform/auto-complete
@@ -190,6 +197,9 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
             position: absolute;
             right: 0px;
             top: 0px;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:focus:after {
+            forced-color-adjust: none;
           }
       id="ComboBox0wrapper"
     >
@@ -464,6 +474,13 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       htmlFor="Toggle4"
       id="Toggle4-label"
     >
@@ -596,6 +613,13 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
             padding-right: 0;
             padding-top: 5px;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="Toggle5"
       id="Toggle5-label"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
@@ -53,6 +53,13 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       id="ComboBox0-label"
     >
       Scaled/virtualized example with 1000 items
@@ -185,6 +192,9 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
             position: absolute;
             right: 0px;
             top: 0px;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:focus:after {
+            forced-color-adjust: none;
           }
       id="ComboBox0wrapper"
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
@@ -38,8 +38,14 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -113,6 +119,12 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -148,6 +160,12 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
                 line-height: 20px;
                 margin-left: 4px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           Show beak
         </span>
@@ -182,6 +200,13 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
               padding-right: 0;
               padding-top: 5px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         id="Dropdown1-label"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
@@ -56,6 +56,13 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         htmlFor="TextField0"
         id="TextFieldLabel2"
       >
@@ -91,6 +98,9 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
             }
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+              forced-color-adjust: none;
             }
       >
         <input
@@ -136,6 +146,10 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
               &::-ms-clear {
                 display: none;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -144,6 +158,9 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::placeholder {
+                color: GrayText;
               }
               &:-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
@@ -154,6 +171,9 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
                 font-weight: 400;
                 opacity: 1;
               }
+              @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                color: GrayText;
+              }
               &::-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -162,6 +182,9 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                color: GrayText;
               }
           id="TextField0"
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Basic.Example.tsx.shot
@@ -92,6 +92,9 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                  forced-color-adjust: none;
+                }
           >
             <input
               aria-expanded={false}
@@ -137,6 +140,10 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
                   &::-ms-clear {
                     display: none;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -145,6 +152,9 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::placeholder {
+                    color: GrayText;
                   }
                   &:-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
@@ -155,6 +165,9 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
                     font-weight: 400;
                     opacity: 1;
                   }
+                  @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                    color: GrayText;
+                  }
                   &::-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -163,6 +176,9 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                    color: GrayText;
                   }
               id="DatePicker0-label"
               onBlur={[Function]}
@@ -248,6 +264,13 @@ exports[`Component Examples renders DatePicker.Basic.Example.tsx correctly 1`] =
             padding-right: 0;
             padding-top: 5px;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       id="Dropdown5-label"
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Bounded.Example.tsx.shot
@@ -97,6 +97,9 @@ Fri, 06 Jan 2017 04:41:20 GMT-Fri, 06 Jan 2017 04:41:20 GMT
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                  forced-color-adjust: none;
+                }
           >
             <input
               aria-expanded={false}
@@ -142,6 +145,10 @@ Fri, 06 Jan 2017 04:41:20 GMT-Fri, 06 Jan 2017 04:41:20 GMT
                   &::-ms-clear {
                     display: none;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -150,6 +157,9 @@ Fri, 06 Jan 2017 04:41:20 GMT-Fri, 06 Jan 2017 04:41:20 GMT
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::placeholder {
+                    color: GrayText;
                   }
                   &:-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
@@ -160,6 +170,9 @@ Fri, 06 Jan 2017 04:41:20 GMT-Fri, 06 Jan 2017 04:41:20 GMT
                     font-weight: 400;
                     opacity: 1;
                   }
+                  @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                    color: GrayText;
+                  }
                   &::-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -168,6 +181,9 @@ Fri, 06 Jan 2017 04:41:20 GMT-Fri, 06 Jan 2017 04:41:20 GMT
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                    color: GrayText;
                   }
               id="DatePicker0-label"
               onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Disabled.Example.tsx.shot
@@ -91,6 +91,9 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                 @media screen and (-ms-high-contrast: active){& {
                   border-color: GrayText;
                 }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             <input
               aria-expanded={false}
@@ -137,6 +140,10 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                   &::-ms-clear {
                     display: none;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: GrayText;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -145,6 +152,9 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::placeholder {
+                    color: GrayText;
                   }
                   &:-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
@@ -155,6 +165,9 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                     font-weight: 400;
                     opacity: 1;
                   }
+                  @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                    color: GrayText;
+                  }
                   &::-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -163,6 +176,9 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                    color: GrayText;
                   }
               disabled={true}
               id="DatePicker0-label"
@@ -297,7 +313,11 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                   word-wrap: break-word;
                 }
                 @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
                   color: GrayText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
             htmlFor="DatePicker5-label"
             id="TextFieldLabel9"
@@ -331,6 +351,9 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                 }
                 @media screen and (-ms-high-contrast: active){& {
                   border-color: GrayText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
           >
             <input
@@ -379,6 +402,10 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                   &::-ms-clear {
                     display: none;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: GrayText;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -387,6 +414,9 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::placeholder {
+                    color: GrayText;
                   }
                   &:-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
@@ -397,6 +427,9 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                     font-weight: 400;
                     opacity: 1;
                   }
+                  @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                    color: GrayText;
+                  }
                   &::-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -405,6 +438,9 @@ exports[`Component Examples renders DatePicker.Disabled.Example.tsx correctly 1`
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                    color: GrayText;
                   }
               disabled={true}
               id="DatePicker5-label"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
@@ -89,6 +89,13 @@ exports[`Component Examples renders DatePicker.Format.Example.tsx correctly 1`] 
                   padding-top: 5px;
                   word-wrap: break-word;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
             htmlFor="DatePicker0-label"
             id="TextFieldLabel4"
           >
@@ -123,6 +130,9 @@ exports[`Component Examples renders DatePicker.Format.Example.tsx correctly 1`] 
                 }
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                  forced-color-adjust: none;
                 }
           >
             <input
@@ -170,6 +180,10 @@ exports[`Component Examples renders DatePicker.Format.Example.tsx correctly 1`] 
                   &::-ms-clear {
                     display: none;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -178,6 +192,9 @@ exports[`Component Examples renders DatePicker.Format.Example.tsx correctly 1`] 
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::placeholder {
+                    color: GrayText;
                   }
                   &:-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
@@ -188,6 +205,9 @@ exports[`Component Examples renders DatePicker.Format.Example.tsx correctly 1`] 
                     font-weight: 400;
                     opacity: 1;
                   }
+                  @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                    color: GrayText;
+                  }
                   &::-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -196,6 +216,9 @@ exports[`Component Examples renders DatePicker.Format.Example.tsx correctly 1`] 
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                    color: GrayText;
                   }
               id="DatePicker0-label"
               onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
@@ -89,6 +89,13 @@ exports[`Component Examples renders DatePicker.Input.Example.tsx correctly 1`] =
                   padding-top: 5px;
                   word-wrap: break-word;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
             htmlFor="DatePicker0-label"
             id="TextFieldLabel4"
           >
@@ -123,6 +130,9 @@ exports[`Component Examples renders DatePicker.Input.Example.tsx correctly 1`] =
                 }
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                  forced-color-adjust: none;
                 }
           >
             <input
@@ -170,6 +180,10 @@ exports[`Component Examples renders DatePicker.Input.Example.tsx correctly 1`] =
                   &::-ms-clear {
                     display: none;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -178,6 +192,9 @@ exports[`Component Examples renders DatePicker.Input.Example.tsx correctly 1`] =
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::placeholder {
+                    color: GrayText;
                   }
                   &:-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
@@ -188,6 +205,9 @@ exports[`Component Examples renders DatePicker.Input.Example.tsx correctly 1`] =
                     font-weight: 400;
                     opacity: 1;
                   }
+                  @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                    color: GrayText;
+                  }
                   &::-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -196,6 +216,9 @@ exports[`Component Examples renders DatePicker.Input.Example.tsx correctly 1`] =
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                    color: GrayText;
                   }
               id="DatePicker0-label"
               onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Required.Example.tsx.shot
@@ -90,10 +90,20 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                   padding-top: 5px;
                   word-wrap: break-word;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
                 &::after {
                   color: #a4262c;
                   content: ' *';
                   padding-right: 12px;
+                }
+                @media screen and (-ms-high-contrast: active){&::after {
+                  color: WindowText;
                 }
             htmlFor="DatePicker0-label"
             id="TextFieldLabel4"
@@ -129,6 +139,9 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                 }
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                  forced-color-adjust: none;
                 }
           >
             <input
@@ -176,6 +189,10 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                   &::-ms-clear {
                     display: none;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -184,6 +201,9 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::placeholder {
+                    color: GrayText;
                   }
                   &:-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
@@ -194,6 +214,9 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                     font-weight: 400;
                     opacity: 1;
                   }
+                  @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                    color: GrayText;
+                  }
                   &::-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -202,6 +225,9 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                    color: GrayText;
                   }
               id="DatePicker0-label"
               onBlur={[Function]}
@@ -341,6 +367,9 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                  forced-color-adjust: none;
+                }
                 &:before {
                   color: #a4262c;
                   content: '*';
@@ -349,6 +378,7 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                   top: -5px;
                 }
                 @media screen and (-ms-high-contrast: active){&:before {
+                  color: WindowText;
                   right: -14px;
                 }
           >
@@ -396,6 +426,10 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                   &::-ms-clear {
                     display: none;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -404,6 +438,9 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::placeholder {
+                    color: GrayText;
                   }
                   &:-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
@@ -414,6 +451,9 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                     font-weight: 400;
                     opacity: 1;
                   }
+                  @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                    color: GrayText;
+                  }
                   &::-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -422,6 +462,9 @@ exports[`Component Examples renders DatePicker.Required.Example.tsx correctly 1`
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                    color: GrayText;
                   }
               id="DatePicker5-label"
               onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.WeekNumbers.Example.tsx.shot
@@ -92,6 +92,9 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                  forced-color-adjust: none;
+                }
           >
             <input
               aria-expanded={false}
@@ -137,6 +140,10 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
                   &::-ms-clear {
                     display: none;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -145,6 +152,9 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::placeholder {
+                    color: GrayText;
                   }
                   &:-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
@@ -155,6 +165,9 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
                     font-weight: 400;
                     opacity: 1;
                   }
+                  @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                    color: GrayText;
+                  }
                   &::-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -163,6 +176,9 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                    color: GrayText;
                   }
               id="DatePicker0-label"
               onBlur={[Function]}
@@ -248,6 +264,13 @@ exports[`Component Examples renders DatePicker.WeekNumbers.Example.tsx correctly
             padding-right: 0;
             padding-top: 5px;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       id="Dropdown5-label"
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Basic.Example.tsx.shot
@@ -95,6 +95,13 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         htmlFor="TextField0"
         id="TextFieldLabel2"
       >
@@ -129,6 +136,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
             }
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+              forced-color-adjust: none;
             }
       >
         <input
@@ -174,6 +184,10 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
               &::-ms-clear {
                 display: none;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -182,6 +196,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::placeholder {
+                color: GrayText;
               }
               &:-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
@@ -192,6 +209,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                 font-weight: 400;
                 opacity: 1;
               }
+              @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                color: GrayText;
+              }
               &::-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -200,6 +220,9 @@ exports[`Component Examples renders DetailsList.Basic.Example.tsx correctly 1`] 
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                color: GrayText;
               }
           id="TextField0"
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Compact.Example.tsx.shot
@@ -95,6 +95,13 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         htmlFor="TextField0"
         id="TextFieldLabel2"
       >
@@ -129,6 +136,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
             }
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+              forced-color-adjust: none;
             }
       >
         <input
@@ -174,6 +184,10 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
               &::-ms-clear {
                 display: none;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -182,6 +196,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::placeholder {
+                color: GrayText;
               }
               &:-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
@@ -192,6 +209,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                 font-weight: 400;
                 opacity: 1;
               }
+              @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                color: GrayText;
+              }
               &::-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -200,6 +220,9 @@ exports[`Component Examples renders DetailsList.Compact.Example.tsx correctly 1`
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                color: GrayText;
               }
           id="TextField0"
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Documents.Example.tsx.shot
@@ -75,6 +75,13 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         htmlFor="Toggle0"
         id="Toggle0-label"
       >
@@ -188,6 +195,13 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
               && {
                 font-weight: 400;
                 margin-bottom: 0;
@@ -248,6 +262,13 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
               padding-right: 0;
               padding-top: 5px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         htmlFor="Toggle1"
         id="Toggle1-label"
@@ -362,6 +383,13 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
               && {
                 font-weight: 400;
                 margin-bottom: 0;
@@ -433,6 +461,13 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           htmlFor="TextField2"
           id="TextFieldLabel4"
         >
@@ -467,6 +502,9 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
               }
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
               }
         >
           <input
@@ -512,6 +550,10 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -520,6 +562,9 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -530,6 +575,9 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -538,6 +586,9 @@ exports[`Component Examples renders DetailsList.Documents.Example.tsx correctly 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="TextField2"
             onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.DragDrop.Example.tsx.shot
@@ -52,6 +52,13 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         htmlFor="Toggle0"
         id="Toggle0-label"
       >
@@ -170,6 +177,13 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
               && {
                 font-weight: 400;
                 margin-bottom: 0;
@@ -240,6 +254,13 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           htmlFor="TextField1"
           id="TextFieldLabel3"
         >
@@ -275,6 +296,9 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
               }
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
               }
         >
           <input
@@ -320,6 +344,10 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -328,6 +356,9 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -338,6 +369,9 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -346,6 +380,9 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="TextField1"
             onBlur={[Function]}
@@ -409,6 +446,13 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           htmlFor="TextField4"
           id="TextFieldLabel6"
         >
@@ -444,6 +488,9 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
               }
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
               }
         >
           <input
@@ -489,6 +536,10 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -497,6 +548,9 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -507,6 +561,9 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -515,6 +572,9 @@ exports[`Component Examples renders DetailsList.DragDrop.Example.tsx correctly 1
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="TextField4"
             onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -176,6 +176,13 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
               word-break: break-all;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         htmlFor="Toggle3"
         id="Toggle3-label"
       >
@@ -310,6 +317,13 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
               padding-top: 5px;
               word-break: break-all;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         htmlFor="Toggle4"
         id="Toggle4-label"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Basic.Example.tsx.shot
@@ -29,8 +29,14 @@ exports[`Component Examples renders Dialog.Basic.Example.tsx correctly 1`] = `
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -104,6 +110,12 @@ exports[`Component Examples renders Dialog.Basic.Example.tsx correctly 1`] = `
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -138,6 +150,12 @@ exports[`Component Examples renders Dialog.Basic.Example.tsx correctly 1`] = `
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Is draggable

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Blocking.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Blocking.Example.tsx.shot
@@ -29,8 +29,14 @@ exports[`Component Examples renders Dialog.Blocking.Example.tsx correctly 1`] = 
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -104,6 +110,12 @@ exports[`Component Examples renders Dialog.Blocking.Example.tsx correctly 1`] = 
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -138,6 +150,12 @@ exports[`Component Examples renders Dialog.Blocking.Example.tsx correctly 1`] = 
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Is draggable

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Modeless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Modeless.Example.tsx.shot
@@ -34,8 +34,14 @@ exports[`Component Examples renders Dialog.Modeless.Example.tsx correctly 1`] = 
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -111,6 +117,12 @@ exports[`Component Examples renders Dialog.Modeless.Example.tsx correctly 1`] = 
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -145,6 +157,12 @@ exports[`Component Examples renders Dialog.Modeless.Example.tsx correctly 1`] = 
                 font-size: 14px;
                 line-height: 20px;
                 margin-left: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           Is draggable

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Basic.Example.tsx.shot
@@ -35,6 +35,9 @@ exports[`Component Examples renders DocumentCard.Basic.Example.tsx correctly 1`]
       @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
         border-color: Highlight;
       }
+      @media screen and (-ms-high-contrast: active) and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+        forced-color-adjust: none;
+      }
       & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
         padding-top: 4px;
       }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
@@ -60,6 +60,9 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
         @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
           border-color: Highlight;
         }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          forced-color-adjust: none;
+        }
         & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
           padding-top: 4px;
         }
@@ -417,6 +420,9 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
         }
         @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
           border-color: Highlight;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          forced-color-adjust: none;
         }
         & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
           padding-top: 4px;
@@ -1083,6 +1089,9 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
         @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
           border-color: Highlight;
         }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          forced-color-adjust: none;
+        }
         & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
           padding-top: 4px;
         }
@@ -1424,6 +1433,9 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
         }
         @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
           border-color: Highlight;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          forced-color-adjust: none;
         }
         & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
           padding-top: 4px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
@@ -36,6 +36,9 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
       @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
         border-color: Highlight;
       }
+      @media screen and (-ms-high-contrast: active) and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+        forced-color-adjust: none;
+      }
       & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
         padding-top: 4px;
       }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Conversation.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Conversation.Example.tsx.shot
@@ -40,6 +40,9 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
         @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
           border-color: Highlight;
         }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          forced-color-adjust: none;
+        }
         & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
           padding-top: 4px;
         }
@@ -493,6 +496,9 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
         @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
           border-color: Highlight;
         }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          forced-color-adjust: none;
+        }
         & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
           padding-top: 4px;
         }
@@ -935,6 +941,9 @@ exports[`Component Examples renders DocumentCard.Conversation.Example.tsx correc
         }
         @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
           border-color: Highlight;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          forced-color-adjust: none;
         }
         & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
           padding-top: 4px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Image.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Image.Example.tsx.shot
@@ -40,6 +40,9 @@ exports[`Component Examples renders DocumentCard.Image.Example.tsx correctly 1`]
         @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
           border-color: Highlight;
         }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          forced-color-adjust: none;
+        }
         & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
           padding-top: 4px;
         }
@@ -477,6 +480,9 @@ exports[`Component Examples renders DocumentCard.Image.Example.tsx correctly 1`]
         }
         @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus:after {
           border-color: Highlight;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){.ms-Fabric--isFocusVisible &:focus:after {
+          forced-color-adjust: none;
         }
         & .ms-DocumentCardLocation + .ms-DocumentCardTitle {
           padding-top: 4px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Basic.Example.tsx.shot
@@ -52,6 +52,13 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       id="Dropdown0-label"
     >
       Basic uncontrolled example
@@ -264,7 +271,11 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             word-wrap: break-word;
           }
           @media screen and (-ms-high-contrast: active){& {
+            background: Window;
             color: GrayText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       id="Dropdown1-label"
     >
@@ -463,6 +474,13 @@ exports[`Component Examples renders Dropdown.Basic.Example.tsx correctly 1`] = `
             padding-right: 0;
             padding-top: 5px;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       id="Dropdown2-label"
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Controlled.Example.tsx.shot
@@ -31,6 +31,13 @@ exports[`Component Examples renders Dropdown.Controlled.Example.tsx correctly 1`
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
     id="Dropdown0-label"
   >
     Controlled example

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.ControlledMulti.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.ControlledMulti.Example.tsx.shot
@@ -31,6 +31,13 @@ exports[`Component Examples renders Dropdown.ControlledMulti.Example.tsx correct
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
     id="Dropdown0-label"
   >
     Multi-select controlled example

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
@@ -52,6 +52,13 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       id="Dropdown0-label"
     >
       Custom example

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Error.Example.tsx.shot
@@ -61,6 +61,13 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       htmlFor="Toggle0"
       id="Toggle0-label"
     >
@@ -174,6 +181,13 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
             && {
               font-weight: 400;
               margin-bottom: 0;
@@ -224,6 +238,13 @@ exports[`Component Examples renders Dropdown.Error.Example.tsx correctly 1`] = `
             padding-right: 0;
             padding-top: 5px;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       id="Dropdown1-label"
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
@@ -75,10 +75,20 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
             &::after {
               color: #a4262c;
               content: ' *';
               padding-right: 12px;
+            }
+            @media screen and (-ms-high-contrast: active){&::after {
+              color: WindowText;
             }
         id="Dropdown0-label"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Basic.Example.tsx.shot
@@ -662,6 +662,13 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
               padding-top: 0px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         htmlFor="Slider7"
       >
         Number of Personas:
@@ -880,6 +887,13 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                 width: 40px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           3
         </label>
@@ -920,6 +934,13 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
               padding-right: 0;
               padding-top: 5px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         id="Dropdown8-label"
       >
@@ -1124,10 +1145,6 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
             background: #005a9e;
             border-color: #005a9e;
           }
-          & .ms-Checkbox-checkbox {
-            background: #0078d4;
-            border-color: #0078d4;
-          }
           @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
             background: Window;
             border-color: Highlight;
@@ -1147,8 +1164,14 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -1228,6 +1251,9 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                 background: Highlight;
                 border-color: Highlight;
               }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -1262,6 +1288,12 @@ exports[`Component Examples renders Facepile.Basic.Example.tsx correctly 1`] = `
                 font-size: 14px;
                 line-height: 20px;
                 margin-left: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           Fade In

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Facepile.Overflow.Example.tsx.shot
@@ -766,6 +766,13 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
               padding-top: 0px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         htmlFor="Slider7"
       >
         Number of Personas:
@@ -984,6 +991,13 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
                 width: 40px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           5
         </label>
@@ -1024,6 +1038,13 @@ exports[`Component Examples renders Facepile.Overflow.Example.tsx correctly 1`] 
               padding-right: 0;
               padding-top: 5px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         id="Dropdown8-label"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -82,6 +82,13 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         htmlFor="Toggle0"
         id="Toggle0-label"
       >
@@ -195,6 +202,13 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
               && {
                 font-weight: 400;
                 margin-bottom: 0;
@@ -266,6 +280,13 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           htmlFor="TextField1"
           id="TextFieldLabel3"
         >
@@ -300,6 +321,9 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
               }
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
               }
         >
           <input
@@ -345,6 +369,10 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -353,6 +381,9 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -363,6 +394,9 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -371,6 +405,9 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="TextField1"
             onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -266,6 +266,13 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           htmlFor="Toggle3"
           id="Toggle3-label"
         >
@@ -379,6 +386,13 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
                   padding-top: 5px;
                   word-wrap: break-word;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
                 && {
                   font-weight: 400;
                   margin-bottom: 0;
@@ -450,6 +464,13 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
                   padding-top: 5px;
                   word-wrap: break-word;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
             htmlFor="TextField4"
             id="TextFieldLabel6"
           >
@@ -484,6 +505,9 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
                 }
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                  forced-color-adjust: none;
                 }
           >
             <input
@@ -529,6 +553,10 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
                   &::-ms-clear {
                     display: none;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -537,6 +565,9 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::placeholder {
+                    color: GrayText;
                   }
                   &:-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
@@ -547,6 +578,9 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
                     font-weight: 400;
                     opacity: 1;
                   }
+                  @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                    color: GrayText;
+                  }
                   &::-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -555,6 +589,9 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                    color: GrayText;
                   }
               id="TextField4"
               onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -266,6 +266,13 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           htmlFor="Toggle3"
           id="Toggle3-label"
         >
@@ -379,6 +386,13 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
                   padding-top: 5px;
                   word-wrap: break-word;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
                 && {
                   font-weight: 400;
                   margin-bottom: 0;
@@ -450,6 +464,13 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
                   padding-top: 5px;
                   word-wrap: break-word;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
             htmlFor="TextField4"
             id="TextFieldLabel6"
           >
@@ -484,6 +505,9 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
                 }
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                  forced-color-adjust: none;
                 }
           >
             <input
@@ -529,6 +553,10 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
                   &::-ms-clear {
                     display: none;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -537,6 +565,9 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::placeholder {
+                    color: GrayText;
                   }
                   &:-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
@@ -547,6 +578,9 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
                     font-weight: 400;
                     opacity: 1;
                   }
+                  @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                    color: GrayText;
+                  }
                   &::-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -555,6 +589,9 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                    color: GrayText;
                   }
               id="TextField4"
               onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
@@ -82,6 +82,13 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         htmlFor="Toggle0"
         id="Toggle0-label"
       >
@@ -194,6 +201,13 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
                 padding-right: 0;
                 padding-top: 5px;
                 word-wrap: break-word;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
               && {
                 font-weight: 400;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
@@ -83,6 +83,13 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           htmlFor="Toggle0"
           id="Toggle0-label"
         >
@@ -195,6 +202,13 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                   padding-right: 0;
                   padding-top: 5px;
                   word-wrap: break-word;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
                 && {
                   font-weight: 400;
@@ -414,6 +428,13 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                     padding-top: 5px;
                     word-wrap: break-word;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
               htmlFor="Toggle4"
               id="Toggle4-label"
             >
@@ -526,6 +547,13 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                       padding-right: 0;
                       padding-top: 5px;
                       word-wrap: break-word;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
                     }
                     && {
                       font-weight: 400;
@@ -745,6 +773,13 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                         padding-top: 5px;
                         word-wrap: break-word;
                       }
+                      @media screen and (-ms-high-contrast: active){& {
+                        background: Window;
+                        color: WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                   htmlFor="Toggle8"
                   id="Toggle8-label"
                 >
@@ -857,6 +892,13 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                           padding-right: 0;
                           padding-top: 5px;
                           word-wrap: break-word;
+                        }
+                        @media screen and (-ms-high-contrast: active){& {
+                          background: Window;
+                          color: WindowText;
+                        }
+                        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                          forced-color-adjust: none;
                         }
                         && {
                           font-weight: 400;
@@ -1089,6 +1131,13 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                         padding-top: 5px;
                         word-wrap: break-word;
                       }
+                      @media screen and (-ms-high-contrast: active){& {
+                        background: Window;
+                        color: WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                   htmlFor="Toggle12"
                   id="Toggle12-label"
                 >
@@ -1201,6 +1250,13 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                           padding-right: 0;
                           padding-top: 5px;
                           word-wrap: break-word;
+                        }
+                        @media screen and (-ms-high-contrast: active){& {
+                          background: Window;
+                          color: WindowText;
+                        }
+                        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                          forced-color-adjust: none;
                         }
                         && {
                           font-weight: 400;
@@ -1445,6 +1501,13 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                     padding-top: 5px;
                     word-wrap: break-word;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
               htmlFor="Toggle16"
               id="Toggle16-label"
             >
@@ -1557,6 +1620,13 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                       padding-right: 0;
                       padding-top: 5px;
                       word-wrap: break-word;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
                     }
                     && {
                       font-weight: 400;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Disabled.Example.tsx.shot
@@ -351,6 +351,9 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                  forced-color-adjust: none;
+                }
           >
             <input
               aria-invalid={false}
@@ -395,6 +398,10 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                   &::-ms-clear {
                     display: none;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -403,6 +410,9 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::placeholder {
+                    color: GrayText;
                   }
                   &:-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
@@ -413,6 +423,9 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                     font-weight: 400;
                     opacity: 1;
                   }
+                  @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                    color: GrayText;
+                  }
                   &::-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -421,6 +434,9 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                    color: GrayText;
                   }
               id="TextField7"
               onBlur={[Function]}
@@ -999,6 +1015,9 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+              forced-color-adjust: none;
+            }
       >
         <input
           aria-invalid={false}
@@ -1043,6 +1062,10 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
               &::-ms-clear {
                 display: none;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -1051,6 +1074,9 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::placeholder {
+                color: GrayText;
               }
               &:-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
@@ -1061,6 +1087,9 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                 font-weight: 400;
                 opacity: 1;
               }
+              @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                color: GrayText;
+              }
               &::-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -1069,6 +1098,9 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                color: GrayText;
               }
           id="TextField23"
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
@@ -371,6 +371,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                   @media screen and (-ms-high-contrast: active){&:hover {
                     border-color: Highlight;
                   }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                    forced-color-adjust: none;
+                  }
             >
               <input
                 aria-invalid={false}
@@ -414,6 +417,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     &::-ms-clear {
                       display: none;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
                     &::placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -422,6 +429,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::placeholder {
+                      color: GrayText;
                     }
                     &:-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
@@ -432,6 +442,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-weight: 400;
                       opacity: 1;
                     }
+                    @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                      color: GrayText;
+                    }
                     &::-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -440,6 +453,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                      color: GrayText;
                     }
                 id="TextField2"
                 onBlur={[Function]}
@@ -566,6 +582,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                   @media screen and (-ms-high-contrast: active){&:hover {
                     border-color: Highlight;
                   }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                    forced-color-adjust: none;
+                  }
             >
               <input
                 aria-invalid={false}
@@ -609,6 +628,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     &::-ms-clear {
                       display: none;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
                     &::placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -617,6 +640,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::placeholder {
+                      color: GrayText;
                     }
                     &:-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
@@ -627,6 +653,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-weight: 400;
                       opacity: 1;
                     }
+                    @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                      color: GrayText;
+                    }
                     &::-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -635,6 +664,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                      color: GrayText;
                     }
                 id="TextField5"
                 onBlur={[Function]}
@@ -1023,6 +1055,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                   @media screen and (-ms-high-contrast: active){&:hover {
                     border-color: Highlight;
                   }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                    forced-color-adjust: none;
+                  }
             >
               <input
                 aria-invalid={false}
@@ -1066,6 +1101,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     &::-ms-clear {
                       display: none;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
                     &::placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -1074,6 +1113,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::placeholder {
+                      color: GrayText;
                     }
                     &:-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
@@ -1084,6 +1126,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-weight: 400;
                       opacity: 1;
                     }
+                    @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                      color: GrayText;
+                    }
                     &::-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -1092,6 +1137,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                      color: GrayText;
                     }
                 id="TextField9"
                 onBlur={[Function]}
@@ -1218,6 +1266,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                   @media screen and (-ms-high-contrast: active){&:hover {
                     border-color: Highlight;
                   }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                    forced-color-adjust: none;
+                  }
             >
               <input
                 aria-invalid={false}
@@ -1261,6 +1312,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     &::-ms-clear {
                       display: none;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
                     &::placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -1269,6 +1324,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::placeholder {
+                      color: GrayText;
                     }
                     &:-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
@@ -1279,6 +1337,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-weight: 400;
                       opacity: 1;
                     }
+                    @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                      color: GrayText;
+                    }
                     &::-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -1287,6 +1348,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                      color: GrayText;
                     }
                 id="TextField12"
                 onBlur={[Function]}
@@ -1675,6 +1739,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                   @media screen and (-ms-high-contrast: active){&:hover {
                     border-color: Highlight;
                   }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                    forced-color-adjust: none;
+                  }
             >
               <input
                 aria-invalid={false}
@@ -1718,6 +1785,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     &::-ms-clear {
                       display: none;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
                     &::placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -1726,6 +1797,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::placeholder {
+                      color: GrayText;
                     }
                     &:-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
@@ -1736,6 +1810,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-weight: 400;
                       opacity: 1;
                     }
+                    @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                      color: GrayText;
+                    }
                     &::-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -1744,6 +1821,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                      color: GrayText;
                     }
                 id="TextField16"
                 onBlur={[Function]}
@@ -1870,6 +1950,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                   @media screen and (-ms-high-contrast: active){&:hover {
                     border-color: Highlight;
                   }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                    forced-color-adjust: none;
+                  }
             >
               <input
                 aria-invalid={false}
@@ -1913,6 +1996,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     &::-ms-clear {
                       display: none;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
                     &::placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -1921,6 +2008,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::placeholder {
+                      color: GrayText;
                     }
                     &:-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
@@ -1931,6 +2021,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-weight: 400;
                       opacity: 1;
                     }
+                    @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                      color: GrayText;
+                    }
                     &::-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -1939,6 +2032,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                      color: GrayText;
                     }
                 id="TextField19"
                 onBlur={[Function]}
@@ -2327,6 +2423,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                   @media screen and (-ms-high-contrast: active){&:hover {
                     border-color: Highlight;
                   }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                    forced-color-adjust: none;
+                  }
             >
               <input
                 aria-invalid={false}
@@ -2370,6 +2469,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     &::-ms-clear {
                       display: none;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
                     &::placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -2378,6 +2481,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::placeholder {
+                      color: GrayText;
                     }
                     &:-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
@@ -2388,6 +2494,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-weight: 400;
                       opacity: 1;
                     }
+                    @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                      color: GrayText;
+                    }
                     &::-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -2396,6 +2505,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                      color: GrayText;
                     }
                 id="TextField23"
                 onBlur={[Function]}
@@ -2522,6 +2634,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                   @media screen and (-ms-high-contrast: active){&:hover {
                     border-color: Highlight;
                   }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                    forced-color-adjust: none;
+                  }
             >
               <input
                 aria-invalid={false}
@@ -2565,6 +2680,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     &::-ms-clear {
                       display: none;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
                     &::placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -2573,6 +2692,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::placeholder {
+                      color: GrayText;
                     }
                     &:-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
@@ -2583,6 +2705,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-weight: 400;
                       opacity: 1;
                     }
+                    @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                      color: GrayText;
+                    }
                     &::-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -2591,6 +2716,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                      color: GrayText;
                     }
                 id="TextField26"
                 onBlur={[Function]}
@@ -2979,6 +3107,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                   @media screen and (-ms-high-contrast: active){&:hover {
                     border-color: Highlight;
                   }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                    forced-color-adjust: none;
+                  }
             >
               <input
                 aria-invalid={false}
@@ -3022,6 +3153,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     &::-ms-clear {
                       display: none;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
                     &::placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -3030,6 +3165,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::placeholder {
+                      color: GrayText;
                     }
                     &:-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
@@ -3040,6 +3178,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-weight: 400;
                       opacity: 1;
                     }
+                    @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                      color: GrayText;
+                    }
                     &::-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -3048,6 +3189,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                      color: GrayText;
                     }
                 id="TextField30"
                 onBlur={[Function]}
@@ -3174,6 +3318,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                   @media screen and (-ms-high-contrast: active){&:hover {
                     border-color: Highlight;
                   }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                    forced-color-adjust: none;
+                  }
             >
               <input
                 aria-invalid={false}
@@ -3217,6 +3364,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     &::-ms-clear {
                       display: none;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
                     &::placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -3225,6 +3376,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::placeholder {
+                      color: GrayText;
                     }
                     &:-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
@@ -3235,6 +3389,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-weight: 400;
                       opacity: 1;
                     }
+                    @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                      color: GrayText;
+                    }
                     &::-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -3243,6 +3400,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                      color: GrayText;
                     }
                 id="TextField33"
                 onBlur={[Function]}
@@ -3631,6 +3791,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                   @media screen and (-ms-high-contrast: active){&:hover {
                     border-color: Highlight;
                   }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                    forced-color-adjust: none;
+                  }
             >
               <input
                 aria-invalid={false}
@@ -3674,6 +3837,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     &::-ms-clear {
                       display: none;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
                     &::placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -3682,6 +3849,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::placeholder {
+                      color: GrayText;
                     }
                     &:-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
@@ -3692,6 +3862,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-weight: 400;
                       opacity: 1;
                     }
+                    @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                      color: GrayText;
+                    }
                     &::-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -3700,6 +3873,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                      color: GrayText;
                     }
                 id="TextField37"
                 onBlur={[Function]}
@@ -3826,6 +4002,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                   @media screen and (-ms-high-contrast: active){&:hover {
                     border-color: Highlight;
                   }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                    forced-color-adjust: none;
+                  }
             >
               <input
                 aria-invalid={false}
@@ -3869,6 +4048,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     &::-ms-clear {
                       display: none;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
                     &::placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -3877,6 +4060,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::placeholder {
+                      color: GrayText;
                     }
                     &:-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
@@ -3887,6 +4073,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-weight: 400;
                       opacity: 1;
                     }
+                    @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                      color: GrayText;
+                    }
                     &::-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -3895,6 +4084,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                      color: GrayText;
                     }
                 id="TextField40"
                 onBlur={[Function]}
@@ -4283,6 +4475,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                   @media screen and (-ms-high-contrast: active){&:hover {
                     border-color: Highlight;
                   }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                    forced-color-adjust: none;
+                  }
             >
               <input
                 aria-invalid={false}
@@ -4326,6 +4521,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     &::-ms-clear {
                       display: none;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
                     &::placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -4334,6 +4533,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::placeholder {
+                      color: GrayText;
                     }
                     &:-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
@@ -4344,6 +4546,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-weight: 400;
                       opacity: 1;
                     }
+                    @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                      color: GrayText;
+                    }
                     &::-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -4352,6 +4557,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                      color: GrayText;
                     }
                 id="TextField44"
                 onBlur={[Function]}
@@ -4478,6 +4686,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                   @media screen and (-ms-high-contrast: active){&:hover {
                     border-color: Highlight;
                   }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                    forced-color-adjust: none;
+                  }
             >
               <input
                 aria-invalid={false}
@@ -4521,6 +4732,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     &::-ms-clear {
                       display: none;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
                     &::placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -4529,6 +4744,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::placeholder {
+                      color: GrayText;
                     }
                     &:-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
@@ -4539,6 +4757,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-weight: 400;
                       opacity: 1;
                     }
+                    @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                      color: GrayText;
+                    }
                     &::-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -4547,6 +4768,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                      color: GrayText;
                     }
                 id="TextField47"
                 onBlur={[Function]}
@@ -4935,6 +5159,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                   @media screen and (-ms-high-contrast: active){&:hover {
                     border-color: Highlight;
                   }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                    forced-color-adjust: none;
+                  }
             >
               <input
                 aria-invalid={false}
@@ -4978,6 +5205,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     &::-ms-clear {
                       display: none;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
                     &::placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -4986,6 +5217,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::placeholder {
+                      color: GrayText;
                     }
                     &:-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
@@ -4996,6 +5230,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-weight: 400;
                       opacity: 1;
                     }
+                    @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                      color: GrayText;
+                    }
                     &::-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -5004,6 +5241,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                      color: GrayText;
                     }
                 id="TextField51"
                 onBlur={[Function]}
@@ -5130,6 +5370,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                   @media screen and (-ms-high-contrast: active){&:hover {
                     border-color: Highlight;
                   }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                    forced-color-adjust: none;
+                  }
             >
               <input
                 aria-invalid={false}
@@ -5173,6 +5416,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     &::-ms-clear {
                       display: none;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
                     &::placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -5181,6 +5428,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::placeholder {
+                      color: GrayText;
                     }
                     &:-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
@@ -5191,6 +5441,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-weight: 400;
                       opacity: 1;
                     }
+                    @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                      color: GrayText;
+                    }
                     &::-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -5199,6 +5452,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                      color: GrayText;
                     }
                 id="TextField54"
                 onBlur={[Function]}
@@ -5587,6 +5843,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                   @media screen and (-ms-high-contrast: active){&:hover {
                     border-color: Highlight;
                   }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                    forced-color-adjust: none;
+                  }
             >
               <input
                 aria-invalid={false}
@@ -5630,6 +5889,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     &::-ms-clear {
                       display: none;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
                     &::placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -5638,6 +5901,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::placeholder {
+                      color: GrayText;
                     }
                     &:-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
@@ -5648,6 +5914,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-weight: 400;
                       opacity: 1;
                     }
+                    @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                      color: GrayText;
+                    }
                     &::-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -5656,6 +5925,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                      color: GrayText;
                     }
                 id="TextField58"
                 onBlur={[Function]}
@@ -5782,6 +6054,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                   @media screen and (-ms-high-contrast: active){&:hover {
                     border-color: Highlight;
                   }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                    forced-color-adjust: none;
+                  }
             >
               <input
                 aria-invalid={false}
@@ -5825,6 +6100,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     &::-ms-clear {
                       display: none;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
                     &::placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -5833,6 +6112,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::placeholder {
+                      color: GrayText;
                     }
                     &:-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
@@ -5843,6 +6125,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-weight: 400;
                       opacity: 1;
                     }
+                    @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                      color: GrayText;
+                    }
                     &::-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -5851,6 +6136,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                      color: GrayText;
                     }
                 id="TextField61"
                 onBlur={[Function]}
@@ -6239,6 +6527,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                   @media screen and (-ms-high-contrast: active){&:hover {
                     border-color: Highlight;
                   }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                    forced-color-adjust: none;
+                  }
             >
               <input
                 aria-invalid={false}
@@ -6282,6 +6573,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     &::-ms-clear {
                       display: none;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
                     &::placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -6290,6 +6585,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::placeholder {
+                      color: GrayText;
                     }
                     &:-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
@@ -6300,6 +6598,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-weight: 400;
                       opacity: 1;
                     }
+                    @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                      color: GrayText;
+                    }
                     &::-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -6308,6 +6609,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                      color: GrayText;
                     }
                 id="TextField65"
                 onBlur={[Function]}
@@ -6434,6 +6738,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                   @media screen and (-ms-high-contrast: active){&:hover {
                     border-color: Highlight;
                   }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                    forced-color-adjust: none;
+                  }
             >
               <input
                 aria-invalid={false}
@@ -6477,6 +6784,10 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                     &::-ms-clear {
                       display: none;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
                     &::placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -6485,6 +6796,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::placeholder {
+                      color: GrayText;
                     }
                     &:-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
@@ -6495,6 +6809,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-weight: 400;
                       opacity: 1;
                     }
+                    @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                      color: GrayText;
+                    }
                     &::-ms-input-placeholder {
                       -moz-osx-font-smoothing: grayscale;
                       -webkit-font-smoothing: antialiased;
@@ -6503,6 +6820,9 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
                       font-size: 14px;
                       font-weight: 400;
                       opacity: 1;
+                    }
+                    @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                      color: GrayText;
                     }
                 id="TextField68"
                 onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
@@ -351,6 +351,9 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                  forced-color-adjust: none;
+                }
           >
             <input
               aria-invalid={false}
@@ -395,6 +398,10 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                   &::-ms-clear {
                     display: none;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -403,6 +410,9 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::placeholder {
+                    color: GrayText;
                   }
                   &:-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
@@ -413,6 +423,9 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                     font-weight: 400;
                     opacity: 1;
                   }
+                  @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                    color: GrayText;
+                  }
                   &::-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -421,6 +434,9 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                    color: GrayText;
                   }
               id="TextField7"
               onBlur={[Function]}
@@ -1215,6 +1231,9 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
                 }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                  forced-color-adjust: none;
+                }
           >
             <input
               aria-invalid={false}
@@ -1259,6 +1278,10 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                   &::-ms-clear {
                     display: none;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -1267,6 +1290,9 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::placeholder {
+                    color: GrayText;
                   }
                   &:-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
@@ -1277,6 +1303,9 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                     font-weight: 400;
                     opacity: 1;
                   }
+                  @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                    color: GrayText;
+                  }
                   &::-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -1285,6 +1314,9 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                    color: GrayText;
                   }
               id="TextField26"
               onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Image.Center.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Image.Center.Example.tsx.shot
@@ -29,6 +29,13 @@ exports[`Component Examples renders Image.Center.Example.tsx correctly 1`] = `
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
   >
     The image is larger than the frame, so all sides are cropped to center the image.
   </label>
@@ -96,6 +103,13 @@ exports[`Component Examples renders Image.Center.Example.tsx correctly 1`] = `
           padding-right: 0;
           padding-top: 5px;
           word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
   >
     The image is smaller than the frame, so there is empty space within the frame. The image is centered in the available space.

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Image.CenterContain.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Image.CenterContain.Example.tsx.shot
@@ -29,6 +29,13 @@ exports[`Component Examples renders Image.CenterContain.Example.tsx correctly 1`
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
   >
     The image is smaller than the frame, so it's centered and rendered at its natural size.
   </label>
@@ -97,6 +104,13 @@ exports[`Component Examples renders Image.CenterContain.Example.tsx correctly 1`
           padding-right: 0;
           padding-top: 5px;
           word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
   >
     The image has a wider width than the frame so it's contained.
@@ -167,6 +181,13 @@ exports[`Component Examples renders Image.CenterContain.Example.tsx correctly 1`
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
   >
     The image is taller than the frame so it's contained.
   </label>
@@ -235,6 +256,13 @@ exports[`Component Examples renders Image.CenterContain.Example.tsx correctly 1`
           padding-right: 0;
           padding-top: 5px;
           word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
   >
     These images are taller and wider than the frame and so they are contained.

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Image.CenterCover.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Image.CenterCover.Example.tsx.shot
@@ -29,6 +29,13 @@ exports[`Component Examples renders Image.CenterCover.Example.tsx correctly 1`] 
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
   >
     The image is smaller than the frame, so it's centered and rendered at its natural size.
   </label>
@@ -97,6 +104,13 @@ exports[`Component Examples renders Image.CenterCover.Example.tsx correctly 1`] 
           padding-right: 0;
           padding-top: 5px;
           word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
   >
     The image has a wider aspect ratio (more landscape) than the frame but is not as tall as the frame, so it's rendered at its natural size while cropping the sides.
@@ -167,6 +181,13 @@ exports[`Component Examples renders Image.CenterCover.Example.tsx correctly 1`] 
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
   >
     The image has a taller aspect ratio (more portrait) than the frame but is not as wide as the frame, so it's rendered at its natural size while cropping the top and bottom.
   </label>
@@ -235,6 +256,13 @@ exports[`Component Examples renders Image.CenterCover.Example.tsx correctly 1`] 
           padding-right: 0;
           padding-top: 5px;
           word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
   >
     These images are taller and wider than the frame, so they grow just enough to "cover" the frame area.

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Image.Contain.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Image.Contain.Example.tsx.shot
@@ -29,6 +29,13 @@ exports[`Component Examples renders Image.Contain.Example.tsx correctly 1`] = `
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
   >
     The image has a wider aspect ratio (more landscape) than the frame, so the image is scaled to fit the width and centered in the available vertical space.
   </label>
@@ -99,6 +106,13 @@ exports[`Component Examples renders Image.Contain.Example.tsx correctly 1`] = `
           padding-right: 0;
           padding-top: 5px;
           word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
   >
     The image has a taller aspect ratio (more portrait) than the frame, so the image is scaled to fit the height and centered in the available horizontal space.

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Image.Cover.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Image.Cover.Example.tsx.shot
@@ -29,6 +29,13 @@ exports[`Component Examples renders Image.Cover.Example.tsx correctly 1`] = `
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
   >
     The image has a wider aspect ratio (more landscape) than the frame, so the image is scaled to fit the height and the sides are cropped evenly.
   </label>
@@ -99,6 +106,13 @@ exports[`Component Examples renders Image.Cover.Example.tsx correctly 1`] = `
           padding-right: 0;
           padding-top: 5px;
           word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
   >
     The image has a taller aspect ratio (more portrait) than the frame, so the image is scaled to fit the width and the top and bottom are cropped evenly.

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Image.Default.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Image.Default.Example.tsx.shot
@@ -29,6 +29,13 @@ exports[`Component Examples renders Image.Default.Example.tsx correctly 1`] = `
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
   >
     Without a width or height specified, the frame remains at its natural size and the image will not be scaled.
   </label>
@@ -90,6 +97,13 @@ exports[`Component Examples renders Image.Default.Example.tsx correctly 1`] = `
           padding-right: 0;
           padding-top: 5px;
           word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
   >
     If only a width is provided, the frame will be set to that width. The image will scale proportionally to fill the available width.
@@ -155,6 +169,13 @@ exports[`Component Examples renders Image.Default.Example.tsx correctly 1`] = `
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
   >
     If only a height is provided, the frame will be set to that height. The image will scale proportionally to fill the available height.
   </label>
@@ -218,6 +239,13 @@ exports[`Component Examples renders Image.Default.Example.tsx correctly 1`] = `
           padding-right: 0;
           padding-top: 5px;
           word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
   >
     If both width and height are provided, the frame will be set to that width and height. The image will scale to fill both the available width and height. 

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Image.MaximizeFrame.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Image.MaximizeFrame.Example.tsx.shot
@@ -29,6 +29,13 @@ exports[`Component Examples renders Image.MaximizeFrame.Example.tsx correctly 1`
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
   >
     The image is placed within a landscape container.
   </label>
@@ -111,6 +118,13 @@ exports[`Component Examples renders Image.MaximizeFrame.Example.tsx correctly 1`
           padding-right: 0;
           padding-top: 5px;
           word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
   >
     The image is placed within a portrait container.

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Image.None.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Image.None.Example.tsx.shot
@@ -29,6 +29,13 @@ exports[`Component Examples renders Image.None.Example.tsx correctly 1`] = `
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
   >
     The image is larger than the frame, so it is cropped to fit. The image is positioned at the upper left of the frame.
   </label>
@@ -93,6 +100,13 @@ exports[`Component Examples renders Image.None.Example.tsx correctly 1`] = `
           padding-right: 0;
           padding-top: 5px;
           word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
   >
     The image is smaller than the frame, so there is empty space within the frame. The image is positioned at the upper left of the frame.

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -621,6 +621,13 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                       pointer-events: none;
                       word-wrap: break-word;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
                 htmlFor="input12"
                 id="Label11"
               >
@@ -1127,6 +1134,13 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                       padding-right: 0;
                       padding-top: 5px;
                       word-wrap: break-word;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
                     }
                     && {
                       font-weight: 400;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
@@ -1169,6 +1169,13 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
             && {
               font-weight: 400;
               margin-bottom: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Label.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Label.Basic.Example.tsx.shot
@@ -26,6 +26,13 @@ exports[`Component Examples renders Label.Basic.Example.tsx correctly 1`] = `
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
   >
     I'm a Label
   </label>
@@ -54,7 +61,11 @@ exports[`Component Examples renders Label.Basic.Example.tsx correctly 1`] = `
           word-wrap: break-word;
         }
         @media screen and (-ms-high-contrast: active){& {
+          background: Window;
           color: GrayText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
   >
     I'm a disabled Label
@@ -83,10 +94,20 @@ exports[`Component Examples renders Label.Basic.Example.tsx correctly 1`] = `
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
         &::after {
           color: #a4262c;
           content: ' *';
           padding-right: 12px;
+        }
+        @media screen and (-ms-high-contrast: active){&::after {
+          color: WindowText;
         }
   >
     I'm a required Label
@@ -114,6 +135,13 @@ exports[`Component Examples renders Label.Basic.Example.tsx correctly 1`] = `
           padding-right: 0;
           padding-top: 5px;
           word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
     htmlFor="anInput0"
   >
@@ -176,6 +204,9 @@ exports[`Component Examples renders Label.Basic.Example.tsx correctly 1`] = `
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+              forced-color-adjust: none;
+            }
       >
         <input
           aria-invalid={false}
@@ -219,6 +250,10 @@ exports[`Component Examples renders Label.Basic.Example.tsx correctly 1`] = `
               &::-ms-clear {
                 display: none;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -227,6 +262,9 @@ exports[`Component Examples renders Label.Basic.Example.tsx correctly 1`] = `
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::placeholder {
+                color: GrayText;
               }
               &:-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
@@ -237,6 +275,9 @@ exports[`Component Examples renders Label.Basic.Example.tsx correctly 1`] = `
                 font-weight: 400;
                 opacity: 1;
               }
+              @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                color: GrayText;
+              }
               &::-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -245,6 +286,9 @@ exports[`Component Examples renders Label.Basic.Example.tsx correctly 1`] = `
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                color: GrayText;
               }
           id="anInput0"
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Basic.Example.tsx.shot
@@ -44,6 +44,13 @@ exports[`Component Examples renders Layer.Basic.Example.tsx correctly 1`] = `
             word-break: break-all;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       htmlFor="Toggle0"
       id="Toggle0-label"
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Customized.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Customized.Example.tsx.shot
@@ -59,6 +59,13 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
             word-break: break-all;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       htmlFor="Toggle1"
       id="Toggle1-label"
     >
@@ -190,6 +197,13 @@ exports[`Component Examples renders Layer.Customized.Example.tsx correctly 1`] =
             padding-top: 5px;
             word-break: break-all;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="Toggle2"
       id="Toggle2-label"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Hosted.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.Hosted.Example.tsx.shot
@@ -51,6 +51,13 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
             word-break: break-all;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       htmlFor="Toggle1"
       id="Toggle1-label"
     >
@@ -197,6 +204,13 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-break: break-all;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="Toggle2"
       id="Toggle2-label"
@@ -350,6 +364,13 @@ exports[`Component Examples renders Layer.Hosted.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-break: break-all;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="Toggle3"
       id="Toggle3-label"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/MarqueeSelection.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/MarqueeSelection.Basic.Example.tsx.shot
@@ -30,10 +30,6 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
           background: #005a9e;
           border-color: #005a9e;
         }
-        & .ms-Checkbox-checkbox {
-          background: #0078d4;
-          border-color: #0078d4;
-        }
         @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
           background: Window;
           border-color: Highlight;
@@ -53,8 +49,14 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -134,6 +136,9 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
               background: Highlight;
               border-color: Highlight;
             }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -168,6 +173,12 @@ exports[`Component Examples renders MarqueeSelection.Basic.Example.tsx correctly
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Is marquee enabled

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/MessageBar.Basic.Example.tsx.shot
@@ -80,6 +80,13 @@ exports[`Component Examples renders MessageBar.Basic.Example.tsx correctly 1`] =
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           id="ChoiceGroup0-label"
         >
           Select a MessageBar Example Below. To test in narrator, show one message at a time.

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Basic.Example.tsx.shot
@@ -30,8 +30,14 @@ exports[`Component Examples renders Modal.Basic.Example.tsx correctly 1`] = `
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -105,6 +111,12 @@ exports[`Component Examples renders Modal.Basic.Example.tsx correctly 1`] = `
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -139,6 +151,12 @@ exports[`Component Examples renders Modal.Basic.Example.tsx correctly 1`] = `
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Is draggable

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Modeless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Modeless.Example.tsx.shot
@@ -30,8 +30,14 @@ exports[`Component Examples renders Modal.Modeless.Example.tsx correctly 1`] = `
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -107,6 +113,12 @@ exports[`Component Examples renders Modal.Modeless.Example.tsx correctly 1`] = `
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -141,6 +153,12 @@ exports[`Component Examples renders Modal.Modeless.Example.tsx correctly 1`] = `
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Is draggable

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
@@ -57,8 +57,14 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -133,6 +139,12 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -167,6 +179,12 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
                 font-size: 14px;
                 line-height: 20px;
                 margin-left: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           A Checkbox

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
@@ -128,8 +128,14 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -203,6 +209,12 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -238,6 +250,12 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
               line-height: 20px;
               margin-left: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Disable People Picker
       </span>
@@ -271,8 +289,14 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -346,6 +370,12 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -380,6 +410,12 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Delay Suggestion Results

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
@@ -2084,8 +2084,14 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -2159,6 +2165,12 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -2194,6 +2206,12 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
               line-height: 20px;
               margin-left: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Disable People Picker
       </span>
@@ -2227,8 +2245,14 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -2302,6 +2326,12 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -2336,6 +2366,12 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Delay Suggestion Results

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
@@ -128,8 +128,14 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -203,6 +209,12 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -238,6 +250,12 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
               line-height: 20px;
               margin-left: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Disable People Picker
       </span>
@@ -271,8 +289,14 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -346,6 +370,12 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -380,6 +410,12 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Delay Suggestion Results

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.List.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.List.Example.tsx.shot
@@ -132,8 +132,14 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -207,6 +213,12 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -242,6 +254,12 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
               line-height: 20px;
               margin-left: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Disable People Picker
       </span>
@@ -275,8 +293,14 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -350,6 +374,12 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -384,6 +414,12 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Delay Suggestion Results

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
@@ -128,8 +128,14 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -203,6 +209,12 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -238,6 +250,12 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
               line-height: 20px;
               margin-left: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Disable People Picker
       </span>
@@ -271,8 +289,14 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -346,6 +370,12 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -380,6 +410,12 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Delay Suggestion Results

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
@@ -1497,8 +1497,14 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -1572,6 +1578,12 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -1607,6 +1619,12 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
               line-height: 20px;
               margin-left: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Disable People Picker
       </span>
@@ -1640,8 +1658,14 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -1715,6 +1739,12 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -1749,6 +1779,12 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Delay Suggestion Results

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
@@ -128,8 +128,14 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -203,6 +209,12 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -238,6 +250,12 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
               line-height: 20px;
               margin-left: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Disable People Picker
       </span>
@@ -271,8 +289,14 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -346,6 +370,12 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -380,6 +410,12 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Delay Suggestion Results

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Basic.Example.tsx.shot
@@ -39,10 +39,6 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           background: #005a9e;
           border-color: #005a9e;
         }
-        & .ms-Checkbox-checkbox {
-          background: #0078d4;
-          border-color: #0078d4;
-        }
         @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
           background: Window;
           border-color: Highlight;
@@ -62,8 +58,14 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -143,6 +145,9 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               background: Highlight;
               border-color: Highlight;
             }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -178,6 +183,12 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               line-height: 20px;
               margin-left: 4px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Include persona details
       </span>
@@ -206,6 +217,13 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           padding-right: 0;
           padding-top: 5px;
           word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
   >
     Size 8 Persona, with no presence
@@ -437,6 +455,13 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           padding-right: 0;
           padding-top: 5px;
           word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
   >
     Size 8 Persona, with presence
@@ -692,6 +717,13 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           padding-right: 0;
           padding-top: 5px;
           word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
   >
     Size 24 Persona
@@ -991,6 +1023,13 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
   >
     Size 32 Persona
   </label>
@@ -1288,6 +1327,13 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           padding-right: 0;
           padding-top: 5px;
           word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
   >
     Size 40 Persona
@@ -1613,6 +1659,13 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
   >
     Size 48 Persona (default) 
   </label>
@@ -1928,6 +1981,13 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           padding-right: 0;
           padding-top: 5px;
           word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
   >
     Size 56 Persona (default) 
@@ -2251,6 +2311,13 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           padding-top: 5px;
           word-wrap: break-word;
         }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
+        }
   >
     Size 72 Persona
   </label>
@@ -2572,6 +2639,13 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           padding-right: 0;
           padding-top: 5px;
           word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
   >
     Size 100 Persona
@@ -2921,6 +2995,13 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
           padding-right: 0;
           padding-top: 5px;
           word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
   >
     Size 120 Persona

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Presence.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Presence.Example.tsx.shot
@@ -77,6 +77,13 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Online
       </label>
@@ -755,6 +762,13 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
               padding-right: 0;
               padding-top: 5px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Online + Out of Office
@@ -1531,6 +1545,13 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Away
       </label>
@@ -2213,6 +2234,13 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
               padding-right: 0;
               padding-top: 5px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Away + Out of Office
@@ -2991,6 +3019,13 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Busy
       </label>
@@ -3657,6 +3692,13 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
               padding-right: 0;
               padding-top: 5px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Busy + Out of Office
@@ -4421,6 +4463,13 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Do not Disturb
       </label>
@@ -5099,6 +5148,13 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
               padding-right: 0;
               padding-top: 5px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Do not Disturb + Out of Office
@@ -5832,6 +5888,13 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
           padding-right: 0;
           padding-top: 5px;
           word-wrap: break-word;
+        }
+        @media screen and (-ms-high-contrast: active){& {
+          background: Window;
+          color: WindowText;
+        }
+        @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+          forced-color-adjust: none;
         }
   >
     Blocked
@@ -6632,6 +6695,13 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Offline
       </label>
@@ -7372,6 +7442,13 @@ exports[`Component Examples renders Persona.Presence.Example.tsx correctly 1`] =
               padding-right: 0;
               padding-top: 5px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Offline + Out of Office

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Basic.Example.tsx.shot
@@ -559,6 +559,13 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         Pivot #1
       </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.IconCount.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.IconCount.Example.tsx.shot
@@ -1049,6 +1049,13 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           Pivot #1
         </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Large.Example.tsx.shot
@@ -559,6 +559,13 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           Pivot #1
         </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.OnChange.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.OnChange.Example.tsx.shot
@@ -748,6 +748,13 @@ exports[`Component Examples renders Pivot.OnChange.Example.tsx correctly 1`] = `
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           Pivot #1
         </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Override.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Override.Example.tsx.shot
@@ -558,6 +558,13 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           Pivot #1
         </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Remove.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Remove.Example.tsx.shot
@@ -748,6 +748,13 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           Click the button below to show/hide this pivot item.
         </label>
@@ -775,6 +782,13 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           The selected item will not change when the number of pivot items changes.
         </label>
@@ -801,6 +815,13 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
                 padding-right: 0;
                 padding-top: 5px;
                 word-wrap: break-word;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           If the selected item was removed, the new first item will be selected.

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Tabs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Tabs.Example.tsx.shot
@@ -747,6 +747,13 @@ exports[`Component Examples renders Pivot.Tabs.Example.tsx correctly 1`] = `
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           Pivot #1
         </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.TabsLarge.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.TabsLarge.Example.tsx.shot
@@ -748,6 +748,13 @@ exports[`Component Examples renders Pivot.TabsLarge.Example.tsx correctly 1`] = 
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           Pivot #1
         </label>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -3662,8 +3662,14 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -3737,6 +3743,12 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -3772,6 +3784,12 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                 line-height: 20px;
                 margin-left: 4px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           Enable caching
         </span>
@@ -3804,8 +3822,14 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -3879,6 +3903,12 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -3914,6 +3944,12 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                 line-height: 20px;
                 margin-left: 4px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           Set onGrowData
         </span>
@@ -3946,8 +3982,14 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
           &:hover .ms-Checkbox-text {
             color: #201f1e;
           }
+          @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+            color: WindowText;
+          }
           &:focus .ms-Checkbox-text {
             color: #201f1e;
+          }
+          @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+            color: WindowText;
           }
     >
       <input
@@ -4021,6 +4063,12 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                 transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                 width: 20px;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                border-color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <i
             aria-hidden={true}
@@ -4055,6 +4103,12 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                 font-size: 14px;
                 line-height: 20px;
                 margin-left: 4px;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           Buttons checked
@@ -4097,6 +4151,13 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                 padding-right: 0;
                 padding-top: 5px;
                 word-wrap: break-word;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
           id="Dropdown64-label"
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
@@ -40,6 +40,13 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       htmlFor="Toggle0"
       id="Toggle0-label"
     >
@@ -158,6 +165,13 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
               padding-right: 0;
               padding-top: 5px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
             && {
               font-weight: 400;
@@ -568,6 +582,9 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                                         0 0 / 90% 100%
                                                         no-repeat;
                                 }
+                                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                                  forced-color-adjust: none;
+                                }
                             style={
                               Object {
                                 "width": "100%",
@@ -877,6 +894,9 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                                           transparent 100%)
                                                         0 0 / 90% 100%
                                                         no-repeat;
+                                }
+                                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                                  forced-color-adjust: none;
                                 }
                             style={
                               Object {
@@ -1188,6 +1208,9 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                                         0 0 / 90% 100%
                                                         no-repeat;
                                 }
+                                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                                  forced-color-adjust: none;
+                                }
                             style={
                               Object {
                                 "width": "100%",
@@ -1497,6 +1520,9 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                                           transparent 100%)
                                                         0 0 / 90% 100%
                                                         no-repeat;
+                                }
+                                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                                  forced-color-adjust: none;
                                 }
                             style={
                               Object {
@@ -1808,6 +1834,9 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                                         0 0 / 90% 100%
                                                         no-repeat;
                                 }
+                                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                                  forced-color-adjust: none;
+                                }
                             style={
                               Object {
                                 "width": "100%",
@@ -2117,6 +2146,9 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                                           transparent 100%)
                                                         0 0 / 90% 100%
                                                         no-repeat;
+                                }
+                                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                                  forced-color-adjust: none;
                                 }
                             style={
                               Object {
@@ -2428,6 +2460,9 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                                         0 0 / 90% 100%
                                                         no-repeat;
                                 }
+                                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                                  forced-color-adjust: none;
+                                }
                             style={
                               Object {
                                 "width": "100%",
@@ -2737,6 +2772,9 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                                           transparent 100%)
                                                         0 0 / 90% 100%
                                                         no-repeat;
+                                }
+                                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                                  forced-color-adjust: none;
                                 }
                             style={
                               Object {
@@ -3048,6 +3086,9 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                                         0 0 / 90% 100%
                                                         no-repeat;
                                 }
+                                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                                  forced-color-adjust: none;
+                                }
                             style={
                               Object {
                                 "width": "100%",
@@ -3357,6 +3398,9 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
                                                           transparent 100%)
                                                         0 0 / 90% 100%
                                                         no-repeat;
+                                }
+                                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                                  forced-color-adjust: none;
                                 }
                             style={
                               Object {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Basic.Example.tsx.shot
@@ -72,6 +72,9 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                                   0 0 / 90% 100%
                                   no-repeat;
           }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       style={
         Object {
           "width": "100%",
@@ -256,6 +259,9 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       style={
         Object {
@@ -442,6 +448,9 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                                   0 0 / 90% 100%
                                   no-repeat;
           }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       style={
         Object {
           "width": "50%",
@@ -627,6 +636,9 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       style={
         Object {
@@ -885,6 +897,9 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       style={
         Object {
@@ -1521,6 +1536,9 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       style={
         Object {
@@ -2158,6 +2176,9 @@ exports[`Component Examples renders Shimmer.Basic.Example.tsx correctly 1`] = `
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       style={
         Object {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.CustomElements.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.CustomElements.Example.tsx.shot
@@ -72,6 +72,9 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                                   0 0 / 90% 100%
                                   no-repeat;
           }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       style={
         Object {
           "width": 350,
@@ -540,6 +543,9 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                                   0 0 / 90% 100%
                                   no-repeat;
           }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       style={
         Object {
           "width": 550,
@@ -952,6 +958,9 @@ exports[`Component Examples renders Shimmer.CustomElements.Example.tsx correctly
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       style={
         Object {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.LoadData.Example.tsx.shot
@@ -138,6 +138,13 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
             && {
               font-weight: 400;
               margin-bottom: 0;
@@ -192,6 +199,9 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       style={
         Object {
@@ -499,6 +509,13 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
             && {
               font-weight: 400;
               margin-bottom: 0;
@@ -553,6 +570,9 @@ exports[`Component Examples renders Shimmer.LoadData.Example.tsx correctly 1`] =
                                     transparent 100%)
                                   0 0 / 90% 100%
                                   no-repeat;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       style={
         Object {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Styling.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Styling.Example.tsx.shot
@@ -95,6 +95,9 @@ Array [
                                     0 0 / 90% 100%
                                     no-repeat;
             }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         style={
           Object {
             "width": "100%",
@@ -766,6 +769,9 @@ Array [
                                     0 0 / 90% 100%
                                     no-repeat;
             }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         style={
           Object {
             "width": 300,
@@ -1208,6 +1214,9 @@ Array [
                                     0 0 / 90% 100%
                                     no-repeat;
             }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         style={
           Object {
             "width": 300,
@@ -1642,192 +1651,8 @@ Array [
                                     0 0 / 90% 100%
                                     no-repeat;
             }
-        style={
-          Object {
-            "width": "75%",
-          }
-        }
-      >
-        <div
-          className=
-              ms-Shimmer-shimmerGradient
-              {
-                animation-direction: normal;
-                animation-duration: 2s;
-                animation-iteration-count: infinite;
-                animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
-                animation-timing-function: ease-in-out;
-                background-color: #deecf9;
-                background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
-                background: #f3f2f1
-                                    linear-gradient(
-                                      to right,
-                                      #f3f2f1 0%,
-                                      #edebe9 50%,
-                                      #f3f2f1 100%)
-                                    0 0 / 90% 100%
-                                    no-repeat;
-                height: 100%;
-                left: 0px;
-                position: absolute;
-                top: 0px;
-                transform: translateX(-100%);
-                width: 100%;
-              }
-        />
-        <div
-          className=
-              ms-ShimmerElementsGroup-root
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                position: relative;
-              }
-          style={
-            Object {
-              "width": "auto",
-            }
-          }
-        >
-          <div
-            className=
-                ms-ShimmerLine-root
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  border-bottom-style: solid;
-                  border-color: #ffffff;
-                  border-top-style: solid;
-                  border-width: 0px;
-                  box-sizing: content-box;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 16px;
-                  position: relative;
-                }
-                @media screen and (-ms-high-contrast: active){& {
-                  border-color: Window;
-                }
-                @media screen and (-ms-high-contrast: active){& > * {
-                  fill: Window;
-                }
-            style={
-              Object {
-                "minWidth": "auto",
-                "width": "100%",
-              }
-            }
-          >
-            <svg
-              className=
-                  ms-ShimmerLine-topLeftCorner
-                  {
-                    fill: #ffffff;
-                    left: 0;
-                    position: absolute;
-                    top: 0;
-                  }
-              height="2"
-              width="2"
-            >
-              <path
-                d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
-              />
-            </svg>
-            <svg
-              className=
-                  ms-ShimmerLine-topRightCorner
-                  {
-                    fill: #ffffff;
-                    position: absolute;
-                    right: 0;
-                    top: 0;
-                  }
-              height="2"
-              width="2"
-            >
-              <path
-                d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
-              />
-            </svg>
-            <svg
-              className=
-                  ms-ShimmerLine-bottomRightCorner
-                  {
-                    bottom: 0;
-                    fill: #ffffff;
-                    position: absolute;
-                    right: 0;
-                  }
-              height="2"
-              width="2"
-            >
-              <path
-                d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
-              />
-            </svg>
-            <svg
-              className=
-                  ms-ShimmerLine-bottomLeftCorner
-                  {
-                    bottom: 0;
-                    fill: #ffffff;
-                    left: 0;
-                    position: absolute;
-                  }
-              height="2"
-              width="2"
-            >
-              <path
-                d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
-              />
-            </svg>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className=
-          ms-Shimmer-container
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            height: auto;
-            position: relative;
-          }
-    >
-      <div
-        className=
-            ms-Shimmer-shimmerWrapper
-            {
-              background-color: #deecf9;
-              overflow: hidden;
-              position: relative;
-              transform: translateZ(0);
-              transition: opacity 200ms;
-            }
-            & > * {
-              transform: translateZ(0);
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              background: WindowText
-                                    linear-gradient(
-                                      to right,
-                                      transparent 0%,
-                                      Window 50%,
-                                      transparent 100%)
-                                    0 0 / 90% 100%
-                                    no-repeat;
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         style={
           Object {
@@ -2016,192 +1841,8 @@ Array [
                                     0 0 / 90% 100%
                                     no-repeat;
             }
-        style={
-          Object {
-            "width": "75%",
-          }
-        }
-      >
-        <div
-          className=
-              ms-Shimmer-shimmerGradient
-              {
-                animation-direction: normal;
-                animation-duration: 2s;
-                animation-iteration-count: infinite;
-                animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
-                animation-timing-function: ease-in-out;
-                background-color: #deecf9;
-                background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
-                background: #f3f2f1
-                                    linear-gradient(
-                                      to right,
-                                      #f3f2f1 0%,
-                                      #edebe9 50%,
-                                      #f3f2f1 100%)
-                                    0 0 / 90% 100%
-                                    no-repeat;
-                height: 100%;
-                left: 0px;
-                position: absolute;
-                top: 0px;
-                transform: translateX(-100%);
-                width: 100%;
-              }
-        />
-        <div
-          className=
-              ms-ShimmerElementsGroup-root
-              {
-                -moz-osx-font-smoothing: grayscale;
-                -webkit-font-smoothing: antialiased;
-                align-items: center;
-                display: flex;
-                flex-wrap: nowrap;
-                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                font-size: 14px;
-                font-weight: 400;
-                position: relative;
-              }
-          style={
-            Object {
-              "width": "auto",
-            }
-          }
-        >
-          <div
-            className=
-                ms-ShimmerLine-root
-                {
-                  -moz-osx-font-smoothing: grayscale;
-                  -webkit-font-smoothing: antialiased;
-                  border-bottom-style: solid;
-                  border-color: #ffffff;
-                  border-top-style: solid;
-                  border-width: 0px;
-                  box-sizing: content-box;
-                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-                  font-size: 14px;
-                  font-weight: 400;
-                  height: 16px;
-                  position: relative;
-                }
-                @media screen and (-ms-high-contrast: active){& {
-                  border-color: Window;
-                }
-                @media screen and (-ms-high-contrast: active){& > * {
-                  fill: Window;
-                }
-            style={
-              Object {
-                "minWidth": "auto",
-                "width": "100%",
-              }
-            }
-          >
-            <svg
-              className=
-                  ms-ShimmerLine-topLeftCorner
-                  {
-                    fill: #ffffff;
-                    left: 0;
-                    position: absolute;
-                    top: 0;
-                  }
-              height="2"
-              width="2"
-            >
-              <path
-                d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
-              />
-            </svg>
-            <svg
-              className=
-                  ms-ShimmerLine-topRightCorner
-                  {
-                    fill: #ffffff;
-                    position: absolute;
-                    right: 0;
-                    top: 0;
-                  }
-              height="2"
-              width="2"
-            >
-              <path
-                d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
-              />
-            </svg>
-            <svg
-              className=
-                  ms-ShimmerLine-bottomRightCorner
-                  {
-                    bottom: 0;
-                    fill: #ffffff;
-                    position: absolute;
-                    right: 0;
-                  }
-              height="2"
-              width="2"
-            >
-              <path
-                d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
-              />
-            </svg>
-            <svg
-              className=
-                  ms-ShimmerLine-bottomLeftCorner
-                  {
-                    bottom: 0;
-                    fill: #ffffff;
-                    left: 0;
-                    position: absolute;
-                  }
-              height="2"
-              width="2"
-            >
-              <path
-                d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
-              />
-            </svg>
-          </div>
-        </div>
-      </div>
-    </div>
-    <div
-      className=
-          ms-Shimmer-container
-          {
-            -moz-osx-font-smoothing: grayscale;
-            -webkit-font-smoothing: antialiased;
-            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
-            font-size: 14px;
-            font-weight: 400;
-            height: auto;
-            position: relative;
-          }
-    >
-      <div
-        className=
-            ms-Shimmer-shimmerWrapper
-            {
-              background-color: #deecf9;
-              overflow: hidden;
-              position: relative;
-              transform: translateZ(0);
-              transition: opacity 200ms;
-            }
-            & > * {
-              transform: translateZ(0);
-            }
-            @media screen and (-ms-high-contrast: active){& {
-              background: WindowText
-                                    linear-gradient(
-                                      to right,
-                                      transparent 0%,
-                                      Window 50%,
-                                      transparent 100%)
-                                    0 0 / 90% 100%
-                                    no-repeat;
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         style={
           Object {
@@ -2389,6 +2030,389 @@ Array [
                                       transparent 100%)
                                     0 0 / 90% 100%
                                     no-repeat;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
+        style={
+          Object {
+            "width": "75%",
+          }
+        }
+      >
+        <div
+          className=
+              ms-Shimmer-shimmerGradient
+              {
+                animation-direction: normal;
+                animation-duration: 2s;
+                animation-iteration-count: infinite;
+                animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
+                animation-timing-function: ease-in-out;
+                background-color: #deecf9;
+                background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
+                background: #f3f2f1
+                                    linear-gradient(
+                                      to right,
+                                      #f3f2f1 0%,
+                                      #edebe9 50%,
+                                      #f3f2f1 100%)
+                                    0 0 / 90% 100%
+                                    no-repeat;
+                height: 100%;
+                left: 0px;
+                position: absolute;
+                top: 0px;
+                transform: translateX(-100%);
+                width: 100%;
+              }
+        />
+        <div
+          className=
+              ms-ShimmerElementsGroup-root
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                position: relative;
+              }
+          style={
+            Object {
+              "width": "auto",
+            }
+          }
+        >
+          <div
+            className=
+                ms-ShimmerLine-root
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  border-bottom-style: solid;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-width: 0px;
+                  box-sizing: content-box;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 16px;
+                  position: relative;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: Window;
+                }
+                @media screen and (-ms-high-contrast: active){& > * {
+                  fill: Window;
+                }
+            style={
+              Object {
+                "minWidth": "auto",
+                "width": "100%",
+              }
+            }
+          >
+            <svg
+              className=
+                  ms-ShimmerLine-topLeftCorner
+                  {
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-topRightCorner
+                  {
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomRightCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomLeftCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Shimmer-container
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: auto;
+            position: relative;
+          }
+    >
+      <div
+        className=
+            ms-Shimmer-shimmerWrapper
+            {
+              background-color: #deecf9;
+              overflow: hidden;
+              position: relative;
+              transform: translateZ(0);
+              transition: opacity 200ms;
+            }
+            & > * {
+              transform: translateZ(0);
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: WindowText
+                                    linear-gradient(
+                                      to right,
+                                      transparent 0%,
+                                      Window 50%,
+                                      transparent 100%)
+                                    0 0 / 90% 100%
+                                    no-repeat;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
+        style={
+          Object {
+            "width": "75%",
+          }
+        }
+      >
+        <div
+          className=
+              ms-Shimmer-shimmerGradient
+              {
+                animation-direction: normal;
+                animation-duration: 2s;
+                animation-iteration-count: infinite;
+                animation-name: keyframes 0%{transform:translateX(-100%);}100%{transform:translateX(100%);};
+                animation-timing-function: ease-in-out;
+                background-color: #deecf9;
+                background-image: linear-gradient(to right, rgba(255, 255, 255, 0) 0%, #c7e0f4 50%, rgba(255, 255, 255, 0) 100%);
+                background: #f3f2f1
+                                    linear-gradient(
+                                      to right,
+                                      #f3f2f1 0%,
+                                      #edebe9 50%,
+                                      #f3f2f1 100%)
+                                    0 0 / 90% 100%
+                                    no-repeat;
+                height: 100%;
+                left: 0px;
+                position: absolute;
+                top: 0px;
+                transform: translateX(-100%);
+                width: 100%;
+              }
+        />
+        <div
+          className=
+              ms-ShimmerElementsGroup-root
+              {
+                -moz-osx-font-smoothing: grayscale;
+                -webkit-font-smoothing: antialiased;
+                align-items: center;
+                display: flex;
+                flex-wrap: nowrap;
+                font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                font-size: 14px;
+                font-weight: 400;
+                position: relative;
+              }
+          style={
+            Object {
+              "width": "auto",
+            }
+          }
+        >
+          <div
+            className=
+                ms-ShimmerLine-root
+                {
+                  -moz-osx-font-smoothing: grayscale;
+                  -webkit-font-smoothing: antialiased;
+                  border-bottom-style: solid;
+                  border-color: #ffffff;
+                  border-top-style: solid;
+                  border-width: 0px;
+                  box-sizing: content-box;
+                  font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+                  font-size: 14px;
+                  font-weight: 400;
+                  height: 16px;
+                  position: relative;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: Window;
+                }
+                @media screen and (-ms-high-contrast: active){& > * {
+                  fill: Window;
+                }
+            style={
+              Object {
+                "minWidth": "auto",
+                "width": "100%",
+              }
+            }
+          >
+            <svg
+              className=
+                  ms-ShimmerLine-topLeftCorner
+                  {
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 2 A 2 2, 0, 0, 1, 2 0 L 0 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-topRightCorner
+                  {
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                    top: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M0 0 A 2 2, 0, 0, 1, 2 2 L 2 0 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomRightCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    position: absolute;
+                    right: 0;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 0 A 2 2, 0, 0, 1, 0 2 L 2 2 Z"
+              />
+            </svg>
+            <svg
+              className=
+                  ms-ShimmerLine-bottomLeftCorner
+                  {
+                    bottom: 0;
+                    fill: #ffffff;
+                    left: 0;
+                    position: absolute;
+                  }
+              height="2"
+              width="2"
+            >
+              <path
+                d="M2 2 A 2 2, 0, 0, 1, 0 0 L 0 2 Z"
+              />
+            </svg>
+          </div>
+        </div>
+      </div>
+    </div>
+    <div
+      className=
+          ms-Shimmer-container
+          {
+            -moz-osx-font-smoothing: grayscale;
+            -webkit-font-smoothing: antialiased;
+            font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
+            font-size: 14px;
+            font-weight: 400;
+            height: auto;
+            position: relative;
+          }
+    >
+      <div
+        className=
+            ms-Shimmer-shimmerWrapper
+            {
+              background-color: #deecf9;
+              overflow: hidden;
+              position: relative;
+              transform: translateZ(0);
+              transition: opacity 200ms;
+            }
+            & > * {
+              transform: translateZ(0);
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: WindowText
+                                    linear-gradient(
+                                      to right,
+                                      transparent 0%,
+                                      Window 50%,
+                                      transparent 100%)
+                                    0 0 / 90% 100%
+                                    no-repeat;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         style={
           Object {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Slider.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Slider.Basic.Example.tsx.shot
@@ -250,6 +250,13 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
               width: 40px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         0
       </label>
@@ -292,6 +299,13 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
             padding-right: 0px;
             padding-top: 0px;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="Slider1"
     >
@@ -511,6 +525,13 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
               width: 40px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         20
       </label>
@@ -555,7 +576,11 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
             word-wrap: break-word;
           }
           @media screen and (-ms-high-contrast: active){& {
+            background: Window;
             color: GrayText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="Slider2"
     >
@@ -729,7 +754,11 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
               word-wrap: break-word;
             }
             @media screen and (-ms-high-contrast: active){& {
+              background: Window;
               color: GrayText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         300
@@ -773,6 +802,13 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
             padding-right: 0px;
             padding-top: 0px;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="Slider3"
     >
@@ -992,6 +1028,13 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
               width: 40px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         0
       </label>
@@ -1034,6 +1077,13 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
             padding-right: 0px;
             padding-top: 0px;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="Slider4"
     >
@@ -1253,6 +1303,13 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
               width: 40px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         0%
       </label>
@@ -1295,6 +1352,13 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
             padding-right: 0px;
             padding-top: 0px;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="Slider5"
     >
@@ -1554,6 +1618,13 @@ exports[`Component Examples renders Slider.Basic.Example.tsx correctly 1`] = `
               white-space: nowrap;
               width: 40px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         2

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Slider.Vertical.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Slider.Vertical.Example.tsx.shot
@@ -61,6 +61,13 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
             padding-top: 0px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       htmlFor="Slider0"
     >
       Basic
@@ -296,6 +303,13 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
               width: 40px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         2
       </label>
@@ -341,7 +355,11 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
             word-wrap: break-word;
           }
           @media screen and (-ms-high-contrast: active){& {
+            background: Window;
             color: GrayText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="Slider1"
     >
@@ -532,7 +550,11 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
               word-wrap: break-word;
             }
             @media screen and (-ms-high-contrast: active){& {
+              background: Window;
               color: GrayText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         300
@@ -577,6 +599,13 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
             padding-right: 0px;
             padding-top: 0px;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="Slider2"
     >
@@ -813,6 +842,13 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
               width: 40px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         0
       </label>
@@ -856,6 +892,13 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
             padding-right: 0px;
             padding-top: 0px;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="Slider3"
     >
@@ -1092,6 +1135,13 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
               width: 40px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         0%
       </label>
@@ -1135,6 +1185,13 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
             padding-right: 0px;
             padding-top: 0px;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="Slider4"
     >
@@ -1411,6 +1468,13 @@ exports[`Component Examples renders Slider.Vertical.Example.tsx correctly 1`] = 
               white-space: nowrap;
               width: 40px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         5

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Basic.Example.tsx.shot
@@ -77,6 +77,13 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
               pointer-events: none;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         htmlFor="input1"
         id="Label0"
       >
@@ -506,6 +513,13 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
               padding-top: 5px;
               pointer-events: none;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         htmlFor="input9"
         id="Label8"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
@@ -56,7 +56,11 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
               word-wrap: break-word;
             }
             @media screen and (-ms-high-contrast: active){& {
+              background: Window;
               color: GrayText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         htmlFor="input1"
         id="Label0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithEndPosition.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithEndPosition.Example.tsx.shot
@@ -77,6 +77,13 @@ exports[`Component Examples renders SpinButton.BasicWithEndPosition.Example.tsx 
               pointer-events: none;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         htmlFor="input1"
         id="Label0"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIcon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIcon.Example.tsx.shot
@@ -77,6 +77,13 @@ exports[`Component Examples renders SpinButton.BasicWithIcon.Example.tsx correct
               pointer-events: none;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         htmlFor="input1"
         id="Label0"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
@@ -79,7 +79,11 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
               word-wrap: break-word;
             }
             @media screen and (-ms-high-contrast: active){& {
+              background: Window;
               color: GrayText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
         htmlFor="input1"
         id="Label0"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.CustomStyled.Example.tsx.shot
@@ -49,6 +49,13 @@ exports[`Component Examples renders SpinButton.CustomStyled.Example.tsx correctl
               pointer-events: none;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         htmlFor="input1"
         id="Label0"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Stateful.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Stateful.Example.tsx.shot
@@ -55,6 +55,13 @@ exports[`Component Examples renders SpinButton.Stateful.Example.tsx correctly 1`
               pointer-events: none;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         htmlFor="input1"
         id="Label0"
       >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Spinner.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Spinner.Basic.Example.tsx.shot
@@ -68,6 +68,13 @@ exports[`Component Examples renders Spinner.Basic.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
     >
       Extra small spinner
     </label>
@@ -148,6 +155,13 @@ exports[`Component Examples renders Spinner.Basic.Example.tsx correctly 1`] = `
             padding-right: 0;
             padding-top: 5px;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
     >
       Small spinner
@@ -230,6 +244,13 @@ exports[`Component Examples renders Spinner.Basic.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
     >
       Medium spinner
     </label>
@@ -310,6 +331,13 @@ exports[`Component Examples renders Spinner.Basic.Example.tsx correctly 1`] = `
             padding-right: 0;
             padding-top: 5px;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
     >
       Large spinner

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Spinner.Labeled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Spinner.Labeled.Example.tsx.shot
@@ -48,6 +48,13 @@ exports[`Component Examples renders Spinner.Labeled.Example.tsx correctly 1`] = 
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
     >
       Spinner with label positioned below
     </label>
@@ -126,6 +133,13 @@ exports[`Component Examples renders Spinner.Labeled.Example.tsx correctly 1`] = 
             padding-right: 0;
             padding-top: 5px;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
     >
       Spinner with label positioned above
@@ -206,6 +220,13 @@ exports[`Component Examples renders Spinner.Labeled.Example.tsx correctly 1`] = 
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
     >
       Spinner with label positioned to right
     </label>
@@ -284,6 +305,13 @@ exports[`Component Examples renders Spinner.Labeled.Example.tsx correctly 1`] = 
             padding-right: 0;
             padding-top: 5px;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
     >
       Spinner with label positioned to left

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Configure.Example.tsx.shot
@@ -116,6 +116,13 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   padding-top: 0px;
                   word-wrap: break-word;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
             htmlFor="Slider0"
           >
             Number of items:
@@ -334,6 +341,13 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     width: 40px;
                     word-wrap: break-word;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               5
             </label>
@@ -388,8 +402,14 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 &:hover .ms-Checkbox-text {
                   color: #201f1e;
                 }
+                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                  color: WindowText;
+                }
                 &:focus .ms-Checkbox-text {
                   color: #201f1e;
+                }
+                @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                  color: WindowText;
                 }
           >
             <input
@@ -463,6 +483,12 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                       transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                       width: 20px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border-color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 <i
                   aria-hidden={true}
@@ -498,6 +524,12 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                       line-height: 20px;
                       margin-left: 4px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 Shadow around items
               </span>
@@ -530,8 +562,14 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 &:hover .ms-Checkbox-text {
                   color: #201f1e;
                 }
+                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                  color: WindowText;
+                }
                 &:focus .ms-Checkbox-text {
                   color: #201f1e;
+                }
+                @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                  color: WindowText;
                 }
           >
             <input
@@ -605,6 +643,12 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                       transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                       width: 20px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border-color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 <i
                   aria-hidden={true}
@@ -639,6 +683,12 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                       font-size: 14px;
                       line-height: 20px;
                       margin-left: 4px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
                     }
               >
                 Prevent item overflow
@@ -732,8 +782,14 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 &:hover .ms-Checkbox-text {
                   color: #201f1e;
                 }
+                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                  color: WindowText;
+                }
                 &:focus .ms-Checkbox-text {
                   color: #201f1e;
+                }
+                @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                  color: WindowText;
                 }
           >
             <input
@@ -807,6 +863,12 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                       transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                       width: 20px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border-color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 <i
                   aria-hidden={true}
@@ -842,6 +904,12 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                       line-height: 20px;
                       margin-left: 4px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 Wrap items
               </span>
@@ -874,8 +942,14 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 &:hover .ms-Checkbox-text {
                   color: #201f1e;
                 }
+                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                  color: WindowText;
+                }
                 &:focus .ms-Checkbox-text {
                   color: #201f1e;
+                }
+                @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                  color: WindowText;
                 }
           >
             <input
@@ -949,6 +1023,12 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                       transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                       width: 20px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border-color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 <i
                   aria-hidden={true}
@@ -983,6 +1063,12 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                       font-size: 14px;
                       line-height: 20px;
                       margin-left: 4px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
                     }
               >
                 Shrink items
@@ -1041,6 +1127,13 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     padding-right: 0px;
                     padding-top: 0px;
                     word-wrap: break-word;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
               htmlFor="Slider5"
             >
@@ -1260,6 +1353,13 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                       width: 40px;
                       word-wrap: break-word;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 100
               </label>
@@ -1362,6 +1462,13 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   padding-right: 0px;
                   padding-top: 0px;
                   word-wrap: break-word;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
             htmlFor="Slider6"
           >
@@ -1581,6 +1688,13 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     width: 40px;
                     word-wrap: break-word;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               0
             </label>
@@ -1623,6 +1737,13 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   padding-right: 0px;
                   padding-top: 0px;
                   word-wrap: break-word;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
             htmlFor="Slider7"
           >
@@ -1842,6 +1963,13 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     width: 40px;
                     word-wrap: break-word;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               0
             </label>
@@ -1921,6 +2049,13 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   padding-right: 0px;
                   padding-top: 0px;
                   word-wrap: break-word;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
             htmlFor="Slider8"
           >
@@ -2140,6 +2275,13 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     width: 40px;
                     word-wrap: break-word;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               0
             </label>
@@ -2182,6 +2324,13 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   padding-right: 0px;
                   padding-top: 0px;
                   word-wrap: break-word;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
             htmlFor="Slider9"
           >
@@ -2401,6 +2550,13 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     width: 40px;
                     word-wrap: break-word;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               0
             </label>
@@ -2480,6 +2636,13 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   padding-right: 0px;
                   padding-top: 0px;
                   word-wrap: break-word;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
             htmlFor="Slider10"
           >
@@ -2699,6 +2862,13 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     width: 40px;
                     word-wrap: break-word;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               0
             </label>
@@ -2741,6 +2911,13 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   padding-right: 0px;
                   padding-top: 0px;
                   word-wrap: break-word;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
             htmlFor="Slider11"
           >
@@ -2960,6 +3137,13 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     width: 40px;
                     word-wrap: break-word;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               0
             </label>
@@ -3033,6 +3217,13 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 padding-right: 0;
                 padding-top: 5px;
                 word-wrap: break-word;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
           id="Dropdown12-label"
         >
@@ -3260,6 +3451,13 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           id="Dropdown13-label"
         >
           Vertical alignment:
@@ -3483,8 +3681,14 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
             &:hover .ms-Checkbox-text {
               color: #201f1e;
             }
+            @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+              color: WindowText;
+            }
             &:focus .ms-Checkbox-text {
               color: #201f1e;
+            }
+            @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+              color: WindowText;
             }
       >
         <input
@@ -3558,6 +3762,12 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                   width: 20px;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  border-color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             <i
               aria-hidden={true}
@@ -3592,6 +3802,12 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   font-size: 14px;
                   line-height: 20px;
                   margin-left: 4px;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
           >
             Hide empty children
@@ -3664,6 +3880,13 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   padding-top: 5px;
                   word-wrap: break-word;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
             htmlFor="TextField15"
             id="TextFieldLabel17"
           >
@@ -3698,6 +3921,9 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                 }
                 @media screen and (-ms-high-contrast: active){&:hover {
                   border-color: Highlight;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                  forced-color-adjust: none;
                 }
           >
             <input
@@ -3743,6 +3969,10 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                   &::-ms-clear {
                     display: none;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
                   &::placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -3751,6 +3981,9 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::placeholder {
+                    color: GrayText;
                   }
                   &:-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
@@ -3761,6 +3994,9 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     font-weight: 400;
                     opacity: 1;
                   }
+                  @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                    color: GrayText;
+                  }
                   &::-ms-input-placeholder {
                     -moz-osx-font-smoothing: grayscale;
                     -webkit-font-smoothing: antialiased;
@@ -3769,6 +4005,9 @@ exports[`Component Examples renders Stack.Horizontal.Configure.Example.tsx corre
                     font-size: 14px;
                     font-weight: 400;
                     opacity: 1;
+                  }
+                  @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                    color: GrayText;
                   }
               id="TextField15"
               onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Shrink.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Shrink.Example.tsx.shot
@@ -60,6 +60,13 @@ exports[`Component Examples renders Stack.Horizontal.Shrink.Example.tsx correctl
             padding-top: 0px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       htmlFor="Slider0"
     >
       Change the stack width to see how child items shrink:
@@ -277,6 +284,13 @@ exports[`Component Examples renders Stack.Horizontal.Shrink.Example.tsx correctl
               white-space: nowrap;
               width: 40px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         100

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Wrap.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.Wrap.Example.tsx.shot
@@ -60,6 +60,13 @@ exports[`Component Examples renders Stack.Horizontal.Wrap.Example.tsx correctly 
             padding-top: 0px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       htmlFor="Slider0"
     >
       Change the stack width to see how child items wrap onto multiple rows:
@@ -277,6 +284,13 @@ exports[`Component Examples renders Stack.Horizontal.Wrap.Example.tsx correctly 
               white-space: nowrap;
               width: 40px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         100

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapAdvanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapAdvanced.Example.tsx.shot
@@ -96,6 +96,13 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
                 padding-top: 0px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           htmlFor="Slider0"
         >
           Stack width:
@@ -314,6 +321,13 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
                   width: 40px;
                   word-wrap: break-word;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             100
           </label>
@@ -372,6 +386,13 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
                 padding-right: 0px;
                 padding-top: 0px;
                 word-wrap: break-word;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
           htmlFor="Slider1"
         >
@@ -591,6 +612,13 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
                   width: 40px;
                   word-wrap: break-word;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             150
           </label>
@@ -663,6 +691,13 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
                 padding-right: 0;
                 padding-top: 5px;
                 word-wrap: break-word;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
           id="Dropdown2-label"
         >
@@ -891,6 +926,13 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           id="Dropdown3-label"
         >
           Vertical alignment:
@@ -1117,6 +1159,13 @@ exports[`Component Examples renders Stack.Horizontal.WrapAdvanced.Example.tsx co
                 padding-right: 0;
                 padding-top: 5px;
                 word-wrap: break-word;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
           id="Dropdown4-label"
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapNested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Horizontal.WrapNested.Example.tsx.shot
@@ -60,6 +60,13 @@ exports[`Component Examples renders Stack.Horizontal.WrapNested.Example.tsx corr
             padding-top: 0px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       htmlFor="Slider0"
     >
       Change the stack width to see how child items wrap onto multiple rows:
@@ -277,6 +284,13 @@ exports[`Component Examples renders Stack.Horizontal.WrapNested.Example.tsx corr
               white-space: nowrap;
               width: 40px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         100

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Configure.Example.tsx.shot
@@ -117,6 +117,13 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   padding-top: 0px;
                   word-wrap: break-word;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
             htmlFor="Slider0"
           >
             Number of items:
@@ -335,6 +342,13 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     width: 40px;
                     word-wrap: break-word;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               5
             </label>
@@ -389,8 +403,14 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 &:hover .ms-Checkbox-text {
                   color: #201f1e;
                 }
+                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                  color: WindowText;
+                }
                 &:focus .ms-Checkbox-text {
                   color: #201f1e;
+                }
+                @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                  color: WindowText;
                 }
           >
             <input
@@ -464,6 +484,12 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                       width: 20px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border-color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 <i
                   aria-hidden={true}
@@ -499,6 +525,12 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       line-height: 20px;
                       margin-left: 4px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 Shadow around items
               </span>
@@ -532,8 +564,14 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 &:hover .ms-Checkbox-text {
                   color: #201f1e;
                 }
+                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                  color: WindowText;
+                }
                 &:focus .ms-Checkbox-text {
                   color: #201f1e;
+                }
+                @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                  color: WindowText;
                 }
           >
             <input
@@ -607,6 +645,12 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                       width: 20px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border-color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 <i
                   aria-hidden={true}
@@ -642,6 +686,12 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       line-height: 20px;
                       margin-left: 4px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 Prevent item overflow
               </span>
@@ -675,8 +725,14 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 &:hover .ms-Checkbox-text {
                   color: #201f1e;
                 }
+                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                  color: WindowText;
+                }
                 &:focus .ms-Checkbox-text {
                   color: #201f1e;
+                }
+                @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                  color: WindowText;
                 }
           >
             <input
@@ -750,6 +806,12 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                       width: 20px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border-color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 <i
                   aria-hidden={true}
@@ -785,6 +847,12 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       line-height: 20px;
                       margin-left: 4px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 Shrink items
               </span>
@@ -817,8 +885,14 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 &:hover .ms-Checkbox-text {
                   color: #201f1e;
                 }
+                @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                  color: WindowText;
+                }
                 &:focus .ms-Checkbox-text {
                   color: #201f1e;
+                }
+                @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                  color: WindowText;
                 }
           >
             <input
@@ -892,6 +966,12 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                       width: 20px;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      border-color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
               >
                 <i
                   aria-hidden={true}
@@ -926,6 +1006,12 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       font-size: 14px;
                       line-height: 20px;
                       margin-left: 4px;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
                     }
               >
                 Wrap items
@@ -1010,7 +1096,11 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   word-wrap: break-word;
                 }
                 @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
                   color: GrayText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
             htmlFor="Slider5"
           >
@@ -1184,7 +1274,11 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     word-wrap: break-word;
                   }
                   @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
                     color: GrayText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
             >
               200
@@ -1208,10 +1302,6 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                 background: #005a9e;
                 border-color: #005a9e;
               }
-              & .ms-Checkbox-checkbox {
-                background: #0078d4;
-                border-color: #0078d4;
-              }
               @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-checkbox {
                 background: Window;
                 border-color: Highlight;
@@ -1231,8 +1321,14 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
               &:hover .ms-Checkbox-text {
                 color: #201f1e;
               }
+              @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                color: WindowText;
+              }
               &:focus .ms-Checkbox-text {
                 color: #201f1e;
+              }
+              @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                color: WindowText;
               }
         >
           <input
@@ -1312,6 +1408,9 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     background: Highlight;
                     border-color: Highlight;
                   }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               <i
                 aria-hidden={true}
@@ -1346,6 +1445,12 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     font-size: 14px;
                     line-height: 20px;
                     margin-left: 4px;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
             >
               Automatic height (based on items)
@@ -1449,6 +1554,13 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   padding-right: 0px;
                   padding-top: 0px;
                   word-wrap: break-word;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
             htmlFor="Slider7"
           >
@@ -1668,6 +1780,13 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     width: 40px;
                     word-wrap: break-word;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               0
             </label>
@@ -1739,6 +1858,13 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       padding-right: 0;
                       padding-top: 5px;
                       word-wrap: break-word;
+                    }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
                     }
                 id="Dropdown8-label"
               >
@@ -1967,6 +2093,13 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       padding-top: 5px;
                       word-wrap: break-word;
                     }
+                    @media screen and (-ms-high-contrast: active){& {
+                      background: Window;
+                      color: WindowText;
+                    }
+                    @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                      forced-color-adjust: none;
+                    }
                 id="Dropdown9-label"
               >
                 Horizontal alignment:
@@ -2190,8 +2323,14 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   &:hover .ms-Checkbox-text {
                     color: #201f1e;
                   }
+                  @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+                    color: WindowText;
+                  }
                   &:focus .ms-Checkbox-text {
                     color: #201f1e;
+                  }
+                  @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+                    color: WindowText;
                   }
             >
               <input
@@ -2265,6 +2404,12 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                         transition-timing-function: cubic-bezier(.4, 0, .23, 1);
                         width: 20px;
                       }
+                      @media screen and (-ms-high-contrast: active){& {
+                        border-color: WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                 >
                   <i
                     aria-hidden={true}
@@ -2299,6 +2444,12 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                         font-size: 14px;
                         line-height: 20px;
                         margin-left: 4px;
+                      }
+                      @media screen and (-ms-high-contrast: active){& {
+                        color: WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                        forced-color-adjust: none;
                       }
                 >
                   Hide empty children
@@ -2372,6 +2523,13 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                         padding-top: 5px;
                         word-wrap: break-word;
                       }
+                      @media screen and (-ms-high-contrast: active){& {
+                        background: Window;
+                        color: WindowText;
+                      }
+                      @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                        forced-color-adjust: none;
+                      }
                   htmlFor="TextField11"
                   id="TextFieldLabel13"
                 >
@@ -2406,6 +2564,9 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                       }
                       @media screen and (-ms-high-contrast: active){&:hover {
                         border-color: Highlight;
+                      }
+                      @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                        forced-color-adjust: none;
                       }
                 >
                   <input
@@ -2451,6 +2612,10 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                         &::-ms-clear {
                           display: none;
                         }
+                        @media screen and (-ms-high-contrast: active){& {
+                          background: Window;
+                          color: WindowText;
+                        }
                         &::placeholder {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
@@ -2459,6 +2624,9 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                           font-size: 14px;
                           font-weight: 400;
                           opacity: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active){&::placeholder {
+                          color: GrayText;
                         }
                         &:-ms-input-placeholder {
                           -moz-osx-font-smoothing: grayscale;
@@ -2469,6 +2637,9 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                           font-weight: 400;
                           opacity: 1;
                         }
+                        @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                          color: GrayText;
+                        }
                         &::-ms-input-placeholder {
                           -moz-osx-font-smoothing: grayscale;
                           -webkit-font-smoothing: antialiased;
@@ -2477,6 +2648,9 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                           font-size: 14px;
                           font-weight: 400;
                           opacity: 1;
+                        }
+                        @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                          color: GrayText;
                         }
                     id="TextField11"
                     onBlur={[Function]}
@@ -2566,6 +2740,13 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   padding-right: 0px;
                   padding-top: 0px;
                   word-wrap: break-word;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
             htmlFor="Slider14"
           >
@@ -2785,6 +2966,13 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     width: 40px;
                     word-wrap: break-word;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               0
             </label>
@@ -2827,6 +3015,13 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   padding-right: 0px;
                   padding-top: 0px;
                   word-wrap: break-word;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
             htmlFor="Slider15"
           >
@@ -3046,6 +3241,13 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     width: 40px;
                     word-wrap: break-word;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               0
             </label>
@@ -3126,6 +3328,13 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   padding-right: 0px;
                   padding-top: 0px;
                   word-wrap: break-word;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
             htmlFor="Slider16"
           >
@@ -3345,6 +3554,13 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     width: 40px;
                     word-wrap: break-word;
                   }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
+                  }
             >
               0
             </label>
@@ -3387,6 +3603,13 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                   padding-right: 0px;
                   padding-top: 0px;
                   word-wrap: break-word;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
                 }
             htmlFor="Slider17"
           >
@@ -3605,6 +3828,13 @@ exports[`Component Examples renders Stack.Vertical.Configure.Example.tsx correct
                     white-space: nowrap;
                     width: 40px;
                     word-wrap: break-word;
+                  }
+                  @media screen and (-ms-high-contrast: active){& {
+                    background: Window;
+                    color: WindowText;
+                  }
+                  @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                    forced-color-adjust: none;
                   }
             >
               0

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Shrink.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Shrink.Example.tsx.shot
@@ -60,6 +60,13 @@ exports[`Component Examples renders Stack.Vertical.Shrink.Example.tsx correctly 
             padding-top: 0px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       htmlFor="Slider0"
     >
       Change the stack height to see how child items shrink:
@@ -277,6 +284,13 @@ exports[`Component Examples renders Stack.Vertical.Shrink.Example.tsx correctly 
               white-space: nowrap;
               width: 40px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         100

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Wrap.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.Wrap.Example.tsx.shot
@@ -60,6 +60,13 @@ exports[`Component Examples renders Stack.Vertical.Wrap.Example.tsx correctly 1`
             padding-top: 0px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       htmlFor="Slider0"
     >
       Change the stack height to see how child items wrap onto multiple columns:
@@ -277,6 +284,13 @@ exports[`Component Examples renders Stack.Vertical.Wrap.Example.tsx correctly 1`
               white-space: nowrap;
               width: 40px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         420

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapAdvanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapAdvanced.Example.tsx.shot
@@ -96,6 +96,13 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
                 padding-top: 0px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           htmlFor="Slider0"
         >
           Stack height:
@@ -314,6 +321,13 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
                   width: 40px;
                   word-wrap: break-word;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             420
           </label>
@@ -372,6 +386,13 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
                 padding-right: 0px;
                 padding-top: 0px;
                 word-wrap: break-word;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
           htmlFor="Slider1"
         >
@@ -591,6 +612,13 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
                   width: 40px;
                   word-wrap: break-word;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
           >
             100
           </label>
@@ -663,6 +691,13 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
                 padding-right: 0;
                 padding-top: 5px;
                 word-wrap: break-word;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
           id="Dropdown2-label"
         >
@@ -891,6 +926,13 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           id="Dropdown3-label"
         >
           Vertical alignment:
@@ -1117,6 +1159,13 @@ exports[`Component Examples renders Stack.Vertical.WrapAdvanced.Example.tsx corr
                 padding-right: 0;
                 padding-top: 5px;
                 word-wrap: break-word;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
           id="Dropdown4-label"
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapNested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Stack.Vertical.WrapNested.Example.tsx.shot
@@ -60,6 +60,13 @@ exports[`Component Examples renders Stack.Vertical.WrapNested.Example.tsx correc
             padding-top: 0px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       htmlFor="Slider0"
     >
       Change the stack height to see how child items wrap onto multiple columns:
@@ -277,6 +284,13 @@ exports[`Component Examples renders Stack.Vertical.WrapNested.Example.tsx correc
               white-space: nowrap;
               width: 40px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         420

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -39,8 +39,14 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
         &:hover .ms-Checkbox-text {
           color: #201f1e;
         }
+        @media screen and (-ms-high-contrast: active){&:hover .ms-Checkbox-text {
+          color: WindowText;
+        }
         &:focus .ms-Checkbox-text {
           color: #201f1e;
+        }
+        @media screen and (-ms-high-contrast: active){&:focus .ms-Checkbox-text {
+          color: WindowText;
         }
   >
     <input
@@ -114,6 +120,12 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
               transition-timing-function: cubic-bezier(.4, 0, .23, 1);
               width: 20px;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              border-color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <i
           aria-hidden={true}
@@ -148,6 +160,12 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
               font-size: 14px;
               line-height: 20px;
               margin-left: 4px;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
       >
         Disable Tag Picker

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Basic.Example.tsx.shot
@@ -94,6 +94,13 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           htmlFor="TextField0"
           id="TextFieldLabel2"
         >
@@ -128,6 +135,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
               }
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
               }
         >
           <input
@@ -173,6 +183,10 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -181,6 +195,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -191,6 +208,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -199,6 +219,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="TextField0"
             onBlur={[Function]}
@@ -264,7 +287,11 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 word-wrap: break-word;
               }
               @media screen and (-ms-high-contrast: active){& {
+                background: Window;
                 color: GrayText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
           htmlFor="TextField3"
           id="TextFieldLabel5"
@@ -298,6 +325,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
               }
               @media screen and (-ms-high-contrast: active){& {
                 border-color: GrayText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           <input
@@ -344,6 +374,10 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: GrayText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -352,6 +386,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -362,6 +399,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -370,6 +410,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             disabled={true}
             id="TextField3"
@@ -434,6 +477,13 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           htmlFor="TextField6"
           id="TextFieldLabel8"
         >
@@ -468,6 +518,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
               }
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
               }
         >
           <input
@@ -513,6 +566,10 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -521,6 +578,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -531,6 +591,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -539,6 +602,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="TextField6"
             onBlur={[Function]}
@@ -604,10 +670,20 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
               &::after {
                 color: #a4262c;
                 content: ' *';
                 padding-right: 12px;
+              }
+              @media screen and (-ms-high-contrast: active){&::after {
+                color: WindowText;
               }
           htmlFor="TextField9"
           id="TextFieldLabel11"
@@ -643,6 +719,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
               }
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
               }
         >
           <input
@@ -688,6 +767,10 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -696,6 +779,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -706,6 +792,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -714,6 +803,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="TextField9"
             onBlur={[Function]}
@@ -785,6 +877,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
               }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
+              }
               &:before {
                 color: #a4262c;
                 content: '*';
@@ -793,6 +888,7 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 top: -5px;
               }
               @media screen and (-ms-high-contrast: active){&:before {
+                color: WindowText;
                 right: -14px;
               }
         >
@@ -839,6 +935,10 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -847,6 +947,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -857,6 +960,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -865,6 +971,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="TextField12"
             onBlur={[Function]}
@@ -929,6 +1038,13 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           htmlFor="TextField15"
           id="TextFieldLabel17"
         >
@@ -964,6 +1080,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
               }
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
               }
         >
           <input
@@ -1010,6 +1129,10 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -1018,6 +1141,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -1028,6 +1154,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -1036,6 +1165,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="TextField15"
             onBlur={[Function]}
@@ -1128,6 +1260,13 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           htmlFor="TextField18"
           id="TextFieldLabel20"
         >
@@ -1162,6 +1301,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
               }
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
               }
         >
           <input
@@ -1207,6 +1349,10 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -1215,6 +1361,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -1225,6 +1374,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -1233,6 +1385,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="TextField18"
             onBlur={[Function]}
@@ -1300,6 +1455,13 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           htmlFor="TextField21"
           id="TextFieldLabel23"
         >
@@ -1334,6 +1496,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
               }
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
               }
         >
           <input
@@ -1379,6 +1544,10 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -1387,6 +1556,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -1397,6 +1569,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -1405,6 +1580,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="TextField21"
             onBlur={[Function]}
@@ -1492,6 +1670,13 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           htmlFor="TextField24"
           id="TextFieldLabel26"
         >
@@ -1526,6 +1711,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
               }
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
               }
         >
           <input
@@ -1571,6 +1759,10 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -1579,6 +1771,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -1589,6 +1784,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -1597,6 +1795,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="TextField24"
             onBlur={[Function]}
@@ -1663,7 +1864,11 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 word-wrap: break-word;
               }
               @media screen and (-ms-high-contrast: active){& {
+                background: Window;
                 color: GrayText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
           htmlFor="TextField27"
           id="TextFieldLabel29"
@@ -1697,6 +1902,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
               }
               @media screen and (-ms-high-contrast: active){& {
                 border-color: GrayText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           <input
@@ -1743,6 +1951,10 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: GrayText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -1751,6 +1963,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -1761,6 +1976,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -1769,6 +1987,9 @@ exports[`Component Examples renders TextField.Basic.Example.tsx correctly 1`] = 
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             disabled={true}
             id="TextField27"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Borderless.Example.tsx.shot
@@ -80,6 +80,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
             @media screen and (-ms-high-contrast: active){&:hover {
               border-bottom-color: Highlight;
             }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+              forced-color-adjust: none;
+            }
       >
         <label
           className=
@@ -106,6 +109,13 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 padding-right: 0px;
                 padding-top: 5px;
                 word-wrap: break-word;
+              }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
           htmlFor="TextField0"
           id="TextFieldLabel2"
@@ -143,6 +153,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
               }
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
               }
         >
           <input
@@ -189,6 +202,10 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -197,6 +214,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -207,6 +227,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -215,6 +238,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="TextField0"
             onBlur={[Function]}
@@ -263,6 +289,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
             @media screen and (-ms-high-contrast: active){& {
               border-color: GrayText;
             }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
       >
         <label
           className=
@@ -291,7 +320,11 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 word-wrap: break-word;
               }
               @media screen and (-ms-high-contrast: active){& {
+                background: Window;
                 color: GrayText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
           htmlFor="TextField3"
           id="TextFieldLabel5"
@@ -328,6 +361,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
               }
               @media screen and (-ms-high-contrast: active){& {
                 border-color: GrayText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           <input
@@ -375,6 +411,10 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: GrayText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -383,6 +423,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -393,6 +436,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -401,6 +447,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             disabled={true}
             id="TextField3"
@@ -452,6 +501,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
             @media screen and (-ms-high-contrast: active){&:hover {
               border-bottom-color: Highlight;
             }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+              forced-color-adjust: none;
+            }
       >
         <label
           className=
@@ -479,10 +531,20 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
               &::after {
                 color: #a4262c;
                 content: ' *';
                 padding-right: 12px;
+              }
+              @media screen and (-ms-high-contrast: active){&::after {
+                color: WindowText;
               }
           htmlFor="TextField6"
           id="TextFieldLabel8"
@@ -520,6 +582,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
               }
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
               }
         >
           <input
@@ -566,6 +631,10 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -574,6 +643,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -584,6 +656,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -592,6 +667,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="TextField6"
             onBlur={[Function]}
@@ -680,6 +758,13 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           htmlFor="TextField9"
           id="TextFieldLabel11"
         >
@@ -714,6 +799,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
               }
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
               }
         >
           <input
@@ -759,6 +847,10 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -767,6 +859,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -777,6 +872,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -785,6 +883,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="TextField9"
             onBlur={[Function]}
@@ -851,6 +952,13 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           htmlFor="TextField12"
           id="TextFieldLabel14"
         >
@@ -886,6 +994,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
               }
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
               }
         >
           <textarea
@@ -935,6 +1046,10 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -943,6 +1058,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -953,6 +1071,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -961,6 +1082,9 @@ exports[`Component Examples renders TextField.Borderless.Example.tsx correctly 1
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="TextField12"
             onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Controlled.Example.tsx.shot
@@ -73,6 +73,13 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         htmlFor="TextField0"
         id="TextFieldLabel2"
       >
@@ -108,6 +115,9 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
             }
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+              forced-color-adjust: none;
             }
       >
         <input
@@ -153,6 +163,10 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
               &::-ms-clear {
                 display: none;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -161,6 +175,9 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::placeholder {
+                color: GrayText;
               }
               &:-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
@@ -171,6 +188,9 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
                 font-weight: 400;
                 opacity: 1;
               }
+              @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                color: GrayText;
+              }
               &::-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -179,6 +199,9 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                color: GrayText;
               }
           id="TextField0"
           onBlur={[Function]}
@@ -242,6 +265,13 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         htmlFor="TextField3"
         id="TextFieldLabel5"
       >
@@ -277,6 +307,9 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
             }
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+              forced-color-adjust: none;
             }
       >
         <input
@@ -322,6 +355,10 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
               &::-ms-clear {
                 display: none;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -330,6 +367,9 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::placeholder {
+                color: GrayText;
               }
               &:-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
@@ -340,6 +380,9 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
                 font-weight: 400;
                 opacity: 1;
               }
+              @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                color: GrayText;
+              }
               &::-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -348,6 +391,9 @@ exports[`Component Examples renders TextField.Controlled.Example.tsx correctly 1
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                color: GrayText;
               }
           id="TextField3"
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
@@ -242,6 +242,9 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+              forced-color-adjust: none;
+            }
       >
         <input
           aria-describedby="TextFieldDescription4"
@@ -287,6 +290,10 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
               &::-ms-clear {
                 display: none;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -295,6 +302,9 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::placeholder {
+                color: GrayText;
               }
               &:-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
@@ -305,6 +315,9 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                 font-weight: 400;
                 opacity: 1;
               }
+              @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                color: GrayText;
+              }
               &::-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -313,6 +326,9 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                color: GrayText;
               }
           id="TextField3"
           onBlur={[Function]}
@@ -414,6 +430,13 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                   padding-top: 5px;
                   word-wrap: break-word;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
+                @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                  forced-color-adjust: none;
+                }
             htmlFor="TextField9"
             id="TextFieldLabel11"
           >
@@ -470,6 +493,9 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
             }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+              forced-color-adjust: none;
+            }
       >
         <input
           aria-invalid={false}
@@ -514,6 +540,10 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
               &::-ms-clear {
                 display: none;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -522,6 +552,9 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::placeholder {
+                color: GrayText;
               }
               &:-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
@@ -532,6 +565,9 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                 font-weight: 400;
                 opacity: 1;
               }
+              @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                color: GrayText;
+              }
               &::-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -540,6 +576,9 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                color: GrayText;
               }
           id="TextField9"
           onBlur={[Function]}
@@ -603,6 +642,13 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         htmlFor="TextField12"
         id="TextFieldLabel14"
       >
@@ -637,6 +683,9 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
             }
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+              forced-color-adjust: none;
             }
       >
         <input
@@ -683,6 +732,10 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
               &::-ms-clear {
                 display: none;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -691,6 +744,9 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::placeholder {
+                color: GrayText;
               }
               &:-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
@@ -701,6 +757,9 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                 font-weight: 400;
                 opacity: 1;
               }
+              @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                color: GrayText;
+              }
               &::-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -709,6 +768,9 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                color: GrayText;
               }
           id="TextField12"
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.ErrorMessage.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.ErrorMessage.Example.tsx.shot
@@ -65,6 +65,13 @@ exports[`Component Examples renders TextField.ErrorMessage.Example.tsx correctly
             word-break: break-all;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       htmlFor="Toggle0"
       id="Toggle0-label"
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Masked.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Masked.Example.tsx.shot
@@ -77,6 +77,13 @@ exports[`Component Examples renders TextField.Masked.Example.tsx correctly 1`] =
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
         htmlFor="TextField0"
         id="TextFieldLabel2"
       >
@@ -111,6 +118,9 @@ exports[`Component Examples renders TextField.Masked.Example.tsx correctly 1`] =
             }
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+              forced-color-adjust: none;
             }
       >
         <input
@@ -156,6 +166,10 @@ exports[`Component Examples renders TextField.Masked.Example.tsx correctly 1`] =
               &::-ms-clear {
                 display: none;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -164,6 +178,9 @@ exports[`Component Examples renders TextField.Masked.Example.tsx correctly 1`] =
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::placeholder {
+                color: GrayText;
               }
               &:-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
@@ -174,6 +191,9 @@ exports[`Component Examples renders TextField.Masked.Example.tsx correctly 1`] =
                 font-weight: 400;
                 opacity: 1;
               }
+              @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                color: GrayText;
+              }
               &::-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -182,6 +202,9 @@ exports[`Component Examples renders TextField.Masked.Example.tsx correctly 1`] =
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                color: GrayText;
               }
           id="TextField0"
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Multiline.Example.tsx.shot
@@ -95,6 +95,13 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           htmlFor="TextField0"
           id="TextFieldLabel2"
         >
@@ -130,6 +137,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
               }
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
               }
         >
           <textarea
@@ -179,6 +189,10 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -187,6 +201,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -197,6 +214,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -205,6 +225,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="TextField0"
             onBlur={[Function]}
@@ -271,7 +294,11 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 word-wrap: break-word;
               }
               @media screen and (-ms-high-contrast: active){& {
+                background: Window;
                 color: GrayText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
           htmlFor="TextField3"
           id="TextFieldLabel5"
@@ -306,6 +333,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
               }
               @media screen and (-ms-high-contrast: active){& {
                 border-color: GrayText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
         >
           <textarea
@@ -356,6 +386,10 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: GrayText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -364,6 +398,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -374,6 +411,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -382,6 +422,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             disabled={true}
             id="TextField3"
@@ -447,6 +490,13 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           htmlFor="TextField6"
           id="TextFieldLabel8"
         >
@@ -482,6 +532,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
               }
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
               }
         >
           <textarea
@@ -533,6 +586,10 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -541,6 +598,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -551,6 +611,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -559,6 +622,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="TextField6"
             onBlur={[Function]}
@@ -644,6 +710,13 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           htmlFor="TextField9"
           id="TextFieldLabel11"
         >
@@ -679,6 +752,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
               }
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
               }
         >
           <textarea
@@ -728,6 +804,10 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -736,6 +816,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -746,6 +829,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -754,6 +840,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="TextField9"
             onBlur={[Function]}
@@ -816,6 +905,13 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           htmlFor="TextField12"
           id="TextFieldLabel14"
         >
@@ -850,6 +946,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
               }
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
               }
         >
           <input
@@ -895,6 +994,10 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -903,6 +1006,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -913,6 +1019,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -921,6 +1030,9 @@ exports[`Component Examples renders TextField.Multiline.Example.tsx correctly 1`
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="TextField12"
             onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.PrefixAndSuffix.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.PrefixAndSuffix.Example.tsx.shot
@@ -94,6 +94,13 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           htmlFor="TextField0"
           id="TextFieldLabel2"
         >
@@ -129,6 +136,9 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
               }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
+              }
         >
           <div
             className=
@@ -145,6 +155,10 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   padding-right: 10px;
                   padding-top: 0;
                   white-space: nowrap;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
                 }
           >
             <span
@@ -201,6 +215,10 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -209,6 +227,9 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -219,6 +240,9 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -227,6 +251,9 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="TextField0"
             onBlur={[Function]}
@@ -292,7 +319,11 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                 word-wrap: break-word;
               }
               @media screen and (-ms-high-contrast: active){& {
+                background: Window;
                 color: GrayText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
               }
           htmlFor="TextField3"
           id="TextFieldLabel5"
@@ -327,6 +358,9 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
               @media screen and (-ms-high-contrast: active){& {
                 border-color: GrayText;
               }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
         >
           <div
             className=
@@ -343,6 +377,10 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   padding-right: 10px;
                   padding-top: 0;
                   white-space: nowrap;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: GrayText;
                 }
           >
             <span
@@ -400,6 +438,10 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: GrayText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -408,6 +450,9 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -418,6 +463,9 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -426,6 +474,9 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             disabled={true}
             id="TextField3"
@@ -512,6 +563,13 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           htmlFor="TextField6"
           id="TextFieldLabel8"
         >
@@ -546,6 +604,9 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
               }
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
               }
         >
           <input
@@ -592,6 +653,10 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -600,6 +665,9 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -610,6 +678,9 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -618,6 +689,9 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="TextField6"
             onBlur={[Function]}
@@ -642,6 +716,10 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   padding-right: 10px;
                   padding-top: 0;
                   white-space: nowrap;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
                 }
           >
             <span
@@ -708,6 +786,13 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                 padding-top: 5px;
                 word-wrap: break-word;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+                forced-color-adjust: none;
+              }
           htmlFor="TextField9"
           id="TextFieldLabel11"
         >
@@ -743,6 +828,9 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
               @media screen and (-ms-high-contrast: active){&:hover {
                 border-color: Highlight;
               }
+              @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+                forced-color-adjust: none;
+              }
         >
           <div
             className=
@@ -759,6 +847,10 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   padding-right: 10px;
                   padding-top: 0;
                   white-space: nowrap;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
                 }
           >
             <span
@@ -815,6 +907,10 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                 &::-ms-clear {
                   display: none;
                 }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
+                }
                 &::placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -823,6 +919,9 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::placeholder {
+                  color: GrayText;
                 }
                 &:-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
@@ -833,6 +932,9 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   font-weight: 400;
                   opacity: 1;
                 }
+                @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                  color: GrayText;
+                }
                 &::-ms-input-placeholder {
                   -moz-osx-font-smoothing: grayscale;
                   -webkit-font-smoothing: antialiased;
@@ -841,6 +943,9 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   font-size: 14px;
                   font-weight: 400;
                   opacity: 1;
+                }
+                @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                  color: GrayText;
                 }
             id="TextField9"
             onBlur={[Function]}
@@ -865,6 +970,10 @@ exports[`Component Examples renders TextField.PrefixAndSuffix.Example.tsx correc
                   padding-right: 10px;
                   padding-top: 0;
                   white-space: nowrap;
+                }
+                @media screen and (-ms-high-contrast: active){& {
+                  background: Window;
+                  color: WindowText;
                 }
           >
             <span

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Styled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Styled.Example.tsx.shot
@@ -91,10 +91,20 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
             &::after {
               color: #a4262c;
               content: ' *';
               padding-right: 12px;
+            }
+            @media screen and (-ms-high-contrast: active){&::after {
+              color: WindowText;
             }
         htmlFor="TextField0"
         id="TextFieldLabel2"
@@ -132,6 +142,9 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
             }
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+              forced-color-adjust: none;
             }
       >
         <input
@@ -177,6 +190,10 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
               &::-ms-clear {
                 display: none;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -185,6 +202,9 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::placeholder {
+                color: GrayText;
               }
               &:-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
@@ -195,6 +215,9 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
                 font-weight: 400;
                 opacity: 1;
               }
+              @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                color: GrayText;
+              }
               &::-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -203,6 +226,9 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                color: GrayText;
               }
           id="TextField0"
           onBlur={[Function]}
@@ -269,10 +295,20 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
             &::after {
               color: #a4262c;
               content: ' *';
               padding-right: 12px;
+            }
+            @media screen and (-ms-high-contrast: active){&::after {
+              color: WindowText;
             }
         htmlFor="TextField3"
         id="TextFieldLabel5"
@@ -308,6 +344,9 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
             }
             @media screen and (-ms-high-contrast: active){&:hover {
               border-color: Highlight;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){&:hover {
+              forced-color-adjust: none;
             }
       >
         <input
@@ -353,6 +392,10 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
               &::-ms-clear {
                 display: none;
               }
+              @media screen and (-ms-high-contrast: active){& {
+                background: Window;
+                color: WindowText;
+              }
               &::placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -361,6 +404,9 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::placeholder {
+                color: GrayText;
               }
               &:-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
@@ -371,6 +417,9 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
                 font-weight: 400;
                 opacity: 1;
               }
+              @media screen and (-ms-high-contrast: active){&:-ms-input-placeholder {
+                color: GrayText;
+              }
               &::-ms-input-placeholder {
                 -moz-osx-font-smoothing: grayscale;
                 -webkit-font-smoothing: antialiased;
@@ -379,6 +428,9 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
                 font-size: 14px;
                 font-weight: 400;
                 opacity: 1;
+              }
+              @media screen and (-ms-high-contrast: active){&::-ms-input-placeholder {
+                color: GrayText;
               }
           id="TextField3"
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.Basic.Example.tsx.shot
@@ -61,6 +61,13 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       htmlFor="Toggle0"
       id="Toggle0-label"
     >
@@ -178,6 +185,13 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
             && {
               font-weight: 400;
               margin-bottom: 0;
@@ -234,6 +248,13 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             padding-right: 0;
             padding-top: 5px;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="Toggle1"
       id="Toggle1-label"
@@ -347,6 +368,13 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
             && {
               font-weight: 400;
               margin-bottom: 0;
@@ -406,7 +434,11 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             word-wrap: break-word;
           }
           @media screen and (-ms-high-contrast: active){& {
+            background: Window;
             color: GrayText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="Toggle2"
       id="Toggle2-label"
@@ -513,6 +545,13 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
             && {
               color: #a19f9d;
               font-weight: 400;
@@ -575,7 +614,11 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             word-wrap: break-word;
           }
           @media screen and (-ms-high-contrast: active){& {
+            background: Window;
             color: GrayText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="Toggle3"
       id="Toggle3-label"
@@ -680,6 +723,13 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
             && {
               color: #a19f9d;
               font-weight: 400;
@@ -743,6 +793,13 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-break: break-all;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="Toggle4"
       id="Toggle4-label"
@@ -856,6 +913,13 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
             && {
               font-weight: 400;
               margin-bottom: 0;
@@ -917,7 +981,11 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             word-wrap: break-word;
           }
           @media screen and (-ms-high-contrast: active){& {
+            background: Window;
             color: GrayText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="Toggle5"
       id="Toggle5-label"
@@ -1022,6 +1090,13 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
             && {
               color: #a19f9d;
               font-weight: 400;
@@ -1086,6 +1161,13 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-break: break-all;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="Toggle6"
       id="Toggle6-label"
@@ -1219,7 +1301,11 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             word-wrap: break-word;
           }
           @media screen and (-ms-high-contrast: active){& {
+            background: Window;
             color: GrayText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="Toggle7"
       id="Toggle7-label"
@@ -1340,6 +1426,13 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       htmlFor="Toggle8"
       id="Toggle8-label"
     >
@@ -1456,6 +1549,13 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
               padding-right: 0;
               padding-top: 5px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
             && {
               font-weight: 400;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.CustomLabel.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.CustomLabel.Example.tsx.shot
@@ -60,6 +60,13 @@ exports[`Component Examples renders Toggle.CustomLabel.Example.tsx correctly 1`]
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       htmlFor="Toggle0"
       id="Toggle0-label"
     >
@@ -205,6 +212,13 @@ exports[`Component Examples renders Toggle.CustomLabel.Example.tsx correctly 1`]
               padding-top: 5px;
               word-wrap: break-word;
             }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
+            }
             && {
               font-weight: 400;
               margin-bottom: 0;
@@ -264,6 +278,13 @@ exports[`Component Examples renders Toggle.CustomLabel.Example.tsx correctly 1`]
             padding-top: 5px;
             word-break: break-all;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
       htmlFor="Toggle2"
       id="Toggle2-label"
@@ -409,6 +430,13 @@ exports[`Component Examples renders Toggle.CustomLabel.Example.tsx correctly 1`]
               padding-right: 0;
               padding-top: 5px;
               word-wrap: break-word;
+            }
+            @media screen and (-ms-high-contrast: active){& {
+              background: Window;
+              color: WindowText;
+            }
+            @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+              forced-color-adjust: none;
             }
             && {
               font-weight: 400;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Overflow.Example.tsx.shot
@@ -44,6 +44,13 @@ exports[`Component Examples renders Tooltip.Overflow.Example.tsx correctly 1`] =
             word-break: break-all;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
       htmlFor="Toggle1"
       id="Toggle1-label"
     >
@@ -168,6 +175,13 @@ exports[`Component Examples renders Tooltip.Overflow.Example.tsx correctly 1`] =
             padding-top: 5px;
             word-wrap: break-word;
           }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
+          }
     >
       Show tooltip when parent's content overflows
     </label>
@@ -244,6 +258,13 @@ exports[`Component Examples renders Tooltip.Overflow.Example.tsx correctly 1`] =
             padding-right: 0;
             padding-top: 5px;
             word-wrap: break-word;
+          }
+          @media screen and (-ms-high-contrast: active){& {
+            background: Window;
+            color: WindowText;
+          }
+          @media screen and (-ms-high-contrast: active) and (forced-colors: active){& {
+            forced-color-adjust: none;
           }
     >
       Show tooltip when TooltipHost's content overflows

--- a/packages/styling/etc/styling.api.md
+++ b/packages/styling/etc/styling.api.md
@@ -121,7 +121,7 @@ export namespace FontWeights {
     bold: IFontWeight;
 }
 
-// @public (undocumented)
+// @public
 export function getEdgeChromiumForcedStylesOffSelector(): {
     [EdgeChromiumHighContrastSelector]: IStyle;
 };

--- a/packages/styling/etc/styling.api.md
+++ b/packages/styling/etc/styling.api.md
@@ -122,7 +122,7 @@ export namespace FontWeights {
 }
 
 // @public
-export function getEdgeChromiumForcedStylesOffSelector(): {
+export function getEdgeChromiumNoHighContrastAdjustSelector(): {
     [EdgeChromiumHighContrastSelector]: IStyle;
 };
 

--- a/packages/styling/etc/styling.api.md
+++ b/packages/styling/etc/styling.api.md
@@ -62,6 +62,9 @@ export const DefaultFontStyles: IFontStyles;
 // @public (undocumented)
 export const DefaultPalette: IPalette;
 
+// @public (undocumented)
+export const EdgeChromiumHighContrastSelector = "@media screen and (-ms-high-contrast: active) and (forced-colors: active)";
+
 // @public
 export function focusClear(): IRawStyle;
 
@@ -117,6 +120,11 @@ export namespace FontWeights {
     const // (undocumented)
     bold: IFontWeight;
 }
+
+// @public (undocumented)
+export function getEdgeChromiumForcedStylesOffSelector(): {
+    [EdgeChromiumHighContrastSelector]: IStyle;
+};
 
 // @public
 export function getFadedOverflowStyle(theme: ITheme, color?: keyof ISemanticColors | keyof IPalette, direction?: 'horizontal' | 'vertical', width?: string | number, height?: string | number): IRawStyle;

--- a/packages/styling/src/styles/CommonStyles.ts
+++ b/packages/styling/src/styles/CommonStyles.ts
@@ -1,4 +1,7 @@
+import { IStyle } from '@uifabric/merge-styles';
+
 export const HighContrastSelector = '@media screen and (-ms-high-contrast: active)';
+export const EdgeChromiumHighContrastSelector = '@media screen and (-ms-high-contrast: active) and (forced-colors: active)';
 export const HighContrastSelectorWhite = '@media screen and (-ms-high-contrast: black-on-white)';
 export const HighContrastSelectorBlack = '@media screen and (-ms-high-contrast: white-on-black)';
 
@@ -18,4 +21,12 @@ export const ScreenWidthMinUhfMobile = 768;
 
 export function getScreenSelector(min: number, max: number): string {
   return `@media only screen and (min-width: ${min}px) and (max-width: ${max}px)`;
+}
+
+export function getEdgeChromiumForcedStylesOffSelector(): { [EdgeChromiumHighContrastSelector]: IStyle } {
+  return {
+    [EdgeChromiumHighContrastSelector]: {
+      forcedColorAdjust: 'none'
+    }
+  };
 }

--- a/packages/styling/src/styles/CommonStyles.ts
+++ b/packages/styling/src/styles/CommonStyles.ts
@@ -24,9 +24,9 @@ export function getScreenSelector(min: number, max: number): string {
 }
 
 /**
- * The style which turns off high contrast adjustment in (only) Edge Chromium browser
+ * The style which turns off high contrast adjustment in (only) Edge Chromium browser.
  */
-export function getEdgeChromiumForcedStylesOffSelector(): { [EdgeChromiumHighContrastSelector]: IStyle } {
+export function getEdgeChromiumNoHighContrastAdjustSelector(): { [EdgeChromiumHighContrastSelector]: IStyle } {
   return {
     [EdgeChromiumHighContrastSelector]: {
       forcedColorAdjust: 'none'

--- a/packages/styling/src/styles/CommonStyles.ts
+++ b/packages/styling/src/styles/CommonStyles.ts
@@ -23,6 +23,9 @@ export function getScreenSelector(min: number, max: number): string {
   return `@media only screen and (min-width: ${min}px) and (max-width: ${max}px)`;
 }
 
+/**
+ * The style which turns off high contrast adjustment in (only) Edge Chromium browser
+ */
 export function getEdgeChromiumForcedStylesOffSelector(): { [EdgeChromiumHighContrastSelector]: IStyle } {
   return {
     [EdgeChromiumHighContrastSelector]: {

--- a/packages/styling/src/styles/getFocusStyle.ts
+++ b/packages/styling/src/styles/getFocusStyle.ts
@@ -1,6 +1,6 @@
 import { IRawStyle } from '@uifabric/merge-styles';
 import { IGetFocusStylesOptions, ITheme } from '../interfaces/index';
-import { HighContrastSelector, getEdgeChromiumForcedStylesOffSelector } from './CommonStyles';
+import { HighContrastSelector, getEdgeChromiumNoHighContrastAdjustSelector } from './CommonStyles';
 import { IsFocusVisibleClassName } from '@uifabric/utilities';
 import { ZIndexes } from './zIndexes';
 
@@ -170,7 +170,7 @@ export const getInputFocusStyle = (
             [HighContrastSelector]: {
               [borderType === 'border' ? 'borderColor' : 'borderBottomColor']: 'Highlight'
             },
-            ...getEdgeChromiumForcedStylesOffSelector()
+            ...getEdgeChromiumNoHighContrastAdjustSelector()
           }
         }
       ]

--- a/packages/styling/src/styles/getFocusStyle.ts
+++ b/packages/styling/src/styles/getFocusStyle.ts
@@ -1,6 +1,6 @@
 import { IRawStyle } from '@uifabric/merge-styles';
 import { IGetFocusStylesOptions, ITheme } from '../interfaces/index';
-import { HighContrastSelector } from './CommonStyles';
+import { HighContrastSelector, getEdgeChromiumForcedStylesOffSelector } from './CommonStyles';
 import { IsFocusVisibleClassName } from '@uifabric/utilities';
 import { ZIndexes } from './zIndexes';
 
@@ -154,23 +154,26 @@ export const getInputFocusStyle = (
   return {
     borderColor,
     selectors: {
-      ':after': {
-        pointerEvents: 'none',
-        content: "''",
-        position: 'absolute',
-        left: isBorderBottom ? 0 : borderPosition,
-        top: borderPosition,
-        bottom: borderPosition,
-        right: isBorderBottom ? 0 : borderPosition,
-        [borderType]: `2px solid ${borderColor}`,
-        borderRadius,
-        width: borderType === 'borderBottom' ? '100%' : undefined,
-        selectors: {
-          [HighContrastSelector]: {
-            [borderType === 'border' ? 'borderColor' : 'borderBottomColor']: 'Highlight'
+      ':after': [
+        {
+          pointerEvents: 'none',
+          content: "''",
+          position: 'absolute',
+          left: isBorderBottom ? 0 : borderPosition,
+          top: borderPosition,
+          bottom: borderPosition,
+          right: isBorderBottom ? 0 : borderPosition,
+          [borderType]: `2px solid ${borderColor}`,
+          borderRadius,
+          width: borderType === 'borderBottom' ? '100%' : undefined,
+          selectors: {
+            [HighContrastSelector]: {
+              [borderType === 'border' ? 'borderColor' : 'borderBottomColor']: 'Highlight'
+            },
+            ...getEdgeChromiumForcedStylesOffSelector()
           }
         }
-      }
+      ]
     }
   };
 };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #11742
- [X] Addresses an existing issue: Fixes #11735, #11540
- [X] Include a change request file using `$ yarn change`

#### Description of changes
**Recap of the issue:**
In old Edge, the `-ms-high-contrast` media query implies `-ms-high-contrast-adjust: none` on each property inside the media query. In new/chromium Edge, this is no longer the case and `-ms-high-contrast-adjust: none` needs to be set explicitly for the properties inside HC media query to take effect.

**Heads-up:** 
The solution to this problem is not ideal. Ideally, this can be somehow addressed/improved at browser-level. However, after talking to folks in Edge, I don't see them offering anything concrete for us any time soon. This PR fixes couple issues raised by users and demo how the fix looks like. I also looking forward hearing alternative ways to fix.

**Principal of the fix:**
1. Increase bundle size as little as possible. Add minimal amount of new css to resolve the issue.
2. No breaking change for styles set by existing use cases: 
Turing off high contrast adjustment can be a breaking change to the styles user set today on our component. For the styles user set today which are expected to be adjusted, this change potentially turns off adjustments for those case and user will need to add styles to set colors explicitly for HC.

**The fix:**
1. Added a new css selector added which turns off the HC adjustment in new Edge, and **only** new Edge (this is ensure principal No.2 above). You can read more about `forced-color-adjust` [here](https://www.w3.org/TR/css-color-adjust-1/#forced). it serves the same purpose as `-ms-high-contrast-adjust: none` in the context of this change.
2. Applies the new css selector in places where set high contrast styles using `HighContrastSelector` so our high contrast styles work in new Edge.
3. Find places where colors were previously expected to get adjusted but no longer are. Explicitly set HC styles for those cases

**Prioritization of this fix / next steps:**
Going forward, we know we need to continue provide HC styles in new Edge. However, ATM I'd like to make fixes on demand (if user opens an issue on a particular components). Reasons being:
1. Developers are still realizing this breaking change made by Edge. I still think Edge team likely will come up with something that ease developers' life. But it will certainly take time. 
2. Based on my conversations with partner teams, a lot of them have not realized this issue yet or they have not started on fixing this in their apps yet.
 
I don't like how messy this fix is if it comes from us, so I think it's better for us to postpone the fix as long as possible in case better solutions pop up later.

Other related problem we have today is we don't have designs for HC. It's hard to tell in some cases what the expected experience should be. I am following up with Ben True more on this. I also think in the long-term, we should move away from using media query to set HC styles. Instead, we provide HC styles through theming.

#### Focus areas to test
- Old Edge
- New Chromium Edge


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11859)