### PR TITLE
Tooltip: Enable dismissing the Tooltip via pressing ESC key

### DIFF
--- a/change/@uifabric-experiments-2020-02-19-15-37-57-tooltipEsc.json
+++ b/change/@uifabric-experiments-2020-02-19-15-37-57-tooltipEsc.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Updating snapshots.",
+  "packageName": "@uifabric/experiments",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "01167a8a185c67c11c236ac71d44f4d30e42ff15",
+  "date": "2020-02-19T23:37:57.636Z"
+}

--- a/change/office-ui-fabric-react-2020-02-19-14-46-49-tooltipEsc.json
+++ b/change/office-ui-fabric-react-2020-02-19-14-46-49-tooltipEsc.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "Tooltip: Enable dismissing the Tooltip via pressing ESC key.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "163eff20c5426ab4999ad92eb833d6ecd7e65372",
+  "date": "2020-02-19T22:46:49.567Z"
+}

--- a/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -947,6 +947,7 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
           }
       onBlurCapture={[Function]}
       onFocusCapture={[Function]}
+      onKeyDown={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
     >

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -108,6 +108,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 1 1`] = `
                       }
                   onBlurCapture={[Function]}
                   onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                 >
@@ -190,6 +191,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 1 1`] = `
                       }
                   onBlurCapture={[Function]}
                   onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                 >
@@ -272,6 +274,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 1 1`] = `
                       }
                   onBlurCapture={[Function]}
                   onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                 >
@@ -354,6 +357,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 1 1`] = `
                       }
                   onBlurCapture={[Function]}
                   onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                 >
@@ -660,6 +664,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 2 1`] = `
                       }
                   onBlurCapture={[Function]}
                   onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                 >
@@ -742,6 +747,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 2 1`] = `
                       }
                   onBlurCapture={[Function]}
                   onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                 >
@@ -865,6 +871,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 3 1`] = `
                       }
                   onBlurCapture={[Function]}
                   onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                 >
@@ -920,6 +927,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 3 1`] = `
                       }
                   onBlurCapture={[Function]}
                   onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                 >
@@ -975,6 +983,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 3 1`] = `
                       }
                   onBlurCapture={[Function]}
                   onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                 >
@@ -1030,6 +1039,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 3 1`] = `
                       }
                   onBlurCapture={[Function]}
                   onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                 >
@@ -1153,6 +1163,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 4 1`] = `
                       }
                   onBlurCapture={[Function]}
                   onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                 >
@@ -1418,6 +1429,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 4 1`] = `
                       }
                   onBlurCapture={[Function]}
                   onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                 >
@@ -1541,6 +1553,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 5 1`] = `
                       }
                   onBlurCapture={[Function]}
                   onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                 >
@@ -2244,6 +2257,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 7 1`] = `
                       }
                   onBlurCapture={[Function]}
                   onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                 >
@@ -2326,6 +2340,7 @@ exports[`Breadcrumb basic rendering renders breadcumb correctly 7 1`] = `
                       }
                   onBlurCapture={[Function]}
                   onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                 >

--- a/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/PersonaCoin/__snapshots__/PersonaCoin.test.tsx.snap
@@ -122,6 +122,7 @@ exports[`Persona renders Persona children correctly 1`] = `
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
@@ -313,6 +314,7 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
@@ -513,6 +515,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
@@ -686,6 +689,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
@@ -1113,6 +1117,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
@@ -1140,6 +1145,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
@@ -1168,6 +1174,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
@@ -1196,6 +1203,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
@@ -1432,6 +1440,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
@@ -1459,6 +1468,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
@@ -1487,6 +1497,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
@@ -1515,6 +1526,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >

--- a/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.deprecated.test.tsx.snap
@@ -149,6 +149,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
@@ -322,6 +323,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >

