### PR TITLE
GroupedList: Adding checks for group and selection being undefined

### DIFF
--- a/change/office-ui-fabric-react-2020-02-19-11-36-46-groupedListUndefinedCheck.json
+++ b/change/office-ui-fabric-react-2020-02-19-11-36-46-groupedListUndefinedCheck.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "GroupedList: Adding checks for group and selection being undefined.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "e8b1bf416fe51e14c69d5733d31996c27f092374",
+  "dependentChangeType": "patch",
+  "date": "2020-02-19T19:36:46.664Z"
+}

--- a/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/GroupedListSection.tsx
@@ -233,7 +233,7 @@ export class GroupedListSection extends React.Component<IGroupedListSectionProps
           <List
             role="presentation"
             ref={this._list}
-            items={group!.children}
+            items={group ? group.children : []}
             onRenderCell={this._renderSubGroup}
             getItemCountForPage={this._returnOne}
             onShouldVirtualize={onShouldVirtualize}
@@ -294,10 +294,12 @@ export class GroupedListSection extends React.Component<IGroupedListSectionProps
 
   private _onSelectionChange(): void {
     const { group, selection } = this.props;
-    const isSelected = selection!.isRangeSelected(group!.startIndex, group!.count);
+    if (selection && group) {
+      const isSelected = selection.isRangeSelected(group.startIndex, group.count);
 
-    if (isSelected !== this.state.isSelected) {
-      this.setState({ isSelected });
+      if (isSelected !== this.state.isSelected) {
+        this.setState({ isSelected });
+      }
     }
   }
 
@@ -382,7 +384,7 @@ export class GroupedListSection extends React.Component<IGroupedListSectionProps
         onRenderGroupShowAll={onRenderGroupShowAll}
         onRenderGroupFooter={onRenderGroupFooter}
         onShouldVirtualize={onShouldVirtualize}
-        groups={group!.children}
+        groups={group ? group.children : []}
         compact={compact}
       />
     ) : null;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11975
- [x] Include a change request file using `$ yarn change`

#### Description of changes

`GroupedList` was assuming that the `groups` variable had a defined value when its props contract specified that it could be `undefined`. This was causing trouble with dynamically generated groups throwing an exception. This PR adds checks for undefined `groups` in the code so that it doesn't throw an exception on render.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12000)