### PR TITLE
For all gulp build:docs tasks that have a src->cache->dest, use cwd/base

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -174,12 +174,6 @@ jobs:
       # No need for checkout since we're using build artifacts.
       - checkout: none
 
-      - task: DeleteFiles@1
-        inputs:
-          SourceFolder: /tmp/gulp-cache
-          Contents: '**/*'
-        condition: always()
-
       - template: azure-pipelines.artifacts.yml
         parameters:
           artifact: Build-PR-$(Build.BuildNumber)
@@ -206,5 +200,11 @@ jobs:
       - task: DeleteFiles@1
         inputs:
           SourceFolder: $(Build.SourcesDirectory)
+          Contents: '**/*'
+        condition: always()
+
+      - task: DeleteFiles@1
+        inputs:
+          SourceFolder: /tmp/gulp-cache
           Contents: '**/*'
         condition: always()

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -174,6 +174,12 @@ jobs:
       # No need for checkout since we're using build artifacts.
       - checkout: none
 
+      - task: DeleteFiles@1
+        inputs:
+          SourceFolder: /tmp/gulp-cache
+          Contents: '**/*'
+        condition: always()
+
       - template: azure-pipelines.artifacts.yml
         parameters:
           artifact: Build-PR-$(Build.BuildNumber)
@@ -200,11 +206,5 @@ jobs:
       - task: DeleteFiles@1
         inputs:
           SourceFolder: $(Build.SourcesDirectory)
-          Contents: '**/*'
-        condition: always()
-
-      - task: DeleteFiles@1
-        inputs:
-          SourceFolder: /tmp/gulp-cache
           Contents: '**/*'
         condition: always()

--- a/scripts/gulp/tasks/docs.ts
+++ b/scripts/gulp/tasks/docs.ts
@@ -74,11 +74,11 @@ const markdownSrc = [
 ];
 const schemaSrc = `${paths.posix.packages('ability-attributes')}/schema.json`;
 
-task('build:docs:component-info', () =>
-  src(componentsSrc, { since: lastRun('build:docs:component-info') })
+task('build:docs:component-info', () => {
+  return src(componentsSrc, { since: lastRun('build:docs:component-info'), cwd: paths.base(), cwdbase: true })
     .pipe(cache(gulpReactDocgen(['DOMAttributes', 'HTMLAttributes']), { name: 'componentInfo-1' }))
-    .pipe(dest(paths.docsSrc('componentInfo')))
-);
+    .pipe(dest(paths.docsSrc('componentInfo'), { cwd: paths.base() }));
+});
 
 task('build:docs:component-menu', () =>
   src(componentsSrc, { since: lastRun('build:docs:component-menu') })
@@ -101,13 +101,13 @@ task('build:docs:example-menu', () =>
 );
 
 task('build:docs:example-sources', () =>
-  src(examplesSrc, { since: lastRun('build:docs:example-sources') })
+  src(examplesSrc, { since: lastRun('build:docs:example-sources'), cwd: paths.base(), cwdbase: true })
     .pipe(
       cache(gulpExampleSource(), {
         name: 'exampleSources'
       })
     )
-    .pipe(dest(paths.docsSrc('exampleSources')))
+    .pipe(dest(paths.docsSrc('exampleSources'), { cwd: paths.base() }))
 );
 
 task(

--- a/scripts/gulp/tasks/docs.ts
+++ b/scripts/gulp/tasks/docs.ts
@@ -74,11 +74,11 @@ const markdownSrc = [
 ];
 const schemaSrc = `${paths.posix.packages('ability-attributes')}/schema.json`;
 
-task('build:docs:component-info', () => {
-  return src(componentsSrc, { since: lastRun('build:docs:component-info'), cwd: paths.base(), cwdbase: true })
+task('build:docs:component-info', () =>
+  src(componentsSrc, { since: lastRun('build:docs:component-info'), cwd: paths.base(), cwdbase: true })
     .pipe(cache(gulpReactDocgen(['DOMAttributes', 'HTMLAttributes']), { name: 'componentInfo-1' }))
-    .pipe(dest(paths.docsSrc('componentInfo'), { cwd: paths.base() }));
-});
+    .pipe(dest(paths.docsSrc('componentInfo'), { cwd: paths.base() }))
+);
 
 task('build:docs:component-menu', () =>
   src(componentsSrc, { since: lastRun('build:docs:component-menu') })


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

We need to specify the cwd and base in these tasks because of the move away from a centralized gulp build call (it now can be that the cwd is different than paths.base). So for caching scenarios, we need to make sure the src, cache and dest use the correct base / cwd values.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12060)