### PR TITLE
Dropdown: fix item hover style

### DIFF
--- a/apps/vr-tests/src/stories/Dropdown.stories.tsx
+++ b/apps/vr-tests/src/stories/Dropdown.stories.tsx
@@ -49,23 +49,6 @@ storiesOf('Dropdown', module)
     ),
     { rtl: true }
   )
-  .addStory('Disabled', () => (
-    <Dropdown
-      placeholder="Select an Option"
-      label="Basic example:"
-      ariaLabel="Basic dropdown example"
-      disabled
-      options={[
-        { key: 'Header', text: 'Actions', itemType: DropdownMenuItemType.Header },
-        { key: 'A', text: 'Option a' },
-        { key: 'B', text: 'Option b' },
-        { key: 'divider_2', text: '-', itemType: DropdownMenuItemType.Divider },
-        { key: 'Header2', text: 'People', itemType: DropdownMenuItemType.Header },
-        { key: 'F', text: 'Option f' },
-        { key: 'G', text: 'Option g' }
-      ]}
-    />
-  ))
   .addStory('Disabled option selected', () => (
     <Dropdown
       placeholder="Select an Option"
@@ -190,6 +173,40 @@ storiesOf('Dropdown', module)
       options={[
         { key: 'A', text: 'Option a' },
         { key: 'B', text: 'Option b' }
+      ]}
+    />
+  ));
+
+storiesOf('Dropdown Disabled', module)
+  .addDecorator(FabricDecorator)
+  .addDecorator(story => (
+    <Screener
+      steps={new Screener.Steps()
+        .snapshot('default', { cropTo: '.testWrapper' })
+        .hover('.ms-Dropdown')
+        .snapshot('hover', { cropTo: '.testWrapper' })
+        .click('.ms-Dropdown')
+        .hover('.ms-Dropdown')
+        .snapshot('click', { cropTo: '.ms-Layer' })
+        .end()}
+    >
+      {story()}
+    </Screener>
+  ))
+  .addStory('Root', () => (
+    <Dropdown
+      placeholder="Select an Option"
+      label="Basic example:"
+      ariaLabel="Basic dropdown example"
+      disabled
+      options={[
+        { key: 'Header', text: 'Actions', itemType: DropdownMenuItemType.Header },
+        { key: 'A', text: 'Option a' },
+        { key: 'B', text: 'Option b' },
+        { key: 'divider_2', text: '-', itemType: DropdownMenuItemType.Divider },
+        { key: 'Header2', text: 'People', itemType: DropdownMenuItemType.Header },
+        { key: 'F', text: 'Option f' },
+        { key: 'G', text: 'Option g' }
       ]}
     />
   ));

--- a/apps/vr-tests/src/stories/Dropdown.stories.tsx
+++ b/apps/vr-tests/src/stories/Dropdown.stories.tsx
@@ -22,6 +22,8 @@ storiesOf('Dropdown', module)
         .click('.ms-Dropdown')
         .hover('.ms-Dropdown')
         .snapshot('click', { cropTo: '.ms-Layer' })
+        .hover('.ms-Dropdown-item')
+        .snapshot('hover item', { cropTo: '.ms-Layer' })
         .end()}
     >
       {story()}

--- a/change/office-ui-fabric-react-2020-02-06-13-29-40-xgao-dropdown-option-style-fix.json
+++ b/change/office-ui-fabric-react-2020-02-06-13-29-40-xgao-dropdown-option-style-fix.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Dropdown: fix item hover style",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "d46c6727c4f1682f8efc1d4a5565eb4092084271",
+  "dependentChangeType": "patch",
+  "date": "2020-02-06T21:29:40.910Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Dropdown/Dropdown.styles.ts
@@ -117,19 +117,21 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
     }
   ];
 
+  const selectedItemBackgroundColor = semanticColors.menuItemBackgroundPressed;
+
   const itemSelectors = (isSelected: boolean = false) => {
     return {
       selectors: {
         '&:hover:focus': [
           {
             color: semanticColors.menuItemTextHovered,
-            backgroundColor: !isSelected ? semanticColors.menuBackground : semanticColors.menuItemBackgroundHovered
+            backgroundColor: !isSelected ? semanticColors.menuItemBackgroundHovered : selectedItemBackgroundColor
           },
           highContrastItemAndTitleStateMixin
         ],
         '&:focus': [
           {
-            backgroundColor: !isSelected ? 'transparent' : semanticColors.menuItemBackgroundHovered
+            backgroundColor: !isSelected ? 'transparent' : selectedItemBackgroundColor
           },
           highContrastItemAndTitleStateMixin
         ],
@@ -156,7 +158,7 @@ export const getStyles: IStyleFunction<IDropdownStyleProps, IDropdownStyles> = p
   const dropdownItemSelected: IStyle = [
     ...dropdownItemStyle,
     {
-      backgroundColor: semanticColors.menuItemBackgroundPressed,
+      backgroundColor: selectedItemBackgroundColor,
       color: semanticColors.menuItemTextHovered
     },
     itemSelectors(true),


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #11888
- [X] Include a change request file using `$ yarn change`

#### Description of changes
Fix to use the correct semantic colors. The styles were regressed from change #11446. 
Added new screener tests to cover the dropdown item on hover cases.

Correct: https://fabricweb.z5.web.core.windows.net/oufr/7.85.0/#/examples/dropdown
Incorrect: https://fabricweb.z5.web.core.windows.net/oufr/7.86.0/#/examples/dropdown

#### Focus areas to test
Hover and focus states


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11892)