### PR TITLE
Fluent : carousel accessibility fixes

### DIFF
--- a/packages/fluentui/accessibility/src/behaviors/Carousel/carouselBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Carousel/carouselBehavior.ts
@@ -8,8 +8,8 @@ import * as keyboardKey from 'keyboard-key';
  * Adds attribute 'aria-label' to 'root' slot if 'navigation' property is false. Does not set the attribute otherwise.
  * Adds attribute 'aria-roledescription' to 'itemsContainer' slot if 'navigation' property is true. Does not set the attribute otherwise.
  * Adds attribute 'aria-label' to 'itemsContainer' slot if 'navigation' property is true. Does not set the attribute otherwise.
+ * Adds attribute 'role=region' to 'itemsContainer' slot if 'navigation' property is true.  Set 'role=none' otherwise.
  * Adds attribute 'tabIndex=-1' to 'itemsContainer' slot if 'navigation' property is false. Does not set the attribute otherwise.
- * Adds attribute 'role=none to 'itemsContainer' slot if 'navigation' property is false. Does not set the attribute otherwise.
  * @specification
  * Adds attribute 'role=region' to 'root' slot.
  * Adds attribute 'aria-live=polite' to 'itemsContainerWrapper' slot if 'ariaLiveOn' property is true. Sets the attribute to 'off' otherwise.
@@ -17,7 +17,6 @@ import * as keyboardKey from 'keyboard-key';
  * Adds attribute 'aria-hidden=true' to 'paddlePrevious' slot if 'navigation' property is true. Does not set the attribute otherwise.
  * Adds attribute 'tabIndex=-1' to 'paddlePrevious' slot if 'navigation' property is true. Does not set the attribute otherwise.
  * Adds attribute 'tabIndex=-1' to 'paddlePrevious' slot if 'navigation' property is true. Does not set the attribute otherwise.
- * Adds attribute 'role=region' to 'itemsContainer' slot if 'navigation' property is true. Does not set the attribute otherwise.
  * Triggers 'showNextSlideByKeyboardNavigation' action with 'ArrowRight' on 'itemsContainer'.
  * Triggers 'showPreviousSlideByKeyboardNavigation' action with 'ArrowLeft' on 'itemsContainer'.
  * Triggers 'showNextSlideByPaddlePress' action with 'Enter' or 'Spacebar' on 'paddleNext'.

--- a/packages/fluentui/accessibility/src/behaviors/Carousel/carouselBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Carousel/carouselBehavior.ts
@@ -2,6 +2,12 @@ import { Accessibility } from '../../types';
 import * as keyboardKey from 'keyboard-key';
 
 /**
+ * @description
+ * Adds attribute 'role=region' to 'root' slot if 'navigation' property is false. Does not set the attribute otherwise.
+ * Adds attribute 'aria-roledescription' to 'root' slot if 'navigation' property is false. Does not set the attribute otherwise.
+ * Adds attribute 'aria-label' to 'root' slot if 'navigation' property is false. Does not set the attribute otherwise.
+ * Adds attribute 'aria-roledescription' to 'itemsContainer' slot if 'navigation' property is true. Does not set the attribute otherwise.
+ * Adds attribute 'aria-label' to 'itemsContainer' slot if 'navigation' property is true. Does not set the attribute otherwise.
  * @specification
  * Adds attribute 'role=region' to 'root' slot.
  * Adds attribute 'aria-live=polite' to 'itemsContainerWrapper' slot if 'ariaLiveOn' property is true. Sets the attribute to 'off' otherwise.
@@ -9,6 +15,7 @@ import * as keyboardKey from 'keyboard-key';
  * Adds attribute 'aria-hidden=true' to 'paddlePrevious' slot if 'navigation' property is true. Does not set the attribute otherwise.
  * Adds attribute 'tabIndex=-1' to 'paddlePrevious' slot if 'navigation' property is true. Does not set the attribute otherwise.
  * Adds attribute 'tabIndex=-1' to 'paddlePrevious' slot if 'navigation' property is true. Does not set the attribute otherwise.
+ * Adds attribute 'role=group' to 'itemsContainer' slot if 'navigation' property is true. Does not set the attribute otherwise.
  * Triggers 'showNextSlideByKeyboardNavigation' action with 'ArrowRight' on 'itemsContainer'.
  * Triggers 'showPreviousSlideByKeyboardNavigation' action with 'ArrowLeft' on 'itemsContainer'.
  * Triggers 'showNextSlideByPaddlePress' action with 'Enter' or 'Spacebar' on 'paddleNext'.
@@ -17,10 +24,15 @@ import * as keyboardKey from 'keyboard-key';
 const carouselBehavior: Accessibility<CarouselBehaviorProps> = props => ({
   attributes: {
     root: {
-      role: 'region'
+      ...(!props.navigation && { role: 'region', 'aria-roledescription': props.ariaRoleDescription, 'aria-label': props.ariaLabel })
     },
     itemsContainerWrapper: {
       'aria-live': props.ariaLiveOn ? 'polite' : 'off'
+    },
+    itemsContainer: {
+      ...(props.navigation
+        ? { role: 'region', 'aria-roledescription': props.ariaRoleDescription, 'aria-label': props.ariaLabel }
+        : { tabIndex: -1, role: 'none' })
     },
 
     paddleNext: {
@@ -63,6 +75,8 @@ export type CarouselBehaviorProps = {
   /** Element type. */
   navigation: Object | Object[];
   ariaLiveOn: boolean;
