### PR TITLE
Panel: use align-items for cross axis alignment.

### DIFF
--- a/change/office-ui-fabric-react-2020-02-21-11-06-46-panel_header.json
+++ b/change/office-ui-fabric-react-2020-02-21-11-06-46-panel_header.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Panel: use align-items for vertical alignment",
+  "packageName": "office-ui-fabric-react",
+  "email": "aneeshak@microsoft.com",
+  "commit": "c465e31ed6e790aa94340698004872df80cd0c70",
+  "dependentChangeType": "patch",
+  "date": "2020-02-21T19:06:46.540Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -273,15 +273,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       !isOpen && isAnimating && isOnRightSide && AnimationClassNames.slideRightOut40,
       focusTrapZoneClassName
     ],
-    commands: [
-      classNames.commands,
-      {
-        marginTop: 18
-      },
-      hasCustomNavigation && {
-        marginTop: 'inherit'
-      }
-    ],
+    commands: [classNames.commands],
     navigation: [
       classNames.navigation,
       {
@@ -292,15 +284,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         height: commandBarHeight
       }
     ],
-    closeButton: [
-      classNames.closeButton,
-      {
-        marginRight: 14
-      },
-      hasCustomNavigation && {
-        marginRight: 0
-      }
-    ],
+    closeButton: [classNames.closeButton],
     contentInner: [
       classNames.contentInner,
       {
@@ -314,13 +298,11 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       classNames.header,
       sharedPaddingStyles,
       {
-        flexShrink: 1,
-        marginRight: 'auto'
+        flexShrink: 1
       },
       hasCustomNavigation && {
         // Ensure that title doesn't shrink if screen is too small
-        flexShrink: 0,
-        marginRight: 0
+        flexShrink: 0
       }
     ],
     headerText: [
@@ -329,7 +311,6 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       {
         color: semanticColors.bodyText,
         lineHeight: '27px',
-        margin: 0,
         overflowWrap: 'break-word',
         wordWrap: 'break-word',
         wordBreak: 'break-word',
@@ -350,7 +331,6 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       classNames.content,
       sharedPaddingStyles,
       {
-        marginBottom: 0,
         paddingBottom: 20
       }
     ],

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -273,7 +273,15 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       !isOpen && isAnimating && isOnRightSide && AnimationClassNames.slideRightOut40,
       focusTrapZoneClassName
     ],
-    commands: [classNames.commands],
+    commands: [
+      classNames.commands,
+      {
+        marginTop: 18
+      },
+      hasCustomNavigation && {
+        marginTop: 'inherit'
+      }
+    ],
     navigation: [
       classNames.navigation,
       {

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -292,7 +292,15 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
         height: commandBarHeight
       }
     ],
-    closeButton: [classNames.closeButton],
+    closeButton: [
+      classNames.closeButton,
+      {
+        marginRight: 14
+      },
+      hasCustomNavigation && {
+        marginRight: 0
+      }
+    ],
     contentInner: [
       classNames.contentInner,
       {

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -286,7 +286,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       classNames.navigation,
       {
         display: 'flex',
-        alignItems: 'flex-end'
+        justifyContent: 'space-between'
       },
       hasCustomNavigation && {
         height: commandBarHeight

--- a/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Panel/Panel.styles.ts
@@ -286,7 +286,7 @@ export const getStyles = (props: IPanelStyleProps): IPanelStyles => {
       classNames.navigation,
       {
         display: 'flex',
-        justifyContent: 'flex-end'
+        alignItems: 'flex-end'
       },
       hasCustomNavigation && {
         height: commandBarHeight

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -237,6 +237,7 @@ exports[`Panel renders Panel correctly 1`] = `
                       font-size: 20px;
                       font-weight: 400;
                       height: 32px;
+                      margin-right: 14px;
                       outline: transparent;
                       padding-bottom: 0;
                       padding-left: 4px;

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -180,8 +180,8 @@ exports[`Panel renders Panel correctly 1`] = `
               className=
                   ms-Panel-navigation
                   {
+                    align-items: flex-end;
                     display: flex;
-                    justify-content: flex-end;
                   }
             >
               <div

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -171,7 +171,9 @@ exports[`Panel renders Panel correctly 1`] = `
           <div
             className=
                 ms-Panel-commands
-
+                {
+                  margin-top: 18px;
+                }
             data-is-visible={true}
           >
             <div

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -180,8 +180,8 @@ exports[`Panel renders Panel correctly 1`] = `
               className=
                   ms-Panel-navigation
                   {
-                    align-items: flex-end;
                     display: flex;
+                    justify-content: space-between;
                   }
             >
               <div

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -171,9 +171,7 @@ exports[`Panel renders Panel correctly 1`] = `
           <div
             className=
                 ms-Panel-commands
-                {
-                  margin-top: 18px;
-                }
+
             data-is-visible={true}
           >
             <div
@@ -189,7 +187,6 @@ exports[`Panel renders Panel correctly 1`] = `
                     ms-Panel-header
                     {
                       flex-shrink: 1;
-                      margin-right: auto;
                       padding-left: 24px;
                       padding-right: 24px;
                     }
@@ -208,10 +205,6 @@ exports[`Panel renders Panel correctly 1`] = `
                         font-weight: 600;
                         hyphens: auto;
                         line-height: 27px;
-                        margin-bottom: 0px;
-                        margin-left: 0px;
-                        margin-right: 0px;
-                        margin-top: 0px;
                         overflow-wrap: break-word;
                         word-break: break-word;
                         word-wrap: break-word;
@@ -242,7 +235,6 @@ exports[`Panel renders Panel correctly 1`] = `
                       font-size: 20px;
                       font-weight: 400;
                       height: 32px;
-                      margin-right: 14px;
                       outline: transparent;
                       padding-bottom: 0;
                       padding-left: 4px;
@@ -380,7 +372,6 @@ exports[`Panel renders Panel correctly 1`] = `
                 className=
                     ms-Panel-content
                     {
-                      margin-bottom: 0px;
                       padding-bottom: 20px;
                       padding-left: 24px;
                       padding-right: 24px;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12020 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Panel's header styles are broken in IE11 because IE11 isn't compliant with the W3 spec on margins - instead of changing the marginRight auto setting (which would break the other browsers), I'm fixing the other problem which is that with flexbox, vertical alignment (cross axis) should be set with alignItems, not justifyContent (that's for the main axis). 

#### Focus areas to test
IE 11:
![image](https://user-images.githubusercontent.com/4161791/75063952-d4cb2000-549a-11ea-8739-7b7351f6259a.png)
Edge:
![image](https://user-images.githubusercontent.com/4161791/75063966-df85b500-549a-11ea-8da1-e01522b5c6f7.png)
Chrome:
![image](https://user-images.githubusercontent.com/4161791/75063978-e6142c80-549a-11ea-9dc2-522115d90197.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12025)