--- a/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Persona/__snapshots__/Persona.test.tsx.snap
@@ -122,6 +122,7 @@ exports[`Persona renders Persona children correctly 1`] = `
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
@@ -313,6 +314,7 @@ exports[`Persona renders Persona correctly with UnknownPersona coin 1`] = `
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
@@ -513,6 +515,7 @@ exports[`Persona renders Persona correctly with image 1`] = `
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
@@ -686,6 +689,7 @@ exports[`Persona renders Persona correctly with initials 1`] = `
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
@@ -1113,6 +1117,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
@@ -1140,6 +1145,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
@@ -1168,6 +1174,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
@@ -1196,6 +1203,7 @@ exports[`Persona renders Persona which calls onRenderCoin callback without image
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
@@ -1432,6 +1440,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
@@ -1459,6 +1468,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
@@ -1487,6 +1497,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >
@@ -1515,6 +1526,7 @@ exports[`Persona renders correctly with onRender callback 1`] = `
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >

--- a/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/TooltipHost.base.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import {
   BaseComponent,
+  KeyCodes,
   divProperties,
   getNativeProps,
   getId,
@@ -79,6 +80,7 @@ export class TooltipHostBase extends BaseComponent<ITooltipHostProps, ITooltipHo
         {...{ onBlurCapture: this._hideTooltip }}
         onMouseEnter={this._onTooltipMouseEnter}
         onMouseLeave={this._onTooltipMouseLeave}
+        onKeyDown={this._onTooltipKeyDown}
         aria-describedby={ariaDescribedBy}
       >
         {children}
@@ -179,6 +181,12 @@ export class TooltipHostBase extends BaseComponent<ITooltipHostProps, ITooltipHo
     }
     if (TooltipHostBase._currentVisibleTooltip === this) {
       TooltipHostBase._currentVisibleTooltip = undefined;
+    }
+  };
+
+  private _onTooltipKeyDown = (ev: React.KeyboardEvent<HTMLElement>): void => {
+    if (ev.which === KeyCodes.escape) {
+      this._hideTooltip();
     }
   };
 

