### PR TITLE
ContextualMenu: change role of category options to menuitemselected

### DIFF
--- a/change/office-ui-fabric-react-2020-02-11-14-25-44-contextualmenu.json
+++ b/change/office-ui-fabric-react-2020-02-11-14-25-44-contextualmenu.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "ContextualMenu: change role of category options where multiple can be selected to menuitemcheckbox",
+  "comment": "ContextualMenu: change role of category options to menuitemcheckbox",
   "packageName": "office-ui-fabric-react",
   "email": "aneeshak@microsoft.com",
   "commit": "7b3f82f7ee65ffdec8a34bed75932904f0e690d0",

--- a/change/office-ui-fabric-react-2020-02-11-14-25-44-contextualmenu.json
+++ b/change/office-ui-fabric-react-2020-02-11-14-25-44-contextualmenu.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "ContextualMenu: change role of category options where multiple can be selected to menuitemcheckbox",
+  "packageName": "office-ui-fabric-react",
+  "email": "aneeshak@microsoft.com",
+  "commit": "7b3f82f7ee65ffdec8a34bed75932904f0e690d0",
+  "dependentChangeType": "patch",
+  "date": "2020-02-11T22:25:44.796Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomizationWithNoWrap.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/examples/ContextualMenu.CustomizationWithNoWrap.Example.tsx
@@ -34,7 +34,7 @@ function renderCategoriesList(item: any): JSX.Element {
           <DefaultButton
             key={category.name}
             className="ms-ContextualMenu-link ms-ContextualMenu-customizationExample-button"
-            role="menuitem"
+            role="menuitemcheckbox"
           >
             <div>
               <span


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #10841
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Multiple of these categories can be selected at the same time so `menuitem` is not the appropriate ARIA role, instead it should be `menuitemcheckbox`.

Before:
![image](https://user-images.githubusercontent.com/4161791/74285249-502e1400-4cda-11ea-9776-700aaff1f0e9.png)

After:
![image](https://user-images.githubusercontent.com/4161791/74285235-4ad0c980-4cda-11ea-8384-564240d67cc7.png)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11924)