### PR TITLE
Tile: Use more Tile props to inform link behavior

### DIFF
--- a/change/@uifabric-experiments-2020-02-24-15-00-09-Tile-link-props.json
+++ b/change/@uifabric-experiments-2020-02-24-15-00-09-Tile-link-props.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Updated Tile (in experiments) to pass some link-specific props (e.g. 'target', 'download') to its internal link so that users of Tile can customize the link behavior. The Tile link now also defaults to <span> (instead of <button>) when no href or onClick is passed. Updated Tile.Media.Example to include a linking demo showing the new functionality.",
+  "packageName": "@uifabric/experiments",
+  "email": "Graham.Langston@microsoft.com",
+  "commit": "e6839e8b1e2e70aa08653ae936ecf828ca6ac597",
+  "dependentChangeType": "patch",
+  "date": "2020-02-24T23:00:09.701Z"
+}

--- a/packages/experiments/src/components/Tile/Tile.tsx
+++ b/packages/experiments/src/components/Tile/Tile.tsx
@@ -160,6 +160,11 @@ export class Tile extends React.Component<ITileProps, ITileState> {
       descriptionAriaLabel,
       href,
       onClick,
+      download,
+      hrefLang,
+      media,
+      rel,
+      target,
       isFluentStyling,
       ariaLabelSelected,
       nameplateOnlyOnHover,
@@ -200,12 +205,17 @@ export class Tile extends React.Component<ITileProps, ITileState> {
       </>
     );
 
-    const LinkAs = href ? 'a' : 'button';
+    const LinkAs = href ? 'a' : onClick ? 'button' : 'span';
 
     const link = (
       <LinkAs
         href={href}
         onClick={onClick}
+        download={download}
+        hrefLang={hrefLang}
+        media={media}
+        target={target}
+        rel={rel === undefined ? (href && target ? 'noopener' : undefined) : rel}
         ref={this.props.linkRef}
         data-selection-invoke={isInvokable && selectionIndex > -1 ? true : undefined}
         className={css('ms-Tile-link', TileStyles.link)}

--- a/packages/experiments/src/components/Tile/examples/Tile.Media.Example.tsx
+++ b/packages/experiments/src/components/Tile/examples/Tile.Media.Example.tsx
@@ -96,6 +96,8 @@ interface IImageTileProps {
   originalImageSize: ISize;
   showBackground: boolean;
   nameplateOnlyOnHover: boolean;
+  linkHref?: string;
+  linkTarget?: string;
   item: typeof ITEMS[0];
 }
 
@@ -111,6 +113,8 @@ const ImageTile: React.FunctionComponent<IImageTileProps> = (props: IImageTilePr
       hideBackground={!props.showBackground}
       showBackgroundFrame={true}
       nameplateOnlyOnHover={props.nameplateOnlyOnHover}
+      href={props.linkHref}
+      target={props.linkTarget}
     />
   );
 
@@ -146,6 +150,8 @@ const ImageTile: React.FunctionComponent<IImageTileProps> = (props: IImageTilePr
 export interface ITileMediaExampleState {
   imagesLoaded: boolean;
   nameplateOnlyOnHover: boolean;
+  generateLinks: boolean;
+  linkInNewTab: boolean;
 }
 
 export class TileMediaExample extends React.Component<{}, ITileMediaExampleState> {
@@ -154,17 +160,24 @@ export class TileMediaExample extends React.Component<{}, ITileMediaExampleState
 
     this.state = {
       imagesLoaded: true,
-      nameplateOnlyOnHover: false
+      nameplateOnlyOnHover: false,
+      generateLinks: false,
+      linkInNewTab: false
     };
   }
 
   public render(): JSX.Element {
-    const { imagesLoaded, nameplateOnlyOnHover } = this.state;
+    const { imagesLoaded, nameplateOnlyOnHover, generateLinks, linkInNewTab } = this.state;
+    const exampleUrl = 'http://www.contoso.com/';
+    const linkHref = generateLinks ? exampleUrl : undefined;
+    const linkTarget = generateLinks && linkInNewTab ? '_blank' : undefined;
 
     return (
       <div>
         <Checkbox label="Show images as loaded" checked={imagesLoaded} onChange={this._onImagesLoadedChanged} />
         <Checkbox label="Show nameplate only on hover" checked={nameplateOnlyOnHover} onChange={this._onNameplateOnlyOnHoverChanged} />
+        <Checkbox label="Generate links" checked={generateLinks} onChange={this._onGenerateLinksChanged} />
+        <Checkbox label="Open links in new tab" disabled={!generateLinks} checked={linkInNewTab} onChange={this._onLinkInNewTabChanged} />
         <h3>Landscape</h3>
         <ImageTile
           tileSize={{
@@ -178,6 +191,8 @@ export class TileMediaExample extends React.Component<{}, ITileMediaExampleState
           }}
           showBackground={imagesLoaded}
           nameplateOnlyOnHover={nameplateOnlyOnHover}
+          linkHref={linkHref}
+          linkTarget={linkTarget}
         />
         <h3>Portrait</h3>
         <ImageTile
@@ -192,6 +207,8 @@ export class TileMediaExample extends React.Component<{}, ITileMediaExampleState
           }}
           showBackground={imagesLoaded}
           nameplateOnlyOnHover={nameplateOnlyOnHover}
+          linkHref={linkHref}
+          linkTarget={linkTarget}
         />
         <h3>Small Image</h3>
         <ImageTile
@@ -206,6 +223,8 @@ export class TileMediaExample extends React.Component<{}, ITileMediaExampleState
           }}
           showBackground={imagesLoaded}
           nameplateOnlyOnHover={nameplateOnlyOnHover}
+          linkHref={linkHref}
+          linkTarget={linkTarget}
         />
         <h3>No preview</h3>
         <div className={css(TileExampleStyles.tile, TileExampleStyles.largeTile)}>
@@ -215,6 +234,8 @@ export class TileMediaExample extends React.Component<{}, ITileMediaExampleState
             foreground={<Icon iconName="play" style={{ margin: '11px', fontSize: '40px' }} />}
             showBackgroundFrame={true}
             nameplateOnlyOnHover={this.state.nameplateOnlyOnHover}
+            href={linkHref}
+            target={linkTarget}
           />
         </div>
       </div>
@@ -230,6 +251,18 @@ export class TileMediaExample extends React.Component<{}, ITileMediaExampleState
   private _onNameplateOnlyOnHoverChanged = (event: React.FormEvent<HTMLInputElement>, checked: boolean): void => {
     this.setState({
       nameplateOnlyOnHover: checked
+    });
+  };
+
+  private _onGenerateLinksChanged = (event: React.FormEvent<HTMLInputElement>, checked: boolean): void => {
+    this.setState({
+      generateLinks: checked
+    });
+  };
+
+  private _onLinkInNewTabChanged = (event: React.FormEvent<HTMLInputElement>, checked: boolean): void => {
+    this.setState({
+      linkInNewTab: checked
     });
   };
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Updated Tile (in experiments) to pass on some link-specific props ('target', 'download', 'hrefLang', 'media' and 'rel') to its internal link so that users of Tile can customize the link behavior. The Tile link now also defaults to &lt;span&gt; (instead of &lt;button&gt;) when no href or onClick is passed. Updated Tile.Media.Example to include a linking demo showing the new functionality.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12044)