### PR TITLE
Fixing touch drag events in the DraggableZone

### DIFF
--- a/change/office-ui-fabric-react-2020-02-18-16-00-50-catalina-ModalTouch.json
+++ b/change/office-ui-fabric-react-2020-02-18-16-00-50-catalina-ModalTouch.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Set touchmove and touchend event handlers to get caught in the capture phase",
+  "packageName": "office-ui-fabric-react",
+  "email": "catalina@microsoft.com",
+  "commit": "a7a7262fee8f15d105564c44c4a20c55417302a9",
+  "date": "2020-02-19T00:00:50.309Z"
+}

--- a/packages/office-ui-fabric-react/src/utilities/DraggableZone/DraggableZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/DraggableZone/DraggableZone.tsx
@@ -153,7 +153,7 @@ export class DraggableZone extends React.Component<IDraggableZoneProps, IDraggab
     // hook up the appropriate mouse/touch events to the body to ensure
     // smooth dragging
     this._events = [
-      on(document.body, this._currentEventType.move, this._onDrag),
+      on(event.currentTarget, this._currentEventType.move, this._onDrag, true /* use capture phase */),
       on(document.body, this._currentEventType.stop, this._onDragStop)
     ];
   };

--- a/packages/office-ui-fabric-react/src/utilities/DraggableZone/DraggableZone.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/DraggableZone/DraggableZone.tsx
@@ -153,8 +153,8 @@ export class DraggableZone extends React.Component<IDraggableZoneProps, IDraggab
     // hook up the appropriate mouse/touch events to the body to ensure
     // smooth dragging
     this._events = [
-      on(event.currentTarget, this._currentEventType.move, this._onDrag, true /* use capture phase */),
-      on(document.body, this._currentEventType.stop, this._onDragStop)
+      on(document.body, this._currentEventType.move, this._onDrag, true /* use capture phase */),
+      on(document.body, this._currentEventType.stop, this._onDragStop, true /* use capture phase */)
     ];
   };
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11963 
- [x] Include a change request file using `$ yarn change`

#### Description of changes
The events do not get caught at the current bubble phase. Setting it do capture phase makes these events get fired and captures first.

#### Focus areas to test
Tested on IE, Firefox, Edge, Edge Beta, and Chrome.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11986)