### PR TITLE
Dropdown: remove unnecessary focus calls

### DIFF
--- a/change/office-ui-fabric-react-2020-02-04-18-04-00-xgao-fix-dropdown-selection.json
+++ b/change/office-ui-fabric-react-2020-02-04-18-04-00-xgao-fix-dropdown-selection.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Dropdown: remove unnecessary focus calls",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "47776890deb9f54dfa633c72114a51c071367319",
+  "dependentChangeType": "patch",
+  "date": "2020-02-05T02:04:00.420Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.base.tsx
@@ -179,10 +179,6 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
     if (prevState.isOpen === true && this.state.isOpen === false) {
       this._gotMouseMove = false;
 
-      if (this._dropDown.current) {
-        this._dropDown.current.focus();
-      }
-
       if (this.props.onDismiss) {
         this.props.onDismiss();
       }
@@ -820,10 +816,6 @@ export class DropdownBase extends React.Component<IDropdownInternalProps, IDropd
 
   private _onDismiss = (): void => {
     this.setState({ isOpen: false });
-
-    if (this._dropDown.current) {
-      this._dropDown.current.focus();
-    }
   };
 
   /** Get all selected indexes for multi-select mode */


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11873
- [x] Include a change request file using `$ yarn change`

#### Description of changes
We should not get dropdown focused every time it closes/dismisses. 


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11876)