### PR TITLE
[cherry pick to 6.0] allowScrollOnElement: fix memory leak caused by closure

### DIFF
--- a/change/@uifabric-utilities-2020-02-19-16-39-15-6.0.json
+++ b/change/@uifabric-utilities-2020-02-19-16-39-15-6.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "fix memory leak caused by closure in scroll util",
+  "packageName": "@uifabric/utilities",
+  "email": "xgao@microsoft.com",
+  "commit": "a47fd3ff5f3cd37c6af72b27142ee6279e429760",
+  "date": "2020-02-20T00:39:15.335Z"
+}

--- a/packages/utilities/src/scroll.ts
+++ b/packages/utilities/src/scroll.ts
@@ -19,7 +19,15 @@ const DisabledScrollClassName = mergeStyles({
  */
 export const DATA_IS_SCROLLABLE_ATTRIBUTE = 'data-is-scrollable';
 
-const _makeElementScrollAllower = () => {
+/**
+ * Allows the user to scroll within a element,
+ * while preventing the user from scrolling the body
+ */
+export const allowScrollOnElement = (element: HTMLElement | null, events: EventGroup): void => {
+  if (!element) {
+    return;
+  }
+
   let _previousClientY = 0;
   let _element: Element | null = null;
 
@@ -66,23 +74,11 @@ const _makeElementScrollAllower = () => {
     }
   };
 
-  return (element: HTMLElement | null, events: EventGroup): void => {
-    if (!element) {
-      return;
-    }
+  events.on(element, 'touchstart', _saveClientY, { passive: false });
+  events.on(element, 'touchmove', _preventOverscrolling, { passive: false });
 
-    events.on(element, 'touchstart', _saveClientY, { passive: false });
-    events.on(element, 'touchmove', _preventOverscrolling, { passive: false });
-
-    _element = element;
-  };
+  _element = element;
 };
-
-/**
- * Allows the user to scroll within a element,
- * while preventing the user from scrolling the body
- */
-export const allowScrollOnElement = _makeElementScrollAllower();
 
 const _disableIosBodyScroll = (event: TouchEvent) => {
   event.preventDefault();


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Cherry-pick https://github.com/OfficeDev/office-ui-fabric-react/pull/12003 to Fabric 6

Repro of the issue (Panel): https://codesandbox.io/s/inspiring-wu-dwrl9?fontsize=14&hidenavigation=1&theme=dark

Removed the outer scope in allowScrollOnElement so that _element does not hold on to the DOM element forever

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12007)