### PR TITLE
SpinButton: remove unneeded validation on tab key

### DIFF
--- a/change/office-ui-fabric-react-2020-02-06-15-19-59-xgao-spin-button.json
+++ b/change/office-ui-fabric-react-2020-02-06-15-19-59-xgao-spin-button.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "SpinButton: remove unneeded validation on tab key",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "1726b7d2ef8b6da56cd26b56e832eb8afb9ca7cf",
+  "dependentChangeType": "patch",
+  "date": "2020-02-06T23:19:59.143Z"
+}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.tsx
@@ -475,7 +475,6 @@ export class SpinButton extends React.Component<ISpinButtonProps, ISpinButtonSta
         this._updateValue(false /* shouldSpin */, this._initialStepDelay, this._onDecrement!);
         break;
       case KeyCodes.enter:
-      case KeyCodes.tab:
         this._validate(event);
         break;
       case KeyCodes.escape:


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #11893
- [X] Include a change request file using `$ yarn change`

#### Description of changes
Tab away the focus will trigger `onBlur`. Since validation is also done in `_onBlur`, we don't need to validate in case of tab keydown.

The reason why we saw the inconsistent behaviors described in #11893 is -
On keydown tab, the keydown event triggers first then on blur event triggers. So what happens is by the time we handle `onBlur`, input is already changed by `_validate` called upon tab. In that case, `onBlur` user prop will receive the validated value from `event`.
In other cases, `onBlur` user prop will receive non-validated value from `event`. 



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11895)