### PR TITLE
MaskedTextField: fix input captures focus on re-render on Edge

### DIFF
--- a/change/office-ui-fabric-react-2020-02-04-16-06-42-xgao-fix-maskTextField.json
+++ b/change/office-ui-fabric-react-2020-02-04-16-06-42-xgao-fix-maskTextField.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "MaskedTextField: fix MaskedTextField captures focus on re-render on Edge",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "9df0b75a75911657f62c81e2a3c8ec418ddbbc47",
+  "dependentChangeType": "patch",
+  "date": "2020-02-05T00:06:42.324Z"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/MaskedTextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/MaskedTextField.tsx
@@ -106,7 +106,7 @@ export class MaskedTextField extends React.Component<ITextFieldProps, IMaskedTex
 
   public componentDidUpdate() {
     // Move the cursor to the start of the mask format on update
-    if (this.state.maskCursorPosition !== undefined && this._textField.current) {
+    if (this._isFocused && this.state.maskCursorPosition !== undefined && this._textField.current) {
       this._textField.current.setSelectionRange(this.state.maskCursorPosition, this.state.maskCursorPosition);
     }
   }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11871, fixes #11835, fixes #7580
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Reason why this is only issue in Edge is because Edge gives element focus if `setSelectionRange` is called. see demo [here](https://codepen.io/xugao/pen/ExjYRoL)

Fix here is checking if TextField has focus.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11875)