### PR TITLE
Pickers: remove input X button in Edge

### DIFF
--- a/change/office-ui-fabric-react-2020-02-04-12-29-12-xgao-picker-clear.json
+++ b/change/office-ui-fabric-react-2020-02-04-12-29-12-xgao-picker-clear.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Pickers: remove input X button in Edge",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "a1db103bb541a92da7c754be85c823daedddca57",
+  "dependentChangeType": "patch",
+  "date": "2020-02-04T20:29:12.073Z"
+}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.SearchResults.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.SearchResults.Example.tsx.shot
@@ -116,6 +116,9 @@ exports[`Component Examples renders Announced.SearchResults.Example.tsx correctl
                   padding-right: 6px;
                   padding-top: 0;
                 }
+                &::-ms-clear {
+                  display: none;
+                }
             data-lpignore={true}
             onBlur={[Function]}
             onChange={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Compact.Example.tsx.shot
@@ -81,6 +81,9 @@ exports[`Component Examples renders PeoplePicker.Compact.Example.tsx correctly 1
                   padding-right: 6px;
                   padding-top: 0;
                 }
+                &::-ms-clear {
+                  display: none;
+                }
             data-lpignore={true}
             disabled={false}
             onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
@@ -81,6 +81,9 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
                     padding-right: 6px;
                     padding-top: 0;
                   }
+                  &::-ms-clear {
+                    display: none;
+                  }
               data-lpignore={true}
               disabled={false}
               onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.LimitedSearch.Example.tsx.shot
@@ -81,6 +81,9 @@ exports[`Component Examples renders PeoplePicker.LimitedSearch.Example.tsx corre
                   padding-right: 6px;
                   padding-top: 0;
                 }
+                &::-ms-clear {
+                  display: none;
+                }
             data-lpignore={true}
             disabled={false}
             onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.List.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.List.Example.tsx.shot
@@ -60,6 +60,9 @@ exports[`Component Examples renders PeoplePicker.List.Example.tsx correctly 1`] 
                 padding-right: 6px;
                 padding-top: 0;
               }
+              &::-ms-clear {
+                display: none;
+              }
           data-lpignore={true}
           disabled={false}
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Normal.Example.tsx.shot
@@ -81,6 +81,9 @@ exports[`Component Examples renders PeoplePicker.Normal.Example.tsx correctly 1`
                   padding-right: 6px;
                   padding-top: 0;
                 }
+                &::-ms-clear {
+                  display: none;
+                }
             data-lpignore={true}
             disabled={false}
             onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
@@ -1450,6 +1450,9 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
                   padding-right: 6px;
                   padding-top: 0;
                 }
+                &::-ms-clear {
+                  display: none;
+                }
             data-lpignore={true}
             disabled={false}
             onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.ProcessSelection.Example.tsx.shot
@@ -81,6 +81,9 @@ exports[`Component Examples renders PeoplePicker.ProcessSelection.Example.tsx co
                   padding-right: 6px;
                   padding-top: 0;
                 }
+                &::-ms-clear {
+                  display: none;
+                }
             data-lpignore={true}
             disabled={false}
             onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TagPicker.Basic.Example.tsx.shot
@@ -233,6 +233,9 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
                   padding-right: 6px;
                   padding-top: 0;
                 }
+                &::-ms-clear {
+                  display: none;
+                }
             data-lpignore={true}
             disabled={false}
             onBlur={[Function]}
@@ -331,6 +334,9 @@ exports[`Component Examples renders TagPicker.Basic.Example.tsx correctly 1`] = 
                   padding-left: 6px;
                   padding-right: 6px;
                   padding-top: 0;
+                }
+                &::-ms-clear {
+                  display: none;
                 }
             data-lpignore={true}
             disabled={false}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.styles.ts
@@ -92,7 +92,12 @@ export function getStyles(props: IBasePickerStyleProps): IBasePickerStyles {
         alignSelf: 'flex-end',
         borderRadius: effects.roundedCorner2,
         backgroundColor: 'transparent',
-        color: semanticColors.inputText
+        color: semanticColors.inputText,
+        selectors: {
+          '::-ms-clear': {
+            display: 'none'
+          }
+        }
       },
       inputClassName
     ],

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -78,6 +78,9 @@ exports[`PeoplePicker renders correctly 1`] = `
                 padding-right: 6px;
                 padding-top: 0;
               }
+              &::-ms-clear {
+                display: none;
+              }
           data-lpignore={true}
           onBlur={[Function]}
           onChange={[Function]}
@@ -640,6 +643,9 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                 padding-left: 6px;
                 padding-right: 6px;
                 padding-top: 0;
+              }
+              &::-ms-clear {
+                display: none;
               }
           data-lpignore={true}
           onBlur={[Function]}

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
@@ -289,6 +289,9 @@ exports[`TagPicker renders correctly 1`] = `
                 padding-right: 6px;
                 padding-top: 0;
               }
+              &::-ms-clear {
+                display: none;
+              }
           data-lpignore={true}
           onBlur={[Function]}
           onChange={[Function]}
@@ -597,6 +600,9 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
                 padding-left: 6px;
                 padding-right: 6px;
                 padding-top: 0;
+              }
+              &::-ms-clear {
+                display: none;
               }
           data-lpignore={true}
           onBlur={[Function]}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11865
- [x] Include a change request file using `$ yarn change`

#### Description of changes
setting `-ms-clear` to hide the "X" button shown in `input` in Edge browser


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11869)