--- a/packages/office-ui-fabric-react/src/components/Tooltip/__snapshots__/TooltipHost.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Tooltip/__snapshots__/TooltipHost.test.tsx.snap
@@ -9,6 +9,7 @@ exports[`TooltipHost renders correctly 1`] = `
       }
   onBlurCapture={[Function]}
   onFocusCapture={[Function]}
+  onKeyDown={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
 />

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -220,6 +220,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
@@ -385,6 +386,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
@@ -550,6 +552,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
@@ -715,6 +718,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
@@ -880,6 +884,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
@@ -1046,6 +1051,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
@@ -1282,6 +1288,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
@@ -1296,6 +1303,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                   onBlurCapture={[Function]}
                   onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                 >
@@ -1439,6 +1447,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
@@ -1453,6 +1462,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                   onBlurCapture={[Function]}
                   onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                 >
@@ -1596,6 +1606,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
@@ -1610,6 +1621,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                   onBlurCapture={[Function]}
                   onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                 >
@@ -1753,6 +1765,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
@@ -1767,6 +1780,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                   onBlurCapture={[Function]}
                   onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                 >
@@ -1910,6 +1924,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
@@ -1924,6 +1939,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                       }
                   onBlurCapture={[Function]}
                   onFocusCapture={[Function]}
+                  onKeyDown={[Function]}
                   onMouseEnter={[Function]}
                   onMouseLeave={[Function]}
                 >
@@ -2068,6 +2084,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
@@ -2304,6 +2321,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
@@ -2469,6 +2487,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
@@ -2634,6 +2653,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
@@ -2799,6 +2819,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
@@ -2964,6 +2985,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
@@ -3130,6 +3152,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
@@ -3532,6 +3555,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
@@ -3679,6 +3703,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
@@ -3827,6 +3852,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
@@ -3980,6 +4006,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
@@ -4246,6 +4273,7 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
@@ -383,6 +383,7 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
@@ -548,6 +549,7 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >
@@ -714,6 +716,7 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         }
                     onBlurCapture={[Function]}
                     onFocusCapture={[Function]}
+                    onKeyDown={[Function]}
                     onMouseEnter={[Function]}
                     onMouseLeave={[Function]}
                   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.Basic.Example.tsx.shot
@@ -1074,6 +1074,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                     }
                 onBlurCapture={[Function]}
                 onFocusCapture={[Function]}
+                onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
               >
@@ -1225,6 +1226,7 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                     }
                 onBlurCapture={[Function]}
                 onFocusCapture={[Function]}
+                onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
               >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
@@ -1079,6 +1079,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                     }
                 onBlurCapture={[Function]}
                 onFocusCapture={[Function]}
+                onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
               >
@@ -1230,6 +1231,7 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                     }
                 onBlurCapture={[Function]}
                 onFocusCapture={[Function]}
+                onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
               >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
@@ -1075,6 +1075,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                   }
               onBlurCapture={[Function]}
               onFocusCapture={[Function]}
+              onKeyDown={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
             >
@@ -1226,6 +1227,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                   }
               onBlurCapture={[Function]}
               onFocusCapture={[Function]}
+              onKeyDown={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
             >
@@ -2925,6 +2927,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                   }
               onBlurCapture={[Function]}
               onFocusCapture={[Function]}
+              onKeyDown={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
             >
@@ -3076,6 +3079,7 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                   }
               onBlurCapture={[Function]}
               onFocusCapture={[Function]}
+              onKeyDown={[Function]}
               onMouseEnter={[Function]}
               onMouseLeave={[Function]}
             >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
@@ -906,6 +906,7 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                     }
                 onBlurCapture={[Function]}
                 onFocusCapture={[Function]}
+                onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
               >
@@ -1373,6 +1374,7 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                     }
                 onBlurCapture={[Function]}
                 onFocusCapture={[Function]}
+                onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
               >
@@ -1524,6 +1526,7 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                     }
                 onBlurCapture={[Function]}
                 onFocusCapture={[Function]}
+                onKeyDown={[Function]}
                 onMouseEnter={[Function]}
                 onMouseLeave={[Function]}
               >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Vertical.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Vertical.Example.tsx.shot
@@ -36,6 +36,7 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
           }
       onBlurCapture={[Function]}
       onFocusCapture={[Function]}
+      onKeyDown={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
     >
@@ -182,6 +183,7 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
           }
       onBlurCapture={[Function]}
       onFocusCapture={[Function]}
+      onKeyDown={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
     >
@@ -328,6 +330,7 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
           }
       onBlurCapture={[Function]}
       onFocusCapture={[Function]}
+      onKeyDown={[Function]}
       onMouseEnter={[Function]}
       onMouseLeave={[Function]}
     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Alternate.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Alternate.Example.tsx.shot
@@ -155,6 +155,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -186,6 +187,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -214,6 +216,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -242,6 +245,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -401,6 +405,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -432,6 +437,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -460,6 +466,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -488,6 +495,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -671,6 +679,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -702,6 +711,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -730,6 +740,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -758,6 +769,7 @@ exports[`Component Examples renders Persona.Alternate.Example.tsx correctly 1`] 
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Basic.Example.tsx.shot
@@ -286,6 +286,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -314,6 +315,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -342,6 +344,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -370,6 +373,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -535,6 +539,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -563,6 +568,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -591,6 +597,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -619,6 +626,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -826,6 +834,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -854,6 +863,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -882,6 +892,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -910,6 +921,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1117,6 +1129,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1145,6 +1158,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1173,6 +1187,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1201,6 +1216,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1408,6 +1424,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1436,6 +1453,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1464,6 +1482,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1492,6 +1511,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1727,6 +1747,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1754,6 +1775,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1782,6 +1804,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1810,6 +1833,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2037,6 +2061,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2064,6 +2089,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2092,6 +2118,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2120,6 +2147,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2353,6 +2381,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2380,6 +2409,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2408,6 +2438,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2436,6 +2467,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2696,6 +2728,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2723,6 +2756,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2751,6 +2785,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2779,6 +2814,7 @@ exports[`Component Examples renders Persona.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.CustomCoinRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.CustomCoinRender.Example.tsx.shot
@@ -187,6 +187,7 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -214,6 +215,7 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -256,6 +258,7 @@ exports[`Component Examples renders Persona.CustomCoinRender.Example.tsx correct
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.CustomRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.CustomRender.Example.tsx.shot
@@ -218,6 +218,7 @@ exports[`Component Examples renders Persona.CustomRender.Example.tsx correctly 1
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -281,6 +282,7 @@ exports[`Component Examples renders Persona.CustomRender.Example.tsx correctly 1
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -309,6 +311,7 @@ exports[`Component Examples renders Persona.CustomRender.Example.tsx correctly 1
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Initials.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.Initials.Example.tsx.shot
@@ -125,6 +125,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -152,6 +153,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -180,6 +182,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -208,6 +211,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -337,6 +341,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -364,6 +369,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -392,6 +398,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -420,6 +427,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -549,6 +557,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -576,6 +585,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -604,6 +614,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -632,6 +643,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -761,6 +773,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -788,6 +801,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -816,6 +830,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -844,6 +859,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -973,6 +989,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1000,6 +1017,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1028,6 +1046,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1056,6 +1075,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1200,6 +1220,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1227,6 +1248,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1255,6 +1277,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1283,6 +1306,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1412,6 +1436,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1439,6 +1464,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1467,6 +1493,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1495,6 +1522,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1639,6 +1667,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1666,6 +1695,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1694,6 +1724,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1722,6 +1753,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1866,6 +1898,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1893,6 +1926,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1921,6 +1955,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1949,6 +1984,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2093,6 +2129,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2120,6 +2157,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2148,6 +2186,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2176,6 +2215,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2305,6 +2345,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2332,6 +2373,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2360,6 +2402,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2388,6 +2431,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2517,6 +2561,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2544,6 +2589,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2572,6 +2618,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2600,6 +2647,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2747,6 +2795,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2774,6 +2823,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2802,6 +2852,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -2830,6 +2881,7 @@ exports[`Component Examples renders Persona.Initials.Example.tsx correctly 1`] =
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.UnknownPersona.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Persona.UnknownPersona.Example.tsx.shot
@@ -140,6 +140,7 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -167,6 +168,7 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -339,6 +341,7 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -366,6 +369,7 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -394,6 +398,7 @@ exports[`Component Examples renders Persona.UnknownPersona.Example.tsx correctly
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SelectedPeopleList.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SelectedPeopleList.Controlled.Example.tsx.shot
@@ -442,6 +442,7 @@ exports[`Component Examples renders SelectedPeopleList.Controlled.Example.tsx co
                           }
                       onBlurCapture={[Function]}
                       onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                     >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Toggle.Basic.Example.tsx.shot
@@ -959,6 +959,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >
@@ -1517,6 +1518,7 @@ exports[`Component Examples renders Toggle.Basic.Example.tsx correctly 1`] = `
               }
           onBlurCapture={[Function]}
           onFocusCapture={[Function]}
+          onKeyDown={[Function]}
           onMouseEnter={[Function]}
           onMouseLeave={[Function]}
         >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Absolute.Position.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Absolute.Position.Example.tsx.shot
@@ -16,6 +16,7 @@ exports[`Component Examples renders Tooltip.Absolute.Position.Example.tsx correc
         }
     onBlurCapture={[Function]}
     onFocusCapture={[Function]}
+    onKeyDown={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Basic.Example.tsx.shot
@@ -10,6 +10,7 @@ exports[`Component Examples renders Tooltip.Basic.Example.tsx correctly 1`] = `
         }
     onBlurCapture={[Function]}
     onFocusCapture={[Function]}
+    onKeyDown={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Custom.Example.tsx.shot
@@ -9,6 +9,7 @@ exports[`Component Examples renders Tooltip.Custom.Example.tsx correctly 1`] = `
       }
   onBlurCapture={[Function]}
   onFocusCapture={[Function]}
+  onKeyDown={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
 >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Display.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Display.Example.tsx.shot
@@ -13,6 +13,7 @@ exports[`Component Examples renders Tooltip.Display.Example.tsx correctly 1`] = 
         }
     onBlurCapture={[Function]}
     onFocusCapture={[Function]}
+    onKeyDown={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >
@@ -36,6 +37,7 @@ exports[`Component Examples renders Tooltip.Display.Example.tsx correctly 1`] = 
         }
     onBlurCapture={[Function]}
     onFocusCapture={[Function]}
+    onKeyDown={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Interactive.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Interactive.Example.tsx.shot
@@ -10,6 +10,7 @@ exports[`Component Examples renders Tooltip.Interactive.Example.tsx correctly 1`
         }
     onBlurCapture={[Function]}
     onFocusCapture={[Function]}
+    onKeyDown={[Function]}
     onMouseEnter={[Function]}
     onMouseLeave={[Function]}
   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.NoScroll.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.NoScroll.Example.tsx.shot
@@ -9,6 +9,7 @@ exports[`Component Examples renders Tooltip.NoScroll.Example.tsx correctly 1`] =
       }
   onBlurCapture={[Function]}
   onFocusCapture={[Function]}
+  onKeyDown={[Function]}
   onMouseEnter={[Function]}
   onMouseLeave={[Function]}
 >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Overflow.Example.tsx.shot
@@ -146,6 +146,7 @@ exports[`Component Examples renders Tooltip.Overflow.Example.tsx correctly 1`] =
             }
         onBlurCapture={[Function]}
         onFocusCapture={[Function]}
+        onKeyDown={[Function]}
         onMouseEnter={[Function]}
         onMouseLeave={[Function]}
       >

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -380,6 +380,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                           }
                       onBlurCapture={[Function]}
                       onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                     >
@@ -408,6 +409,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                           }
                       onBlurCapture={[Function]}
                       onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                     >
@@ -436,6 +438,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                           }
                       onBlurCapture={[Function]}
                       onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                     >
@@ -464,6 +467,7 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                           }
                       onBlurCapture={[Function]}
                       onFocusCapture={[Function]}
+                      onKeyDown={[Function]}
                       onMouseEnter={[Function]}
                       onMouseLeave={[Function]}
                     >


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11991
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The `Tooltip` in Fabric 6 wasn't dismissing when pressing the `ESC` key while the target was focused. This PR adds the described behavior by replicating what we have in Fabric 7.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12004)