### PR TITLE
Fixing yarn start for Windows machines

### DIFF
--- a/scripts/start.js
+++ b/scripts/start.js
@@ -31,5 +31,8 @@ const suggest = (input, choices) => Promise.resolve(choices.filter(i => i.title.
     choices: [...defaults.map(p => ({ title: p, value: p })), ...projectsWithStartCommand]
   });
 
-  spawnSync('yarn', ['workspace', response.project, 'start', ...(extraArgs.length > 0 ? [extraArgs] : [])], { stdio: 'inherit' });
+  spawnSync('yarn', ['workspace', response.project, 'start', ...(extraArgs.length > 0 ? [extraArgs] : [])], {
+    shell: true,
+    stdio: 'inherit'
+  });
 })();


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

#11939 introduced an enhanced experience for using the `yarn start` command. However, this experience was not working for Windows machines because `spawnSync` by default does not spawn a shell for the command to run in. This PR fixes this issue by passing the `shell: true` option to `spawnSync`.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11940)