### PR TITLE
TeachingBubble: Fixing styling when TeachingBubble has close button but no headline

### DIFF
--- a/change/office-ui-fabric-react-2020-02-03-17-24-12-teachingBubbleWithNoHeadline.json
+++ b/change/office-ui-fabric-react-2020-02-03-17-24-12-teachingBubbleWithNoHeadline.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "TeachingBubble: Fixing styling when TeachingBubble has close button but no headline.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "010803b8e84dbdbf0a3081975fc9725bbfaf2a4c",
+  "dependentChangeType": "patch",
+  "date": "2020-02-04T01:24:12.246Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -7593,6 +7593,7 @@ export type ITeachingBubbleStyleProps = Required<Pick<ITeachingBubbleProps, 'the
     primaryButtonClassName?: string;
     secondaryButtonClassName?: string;
     hasCloseButton?: boolean;
+    hasHeadline?: boolean;
 };
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.styles.ts
@@ -88,6 +88,7 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
     hasCondensedHeadline,
     hasSmallHeadline,
     hasCloseButton,
+    hasHeadline,
     isWide,
     primaryButtonClassName,
     secondaryButtonClassName,
@@ -101,6 +102,7 @@ export const getStyles = (props: ITeachingBubbleStyleProps): ITeachingBubbleStyl
     root: [classNames.root, fonts.medium, calloutClassName],
     body: [
       classNames.body,
+      hasCloseButton && !hasHeadline && { marginRight: 24 },
       {
         selectors: {
           ':not(:last-child)': {

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.types.ts
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubble.types.ts
@@ -134,6 +134,8 @@ export type ITeachingBubbleStyleProps = Required<Pick<ITeachingBubbleProps, 'the
     secondaryButtonClassName?: string;
     /** If the close button is visible. */
     hasCloseButton?: boolean;
+    /** If a headline has been specified. */
+    hasHeadline?: boolean;
   };
 
 /**

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/TeachingBubbleContent.base.tsx
@@ -77,6 +77,7 @@ export class TeachingBubbleContentBase extends BaseComponent<ITeachingBubbleProp
       hasCondensedHeadline,
       hasSmallHeadline,
       hasCloseButton,
+      hasHeadline: !!headline,
       isWide,
       primaryButtonClassName: primaryButtonProps ? primaryButtonProps.className : undefined,
       secondaryButtonClassName: secondaryButtonProps ? secondaryButtonProps.className : undefined


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11779
- [x] Include a change request file using `$ yarn change`

#### Description of changes

On cases where no headline was provided to the `TeachingBubble` but it was determined for it to have a close button there were occasions in which the close button overlapped with the contents' text. This PR fixes this issue by adding style rules that account for this case.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11861)