### PR TITLE
Turning on tslint deprecation rule for the styling, utilities and experiments packages

### DIFF
--- a/change/@uifabric-experiments-2020-02-25-15-52-27-deprecationStylingUtilitiesExperiments.json
+++ b/change/@uifabric-experiments-2020-02-25-15-52-27-deprecationStylingUtilitiesExperiments.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Turning on tslint 'deprecation' rule.",
+  "packageName": "@uifabric/experiments",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "54a88d96894aeb605e765a1d3d66e02198c38a7e",
+  "dependentChangeType": "patch",
+  "date": "2020-02-25T23:51:19.279Z"
+}

--- a/change/@uifabric-styling-2020-02-25-15-52-27-deprecationStylingUtilitiesExperiments.json
+++ b/change/@uifabric-styling-2020-02-25-15-52-27-deprecationStylingUtilitiesExperiments.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Turning on tslint 'deprecation' rule.",
+  "packageName": "@uifabric/styling",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "54a88d96894aeb605e765a1d3d66e02198c38a7e",
+  "dependentChangeType": "patch",
+  "date": "2020-02-25T23:52:17.377Z"
+}

--- a/change/@uifabric-utilities-2020-02-25-15-52-27-deprecationStylingUtilitiesExperiments.json
+++ b/change/@uifabric-utilities-2020-02-25-15-52-27-deprecationStylingUtilitiesExperiments.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Turning on tslint 'deprecation' rule.",
+  "packageName": "@uifabric/utilities",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "54a88d96894aeb605e765a1d3d66e02198c38a7e",
+  "dependentChangeType": "patch",
+  "date": "2020-02-25T23:52:26.887Z"
+}

--- a/change/office-ui-fabric-react-2020-02-25-15-52-27-deprecationStylingUtilitiesExperiments.json
+++ b/change/office-ui-fabric-react-2020-02-25-15-52-27-deprecationStylingUtilitiesExperiments.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Using tslint:disable-next-line instead of tslint:disable without a corresponding tslint:enable afterwards for all non-tests and non-data files.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "54a88d96894aeb605e765a1d3d66e02198c38a7e",
+  "dependentChangeType": "patch",
+  "date": "2020-02-25T23:52:04.096Z"
+}

--- a/packages/experiments/src/components/BAFAccordion/Accordion.tsx
+++ b/packages/experiments/src/components/BAFAccordion/Accordion.tsx
@@ -31,6 +31,7 @@ export class Accordion extends BaseComponent<IAccordionProps, IAccordionState> i
   }
 
   public render(): JSX.Element {
+    // tslint:disable-next-line:deprecation
     const { onRenderMenu, className, buttonAs, onClick, ...other } = this.props;
     let { menuIconProps } = this.props;
 

--- a/packages/experiments/src/components/Button/examples/Button.Slots.Example.tsx
+++ b/packages/experiments/src/components/Button/examples/Button.Slots.Example.tsx
@@ -59,7 +59,7 @@ const RibbonMenuButtonVerticalStyles: IMenuButtonStyles = {
   }
 };
 