+  ariaRoleDescription?: string;
+  ariaLabel?: string;
 };
 
 export default carouselBehavior;

--- a/packages/fluentui/accessibility/src/behaviors/Carousel/carouselBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Carousel/carouselBehavior.ts
@@ -8,6 +8,8 @@ import * as keyboardKey from 'keyboard-key';
  * Adds attribute 'aria-label' to 'root' slot if 'navigation' property is false. Does not set the attribute otherwise.
  * Adds attribute 'aria-roledescription' to 'itemsContainer' slot if 'navigation' property is true. Does not set the attribute otherwise.
  * Adds attribute 'aria-label' to 'itemsContainer' slot if 'navigation' property is true. Does not set the attribute otherwise.
+ * Adds attribute 'tabIndex=-1' to 'itemsContainer' slot if 'navigation' property is false. Does not set the attribute otherwise.
+ * Adds attribute 'role=none to 'itemsContainer' slot if 'navigation' property is false. Does not set the attribute otherwise.
  * @specification
  * Adds attribute 'role=region' to 'root' slot.
  * Adds attribute 'aria-live=polite' to 'itemsContainerWrapper' slot if 'ariaLiveOn' property is true. Sets the attribute to 'off' otherwise.
@@ -15,7 +17,7 @@ import * as keyboardKey from 'keyboard-key';
  * Adds attribute 'aria-hidden=true' to 'paddlePrevious' slot if 'navigation' property is true. Does not set the attribute otherwise.
  * Adds attribute 'tabIndex=-1' to 'paddlePrevious' slot if 'navigation' property is true. Does not set the attribute otherwise.
  * Adds attribute 'tabIndex=-1' to 'paddlePrevious' slot if 'navigation' property is true. Does not set the attribute otherwise.
- * Adds attribute 'role=group' to 'itemsContainer' slot if 'navigation' property is true. Does not set the attribute otherwise.
+ * Adds attribute 'role=region' to 'itemsContainer' slot if 'navigation' property is true. Does not set the attribute otherwise.
  * Triggers 'showNextSlideByKeyboardNavigation' action with 'ArrowRight' on 'itemsContainer'.
  * Triggers 'showPreviousSlideByKeyboardNavigation' action with 'ArrowLeft' on 'itemsContainer'.
  * Triggers 'showNextSlideByPaddlePress' action with 'Enter' or 'Spacebar' on 'paddleNext'.

