### PR TITLE
Tooltip: allow scrolling tooltip content

### DIFF
--- a/change/office-ui-fabric-react-2020-02-10-12-55-50-xgao-tooltip-scroll.json
+++ b/change/office-ui-fabric-react-2020-02-10-12-55-50-xgao-tooltip-scroll.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Tooltip: allow scrolling tooltip content",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "75d729ac4e0e00ad8b52f27b3da05f03cd6ed24b",
+  "dependentChangeType": "patch",
+  "date": "2020-02-10T20:55:50.865Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
@@ -106,7 +106,6 @@ export class TooltipHostBase extends React.Component<ITooltipHostProps, ITooltip
             })}
             onMouseEnter={this._onTooltipMouseEnter}
             onMouseLeave={this._onTooltipMouseLeave}
-            onWheel={this._hideTooltip}
             {...getNativeProps(this.props, divProperties)}
             {...tooltipProps}
           />


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11907
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Previously in PR #9749, we added the logic to dismiss the tooltip on wheel, which was added to fix #9694. This is what's causing tooltip content not being scrollable. I removed the `onWheel` handler because #9694 no longer repros without this change. 

#### Focus areas to test
Issues reported in #9694 & #11907


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11908)