-const RibbonMenuButton: React.SFC<IRibbonMenuButtonProps> = props => {
+const RibbonMenuButton: React.FunctionComponent<IRibbonMenuButtonProps> = props => {
   const mergedProps: IMenuButtonProps = props.vertical
     ? {
         ...props,
@@ -116,7 +116,7 @@ const SplitMenuButtonVerticalSlots: ISplitRibbonMenuButtonProps['slots'] = {
   splitDivider: { render: () => null }
 };
 
-const RibbonSplitMenuButton: React.SFC<ISplitRibbonMenuButtonProps> = props => {
+const RibbonSplitMenuButton: React.FunctionComponent<ISplitRibbonMenuButtonProps> = props => {
   const { content, vertical, ...rest } = props;
 
   const rootProps: React.DetailedHTMLProps<React.HtmlHTMLAttributes<any>, any> = {

--- a/packages/experiments/src/components/Chiclet/examples/Chiclet.Footer.Example.tsx
+++ b/packages/experiments/src/components/Chiclet/examples/Chiclet.Footer.Example.tsx
@@ -63,6 +63,7 @@ export const ChicletFooterExample: React.FunctionComponent<{}> = () => {
   );
 };
 
+// tslint:disable-next-line:deprecation
 export interface IFooterComponent extends React.Props<FooterComponent> {
   buttonProps: IButtonProps[];
   activities: string;

--- a/packages/experiments/src/components/Chiclet/examples/Chiclet.Xsmall.Footer.Example.tsx
+++ b/packages/experiments/src/components/Chiclet/examples/Chiclet.Xsmall.Footer.Example.tsx
@@ -62,6 +62,7 @@ class FooterComponent extends React.Component<IFooterComponent, {}> {
   }
 }
 
+// tslint:disable-next-line:deprecation
 interface IFooterComponent extends React.Props<FooterComponent> {
   buttonProps: IButtonProps[];
   attachProps: IIconProps;

--- a/packages/experiments/src/components/FloatingSuggestions/FloatingSuggestions.tsx
+++ b/packages/experiments/src/components/FloatingSuggestions/FloatingSuggestions.tsx
@@ -239,6 +239,7 @@ export class FloatingSuggestions<TItem> extends BaseComponent<IFloatingSuggestio
     ) {
       return;
     }
+    // tslint:disable-next-line:deprecation
     const keyCode = ev.which;
     switch (keyCode) {
       case KeyCodes.escape:

--- a/packages/experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsControl.tsx
+++ b/packages/experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsControl.tsx
@@ -202,6 +202,7 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
           const isSelected = selectedHeaderIndex !== -1 && selectedHeaderIndex === index;
           return headerItemProps.shouldShow() ? (
             <div
+              // tslint:disable-next-line:deprecation
               ref={this._resolveRef(isSelected ? '_selectedElement' : '')}
               id={'sug-header' + index}
               key={'sug-header' + index}
@@ -236,6 +237,7 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
           const isSelected = selectedFooterIndex !== -1 && selectedFooterIndex === index;
           return footerItemProps.shouldShow() ? (
             <div
+              // tslint:disable-next-line:deprecation
               ref={this._resolveRef(isSelected ? '_selectedElement' : '')}
               id={'sug-footer' + index}
               key={'sug-footer' + index}
@@ -257,6 +259,7 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
   }
 
   private _renderSuggestions(): JSX.Element {
+    // tslint:disable-next-line:deprecation
     return <SuggestionsCore<T> ref={this._resolveRef('_suggestions')} {...this.props} suggestions={this.state.suggestions} />;
   }
 

--- a/packages/experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsCore.tsx
+++ b/packages/experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsCore.tsx
@@ -151,6 +151,7 @@ export class SuggestionsCore<T> extends BaseComponent<ISuggestionsCoreProps<T>, 
       >
         {suggestions.map((suggestion: ISuggestionModel<T>, index: number) => (
           <div
+            // tslint:disable-next-line:deprecation
             ref={this._resolveRef(suggestion.selected || index === this.currentIndex ? '_selectedElement' : '')}
             key={hasKey(suggestion.item) ? suggestion.item.key : index}
             id={'sug-' + index}

--- a/packages/experiments/src/components/FolderCover/FolderCover.types.ts
+++ b/packages/experiments/src/components/FolderCover/FolderCover.types.ts
@@ -38,5 +38,6 @@ export interface IFolderCoverProps extends IBaseProps, React.HTMLAttributes<HTML
   /**
    * The children to pass into the content area of the folder cover.
    */
+  // tslint:disable-next-line:deprecation
   children?: React.Props<{}>['children'] | ((childrenProps: IFolderCoverChildrenProps) => JSX.Element | null);
 }

--- a/packages/experiments/src/components/Sidebar/Sidebar.tsx
+++ b/packages/experiments/src/components/Sidebar/Sidebar.tsx
@@ -136,17 +136,19 @@ export class Sidebar extends BaseComponent<ISidebarProps, ISidebarState> impleme
     }
 
     const ButtonAs = this._getButtonAs(item);
+    // tslint:disable-next-line:deprecation
+    const name = item.text || item.name;
 
     return (
       <div key={item.key}>
         <ButtonAs
-          text={this.state.isCollapsed && !overrideCollapse ? null : item.name}
+          text={this.state.isCollapsed && !overrideCollapse ? null : name}
           iconProps={item.iconProps ? item.iconProps : { iconName: '' }}
           menuIconProps={this.state.isCollapsed ? null : item.subMenuIconProps}
           className={this._getClassNames('ba-SidebarButton', item)}
           role="menuitem"
-          ariaLabel={item.name}
-          title={item.title ? item.title : item.name}
+          ariaLabel={name}
+          title={item.title ? item.title : name}
           styles={concatStyleSets(this._buttonStyles, item.styles)}
           theme={this._theme}
           checked={item.active}
@@ -184,15 +186,17 @@ export class Sidebar extends BaseComponent<ISidebarProps, ISidebarState> impleme
     }
 
     const ButtonAs = this._getButtonAs(item);
+    // tslint:disable-next-line:deprecation
+    const name = item.text || item.name;
 
     return (
       <div className={this._getClassNames('ba-SidebarAccordion', item)} key={item.key}>
         <Accordion
-          text={item.name}
+          text={name}
           iconProps={item.iconProps}
           menuIconProps={item.subMenuIconProps}
           role={'menuitem'}
-          ariaLabel={item.name}
+          ariaLabel={name}
           title={item.tooltip}
           styles={concatStyleSets(this._buttonStyles, item.styles as IButtonStyles)}
           theme={this._theme}
@@ -246,10 +250,13 @@ export class Sidebar extends BaseComponent<ISidebarProps, ISidebarState> impleme
       return child;
     });
 
-    if (item.name) {
+    // tslint:disable-next-line:deprecation
+    const name = item.text || item.name;
+
+    if (name) {
       children.unshift({
-        key: item.name + '-header',
-        name: item.name,
+        key: name + '-header',
+        name: name,
         iconProps: { iconName: '' },
         className: 'ba-SidebarContextualMenuButton-header ',
         disabled: true,
@@ -274,13 +281,13 @@ export class Sidebar extends BaseComponent<ISidebarProps, ISidebarState> impleme
       <div key={item.key}>
         <ButtonAs
           key={item.key}
-          text={this.state.isCollapsed ? '' : item.name}
+          text={this.state.isCollapsed ? '' : name}
           iconProps={item.iconProps}
           menuIconProps={this.state.isCollapsed ? { iconName: '' } : item.subMenuIconProps}
           menuProps={{
             items: children,
             directionalHint: DirectionalHint.rightTopEdge,
-            ariaLabel: item.name,
+            ariaLabel: name,
             calloutProps: {
               styles: {
                 root: {
@@ -292,8 +299,8 @@ export class Sidebar extends BaseComponent<ISidebarProps, ISidebarState> impleme
           menuTriggerKeyCode={KeyCodes.right}
           className={this._getClassNames('ba-SidebarContextualMenuButton', item)}
           role="menuitem"
-          ariaLabel={item.name}
-          title={item.title ? item.title : item.name}
+          ariaLabel={name}
+          title={item.title ? item.title : name}
           styles={concatStyleSets(this._buttonStyles, item.styles)}
           theme={this._theme}
           checked={numActiveChildren > 0 ? true : false}

--- a/packages/experiments/src/components/Slider/Slider.base.tsx
+++ b/packages/experiments/src/components/Slider/Slider.base.tsx
@@ -404,6 +404,7 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
 
     let diff: number | undefined = 0;
 
+    // tslint:disable-next-line:deprecation
     switch (event.which) {
       case getRTLSafeKeyCode(KeyCodes.left):
       case KeyCodes.down:

--- a/packages/experiments/src/components/TilesList/TilesList.types.ts
+++ b/packages/experiments/src/components/TilesList/TilesList.types.ts
@@ -104,6 +104,7 @@ export interface ITilesGridSegment<TItem> {
 
 export { ISize as ITileSize };
 
+// tslint:disable-next-line:deprecation
 export interface ITilesListProps<TItem> extends IBaseProps, React.Props<TilesList<TItem>>, React.HTMLAttributes<HTMLDivElement> {
   /**
    * An array of items to assign to the list.

--- a/packages/experiments/src/theming/examples/Theming.Schemes.Custom.Example.tsx
+++ b/packages/experiments/src/theming/examples/Theming.Schemes.Custom.Example.tsx
@@ -267,7 +267,8 @@ export class ThemingSchemesCustomExample extends React.Component<{}, IThemingExa
   };
 }
 
-const onCommandClick = (ev: any, item?: ICommandBarItemProps) => console.log(item && item.name);
+// tslint:disable-next-line:deprecation
+const onCommandClick = (ev: any, item?: ICommandBarItemProps) => console.log(item && (item.text || item.name));
 const items: ICommandBarItemProps[] = [
   {
     key: 'newItem',

--- a/packages/experiments/src/theming/examples/Theming.Schemes.Variant.Example.tsx
+++ b/packages/experiments/src/theming/examples/Theming.Schemes.Variant.Example.tsx
@@ -146,7 +146,8 @@ export class ThemingSchemesVariantExample extends React.Component<{}, IThemingEx
   };
 }
 
-const onCommandClick = (ev: any, item?: ICommandBarItemProps) => console.log(item && item.name);
+// tslint:disable-next-line:deprecation
+const onCommandClick = (ev: any, item?: ICommandBarItemProps) => console.log(item && (item.text || item.name));
 const items: ICommandBarItemProps[] = [
   {
     key: 'newItem',

--- a/packages/experiments/tslint.json
+++ b/packages/experiments/tslint.json
@@ -1,7 +1,6 @@
 {
   "extends": ["@uifabric/tslint-rules"],
   "rules": {
-    "deprecation": false,
     "no-any": false,
     "typedef": [false]
   }

--- a/packages/office-ui-fabric-react/src/components/Button/Button.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/Button.tsx
@@ -8,8 +8,6 @@ import { CompoundButton } from './CompoundButton/CompoundButton';
 import { IconButton } from './IconButton/IconButton';
 import { PrimaryButton } from './PrimaryButton/PrimaryButton';
 
-// tslint:disable:deprecation
-
 /**
  * This class is deprecated. Use the individual *Button components instead.
  * @deprecated Use the individual *Button components instead.
@@ -33,6 +31,7 @@ export class Button extends BaseComponent<IButtonProps, {}> {
   public render(): JSX.Element {
     const props = this.props;
 
+    // tslint:disable-next-line:deprecation
     switch (props.buttonType) {
       case ButtonType.command:
         return <ActionButton {...props} />;

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SelectedItemWithMenu.tsx
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/PeoplePickerItems/SelectedItemWithMenu.tsx
@@ -6,8 +6,6 @@ import { ContextualMenu, DirectionalHint } from '../../../../ContextualMenu';
 import { IconButton } from '../../../../Button';
 import { FocusZone } from '../../../../FocusZone';
 
-// tslint:disable:deprecation
-
 import * as stylesImport from './PickerItemsDefault.scss';
 const styles: any = stylesImport;
 
@@ -20,6 +18,7 @@ export interface IPeoplePickerItemWithMenuState {
  * PeoplePickerItem with an additional contextual menu.
  * @deprecated Do not use. Will be removed in Fabric 7.0
  */
+// tslint:disable-next-line:deprecation
 export class SelectedItemWithMenu extends BaseComponent<IPeoplePickerItemWithMenuProps, IPeoplePickerItemWithMenuState> {
   public refs: {
     [key: string]: any;
@@ -27,6 +26,7 @@ export class SelectedItemWithMenu extends BaseComponent<IPeoplePickerItemWithMen
 
   private _ellipsisRef = React.createRef<HTMLDivElement>();
 
+  // tslint:disable-next-line:deprecation
   constructor(props: IPeoplePickerItemWithMenuProps) {
     super(props);
     this.state = { contextualMenuVisible: false };

--- a/packages/styling/src/styles/theme.ts
+++ b/packages/styling/src/styles/theme.ts
@@ -300,7 +300,9 @@ function _fixDeprecatedSlots(s: ISemanticColors, depComments: boolean): ISemanti
     dep = ' /* @deprecated */';
   }
 
+  // tslint:disable-next-line:deprecation
   s.listTextColor = s.listText + dep;
+  // tslint:disable-next-line:deprecation
   s.menuItemBackgroundChecked += dep;
   return s;
 }

--- a/packages/styling/src/utilities/icons.ts
+++ b/packages/styling/src/utilities/icons.ts
@@ -189,6 +189,7 @@ export function getIcon(name?: string): IIconRecord | undefined {
         }
       }
     } else {
+      // tslint:disable-next-line:deprecation
       if (!options.disableWarnings && options.warnOnMissingIcons) {
         warn(`The icon "${name}" was used but not registered. See http://aka.ms/fabric-icon-usage for more information.`);
       }

--- a/packages/styling/tslint.json
+++ b/packages/styling/tslint.json
@@ -1,7 +1,6 @@
 {
   "extends": ["@uifabric/tslint-rules"],
   "rules": {
-    "deprecation": false,
     "prefer-const": false
   }
 }

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -34,7 +34,7 @@ export function arraysEqual<T>(array1: T[], array2: T[]): boolean;
 
 // @public
 export function asAsync<TProps>(options: IAsAsyncOptions<TProps>): React.ForwardRefExoticComponent<React.PropsWithoutRef<TProps & {
-    asyncPlaceholder?: React.ReactType;
+    asyncPlaceholder?: React.ElementType;
 }>>;
 
 // @public
@@ -393,7 +393,7 @@ export const htmlElementProperties: string[];
 
 // @public (undocumented)
 export interface IAsAsyncOptions<TProps> {
-    load: () => Promise<React.ReactType<TProps>>;
+    load: () => Promise<React.ElementType<TProps>>;
     onError?: (error: Error) => void;
     onLoad?: () => void;
 }

--- a/packages/utilities/src/BaseComponent.test.tsx
+++ b/packages/utilities/src/BaseComponent.test.tsx
@@ -11,6 +11,7 @@ describe('BaseComponent', () => {
       public root: HTMLElement;
 
       public render(): JSX.Element {
+        // tslint:disable-next-line:deprecation
         return <div ref={this._resolveRef('root')} />;
       }
     }

--- a/packages/utilities/src/DelayedRender.tsx
+++ b/packages/utilities/src/DelayedRender.tsx
@@ -5,6 +5,7 @@ import * as React from 'react';
  *
  * @public
  */
+// tslint:disable-next-line:deprecation
 export interface IDelayedRenderProps extends React.Props<{}> {
   /**
    * Number of milliseconds to delay rendering children.

--- a/packages/utilities/src/asAsync.test.tsx
+++ b/packages/utilities/src/asAsync.test.tsx
@@ -4,7 +4,7 @@ import { mount } from 'enzyme';
 
 describe('asAsync', () => {
   it('can async load exports', (done: () => undefined) => {
-    let _resolve: (result: React.ReactType<{}>) => void = () => undefined;
+    let _resolve: (result: React.ElementType<{}>) => void = () => undefined;
     let _loadCalled = false;
     // tslint:disable-next-line:no-any
     const loadThingPromise = new Promise<any>((resolve: any) => {
@@ -39,7 +39,7 @@ describe('asAsync', () => {
   });
 
   it('can async load with placeholder', (done: () => undefined) => {
-    let _resolve: (result: React.ReactType<{}>) => void = () => undefined;
+    let _resolve: (result: React.ElementType<{}>) => void = () => undefined;
     let _loadCalled = false;
     // tslint:disable-next-line:no-any
     const loadThingPromise = new Promise<any>((resolve: any) => {

--- a/packages/utilities/src/asAsync.tsx
+++ b/packages/utilities/src/asAsync.tsx
@@ -19,7 +19,7 @@ export interface IAsAsyncOptions<TProps> {
   /**
    * Callback which returns a promise resolving an object which exports the component.
    */
-  load: () => Promise<React.ReactType<TProps>>;
+  load: () => Promise<React.ElementType<TProps>>;
 
   /**
    * Callback executed when async loading is complete.
@@ -40,7 +40,7 @@ export interface IAsAsyncOptions<TProps> {
 const _syncModuleCache =
   typeof WeakMap !== 'undefined'
     ? // tslint:disable-next-line:no-any
-      new WeakMap<() => Promise<React.ReactType<any>>, React.ReactType<any> | undefined>()
+      new WeakMap<() => Promise<React.ElementType<any>>, React.ElementType<any> | undefined>()
     : undefined;
 
 /**
@@ -51,16 +51,16 @@ const _syncModuleCache =
  */
 export function asAsync<TProps>(
   options: IAsAsyncOptions<TProps>
-): React.ForwardRefExoticComponent<React.PropsWithoutRef<TProps & { asyncPlaceholder?: React.ReactType }>> {
+): React.ForwardRefExoticComponent<React.PropsWithoutRef<TProps & { asyncPlaceholder?: React.ElementType }>> {
   class Async extends React.Component<
     TProps & {
-      asyncPlaceholder?: React.ReactType;
+      asyncPlaceholder?: React.ElementType;
       forwardedRef: React.Ref<TProps>;
     },
-    { Component?: React.ReactType<TProps> }
+    { Component?: React.ElementType<TProps> }
   > {
     public state = {
-      Component: _syncModuleCache ? (_syncModuleCache.get(options.load) as React.ReactType<TProps>) : undefined
+      Component: _syncModuleCache ? (_syncModuleCache.get(options.load) as React.ElementType<TProps>) : undefined
     };
 
     public render(): JSX.Element | null {
@@ -77,7 +77,7 @@ export function asAsync<TProps>(
       if (!Component) {
         options
           .load()
-          .then((LoadedComponent: React.ReactType<TProps>) => {
+          .then((LoadedComponent: React.ElementType<TProps>) => {
             if (LoadedComponent) {
               // Cache component for future reference.
               _syncModuleCache && _syncModuleCache.set(options.load, LoadedComponent);
@@ -95,7 +95,7 @@ export function asAsync<TProps>(
       }
     }
   }
-  return React.forwardRef((props: TProps & { asyncPlaceholder?: React.ReactType }, ref: React.Ref<TProps>) => (
+  return React.forwardRef((props: TProps & { asyncPlaceholder?: React.ElementType }, ref: React.Ref<TProps>) => (
     <Async {...props} forwardedRef={ref} />
   ));
 }

--- a/packages/utilities/src/initializeFocusRects.ts
+++ b/packages/utilities/src/initializeFocusRects.ts
@@ -34,5 +34,6 @@ function _onMouseDown(ev: MouseEvent): void {
 }
 
 function _onKeyDown(ev: KeyboardEvent): void {
+  // tslint:disable-next-line:deprecation
   isDirectionalKeyCode(ev.which) && setFocusVisibility(true, ev.target as Element);
 }

--- a/packages/utilities/tslint.json
+++ b/packages/utilities/tslint.json
@@ -1,7 +1,6 @@
 {
   "extends": ["@uifabric/tslint-rules"],
   "rules": {
-    "deprecation": false,
     "prefer-const": false
   }
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR turns on the `deprecation` tslint rule in the `styling`, `utilities` and `experiments` packages and makes the use of every deprecated prop or interface be opt-in by disabling the tslint rule on a case by case basis.

This PR also makes some changes on some of the files modified in #12045 to not use `tslint:disable` for the entire file but instead use `tslint:disable-next-line` so that subsequent deprecations are not hidden later on.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12063)