### PR TITLE
Test: Disable problematic List test

### DIFF
--- a/change/office-ui-fabric-react-2020-02-11-13-03-33-jg-disable-list-test.json
+++ b/change/office-ui-fabric-react-2020-02-11-13-03-33-jg-disable-list-test.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "none",
   "comment": "Disable List test causing intermittent test failures.",
   "packageName": "office-ui-fabric-react",
   "email": "jagore@microsoft.com",

--- a/change/office-ui-fabric-react-2020-02-11-13-03-33-jg-disable-list-test.json
+++ b/change/office-ui-fabric-react-2020-02-11-13-03-33-jg-disable-list-test.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Disable List test causing intermittent test failures.",
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com",
+  "commit": "079a40a86a1562d1fa558957cee86997e97bea8a",
+  "dependentChangeType": "patch",
+  "date": "2020-02-11T21:03:33.500Z"
+}

--- a/packages/office-ui-fabric-react/src/components/List/List.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.test.tsx
@@ -126,7 +126,8 @@ describe('List', () => {
   });
 
   describe('if provided', () => {
-    it('invokes optional onRenderCell prop per item render', done => {
+    // This test is causing intermittent PR failures so it's disabled for now.
+    xit('invokes optional onRenderCell prop per item render', done => {
       const onRenderCellMock = jest.fn();
       const wrapper = mount(<List items={mockData(100)} />);
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This List test has been intermittently failing PRs for the last few weeks. This PR temporarily disables it.

```
office-ui-fabric-react:   ● List › if provided › invokes optional onRenderCell prop per item render
office-ui-fabric-react:     expect(jest.fn()).toHaveBeenCalledTimes(expected)
office-ui-fabric-react:     Expected number of calls: 10
office-ui-fabric-react:     Received number of calls: 110
office-ui-fabric-react: 
office-ui-fabric-react:       133 |       wrapper.setProps({ items: mockData(100), onRenderCell: onRenderCellMock, onPagesUpdated: (pages: IPage[]) => done() });
office-ui-fabric-react:       134 | 
office-ui-fabric-react:     > 135 |       expect(onRenderCellMock).toHaveBeenCalledTimes(10);
office-ui-fabric-react:           |                                ^
office-ui-fabric-react:       136 |     });
office-ui-fabric-react:       137 | 
office-ui-fabric-react:       138 |     it('respects optional startIndex prop during row rendering', done => {
office-ui-fabric-react: 
office-ui-fabric-react:       at Object.<anonymous> (src/components/List/List.test.tsx:135:32)
```


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11920)