### PR TITLE
MaskedTextField: Fixing focus capture on input in re-renders on IE11 and Edge (cherrypick of #11875)

### DIFF
--- a/change/office-ui-fabric-react-2020-02-06-11-29-21-maskedTextFieldFocusCapture.json
+++ b/change/office-ui-fabric-react-2020-02-06-11-29-21-maskedTextFieldFocusCapture.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "MaskedTextField: Fixing focus capture on input in re-renders on IE11 and Edge.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "df03e220e37a8189bdf5391c381b031411b8c8fa",
+  "date": "2020-02-06T19:29:21.086Z"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/MaskedTextField.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/MaskedTextField/MaskedTextField.tsx
@@ -105,7 +105,7 @@ export class MaskedTextField extends React.Component<ITextFieldProps, IMaskedTex
 
   public componentDidUpdate() {
     // Move the cursor to the start of the mask format on update
-    if (this.state.maskCursorPosition !== undefined && this._textField.current) {
+    if (this._isFocused && this.state.maskCursorPosition !== undefined && this._textField.current) {
       this._textField.current.setSelectionRange(this.state.maskCursorPosition, this.state.maskCursorPosition);
     }
   }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11871, fixes #11835, fixes #7580
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR fixes an issue of focus being captured on the `MaskedTextField` input after re-render. Cherrypick of #11875.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11890)