--- a/packages/fluentui/accessibility/src/behaviors/Carousel/carouselItemBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Carousel/carouselItemBehavior.ts
@@ -2,6 +2,8 @@ import { Accessibility } from '../../types';
 import * as keyboardKey from 'keyboard-key';
 
 /**
+ * @description
+ * Adds attribute 'tabIndex=0' to 'root' slot if 'active' property and 'navigation' property is true. Sets the attribute to '-1' otherwise.
  * @specification
  * Adds attribute 'role=tabpanel' to 'root' slot if 'navigation' property is true. Sets the attribute to 'group' otherwise.
  * Adds attribute 'aria-hidden=false' to 'root' slot if 'active' property is true. Sets the attribute to 'true' otherwise.
@@ -11,9 +13,9 @@ import * as keyboardKey from 'keyboard-key';
 const carouselItemBehavior: Accessibility<CarouselItemProps> = props => ({
   attributes: {
     root: {
-      role: props.navigation ? 'tabpanel' : 'group',
+      role: props.navigation ? 'tabpanel' : undefined,
       'aria-hidden': props.active ? 'false' : 'true',
-      tabIndex: props.active ? 0 : -1
+      tabIndex: props.navigation ? (props.active ? 0 : -1) : undefined
     }
   },
 

--- a/packages/fluentui/accessibility/src/behaviors/Carousel/carouselItemBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Carousel/carouselItemBehavior.ts
@@ -5,9 +5,8 @@ import * as keyboardKey from 'keyboard-key';
  * @description
  * Adds attribute 'tabIndex=0' to 'root' slot if 'active' property and 'navigation' property is true. Sets the attribute to '-1' otherwise.
  * @specification
- * Adds attribute 'role=tabpanel' to 'root' slot if 'navigation' property is true. Sets the attribute to 'group' otherwise.
+ * Adds attribute 'role=tabpanel' based on the property 'navigation' to 'root' slot.
  * Adds attribute 'aria-hidden=false' to 'root' slot if 'active' property is true. Sets the attribute to 'true' otherwise.
- * Adds attribute 'tabIndex=0' to 'root' slot if 'active' property is true. Sets the attribute to '-1' otherwise.
  * Triggers 'arrowKeysNavigationStopPropagation' action with 'ArrowRight' or 'ArrowLeft' on 'root'.
  */
 const carouselItemBehavior: Accessibility<CarouselItemProps> = props => ({

--- a/packages/fluentui/accessibility/test/behaviors/caroselBehavior-test.tsx
+++ b/packages/fluentui/accessibility/test/behaviors/caroselBehavior-test.tsx
@@ -44,7 +44,7 @@ describe('carouselBehavior.ts', () => {
   describe('itemsContainer', () => {
     test(`sets "role=region" when carousel has navigation`, () => {
       const expectedResult = carouselBehavior({ ariaLiveOn: false, navigation: true });
-      expect(expectedResult.attributes.root.role).toEqual('region');
+      expect(expectedResult.attributes.itemsContainer.role).toEqual('region');
     });
 
     test('sets "aria-roledescription" when carousel has navigation', () => {
@@ -83,7 +83,7 @@ describe('carouselBehavior.ts', () => {
 
     test(`sets "tabindex=-1" when carousel has NO navigation`, () => {
       const expectedResult = carouselBehavior({ ariaLiveOn: false, navigation: false });
-      expect(expectedResult.attributes.itemsContainer.tabIndex).toEqual('-1');
+      expect(expectedResult.attributes.itemsContainer.tabIndex).toEqual(-1);
     });
   });
 });

--- a/packages/fluentui/accessibility/test/behaviors/caroselBehavior-test.tsx
+++ b/packages/fluentui/accessibility/test/behaviors/caroselBehavior-test.tsx
@@ -28,31 +28,25 @@ describe('carouselBehavior.ts', () => {
       expect(expectedResult.attributes.root['aria-label']).toEqual(label);
     });
 
-    test('do NOT set "aria-roledescription" when carousel has navigation', () => {
+    test('do NOT set aria atributes and role when carousel has navigation', () => {
       const expectedResult = carouselBehavior({
         ariaLiveOn: false,
         navigation: true,
-        ariaRoleDescription: roleDescription
-      });
-      expect(expectedResult.attributes.root['aria-roledescription']).toBeUndefined();
-    });
-
-    test('do NOT set "aria-label" when carousel has navigation', () => {
-      const expectedResult = carouselBehavior({
-        ariaLiveOn: false,
-        navigation: true,
+        ariaRoleDescription: roleDescription,
         ariaLabel: label
       });
+      expect(expectedResult.attributes.root['aria-roledescription']).toBeUndefined();
       expect(expectedResult.attributes.root['aria-label']).toBeUndefined();
-    });
-
-    test(`do NOT set "role=region" when carousel has navigation`, () => {
-      const expectedResult = carouselBehavior({ ariaLiveOn: false, navigation: true });
       expect(expectedResult.attributes.root.role).toBeUndefined();
     });
   });
 
   describe('itemsContainer', () => {
+    test(`sets "role=region" when carousel has navigation`, () => {
+      const expectedResult = carouselBehavior({ ariaLiveOn: false, navigation: true });
+      expect(expectedResult.attributes.root.role).toEqual('region');
+    });
+
     test('sets "aria-roledescription" when carousel has navigation', () => {
       const expectedResult = carouselBehavior({
         ariaLiveOn: false,
@@ -71,27 +65,25 @@ describe('carouselBehavior.ts', () => {
       expect(expectedResult.attributes.itemsContainer['aria-label']).toEqual(label);
     });
 
-    test('do NOT set "aria-roledescription" when carousel has NO navigation', () => {
+    test('do NOT set aria attributes when carousel has NO navigation', () => {
       const expectedResult = carouselBehavior({
         ariaLiveOn: false,
         navigation: false,
-        ariaRoleDescription: roleDescription
-      });
-      expect(expectedResult.attributes.itemsContainer['aria-roledescription']).toBeUndefined();
-    });
-
-    test('do NOT set "aria-label" when carousel has NO navigation', () => {
-      const expectedResult = carouselBehavior({
-        ariaLiveOn: false,
-        navigation: false,
+        ariaRoleDescription: roleDescription,
         ariaLabel: label
       });
+      expect(expectedResult.attributes.itemsContainer['aria-roledescription']).toBeUndefined();
       expect(expectedResult.attributes.itemsContainer['aria-label']).toBeUndefined();
     });
 
-    test(`do NOT set "role=group" when carousel has NO navigation`, () => {
+    test(`sets "role=none" when carousel has NO navigation`, () => {
       const expectedResult = carouselBehavior({ ariaLiveOn: false, navigation: false });
-      expect(expectedResult.attributes.itemsContainer.role).toBeUndefined();
+      expect(expectedResult.attributes.itemsContainer.role).toEqual('none');
+    });
+
+    test(`sets "tabindex=-1" when carousel has NO navigation`, () => {
+      const expectedResult = carouselBehavior({ ariaLiveOn: false, navigation: false });
+      expect(expectedResult.attributes.itemsContainer.tabIndex).toEqual('-1');
     });
   });
 });

--- a/packages/fluentui/accessibility/test/behaviors/caroselBehavior-test.tsx
+++ b/packages/fluentui/accessibility/test/behaviors/caroselBehavior-test.tsx
@@ -1,0 +1,97 @@
+import { carouselBehavior } from '@fluentui/accessibility';
+
+const roleDescription = 'carousel';
+const label = 'portrait collection';
+
+describe('carouselBehavior.ts', () => {
+  describe('root', () => {
+    test(`sets "role=region" when carousel has NO navigation`, () => {
+      const expectedResult = carouselBehavior({ ariaLiveOn: false, navigation: false });
+      expect(expectedResult.attributes.root.role).toEqual('region');
+    });
+
+    test('sets "aria-roledescription" when carousel has NO navigation', () => {
+      const expectedResult = carouselBehavior({
+        ariaLiveOn: false,
+        navigation: false,
+        ariaRoleDescription: roleDescription
+      });
+      expect(expectedResult.attributes.root['aria-roledescription']).toEqual(roleDescription);
+    });
+
+    test('sets "aria-label" when carousel has NO navigation', () => {
+      const expectedResult = carouselBehavior({
+        ariaLiveOn: false,
+        navigation: false,
+        ariaLabel: label
+      });
+      expect(expectedResult.attributes.root['aria-label']).toEqual(label);
+    });
+
+    test('do NOT set "aria-roledescription" when carousel has navigation', () => {
+      const expectedResult = carouselBehavior({
+        ariaLiveOn: false,
+        navigation: true,
+        ariaRoleDescription: roleDescription
+      });
+      expect(expectedResult.attributes.root['aria-roledescription']).toBeUndefined();
+    });
+
+    test('do NOT set "aria-label" when carousel has navigation', () => {
+      const expectedResult = carouselBehavior({
+        ariaLiveOn: false,
+        navigation: true,
+        ariaLabel: label
+      });
+      expect(expectedResult.attributes.root['aria-label']).toBeUndefined();
+    });
+
+    test(`do NOT set "role=region" when carousel has navigation`, () => {
+      const expectedResult = carouselBehavior({ ariaLiveOn: false, navigation: true });
+      expect(expectedResult.attributes.root.role).toBeUndefined();
+    });
+  });
+
+  describe('itemsContainer', () => {
+    test('sets "aria-roledescription" when carousel has navigation', () => {
+      const expectedResult = carouselBehavior({
+        ariaLiveOn: false,
+        navigation: true,
+        ariaRoleDescription: roleDescription
+      });
+      expect(expectedResult.attributes.itemsContainer['aria-roledescription']).toEqual(roleDescription);
+    });
+
+    test('sets "aria-label" when carousel has navigation', () => {
+      const expectedResult = carouselBehavior({
+        ariaLiveOn: false,
+        navigation: true,
+        ariaLabel: label
+      });
+      expect(expectedResult.attributes.itemsContainer['aria-label']).toEqual(label);
+    });
+
+    test('do NOT set "aria-roledescription" when carousel has NO navigation', () => {
+      const expectedResult = carouselBehavior({
+        ariaLiveOn: false,
+        navigation: false,
+        ariaRoleDescription: roleDescription
+      });
+      expect(expectedResult.attributes.itemsContainer['aria-roledescription']).toBeUndefined();
+    });
+
+    test('do NOT set "aria-label" when carousel has NO navigation', () => {
+      const expectedResult = carouselBehavior({
+        ariaLiveOn: false,
+        navigation: false,
+        ariaLabel: label
+      });
+      expect(expectedResult.attributes.itemsContainer['aria-label']).toBeUndefined();
+    });
+
+    test(`do NOT set "role=group" when carousel has NO navigation`, () => {
+      const expectedResult = carouselBehavior({ ariaLiveOn: false, navigation: false });
+      expect(expectedResult.attributes.itemsContainer.role).toBeUndefined();
+    });
+  });
+});

--- a/packages/fluentui/accessibility/test/behaviors/caroseltemBehavior-test.tsx
+++ b/packages/fluentui/accessibility/test/behaviors/caroseltemBehavior-test.tsx
@@ -1,0 +1,23 @@
+import { carouselItemBehavior } from '@fluentui/accessibility';
+
+describe('carouselItemBehavior.ts', () => {
+  test('sets tabIndex="0" on root when carousel has navigation and item is visible ', () => {
+    const expectedResult = carouselItemBehavior({ navigation: true, active: true });
+    expect(expectedResult.attributes.root.tabIndex).toEqual(0);
+  });
+
+  test('sets tabIndex="-1" on root when carousel has navigation and item is NOT visible ', () => {
+    const expectedResult = carouselItemBehavior({ navigation: true, active: false });
+    expect(expectedResult.attributes.root.tabIndex).toEqual(-1);
+  });
+
+  test('sets tabIndex="-1" on root when carousel has NO navigation and item is visible', () => {
+    const expectedResult = carouselItemBehavior({ navigation: false, active: true });
+    expect(expectedResult.attributes.root.tabIndex).toEqual(-1);
+  });
+
+  test('sets tabIndex="-1" on root when carousel has NO navigation and item is NOT visible', () => {
+    const expectedResult = carouselItemBehavior({ navigation: false, active: false });
+    expect(expectedResult.attributes.root.tabIndex).toEqual(-1);
+  });
+});

--- a/packages/fluentui/accessibility/test/behaviors/caroseltemBehavior-test.tsx
+++ b/packages/fluentui/accessibility/test/behaviors/caroseltemBehavior-test.tsx
@@ -11,13 +11,8 @@ describe('carouselItemBehavior.ts', () => {
     expect(expectedResult.attributes.root.tabIndex).toEqual(-1);
   });
 
-  test('sets tabIndex="-1" on root when carousel has NO navigation and item is visible', () => {
+  test('do NOT set tabIndex on root when carousel has NO navigation', () => {
     const expectedResult = carouselItemBehavior({ navigation: false, active: true });
-    expect(expectedResult.attributes.root.tabIndex).toEqual(-1);
-  });
-
-  test('sets tabIndex="-1" on root when carousel has NO navigation and item is NOT visible', () => {
-    const expectedResult = carouselItemBehavior({ navigation: false, active: false });
-    expect(expectedResult.attributes.root.tabIndex).toEqual(-1);
+    expect(expectedResult.attributes.root.tabIndex).toBeUndefined;
   });
 });

--- a/packages/fluentui/docs/src/examples/components/Carousel/BestPractices/CarouselBestPractices.tsx
+++ b/packages/fluentui/docs/src/examples/components/Carousel/BestPractices/CarouselBestPractices.tsx
@@ -14,7 +14,7 @@ const doList = [
   <Box>
     If carousel contains `navigation`:
     <ul>
-      <li> provide label to `navigation` and to navigation item using `aria-label` attribute</li>
+      <li> provide label to `navigation` slot and to navigation item using `aria-label` attribute</li>
       <li> add `aria-controls` attribute to navigation item referencing to `carouselItem` id </li>
     </ul>
   </Box>

--- a/packages/fluentui/docs/src/examples/components/Carousel/BestPractices/CarouselBestPractices.tsx
+++ b/packages/fluentui/docs/src/examples/components/Carousel/BestPractices/CarouselBestPractices.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { Text } from '@fluentui/react';
+import { Text, Box } from '@fluentui/react';
 import { link } from '../../../../utils/helpers';
 
 import ComponentBestPractices from 'docs/src/components/ComponentBestPractices';
@@ -8,7 +8,16 @@ const doList = [
   <Text>
     'Add textual representation for `CarouselItem`. Use `aria-label` attribute ( refer to{' '}
     {link('reported issue', 'https://bugs.chromium.org/p/chromium/issues/detail?id=1040924')} for details).
-  </Text>
+  </Text>,
+  'Provide  localized string of the "carousel" using `ariaRoleDescription` prop.',
+  'Provide label to the carousel using `ariaLabel` prop.',
+  <Box>
+    If carousel contains `navigation`:
+    <ul>
+      <li> provide label to `navigation` and to navigation item using `aria-label` attribute</li>
+      <li> add `aria-controls` attribute to navigation item referencing to `carouselItem` id </li>
+    </ul>
+  </Box>
 ];
 
 const CarouselBestPractices: React.FunctionComponent<{}> = () => {

--- a/packages/fluentui/docs/src/examples/components/Carousel/Types/CarouselExample.tsx
+++ b/packages/fluentui/docs/src/examples/components/Carousel/Types/CarouselExample.tsx
@@ -37,6 +37,7 @@ const carouselItems = [
 const CarouselExample = () => (
   <Carousel
     ariaRoleDescription="carousel"
+    ariaLabel="Portrait collection"
     navigation={{
       'aria-label': 'people portraits',
       items: carouselItems.map((item, index) => ({

--- a/packages/fluentui/docs/src/examples/components/Carousel/Types/CarouselPaginationExample.tsx
+++ b/packages/fluentui/docs/src/examples/components/Carousel/Types/CarouselPaginationExample.tsx
@@ -23,6 +23,7 @@ const carouselItems = [
 const CarouselExample = () => (
   <Carousel
     ariaRoleDescription="carousel"
+    ariaLabel="Portrait collection"
     items={carouselItems}
     paddleNext={{ 'aria-label': 'go to next slide' }}
     paddlePrevious={{ 'aria-label': 'go to previous slide' }}

--- a/packages/fluentui/docs/src/examples/components/Carousel/Variations/CarouselCircularExample.tsx
+++ b/packages/fluentui/docs/src/examples/components/Carousel/Variations/CarouselCircularExample.tsx
@@ -34,6 +34,7 @@ const CarouselExample = () => (
   <Carousel
     circular
     ariaRoleDescription="carousel"
+    ariaLabel="Portrait collection"
     navigation={{
       'aria-label': 'people portraits',
       items: carouselItems.map((item, index) => ({

--- a/packages/fluentui/react/src/components/Carousel/Carousel.tsx
+++ b/packages/fluentui/react/src/components/Carousel/Carousel.tsx
@@ -49,6 +49,11 @@ export interface CarouselProps extends UIComponentProps, ChildrenComponentProps 
    */
   ariaRoleDescription?: string;
 
+  /**
+   * Sets the aria-label attribute for carousel.
+   */
+  ariaLabel?: string;
+
   /** Specifies if the process of switching slides is circular. */
   circular?: boolean;
 
@@ -126,6 +131,7 @@ class Carousel extends AutoControlledComponent<WithAsProp<CarouselProps>, Carous
     }),
     activeIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     ariaRoleDescription: PropTypes.string,
+    ariaLabel: PropTypes.string,
     circular: PropTypes.bool,
     defaultActiveIndex: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
     getItemPositionText: PropTypes.func,
@@ -178,27 +184,13 @@ class Carousel extends AutoControlledComponent<WithAsProp<CarouselProps>, Carous
     },
     showNextSlideByPaddlePress: e => {
       e.preventDefault();
-      const { activeIndex } = this.state;
-      const { circular, items, navigation } = this.props;
-
       this.showNextSlide(e, false);
-
-      // if 'next' paddle will disappear, will focus 'previous' one.
-      if (!navigation && activeIndex >= items.length - 2 && !circular) {
-        this.paddlePreviousRef.current.focus();
-      }
+      this.handleNextPaddleFocus();
     },
     showPreviousSlideByPaddlePress: e => {
       e.preventDefault();
-      const { activeIndex } = this.state;
-      const { circular, navigation } = this.props;
-
       this.showPreviousSlide(e, false);
-
-      // if 'previous' paddle will disappear, will focus 'next' one.
-      if (!navigation && activeIndex <= 1 && !circular) {
-        this.paddleNextRef.current.focus();
-      }
+      this.handlePreviousPaddleFocus();
     }
   };
 
@@ -269,7 +261,7 @@ class Carousel extends AutoControlledComponent<WithAsProp<CarouselProps>, Carous
   });
 
   renderContent = (accessibility, classes, unhandledProps) => {
-    const { ariaRoleDescription, getItemPositionText, items, circular } = this.props;
+    const { getItemPositionText, items, circular } = this.props;
     const { activeIndex, itemIds, prevActiveIndex } = this.state;
 
     this.itemRefs = [];
@@ -278,7 +270,6 @@ class Carousel extends AutoControlledComponent<WithAsProp<CarouselProps>, Carous
       <div className={classes.itemsContainerWrapper} {...accessibility.attributes.itemsContainerWrapper}>
         <div
           className={cx(Carousel.slotClassNames.itemsContainer, classes.itemsContainer)}
-          aria-roledescription={ariaRoleDescription}
           {...accessibility.attributes.itemsContainer}
           {...applyAccessibilityKeyHandlers(accessibility.keyHandlers.itemsContainer, unhandledProps)}
         >
@@ -336,6 +327,20 @@ class Carousel extends AutoControlledComponent<WithAsProp<CarouselProps>, Carous
     );
   };
 
+  handleNextPaddleFocus = () => {
+    // if 'next' paddle will disappear, will focus 'previous' one.
+    if (!this.props.navigation && this.state.activeIndex >= this.props.items.length - 2 && !this.props.circular) {
+      this.paddlePreviousRef.current.focus();
+    }
+  };
+
+  handlePreviousPaddleFocus = () => {
+    // if 'previous' paddle will disappear, will focus 'next' one.
+    if (!this.props.navigation && this.state.activeIndex <= 1 && !this.props.circular) {
+      this.paddleNextRef.current.focus();
+    }
+  };
+
   showPreviousSlide = (e: React.SyntheticEvent, focusItem: boolean) => {
     this.setActiveIndex(e, this.state.activeIndex - 1, focusItem);
   };
@@ -349,8 +354,10 @@ class Carousel extends AutoControlledComponent<WithAsProp<CarouselProps>, Carous
       _.invoke(predefinedProps, 'onClick', e, buttonProps);
       if (paddleName === 'paddleNext') {
         this.showNextSlide(e, false);
+        this.handleNextPaddleFocus();
       } else if (paddleName === 'paddlePrevious') {
         this.showPreviousSlide(e, false);
+        this.handlePreviousPaddleFocus();
       }
     },
     onBlur: (e: React.FocusEvent, buttonProps: ButtonProps) => {
@@ -428,7 +435,7 @@ class Carousel extends AutoControlledComponent<WithAsProp<CarouselProps>, Carous
         })
       })
     ) : (
-      <Text className={Carousel.slotClassNames.pagination} content={getItemPositionText(activeIndex, items.length)} />
+      <Text aria-hidden="true" className={Carousel.slotClassNames.pagination} content={getItemPositionText(activeIndex, items.length)} />
     );
   };
 


### PR DESCRIPTION
This PR is created based on the from another repository:
https://github.com/microsoft/fluent-ui-react/pull/2278/files

Related carousel: Carousel with Pagination

In this PR are fixes related to the feedback which we got from Rekha + feedback from testing.

1. 
Issue: Index numbers (1 of 4) are read twice as you down arrow through the carousel item.
Fix: add aria-hidden="true" on the text

2.1 Issue: The first and the last item in the carousel are not read when the prev/next button is pressed in browse mode.
2.2 #2224
Fix: moving focusing the next/previous paddle to generic function, which is call always, even when "onclick" is executed...

3.
Issue: Should there be focus on the entire carousel control and the left/right buttons? Seems redundant and adds more keyboard stops
Fix: change the behavior that for carousel without the "tab" navigation there will be tabindex=-1 on itemsContainer

4.
Issue: Carousel itself should have a label property defined. The roledescription is set to “Carousel” so label can be “Portrait collection” for this example
Fix: added prop aria-label to be able label the carousel

5.
Issue: #2225
Fix: was decided that if reader will narrate "carousel" user will know how to use keyboard to rotate through the carousel
For this reason to narrate "carousel" in application mode was added additional props(role, aria-label,aria-roledescription) into "itemsContainer" in "carouselBehavior.ts".
Now there is role "group". After more testing could be change for "region". For me region was not narrating "carousel" in focus mode for NVDA.

6.
Issue: Programmatically Prev/Next buttons are outside carousel container so it will likely confuse the user. Carousel container element should include all elements within carousel.
Fix: apply region only for "Carousel with Pagination", provide there proper label and roledescription. Fix is in "carouselBehavior.ts" for "root" slot.




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12050)