### PR TITLE
Fix incorrect icon color for disabled ContexualMenu icon with Azure theme.

### DIFF
--- a/change/@uifabric-azure-themes-2020-02-05-20-32-11-xinyan-azdcmt.json
+++ b/change/@uifabric-azure-themes-2020-02-05-20-32-11-xinyan-azdcmt.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Fix incorrect icon color for disabled contextual menu icon.",
+  "packageName": "@uifabric/azure-themes",
+  "email": "xinychen@microsoft.com",
+  "commit": "a8cc3ded60b29cc19e088d44b486055037752d1f",
+  "date": "2020-02-05T12:32:11.621Z"
+}

--- a/packages/azure-themes/src/azure/styles/ContextualMenu.styles.ts
+++ b/packages/azure-themes/src/azure/styles/ContextualMenu.styles.ts
@@ -41,7 +41,7 @@ export const ContextualMenuStyles = (props: IContextualMenuStyleProps): Partial<
           divider: {
             backgroundColor: semanticColors.inputBorder
           },
-          icon: {
+          iconColor: {
             color: semanticColors.focusBorder
           },
           item: {


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11882
- [x] Include a change request file using `$ yarn change`

#### Description of changes
This change fixed the incorrect style override in Azure theme according to https://github.com/OfficeDev/office-ui-fabric-react/blob/3011e25bba47808e2ad187de0231c6917da7028c/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.cnstyles.ts#L175 so it won't interfere with the disabled icon color.

#### Focus areas to test


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11883)