### PR TITLE
DetailsList: fix memory leak caused by incorrect component memoization

### DIFF
--- a/change/office-ui-fabric-react-2020-02-21-18-26-16-xgao-dl-mem-leak.json
+++ b/change/office-ui-fabric-react-2020-02-21-18-26-16-xgao-dl-mem-leak.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "DetailsList: fix memory leak caused by incorrect component memoization",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "b292e82b235d6e6ee76f60d6b52aa0c8f7d2f418",
+  "dependentChangeType": "patch",
+  "date": "2020-02-22T02:26:16.228Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -1294,9 +1294,6 @@ export function getAllSelectedOptions(options: ISelectableOption[], selectedIndi
 export function getBackgroundShade(color: IColor, shade: Shade, isInverted?: boolean): IColor | null;
 
 // @public
-export const getCheck: (theme?: ITheme | undefined, checked?: boolean | undefined, className?: string | undefined) => JSX.Element;
-
-// @public
 export function getColorFromHSV(hsv: IHSV, a?: number): IColor;
 
 // @public

--- a/packages/office-ui-fabric-react/src/components/Check/Check.tsx
+++ b/packages/office-ui-fabric-react/src/components/Check/Check.tsx
@@ -1,9 +1,8 @@
 import * as React from 'react';
-import { styled, memoizeFunction } from '../../Utilities';
+import { styled } from '../../Utilities';
 import { ICheckProps, ICheckStyleProps, ICheckStyles } from './Check.types';
 import { CheckBase } from './Check.base';
 import { getStyles } from './Check.styles';
-import { ITheme } from '../../Styling';
 
 export const Check: React.FunctionComponent<ICheckProps> = styled<ICheckProps, ICheckStyleProps, ICheckStyles>(
   CheckBase,
@@ -14,13 +13,3 @@ export const Check: React.FunctionComponent<ICheckProps> = styled<ICheckProps, I
   },
   true
 );
-
-/**
- * Memoized helper for rendering a Check. Always uses fast icons.
- * @param theme - Theme, so the check can be re-rendered if it changes.
- * @param checked - Whether the check is checked.
- * @param className - Class name for styling the check.
- */
-export const getCheck = memoizeFunction((theme?: ITheme, checked?: boolean, className?: string) => {
-  return <Check theme={theme} checked={checked} className={className} useFastIcons />;
-});

--- a/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/DetailsRowCheck.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
 import { IDetailsRowCheckProps, IDetailsCheckboxProps, IDetailsRowCheckStyleProps, IDetailsRowCheckStyles } from './DetailsRowCheck.types';
 import { css, styled, classNamesFunction } from '../../Utilities';
-import { Check, getCheck } from '../../Check';
+import { Check } from '../../Check';
 import { getStyles } from './DetailsRowCheck.styles';
 import { composeRenderFunction } from '@uifabric/utilities';
+import { ITheme } from '../../Styling';
 
 const getClassNames = classNamesFunction<IDetailsRowCheckStyleProps, IDetailsRowCheckStyles>();
 
@@ -61,12 +62,16 @@ const DetailsRowCheckBase: React.FunctionComponent<IDetailsRowCheckProps> = prop
   );
 };
 
+const FastCheck = React.memo((props: { theme?: ITheme; checked?: boolean; className?: string }) => {
+  return <Check theme={props.theme} checked={props.checked} className={props.className} useFastIcons />;
+});
+
 function _defaultCheckboxRender(checkboxProps: IDetailsCheckboxProps) {
   return <Check checked={checkboxProps.checked} />;
 }
 
 function _fastDefaultCheckboxRender(checkboxProps: IDetailsCheckboxProps) {
-  return getCheck(checkboxProps.theme, checkboxProps.checked);
+  return <FastCheck theme={checkboxProps.theme} checked={checkboxProps.checked} />;
 }
 
 export const DetailsRowCheck = styled<IDetailsRowCheckProps, IDetailsRowCheckStyleProps, IDetailsRowCheckStyles>(


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11955
- [x] Include a change request file using `$ yarn change`

#### Description of changes

`DetailsRowCheck` incorrect `getCheck`, which mis-used `memoizeFunction` which is causing react component being kept/saved in memory regardless of its life cycle.

Note: I decided removed `getCheck`  since it doesn't fit to as a public interface/component. I don't think we need to deprecate it as I highly doubt anyone outside is using it.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12028)