### PR TITLE
Adds ignoreScrollingState to List to avoid extra scrolling renders

### DIFF
--- a/change/office-ui-fabric-react-2020-02-17-11-21-10-master.json
+++ b/change/office-ui-fabric-react-2020-02-17-11-21-10-master.json
@@ -1,9 +1,9 @@
 {
-  "type": "patch",
+  "type": "minor",
   "comment": "Adds ignoreScrollingState to List, to avoid updates to scrolling state when it's not being used",
   "packageName": "office-ui-fabric-react",
   "email": "chce@netcompany.com",
   "commit": "75d13a8a34e064a42b99763bdc43f8d8ca668982",
-  "dependentChangeType": "patch",
+  "dependentChangeType": "minor",
   "date": "2020-02-17T10:21:10.193Z"
 }

--- a/change/office-ui-fabric-react-2020-02-17-11-21-10-master.json
+++ b/change/office-ui-fabric-react-2020-02-17-11-21-10-master.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Adds ignoreScrollingState to List, to avoid updates to scrolling state when it's not being used",
+  "packageName": "office-ui-fabric-react",
+  "email": "chce@netcompany.com",
+  "commit": "75d13a8a34e064a42b99763bdc43f8d8ca668982",
+  "dependentChangeType": "patch",
+  "date": "2020-02-17T10:21:10.193Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -5411,6 +5411,7 @@ export interface IListProps<T = any> extends React.HTMLAttributes<List<T> | HTML
     getPageHeight?: (itemIndex?: number, visibleRect?: IRectangle, itemCount?: number) => number;
     getPageSpecification?: (itemIndex?: number, visibleRect?: IRectangle) => IPageSpecification;
     getPageStyle?: (page: IPage<T>) => any;
+    ignoreScrollingState?: boolean;
     items?: T[];
     onPageAdded?: (page: IPage<T>) => void;
     onPageRemoved?: (page: IPage<T>) => void;

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -347,7 +347,7 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     let shouldComponentUpdate = false;
 
     // Update if the page stops scrolling
-    if (!newState.isScrolling && this.state.isScrolling) {
+    if (!newState.isScrolling && this.state.isScrolling && !this.props.ignoreScrollingState) {
       return true;
     }
 
@@ -527,7 +527,7 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
    * we will call onAsyncIdle which will reset it back to it's correct value.
    */
   private _onScroll(): void {
-    if (!this.state.isScrolling) {
+    if (!this.state.isScrolling && !this.props.ignoreScrollingState) {
       this.setState({ isScrolling: true });
     }
     this._resetRequiredWindows();
@@ -583,7 +583,9 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
    * This function is debounced.
    */
   private _onScrollingDone(): void {
-    this.setState({ isScrolling: false });
+    if (!this.props.ignoreScrollingState) {
+      this.setState({ isScrolling: false });
+    }
   }
 
   private _onAsyncResize(): void {

--- a/packages/office-ui-fabric-react/src/components/List/List.tsx
+++ b/packages/office-ui-fabric-react/src/components/List/List.tsx
@@ -347,7 +347,7 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
     let shouldComponentUpdate = false;
 
     // Update if the page stops scrolling
-    if (!newState.isScrolling && this.state.isScrolling && !this.props.ignoreScrollingState) {
+    if (!newState.isScrolling && this.state.isScrolling) {
       return true;
     }
 
@@ -498,7 +498,7 @@ export class List<T = any> extends React.Component<IListProps<T>, IListState<T>>
 
       cells.push(
         <div role={cellRole} className={'ms-List-cell'} key={itemKey} data-list-index={index} data-automationid="ListCell">
-          {onRenderCell && onRenderCell(item, index, this.state.isScrolling)}
+          {onRenderCell && onRenderCell(item, index, !this.props.ignoreScrollingState ? this.state.isScrolling : undefined)}
         </div>
       );
     }

--- a/packages/office-ui-fabric-react/src/components/List/List.types.ts
+++ b/packages/office-ui-fabric-react/src/components/List/List.types.ts
@@ -186,7 +186,7 @@ export interface IListProps<T = any> extends React.HTMLAttributes<List<T> | HTML
   version?: {};
 
   /**
-   * Boolean value to disable scroll state updates. WARNING: This will cause the isScrolling argument in onRenderCell to always be false.
+   * Boolean value to disable scroll state updates. This will cause the isScrolling argument in onRenderCell to always be undefined.
    * This is a performance optimization to let List skip a render cycle by not updating its scrolling state.
    */
   ignoreScrollingState?: boolean;

--- a/packages/office-ui-fabric-react/src/components/List/List.types.ts
+++ b/packages/office-ui-fabric-react/src/components/List/List.types.ts
@@ -184,6 +184,12 @@ export interface IListProps<T = any> extends React.HTMLAttributes<List<T> | HTML
    * An object which can be passed in as a fresh instance to 'force update' the list.
    */
   version?: {};
+
+  /**
+   * Boolean value to disable scroll state updates. WARNING: This will cause the isScrolling argument in onRenderCell to always be false.
+   * This is a performance optimization to let List skip a render cycle by not updating its scrolling state.
+   */
+  ignoreScrollingState?: boolean;
 }
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11953
- [x] Include a change request file using `$ yarn change`

#### Description of changes

I added ignoreScrollingState to List, and wrapped all setting of scrolling state in an if-statement checking the prop. If it's not set, it will work as before, and when set, it will not cause an extra render.

#### Focus areas to test

I checked that it worked as intended on the List Ghosting example (Turning it on and off worked as expected with the ghosting), as well as on a DetailsList. I suggest checking the same. 


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11969)