### PR TITLE
List: fixing a leak where an element reference is retained after unmount

### DIFF
--- a/change/office-ui-fabric-react-2020-02-12-09-56-12-list-leak-fix.json
+++ b/change/office-ui-fabric-react-2020-02-12-09-56-12-list-leak-fix.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "List: clearing scrollElement on unmount to avoid retaining an edge to a dom element and leaking.",
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com",
+  "commit": "8a1f887f42f85fcbdbea98970b8751411b79954a",
+  "dependentChangeType": "patch",
+  "date": "2020-02-12T17:56:12.130Z"
+}

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -318,6 +318,8 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
   public componentWillUnmount(): void {
     this._async.dispose();
     this._events.dispose();
+
+    delete this._scrollElement;
   }
 
   // tslint:disable-next-line function-name


### PR DESCRIPTION
Simple cleanup; we need to clear element references in unmounting.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11954)