### PR TITLE
TextField example: fix onChange typing error when strictFunctionTypes is true

### DIFF
--- a/change/office-ui-fabric-react-2020-02-11-19-45-19-xgao-fix-example-typing.json
+++ b/change/office-ui-fabric-react-2020-02-11-19-45-19-xgao-fix-example-typing.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "TextField example: fix onChange typing error when strictFunctionType is true",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "3602dd11de72d6b10d60bc5eeb624175d8cec8eb",
+  "dependentChangeType": "patch",
+  "date": "2020-02-12T03:45:19.262Z"
+}

--- a/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.Controlled.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.Controlled.Example.tsx
@@ -30,11 +30,11 @@ export class TextFieldControlledExample extends React.Component<{}, ITextFieldCo
     );
   }
 
-  private _onChange1 = (ev: React.FormEvent<HTMLInputElement>, newValue?: string) => {
+  private _onChange1 = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
     this.setState({ value1: newValue || '' });
   };
 
-  private _onChange2 = (ev: React.FormEvent<HTMLInputElement>, newValue?: string) => {
+  private _onChange2 = (event: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string) => {
     if (!newValue || newValue.length <= 5) {
       this.setState({ value2: newValue || '' });
     } else {

--- a/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.Multiline.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/TextField/examples/TextField.Multiline.Example.tsx
@@ -38,7 +38,7 @@ export class TextFieldMultilineExample extends React.Component<{}, ITextFieldMul
     );
   }
 
-  private _onChange = (ev: any, newText: string): void => {
+  private _onChange = (ev: React.FormEvent<HTMLInputElement | HTMLTextAreaElement>, newText: string): void => {
     const newMultiline = newText.length > 50;
     if (newMultiline !== this.state.multiline) {
       this.setState({ multiline: newMultiline });


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11927
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Fix the typing error for `onChange` inside TextField examples when `strictFunctionTypes` is set to `true`
```
      TS2322: Type '(ev: React.FormEvent<HTMLInputElement>, newValue?: string | undefined) => void' is not assignable to type '(event: FormEvent<HTMLInputElement | HTMLTextAreaElement>, newValue?: string | undefined) => void'.
  Types of parameters 'ev' and 'event' are incompatible.
    Type 'FormEvent<HTMLInputElement | HTMLTextAreaElement>' is not assignable to type 'FormEvent<HTMLInputElement>'.
      Type 'HTMLInputElement | HTMLTextAreaElement' is not assignable to type 'HTMLInputElement'.
        Type 'HTMLTextAreaElement' is missing the following properties from type 'HTMLInputElement': accept, align, alt, checked, and 23 more.
```


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11928)