### PR TITLE
Link: text decoration should be removed regardless of link vs button.

### DIFF
--- a/change/office-ui-fabric-react-2020-02-11-21-53-50-link-fix.json
+++ b/change/office-ui-fabric-react-2020-02-11-21-53-50-link-fix.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Link: text decoration should not show up even for buttons.",
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com",
+  "commit": "746dbdc5c75cdd68e91b9f37c0467f44b83dff19",
+  "dependentChangeType": "patch",
+  "date": "2020-02-12T05:53:50.536Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
@@ -26,6 +26,8 @@ export const getStyles = (props: ILinkStyleProps): ILinkStyles => {
         outline: 'none',
         fontSize: 'inherit',
         fontWeight: 'inherit',
+        textDecoration: 'none',
+
         selectors: {
           '.ms-Fabric--isFocusVisible &:focus': {
             // Can't use getFocusStyle because it doesn't support wrapping links
@@ -67,9 +69,7 @@ export const getStyles = (props: ILinkStyleProps): ILinkStyles => {
           }
         }
       },
-      !isButton && {
-        textDecoration: 'none'
-      },
+
       isDisabled && [
         'is-disabled',
         {

--- a/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -74,6 +74,7 @@ exports[`Link renders Link with "as=div" a div element 1`] = `
         padding-right: 0px;
         padding-top: 0px;
         text-align: left;
+        text-decoration: none;
         text-overflow: inherit;
         user-select: text;
       }
@@ -187,6 +188,7 @@ exports[`Link renders Link with no href as a button 1`] = `
         padding-right: 0px;
         padding-top: 0px;
         text-align: left;
+        text-decoration: none;
         text-overflow: inherit;
         user-select: text;
       }
@@ -295,6 +297,7 @@ exports[`Link renders disabled Link with no href as a button correctly 1`] = `
         padding-right: 0px;
         padding-top: 0px;
         text-align: left;
+        text-decoration: none;
         text-overflow: inherit;
         user-select: text;
       }
@@ -357,6 +360,7 @@ exports[`Link supports non button/anchor html attributes when "as=" is used 1`] 
         padding-right: 0px;
         padding-top: 0px;
         text-align: left;
+        text-decoration: none;
         text-overflow: inherit;
         user-select: text;
       }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Basic.Example.tsx.shot
@@ -91,6 +91,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
                 padding-right: 0px;
                 padding-top: 0px;
                 text-align: left;
+                text-decoration: none;
                 text-overflow: inherit;
                 user-select: text;
               }
@@ -170,6 +171,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
                 padding-right: 0px;
                 padding-top: 0px;
                 text-align: left;
+                text-decoration: none;
                 text-overflow: inherit;
                 user-select: text;
               }
@@ -317,6 +319,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
                 padding-right: 0px;
                 padding-top: 0px;
                 text-align: left;
+                text-decoration: none;
                 text-overflow: inherit;
                 user-select: text;
               }
@@ -473,6 +476,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
                 padding-right: 0px;
                 padding-top: 0px;
                 text-align: left;
+                text-decoration: none;
                 text-overflow: inherit;
                 user-select: text;
               }
@@ -541,6 +545,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
                 padding-right: 0px;
                 padding-top: 0px;
                 text-align: left;
+                text-decoration: none;
                 text-overflow: inherit;
                 user-select: text;
               }
@@ -609,6 +614,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
                 padding-right: 0px;
                 padding-top: 0px;
                 text-align: left;
+                text-decoration: none;
                 text-overflow: inherit;
                 user-select: text;
               }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
@@ -167,6 +167,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 padding-right: 0px;
                 padding-top: 0px;
                 text-align: left;
+                text-decoration: none;
                 text-overflow: inherit;
                 user-select: text;
               }
@@ -471,6 +472,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 padding-right: 0px;
                 padding-top: 0px;
                 text-align: left;
+                text-decoration: none;
                 text-overflow: inherit;
                 user-select: text;
               }
@@ -539,6 +541,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 padding-right: 0px;
                 padding-top: 0px;
                 text-align: left;
+                text-decoration: none;
                 text-overflow: inherit;
                 user-select: text;
               }
@@ -607,6 +610,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 padding-right: 0px;
                 padding-top: 0px;
                 text-align: left;
+                text-decoration: none;
                 text-overflow: inherit;
                 user-select: text;
               }
@@ -965,6 +969,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 padding-right: 0px;
                 padding-top: 0px;
                 text-align: left;
+                text-decoration: none;
                 text-overflow: inherit;
                 user-select: text;
               }
@@ -1033,6 +1038,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 padding-right: 0px;
                 padding-top: 0px;
                 text-align: left;
+                text-decoration: none;
                 text-overflow: inherit;
                 user-select: text;
               }
@@ -1451,6 +1457,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 padding-right: 0px;
                 padding-top: 0px;
                 text-align: left;
+                text-decoration: none;
                 text-overflow: inherit;
                 user-select: text;
               }
@@ -1519,6 +1526,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
                 padding-right: 0px;
                 padding-top: 0px;
                 text-align: left;
+                text-decoration: none;
                 text-overflow: inherit;
                 user-select: text;
               }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.BulkOperations.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.BulkOperations.Example.tsx.shot
@@ -1645,6 +1645,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       padding-right: 0px;
                                       padding-top: 0px;
                                       text-align: left;
+                                      text-decoration: none;
                                       text-overflow: inherit;
                                       user-select: text;
                                     }
@@ -2287,6 +2288,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       padding-right: 0px;
                                       padding-top: 0px;
                                       text-align: left;
+                                      text-decoration: none;
                                       text-overflow: inherit;
                                       user-select: text;
                                     }
@@ -2929,6 +2931,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       padding-right: 0px;
                                       padding-top: 0px;
                                       text-align: left;
+                                      text-decoration: none;
                                       text-overflow: inherit;
                                       user-select: text;
                                     }
@@ -3571,6 +3574,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       padding-right: 0px;
                                       padding-top: 0px;
                                       text-align: left;
+                                      text-decoration: none;
                                       text-overflow: inherit;
                                       user-select: text;
                                     }
@@ -4213,6 +4217,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       padding-right: 0px;
                                       padding-top: 0px;
                                       text-align: left;
+                                      text-decoration: none;
                                       text-overflow: inherit;
                                       user-select: text;
                                     }
@@ -4855,6 +4860,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       padding-right: 0px;
                                       padding-top: 0px;
                                       text-align: left;
+                                      text-decoration: none;
                                       text-overflow: inherit;
                                       user-select: text;
                                     }
@@ -5497,6 +5503,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       padding-right: 0px;
                                       padding-top: 0px;
                                       text-align: left;
+                                      text-decoration: none;
                                       text-overflow: inherit;
                                       user-select: text;
                                     }
@@ -6139,6 +6146,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       padding-right: 0px;
                                       padding-top: 0px;
                                       text-align: left;
+                                      text-decoration: none;
                                       text-overflow: inherit;
                                       user-select: text;
                                     }
@@ -6781,6 +6789,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       padding-right: 0px;
                                       padding-top: 0px;
                                       text-align: left;
+                                      text-decoration: none;
                                       text-overflow: inherit;
                                       user-select: text;
                                     }
@@ -7423,6 +7432,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                       padding-right: 0px;
                                       padding-top: 0px;
                                       text-align: left;
+                                      text-decoration: none;
                                       text-overflow: inherit;
                                       user-select: text;
                                     }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -346,6 +346,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         padding-top: 0;
                         position: relative;
                         text-align: left;
+                        text-decoration: none;
                         text-overflow: ellipsis;
                         user-select: text;
                         white-space: nowrap;
@@ -595,6 +596,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         padding-top: 0;
                         position: relative;
                         text-align: left;
+                        text-decoration: none;
                         text-overflow: ellipsis;
                         user-select: text;
                         white-space: nowrap;
@@ -1464,6 +1466,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         padding-top: 0;
                         position: relative;
                         text-align: left;
+                        text-decoration: none;
                         text-overflow: ellipsis;
                         user-select: text;
                         white-space: nowrap;
@@ -1624,6 +1627,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         padding-top: 0;
                         position: relative;
                         text-align: left;
+                        text-decoration: none;
                         text-overflow: ellipsis;
                         user-select: text;
                         white-space: nowrap;
@@ -1941,6 +1945,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         padding-top: 0;
                         position: relative;
                         text-align: left;
+                        text-decoration: none;
                         text-overflow: ellipsis;
                         user-select: text;
                         white-space: nowrap;
@@ -2096,6 +2101,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         padding-top: 0;
                         position: relative;
                         text-align: left;
+                        text-decoration: none;
                         text-overflow: ellipsis;
                         user-select: text;
                         white-space: nowrap;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Collapsing.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Collapsing.Example.tsx.shot
@@ -150,6 +150,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         padding-top: 0;
                         position: relative;
                         text-align: left;
+                        text-decoration: none;
                         text-overflow: ellipsis;
                         user-select: text;
                         white-space: nowrap;
@@ -310,6 +311,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         padding-top: 0;
                         position: relative;
                         text-align: left;
+                        text-decoration: none;
                         text-overflow: ellipsis;
                         user-select: text;
                         white-space: nowrap;
@@ -470,6 +472,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         padding-top: 0;
                         position: relative;
                         text-align: left;
+                        text-decoration: none;
                         text-overflow: ellipsis;
                         user-select: text;
                         white-space: nowrap;
@@ -630,6 +633,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         padding-top: 0;
                         position: relative;
                         text-align: left;
+                        text-decoration: none;
                         text-overflow: ellipsis;
                         user-select: text;
                         white-space: nowrap;
@@ -879,6 +883,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         padding-top: 0;
                         position: relative;
                         text-align: left;
+                        text-decoration: none;
                         text-overflow: ellipsis;
                         user-select: text;
                         white-space: nowrap;
@@ -1304,6 +1309,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         padding-top: 0;
                         position: relative;
                         text-align: left;
+                        text-decoration: none;
                         text-overflow: ellipsis;
                         user-select: text;
                         white-space: nowrap;
@@ -1553,6 +1559,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         padding-top: 0;
                         position: relative;
                         text-align: left;
+                        text-decoration: none;
                         text-overflow: ellipsis;
                         user-select: text;
                         white-space: nowrap;
@@ -1782,6 +1789,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         padding-top: 0;
                         position: relative;
                         text-align: left;
+                        text-decoration: none;
                         text-overflow: ellipsis;
                         user-select: text;
                         white-space: nowrap;
@@ -2139,6 +2147,7 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         padding-top: 0;
                         position: relative;
                         text-align: left;
+                        text-decoration: none;
                         text-overflow: ellipsis;
                         user-select: text;
                         white-space: nowrap;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
@@ -322,6 +322,7 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         padding-top: 0;
                         position: relative;
                         text-align: left;
+                        text-decoration: none;
                         text-overflow: ellipsis;
                         user-select: text;
                         white-space: nowrap;
@@ -571,6 +572,7 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         padding-top: 0;
                         position: relative;
                         text-align: left;
+                        text-decoration: none;
                         text-overflow: ellipsis;
                         user-select: text;
                         white-space: nowrap;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -793,6 +793,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                     padding-right: 0px;
                                     padding-top: 0px;
                                     text-align: left;
+                                    text-decoration: none;
                                     text-overflow: inherit;
                                     user-select: text;
                                   }
@@ -858,6 +859,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                     padding-right: 0px;
                                     padding-top: 0px;
                                     text-align: left;
+                                    text-decoration: none;
                                     text-overflow: inherit;
                                     user-select: text;
                                   }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -1091,6 +1091,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   padding-right: 0px;
                                   padding-top: 0px;
                                   text-align: left;
+                                  text-decoration: none;
                                   text-overflow: inherit;
                                   user-select: text;
                                 }
@@ -1617,6 +1618,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   padding-right: 0px;
                                   padding-top: 0px;
                                   text-align: left;
+                                  text-decoration: none;
                                   text-overflow: inherit;
                                   user-select: text;
                                 }
@@ -2143,6 +2145,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   padding-right: 0px;
                                   padding-top: 0px;
                                   text-align: left;
+                                  text-decoration: none;
                                   text-overflow: inherit;
                                   user-select: text;
                                 }
@@ -2669,6 +2672,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   padding-right: 0px;
                                   padding-top: 0px;
                                   text-align: left;
+                                  text-decoration: none;
                                   text-overflow: inherit;
                                   user-select: text;
                                 }
@@ -3195,6 +3199,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   padding-right: 0px;
                                   padding-top: 0px;
                                   text-align: left;
+                                  text-decoration: none;
                                   text-overflow: inherit;
                                   user-select: text;
                                 }
@@ -3721,6 +3726,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   padding-right: 0px;
                                   padding-top: 0px;
                                   text-align: left;
+                                  text-decoration: none;
                                   text-overflow: inherit;
                                   user-select: text;
                                 }
@@ -4247,6 +4253,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   padding-right: 0px;
                                   padding-top: 0px;
                                   text-align: left;
+                                  text-decoration: none;
                                   text-overflow: inherit;
                                   user-select: text;
                                 }
@@ -4773,6 +4780,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   padding-right: 0px;
                                   padding-top: 0px;
                                   text-align: left;
+                                  text-decoration: none;
                                   text-overflow: inherit;
                                   user-select: text;
                                 }
@@ -5299,6 +5307,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                   padding-right: 0px;
                                   padding-top: 0px;
                                   text-align: left;
+                                  text-decoration: none;
                                   text-overflow: inherit;
                                   user-select: text;
                                 }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
@@ -74,6 +74,7 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
             padding-right: 0px;
             padding-top: 0px;
             text-align: left;
+            text-decoration: none;
             text-overflow: inherit;
             user-select: text;
           }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Basic.Example.tsx.shot
@@ -56,6 +56,7 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
             padding-right: 0px;
             padding-top: 0px;
             text-align: left;
+            text-decoration: none;
             text-overflow: inherit;
             user-select: text;
           }
@@ -131,6 +132,7 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
             padding-right: 0px;
             padding-top: 0px;
             text-align: left;
+            text-decoration: none;
             text-overflow: inherit;
             user-select: text;
           }
@@ -206,6 +208,7 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
             padding-right: 0px;
             padding-top: 0px;
             text-align: left;
+            text-decoration: none;
             text-overflow: inherit;
             user-select: text;
           }


### PR DESCRIPTION
Tried providing an example of react-router to a developer, found that links were being underlined if buttons.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11930)