### PR TITLE
styled: do not create new styles function if styles prop is not changed

### DIFF
--- a/change/@uifabric-utilities-2020-02-18-18-08-34-xgao-styled.json
+++ b/change/@uifabric-utilities-2020-02-18-18-08-34-xgao-styled.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "styled: do not create new styles function if styles prop is not changed",
+  "packageName": "@uifabric/utilities",
+  "email": "xgao@microsoft.com",
+  "commit": "33fd9733154fab69a3ed29f39fea34d8f07bc632",
+  "dependentChangeType": "patch",
+  "date": "2020-02-19T02:08:34.722Z"
+}

--- a/packages/utilities/src/styled.test.tsx
+++ b/packages/utilities/src/styled.test.tsx
@@ -347,7 +347,7 @@ describe('styled', () => {
     );
   });
 
-  it('do not re-render if styles has not changed', () => {
+  it('will not re-render if styles have not changed', () => {
     component = mount(<Test styles={{ root: { background: 'red' } }} />);
     expect(_renderCount).toEqual(1);
     const stylesProp = lastStylesInBaseComponent;

--- a/packages/utilities/src/styled.test.tsx
+++ b/packages/utilities/src/styled.test.tsx
@@ -21,6 +21,7 @@ let _lastProps: ITestProps | undefined;
 let _renderCount: number;
 let _styleEval: number;
 let component: ReturnType<typeof mount> | undefined;
+let lastStylesInBaseComponent: IStyleFunctionOrObject<{}, ITestStyles> | undefined;
 
 const getClassNames = classNamesFunction<{}, ITestStyles>();
 
@@ -35,6 +36,7 @@ class TestBase extends React.Component<ITestProps> {
     _lastProps = this.props;
 
     const classNames = getClassNames(this.props.styles, { cool: this.props.cool });
+    lastStylesInBaseComponent = this.props.styles;
 
     return <div className={classNames.root}>{this.props.children}</div>;
   }
@@ -74,6 +76,8 @@ describe('styled', () => {
       component.unmount();
       component = undefined;
     }
+
+    lastStylesInBaseComponent = undefined;
   });
 
   it('can create pure components', () => {
@@ -341,5 +345,16 @@ describe('styled', () => {
         expect(_renderCount).toEqual(4);
       }
     );
+  });
+
+  it('do not re-render if styles has not changed', () => {
+    component = mount(<Test styles={{ root: { background: 'red' } }} />);
+    expect(_renderCount).toEqual(1);
+    const stylesProp = lastStylesInBaseComponent;
+
+    component.setProps({ cool: true });
+
+    expect(_renderCount).toEqual(2);
+    expect(stylesProp).toBe(lastStylesInBaseComponent);
   });
 });

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -96,7 +96,8 @@ export function styled<
 
     private _updateStyles(customizedStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet>): void {
       // tslint:disable-next-line:no-any
-      if (!this._styles || customizedStyles !== (this._styles as any).__cachedInputs__[1] || !!this.props.styles) {
+      const cache = (this._styles && (this._styles as any).__cachedInputs__) || [];
+      if (!this._styles || customizedStyles !== cache[1] || (!!this.props.styles && this.props.styles !== cache[2])) {
         // Cache the customized styles.
         // this._customizedStyles = customizedStyles;
 

--- a/packages/utilities/src/styled.tsx
+++ b/packages/utilities/src/styled.tsx
@@ -97,7 +97,7 @@ export function styled<
     private _updateStyles(customizedStyles: IStyleFunctionOrObject<TStyleProps, TStyleSet>): void {
       // tslint:disable-next-line:no-any
       const cache = (this._styles && (this._styles as any).__cachedInputs__) || [];
-      if (!this._styles || customizedStyles !== cache[1] || (!!this.props.styles && this.props.styles !== cache[2])) {
+      if (!this._styles || customizedStyles !== cache[1] || this.props.styles !== cache[2]) {
         // Cache the customized styles.
         // this._customizedStyles = customizedStyles;
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11979
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Currently, as long as `styles` prop is present in `styled`, we will create new `styles` function and pass as prop to base component. We should not create new `styles` prop for base component if `styles` passed to styled component is not changed on update, to avoid unnecessary re-renders.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/11990)