### PR TITLE
ShimmeredDetailsList: set aria-busy to true when shimmer is enabled

### DIFF
--- a/change/office-ui-fabric-react-2020-02-14-16-00-46-xgao-shimmer.json
+++ b/change/office-ui-fabric-react-2020-02-14-16-00-46-xgao-shimmer.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "ShimmeredDetailsList: add aria-busy=true when shimmer is enabled",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "3be35a40104099e1b7a35a2dde5d96b9069365cd",
+  "dependentChangeType": "patch",
+  "date": "2020-02-15T00:00:46.900Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsList.base.tsx
@@ -428,6 +428,7 @@ export class DetailsListBase extends React.Component<IDetailsListProps, IDetails
           aria-rowcount={isPlaceholderData ? -1 : rowCount}
           aria-colcount={(selectAllVisibility !== SelectAllVisibility.none ? 1 : 0) + (adjustedColumns ? adjustedColumns.length : 0)}
           aria-readonly="true"
+          aria-busy={isPlaceholderData}
         >
           <div onKeyDown={this._onHeaderKeyDown} role="presentation" className={classNames.headerWrapper}>
             {isHeaderVisible &&

--- a/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/__snapshots__/ShimmeredDetailsList.test.tsx.snap
@@ -35,6 +35,7 @@ exports[`ShimmeredDetailsList renders List correctly 1`] = `
     data-is-scrollable="false"
   >
     <div
+      aria-busy={true}
       aria-colcount={1}
       aria-readonly="true"
       aria-rowcount={-1}

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Shimmer.Application.Example.tsx.shot
@@ -213,6 +213,7 @@ exports[`Component Examples renders Shimmer.Application.Example.tsx correctly 1`
         data-is-scrollable="false"
       >
         <div
+          aria-busy={true}
           aria-colcount={1}
           aria-label="Content is being fetched"
           aria-readonly="true"


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #11916
- [X] Include a change request file using `$ yarn change`

#### Description of changes
List when shimmer is enabled will announce "busy" upon entering 



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11964)