### PR TITLE
ChoiceGroup: fix option label text being cutoff

### DIFF
--- a/change/office-ui-fabric-react-2020-02-03-17-30-27-xgao-choicegrou.json
+++ b/change/office-ui-fabric-react-2020-02-03-17-30-27-xgao-choicegrou.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "ChoiceGroup: fix option label text being cutoff",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "3d48d2e62a81654795aba1ea59f8e2e1641d6400",
+  "dependentChangeType": "patch",
+  "date": "2020-02-04T01:30:27.401Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
@@ -400,8 +400,8 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
         height: labelWrapperHeight,
         lineHeight: labelWrapperLineHeight,
         maxWidth: imageSize!.width * 2, // using non-null assertion because we have a default in `ChoiceGroupOptionBase` class.
-        whiteSpace: 'pre-wrap',
-        overflow: 'hidden'
+        overflow: 'hidden',
+        whiteSpace: 'pre-wrap'
       }
     ]
   };

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/ChoiceGroupOption.styles.ts
@@ -15,6 +15,7 @@ const GlobalClassNames = {
 };
 
 const labelWrapperLineHeight = 15;
+const labelWrapperHeight = labelWrapperLineHeight * 2 + 2; // adding 2px height to ensure text doesn't get cutoff
 const iconSize = 32;
 const choiceFieldSize = 20;
 const choiceFieldTransitionDuration = '200ms';
@@ -395,13 +396,12 @@ export const getStyles = (props: IChoiceGroupOptionStyleProps): IChoiceGroupOpti
       (hasIcon || hasImage) && {
         display: 'block',
         position: 'relative',
-        margin: '4px 8px',
-        height: labelWrapperLineHeight * 2,
+        margin: '4px 8px 2px 8px',
+        height: labelWrapperHeight,
         lineHeight: labelWrapperLineHeight,
         maxWidth: imageSize!.width * 2, // using non-null assertion because we have a default in `ChoiceGroupOptionBase` class.
-        overflow: 'hidden',
         whiteSpace: 'pre-wrap',
-        textOverflow: 'ellipsis'
+        overflow: 'hidden'
       }
     ]
   };

--- a/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ChoiceGroup/ChoiceGroupOption/__snapshots__/ChoiceGroupOption.test.tsx.snap
@@ -1256,16 +1256,15 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 30px;
+                height: 32px;
                 line-height: 15px;
-                margin-bottom: 4px;
+                margin-bottom: 2px;
                 margin-left: 8px;
                 margin-right: 8px;
                 margin-top: 4px;
                 max-width: 64px;
                 overflow: hidden;
                 position: relative;
-                text-overflow: ellipsis;
                 white-space: pre-wrap;
               }
         >
@@ -1482,16 +1481,15 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 30px;
+                height: 32px;
                 line-height: 15px;
-                margin-bottom: 4px;
+                margin-bottom: 2px;
                 margin-left: 8px;
                 margin-right: 8px;
                 margin-top: 4px;
                 max-width: 64px;
                 overflow: hidden;
                 position: relative;
-                text-overflow: ellipsis;
                 white-space: pre-wrap;
               }
         >
@@ -1706,16 +1704,15 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 30px;
+                height: 32px;
                 line-height: 15px;
-                margin-bottom: 4px;
+                margin-bottom: 2px;
                 margin-left: 8px;
                 margin-right: 8px;
                 margin-top: 4px;
                 max-width: 64px;
                 overflow: hidden;
                 position: relative;
-                text-overflow: ellipsis;
                 white-space: pre-wrap;
               }
         >
@@ -1907,16 +1904,15 @@ exports[`ChoiceGroupOption renders ChoiceGroup correctly 1`] = `
                 font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                 font-size: 14px;
                 font-weight: 400;
-                height: 30px;
+                height: 32px;
                 line-height: 15px;
-                margin-bottom: 4px;
+                margin-bottom: 2px;
                 margin-left: 8px;
                 margin-right: 8px;
                 margin-top: 4px;
                 max-width: 64px;
                 overflow: hidden;
                 position: relative;
-                text-overflow: ellipsis;
                 white-space: pre-wrap;
               }
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Icon.Example.tsx.shot
@@ -262,16 +262,15 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 30px;
+                    height: 32px;
                     line-height: 15px;
-                    margin-bottom: 4px;
+                    margin-bottom: 2px;
                     margin-left: 8px;
                     margin-right: 8px;
                     margin-top: 4px;
                     max-width: 64px;
                     overflow: hidden;
                     position: relative;
-                    text-overflow: ellipsis;
                     white-space: pre-wrap;
                   }
             >
@@ -472,16 +471,15 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 30px;
+                    height: 32px;
                     line-height: 15px;
-                    margin-bottom: 4px;
+                    margin-bottom: 2px;
                     margin-left: 8px;
                     margin-right: 8px;
                     margin-top: 4px;
                     max-width: 64px;
                     overflow: hidden;
                     position: relative;
-                    text-overflow: ellipsis;
                     white-space: pre-wrap;
                   }
             >
@@ -678,16 +676,15 @@ exports[`Component Examples renders ChoiceGroup.Icon.Example.tsx correctly 1`] =
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 30px;
+                    height: 32px;
                     line-height: 15px;
-                    margin-bottom: 4px;
+                    margin-bottom: 2px;
                     margin-left: 8px;
                     margin-right: 8px;
                     margin-top: 4px;
                     max-width: 64px;
                     overflow: hidden;
                     position: relative;
-                    text-overflow: ellipsis;
                     white-space: pre-wrap;
                   }
             >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ChoiceGroup.Image.Example.tsx.shot
@@ -347,16 +347,15 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 30px;
+                    height: 32px;
                     line-height: 15px;
-                    margin-bottom: 4px;
+                    margin-bottom: 2px;
                     margin-left: 8px;
                     margin-right: 8px;
                     margin-top: 4px;
                     max-width: 64px;
                     overflow: hidden;
                     position: relative;
-                    text-overflow: ellipsis;
                     white-space: pre-wrap;
                   }
             >
@@ -642,16 +641,15 @@ exports[`Component Examples renders ChoiceGroup.Image.Example.tsx correctly 1`] 
                     font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                     font-size: 14px;
                     font-weight: 400;
-                    height: 30px;
+                    height: 32px;
                     line-height: 15px;
-                    margin-bottom: 4px;
+                    margin-bottom: 2px;
                     margin-left: 8px;
                     margin-right: 8px;
                     margin-top: 4px;
                     max-width: 64px;
                     overflow: hidden;
                     position: relative;
-                    text-overflow: ellipsis;
                     white-space: pre-wrap;
                   }
             >


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11860
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Adding more height to the wrapper components so the text doesn't get cut-off. meanwhile, reduced the margin bottom to make up the height increase so that the height of the option root doesn't change.
Before:
![image](https://user-images.githubusercontent.com/1207059/73706080-5f92d900-46ac-11ea-9dab-71c6772f9526.png)
After:
![image](https://user-images.githubusercontent.com/1207059/73706100-6e798b80-46ac-11ea-9ccf-f453e7a2d941.png)

Also removed `textOverflow: 'ellipsis'` as it doesn't do anything.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11862)