### PR TITLE
Fluent build: fix config types and doctoc/prettier conflict

### DIFF
--- a/scripts/config.ts
+++ b/scripts/config.ts
@@ -60,11 +60,14 @@ const tempPaths = {
   withRootAt: (root: string, ...subpaths: string[]) => (...args: string[]) => path.resolve(root, ...subpaths, ...args)
 };
 
-const paths = {
+const paths: typeof tempPaths & {
+  base: typeof base;
+  posix: typeof tempPaths;
+} = {
   base,
   ...tempPaths,
   // all the sibling values, but with forward slashes regardless the OS
-  posix: _.mapValues(tempPaths, (func: (...args: string[]) => string) => (...args: string[]) => func(...args).replace(/\\/g, '/'))
+  posix: _.mapValues(tempPaths, (func: (...args: string[]) => string) => (...args: string[]) => func(...args).replace(/\\/g, '/')) as any
 };
 
 const isRoot = process.cwd() === envConfig.path_base;

--- a/scripts/gulp/plugins/gulp-doctoc.ts
+++ b/scripts/gulp/plugins/gulp-doctoc.ts
@@ -3,13 +3,15 @@ import through2 from 'through2';
 
 import config from '../../config';
 import sh from '../sh';
+import { runPrettier } from '../../prettier/prettier-helpers';
 
 const insideGitRepo = fs.existsSync(config.paths.base('.git'));
 
 export default () =>
   through2.obj((file, enc, done) => {
     sh(`doctoc ${file.path} --github --maxlevel 4`)
-      .then(() => insideGitRepo && sh(`git add ${file.path}`))
+      .then<any>(() => runPrettier([file.path], false, true))
+      .then<any>(() => insideGitRepo && sh(`git add ${file.path}`))
       .then(() => {
         done(null, file);
       })

--- a/scripts/gulp/tasks/docs.ts
+++ b/scripts/gulp/tasks/docs.ts
@@ -15,7 +15,7 @@ import sh from '../sh';
 import config from '../../config';
 import gulpComponentMenu from '../plugins/gulp-component-menu';
 import gulpComponentMenuBehaviors from '../plugins/gulp-component-menu-behaviors';
-// import gulpDoctoc from '../plugins/gulp-doctoc';
+import gulpDoctoc from '../plugins/gulp-doctoc';
 import gulpExampleMenu from '../plugins/gulp-example-menu';
 import gulpExampleSource from '../plugins/gulp-example-source';
 import gulpReactDocgen from '../plugins/gulp-react-docgen';
@@ -64,14 +64,14 @@ const componentsSrc = [
 const behaviorSrc = [`${paths.posix.packageSrc('accessibility')}/behaviors/*/[a-z]*Behavior.ts`];
 const examplesIndexSrc = `${paths.posix.docsSrc()}/examples/*/*/*/index.tsx`;
 const examplesSrc = `${paths.posix.docsSrc()}/examples/*/*/*/!(*index|.knobs).tsx`;
-// const markdownSrc = [
-//   '.github/CONTRIBUTING.md',
-//   '.github/setup-local-development.md',
-//   '.github/add-a-feature.md',
-//   '.github/document-a-feature.md',
-//   '.github/test-a-feature.md',
-//   'specifications/*.md'
-// ];
+const markdownSrc = [
+  '.github/CONTRIBUTING.md',
+  '.github/setup-local-development.md',
+  '.github/add-a-feature.md',
+  '.github/document-a-feature.md',
+  '.github/test-a-feature.md',
+  'specifications/*.md'
+];
 const schemaSrc = `${paths.posix.packages('ability-attributes')}/schema.json`;
 
 task('build:docs:component-info', () =>
@@ -124,15 +124,12 @@ task('build:docs:html', () => src(paths.docsSrc('404.html')).pipe(dest(paths.doc
 
 task('build:docs:images', () => src(`${paths.docsSrc()}/**/*.{png,jpg,gif}`).pipe(dest(paths.docsDist())));
 
-// Disable temporarily to prevent conflicts with prettier
-task(
-  'build:docs:toc',
-  done => done()
-  // src(markdownSrc, { since: lastRun('build:docs:toc') }).pipe(
-  //   cache(gulpDoctoc(), {
-  //     name: 'md-docs'
-  //   })
-  // )
+task('build:docs:toc', () =>
+  src(markdownSrc, { since: lastRun('build:docs:toc') }).pipe(
+    cache(gulpDoctoc(), {
+      name: 'md-docs'
+    })
+  )
 );
 
 task('build:docs:schema', () =>


### PR DESCRIPTION
Fix some typing issues in the fluent `config.ts` used to generate paths in various places.

Fix the conflict between doctoc formatting and prettier formatting when adding tables of contents to various markdown files.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12054)