### PR TITLE
Make sure breaking FluentUI Screener failures actually break the build

### DIFF
--- a/packages/fluentui/docs/src/examples/components/Accordion/Usage/AccordionPanelCustomContentExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Accordion/Usage/AccordionPanelCustomContentExample.shorthand.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react'
-import { Accordion, Button, Flex } from '@fluentui/react'
+import * as React from 'react';
+import { Accordion, Button, Flex } from '@fluentui/react';
 
 const AccordionPanelCustomContentExample = () => {
   const panels = [
@@ -7,14 +7,14 @@ const AccordionPanelCustomContentExample = () => {
       title: 'Pets',
       content: (
         <Flex gap="gap.smaller" key="animals">
-          <Button primary>Add pet</Button>
+          <Button primary>Add pet CHANGED</Button>
           <Button>Remove pet</Button>
         </Flex>
-      ),
-    },
-  ]
+      )
+    }
+  ];
 
-  return <Accordion defaultActiveIndex={[0]} panels={panels} />
-}
+  return <Accordion defaultActiveIndex={[0]} panels={panels} />;
+};
 
-export default AccordionPanelCustomContentExample
+export default AccordionPanelCustomContentExample;

--- a/packages/fluentui/docs/src/examples/components/Accordion/Usage/AccordionPanelCustomContentExample.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Accordion/Usage/AccordionPanelCustomContentExample.shorthand.tsx
@@ -1,5 +1,5 @@
-import * as React from 'react';
-import { Accordion, Button, Flex } from '@fluentui/react';
+import * as React from 'react'
+import { Accordion, Button, Flex } from '@fluentui/react'
 
 const AccordionPanelCustomContentExample = () => {
   const panels = [
@@ -7,14 +7,14 @@ const AccordionPanelCustomContentExample = () => {
       title: 'Pets',
       content: (
         <Flex gap="gap.smaller" key="animals">
-          <Button primary>Add pet CHANGED</Button>
+          <Button primary>Add pet</Button>
           <Button>Remove pet</Button>
         </Flex>
-      )
-    }
-  ];
+      ),
+    },
+  ]
 
-  return <Accordion defaultActiveIndex={[0]} panels={panels} />;
-};
+  return <Accordion defaultActiveIndex={[0]} panels={panels} />
+}
 
-export default AccordionPanelCustomContentExample;
+export default AccordionPanelCustomContentExample

--- a/scripts/screener/screener.config.js
+++ b/scripts/screener/screener.config.js
@@ -78,8 +78,6 @@ module.exports = {
 
   alwaysAcceptBaseBranch: true,
 
-  failureExitCode: 0,
-
   baseBranch,
 
   ...(sourceBranch && sourceBranch.indexOf('refs/pull') > -1


### PR DESCRIPTION
This fixes the bug where failing screener for FluentUI didn't actually break the build.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12039)