### PR TITLE
DocumentCard: Updating DocumentCardLocations styles to latest Fluent specs

### DIFF
--- a/change/office-ui-fabric-react-2020-02-04-15-58-06-documentCardLocationsStyles.json
+++ b/change/office-ui-fabric-react-2020-02-04-15-58-06-documentCardLocationsStyles.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "DocumentCard: Updating DocumentCardLocations styles to latest Fluent specs.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "7c633354c815d882a1eae4f1a5ecf0b9000199a2",
+  "dependentChangeType": "patch",
+  "date": "2020-02-04T23:58:06.010Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardLocation.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/DocumentCard/DocumentCardLocation.styles.ts
@@ -1,4 +1,4 @@
-import { getGlobalClassNames } from '../../Styling';
+import { getGlobalClassNames, FontWeights } from '../../Styling';
 import { IDocumentCardLocationStyleProps, IDocumentCardLocationStyles } from './DocumentCardLocation.types';
 
 export const DocumentCardLocationGlobalClassNames = {
@@ -16,12 +16,13 @@ export const getStyles = (props: IDocumentCardLocationStyleProps): IDocumentCard
       classNames.root,
       fonts.small,
       {
-        color: palette.neutralPrimary,
+        color: palette.themePrimary,
         display: 'block',
+        fontWeight: FontWeights.semibold,
+        overflow: 'hidden',
         padding: '8px 16px',
         position: 'relative',
         textDecoration: 'none',
-        overflow: 'hidden',
         textOverflow: 'ellipsis',
         whiteSpace: 'nowrap',
 

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
@@ -443,11 +443,11 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
-          color: #323130;
+          color: #0078d4;
           display: block;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 12px;
-          font-weight: 400;
+          font-weight: 600;
           overflow: hidden;
           padding-bottom: 8px;
           padding-left: 16px;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10659
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The `DocumentCardLocation` component was a link that didn't have any visual indication of being one until hovered, which made it seem like regular text. This PR updates its styles to the latest Fluent specs, which fixes this issue by providing correct visual indicators.

__Before:__
![image](https://user-images.githubusercontent.com/7798177/73798212-08057380-4767-11ea-9ca3-aaad32d14ed3.png)

__After:__
![image](https://user-images.githubusercontent.com/7798177/73798223-0d62be00-4767-11ea-9cbf-ff36339e9974.png)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11872)