### PR TITLE
DatePicker: Fixing onSelectDate event being called twice when allowTextInput is set to true

### DIFF
--- a/change/@uifabric-date-time-2020-02-18-16-30-59-datePickerOnSelectDateTwice.json
+++ b/change/@uifabric-date-time-2020-02-18-16-30-59-datePickerOnSelectDateTwice.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "DatePicker: Fixing onSelectDate event being called twice when allowTextInput is set to true.",
+  "packageName": "@uifabric/date-time",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "14fa26d0ce716ddb08a64adeb81e1e3507cd2493",
+  "dependentChangeType": "patch",
+  "date": "2020-02-19T00:30:56.711Z"
+}

--- a/change/office-ui-fabric-react-2020-02-18-16-30-59-datePickerOnSelectDateTwice.json
+++ b/change/office-ui-fabric-react-2020-02-18-16-30-59-datePickerOnSelectDateTwice.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "DatePicker: Fixing onSelectDate event being called twice when allowTextInput is set to true.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "14fa26d0ce716ddb08a64adeb81e1e3507cd2493",
+  "dependentChangeType": "patch",
+  "date": "2020-02-19T00:30:59.116Z"
+}

--- a/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
@@ -442,7 +442,10 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
         // The formatted string might be ambiguous (ex: "1/2/3" or "New Year Eve") and the parser might
         // not be able to come up with the exact same date.
         if (this.state.selectedDate && formatDate && formatDate(this.state.selectedDate) === inputValue) {
-          date = this.state.selectedDate;
+          this.setState({
+            errorMessage: ''
+          });
+          return;
         } else {
           date = parseDateFromString!(inputValue);
         }

--- a/packages/date-time/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/date-time/src/components/DatePicker/DatePicker.test.tsx
@@ -138,7 +138,7 @@ describe('DatePicker', () => {
     datePicker.setState({ isDatePickerShown: true });
     ReactTestUtils.Simulate.click(document.querySelector('[class^="dayIsToday"], [class*="dayIsToday"]') as HTMLButtonElement);
 
-    expect(onSelectDate).toHaveBeenCalledTimes(2);
+    expect(onSelectDate).toHaveBeenCalledTimes(1);
 
     datePicker.setState({ isDatePickerShown: false });
 

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.base.tsx
@@ -447,7 +447,10 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
         // The formatted string might be ambiguous (ex: "1/2/3" or "New Year Eve") and the parser might
         // not be able to come up with the exact same date.
         if (this.state.selectedDate && formatDate && formatDate(this.state.selectedDate) === inputValue) {
-          date = this.state.selectedDate;
+          this.setState({
+            errorMessage: ''
+          });
+          return;
         } else {
           date = parseDateFromString!(inputValue);
         }

--- a/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/DatePicker/DatePicker.test.tsx
@@ -175,7 +175,7 @@ describe('DatePicker', () => {
     datePicker.setState({ isDatePickerShown: true });
     ReactTestUtils.Simulate.click(document.querySelector('.ms-DatePicker-day--today') as HTMLButtonElement);
 
-    expect(onSelectDate).toHaveBeenCalledTimes(2);
+    expect(onSelectDate).toHaveBeenCalledTimes(1);
 
     datePicker.setState({ isDatePickerShown: false });
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11978
- [x] Include a change request file using `$ yarn change`

#### Description of changes

When `allowTextInput` was set to true the `DatePicker` was firing the `onSelectDate` event twice when selecting a new value. This PR fixes the issue and fixes tests that were supposed to guard against this but were modified.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11989)