### PR TITLE
perf: add variables caching to v0

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -62,7 +62,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add styles caching when there aren't inline overrides defined @mnajdova ([#2309](https://github.com/microsoft/fluent-ui-react/pull/2309))
 - Styles for `Animation` component are computed again only on prop changes @layershifter ([#2258](https://github.com/microsoft/fluent-ui-react/pull/2258))
 - switch to `inline-style-expand-shorthand` for expanding CSS properties @layershifter ([#1925](https://github.com/microsoft/fluent-ui-react/pull/1925))
-- Add `enableBooleanVariablesCaching` to have styles caching for primitive `variables` overrides @layershifter ([#2373](https://github.com/microsoft/fluent-ui-react/pull/2373))
+- Add `enableBooleanVariablesCaching` to have styles caching for primitive `variables` overrides @layershifter ([#12073](https://github.com/OfficeDev/office-ui-fabric-react/pull/12073))
 
 <!--------------------------------[ v0.44.0 ]------------------------------- -->
 ## [v0.44.0](https://github.com/microsoft/fluent-ui-react/tree/v0.44.0) (2020-02-05)

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -62,6 +62,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add styles caching when there aren't inline overrides defined @mnajdova ([#2309](https://github.com/microsoft/fluent-ui-react/pull/2309))
 - Styles for `Animation` component are computed again only on prop changes @layershifter ([#2258](https://github.com/microsoft/fluent-ui-react/pull/2258))
 - switch to `inline-style-expand-shorthand` for expanding CSS properties @layershifter ([#1925](https://github.com/microsoft/fluent-ui-react/pull/1925))
+- Add `enableHardVariablesCaching` to have styles caching for primitive `variables` overrides @layershifter ([#2373](https://github.com/microsoft/fluent-ui-react/pull/2373))
 
 <!--------------------------------[ v0.44.0 ]------------------------------- -->
 ## [v0.44.0](https://github.com/microsoft/fluent-ui-react/tree/v0.44.0) (2020-02-05)

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -62,7 +62,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add styles caching when there aren't inline overrides defined @mnajdova ([#2309](https://github.com/microsoft/fluent-ui-react/pull/2309))
 - Styles for `Animation` component are computed again only on prop changes @layershifter ([#2258](https://github.com/microsoft/fluent-ui-react/pull/2258))
 - switch to `inline-style-expand-shorthand` for expanding CSS properties @layershifter ([#1925](https://github.com/microsoft/fluent-ui-react/pull/1925))
-- Add `enableHardVariablesCaching` to have styles caching for primitive `variables` overrides @layershifter ([#2373](https://github.com/microsoft/fluent-ui-react/pull/2373))
+- Add `enableBooleanVariablesCaching` to have styles caching for primitive `variables` overrides @layershifter ([#2373](https://github.com/microsoft/fluent-ui-react/pull/2373))
 
 <!--------------------------------[ v0.44.0 ]------------------------------- -->
 ## [v0.44.0](https://github.com/microsoft/fluent-ui-react/tree/v0.44.0) (2020-02-05)

--- a/packages/fluentui/react-bindings/src/hooks/useStyles.ts
+++ b/packages/fluentui/react-bindings/src/hooks/useStyles.ts
@@ -36,7 +36,8 @@ const defaultContext: StylesContextValue<{ renderRule: RendererRenderRule }> = {
   performance: {
     enableSanitizeCssPlugin: process.env.NODE_ENV !== 'production',
     enableStylesCaching: true,
-    enableVariablesCaching: true
+    enableVariablesCaching: true,
+    enableHardVariablesCaching: false
   },
   renderer: { renderRule: () => '' },
   theme: emptyTheme

--- a/packages/fluentui/react-bindings/src/hooks/useStyles.ts
+++ b/packages/fluentui/react-bindings/src/hooks/useStyles.ts
@@ -37,7 +37,7 @@ const defaultContext: StylesContextValue<{ renderRule: RendererRenderRule }> = {
     enableSanitizeCssPlugin: process.env.NODE_ENV !== 'production',
     enableStylesCaching: true,
     enableVariablesCaching: true,
-    enableHardVariablesCaching: false
+    enableBooleanVariablesCaching: false
   },
   renderer: { renderRule: () => '' },
   theme: emptyTheme

--- a/packages/fluentui/react-bindings/src/styles/resolveStyles.ts
+++ b/packages/fluentui/react-bindings/src/styles/resolveStyles.ts
@@ -48,32 +48,29 @@ const resolveStyles = (
   const { className, design, styles, variables, ...stylesProps } = props;
 
   const noInlineStylesOverrides = !(design || styles);
-  const noVariableOverrides = performance.enableHardVariablesCaching || !variables;
+  let noVariableOverrides = performance.enableBooleanVariablesCaching || !variables;
 
   /* istanbul ignore else */
   if (process.env.NODE_ENV !== 'production') {
-    if (!performance.enableStylesCaching && performance.enableHardVariablesCaching) {
+    if (!performance.enableStylesCaching && performance.enableBooleanVariablesCaching) {
       throw new Error(
-        '@fluentui/react: Please check your "performance" settings on "Provider", to enable "enableHardVariablesCaching" you need to enable "enableStylesCaching"'
+        '@fluentui/react: Please check your "performance" settings on "Provider", to enable "enableBooleanVariablesCaching" you need to enable "enableStylesCaching"'
       );
     }
+  }
 
-    if (performance.enableHardVariablesCaching && variables) {
-      if (!_.isPlainObject(variables)) {
-        throw new Error('@fluentui/react: With "enableHardVariablesCaching" only plain objects can be passed to "variables" prop.');
-      }
-
-      const hasOnlyBooleanVariables = Object.keys(variables).every(variableName => {
-        return (
-          variables[variableName] === null || typeof variables[variableName] === 'boolean' || typeof variables[variableName] === 'undefined'
-        );
-      });
+  if (performance.enableBooleanVariablesCaching) {
+    if (_.isPlainObject(variables)) {
+      const hasOnlyBooleanVariables = Object.keys(variables).every(
+        variableName =>
+          variables[variableName] === null || typeof variables[variableName] === 'undefined' || typeof variables[variableName] === 'boolean'
+      );
 
       if (!hasOnlyBooleanVariables) {
-        throw new Error(
-          '@fluentui/react: With "enableHardVariablesCaching" only boolean or nil properties can bepassed to "variables" prop.'
-        );
+        noVariableOverrides = false;
       }
+    } else {
+      noVariableOverrides = false;
     }
   }
 
@@ -128,7 +125,7 @@ const resolveStyles = (
   }
 
   const propsCacheKey = cacheEnabled ? JSON.stringify(stylesProps) : '';
-  const variablesCacheKey = performance.enableHardVariablesCaching ? JSON.stringify(variables) : '';
+  const variablesCacheKey = cacheEnabled && performance.enableBooleanVariablesCaching ? JSON.stringify(variables) : '';
   const componentCacheKey = cacheEnabled
     ? `${displayName}:${propsCacheKey}:${variablesCacheKey}:${styleParam.rtl}${styleParam.disableAnimations}`
     : '';

--- a/packages/fluentui/react-bindings/src/styles/types.ts
+++ b/packages/fluentui/react-bindings/src/styles/types.ts
@@ -66,6 +66,7 @@ export interface StylesContextPerformance {
   enableSanitizeCssPlugin: boolean;
   enableStylesCaching: boolean;
   enableVariablesCaching: boolean;
+  enableHardVariablesCaching: boolean;
 }
 
 export type StylesContextPerformanceInput = Partial<StylesContextPerformance>;

--- a/packages/fluentui/react-bindings/src/styles/types.ts
+++ b/packages/fluentui/react-bindings/src/styles/types.ts
@@ -66,7 +66,7 @@ export interface StylesContextPerformance {
   enableSanitizeCssPlugin: boolean;
   enableStylesCaching: boolean;
   enableVariablesCaching: boolean;
-  enableHardVariablesCaching: boolean;
+  enableBooleanVariablesCaching: boolean;
 }
 
 export type StylesContextPerformanceInput = Partial<StylesContextPerformance>;

--- a/packages/fluentui/react-bindings/test/styles/resolveStyles-test.ts
+++ b/packages/fluentui/react-bindings/test/styles/resolveStyles-test.ts
@@ -325,7 +325,7 @@ describe('resolveStyles', () => {
       expect(() => resolveStyles(options, resolvedVariables)).toThrowError(/Please check your "performance" settings on "Provider"/);
     });
 
-    test('when enabled only plain objects can be passed as "variables"', () => {
+    test('when enabled only "variables" as plain objects can be cached', () => {
       spyOn(componentStyles, 'root').and.callThrough();
       const options = resolveStylesOptions({
         props: { variables: () => {} },
@@ -337,7 +337,7 @@ describe('resolveStyles', () => {
       expect(componentStyles.root).toHaveBeenCalledTimes(2);
     });
 
-    test('when enabled only boolean or nil properties can be passed to "variables"', () => {
+    test('when enabled only "variables" as boolean or nil properties can be cached', () => {
       spyOn(componentStyles, 'root').and.callThrough();
       const options = resolveStylesOptions({
         props: { variables: { foo: 'bar' } },

--- a/packages/fluentui/react-bindings/test/styles/resolveStyles-test.ts
+++ b/packages/fluentui/react-bindings/test/styles/resolveStyles-test.ts
@@ -4,8 +4,9 @@ import resolveStyles from '../../src/styles/resolveStyles';
 import { ResolveStylesOptions, StylesContextPerformance } from '../../src/styles/types';
 
 const componentStyles: ComponentSlotStylesPrepared<{}, { color: string }> = {
-  root: ({ variables: v }): ICSSInJSStyle => ({
-    color: v.color
+  root: ({ variables: v, rtl }): ICSSInJSStyle => ({
+    color: v.color,
+    content: `"rtl:${rtl.toString()}"`
   })
 };
 
@@ -16,15 +17,17 @@ const resolvedVariables: ComponentVariablesObject = {
 const defaultPerformanceOptions: StylesContextPerformance = {
   enableSanitizeCssPlugin: true,
   enableStylesCaching: true,
-  enableVariablesCaching: true
+  enableVariablesCaching: true,
+  enableHardVariablesCaching: false
 };
 
 const resolveStylesOptions = (options?: {
   displayName?: ResolveStylesOptions['displayName'];
-  performance?: ResolveStylesOptions['performance'];
+  performance?: Partial<ResolveStylesOptions['performance']>;
   props?: ResolveStylesOptions['props'];
+  rtl?: ResolveStylesOptions['rtl'];
 }): ResolveStylesOptions => {
-  const { displayName = 'Test', performance = defaultPerformanceOptions, props = {} } = options || {};
+  const { displayName = 'Test', performance, props = {}, rtl = false } = options || {};
 
   return {
     theme: {
@@ -35,12 +38,12 @@ const resolveStylesOptions = (options?: {
     },
     displayName,
     props,
-    rtl: false,
+    rtl,
     disableAnimations: false,
     renderer: {
       renderRule: () => ''
     },
-    performance,
+    performance: { ...defaultPerformanceOptions, ...performance },
     saveDebug: () => {}
   };
 };
@@ -75,7 +78,7 @@ describe('resolveStyles', () => {
     const { classes } = resolveStyles(resolveStylesOptions(), resolvedVariables, renderStyles);
 
     expect(classes['root']).toBeDefined();
-    expect(renderStyles).toHaveBeenCalledWith({ color: 'red' });
+    expect(renderStyles).toHaveBeenCalledWith(expect.objectContaining({ color: 'red' }));
   });
 
   test('caches rendered classes', () => {
@@ -83,7 +86,7 @@ describe('resolveStyles', () => {
     const { classes } = resolveStyles(resolveStylesOptions(), resolvedVariables, renderStyles);
 
     expect(classes['root']).toBeDefined();
-    expect(renderStyles).toHaveBeenCalledWith({ color: 'red' });
+    expect(renderStyles).toHaveBeenCalledWith(expect.objectContaining({ color: 'red' }));
     expect(classes['root']).toBeDefined();
     expect(renderStyles).toHaveBeenCalledTimes(1);
   });
@@ -94,9 +97,9 @@ describe('resolveStyles', () => {
     const { resolvedStyles } = resolveStyles(options, resolvedVariables);
     const { resolvedStyles: secondResolvedStyles } = resolveStyles(options, resolvedVariables);
 
-    expect(resolvedStyles.root).toMatchObject({ color: 'red' });
+    expect(resolvedStyles.root).toMatchObject(expect.objectContaining({ color: 'red' }));
     expect(componentStyles.root).toHaveBeenCalledTimes(1);
-    expect(secondResolvedStyles.root).toMatchObject({ color: 'red' });
+    expect(secondResolvedStyles.root).toMatchObject(expect.objectContaining({ color: 'red' }));
     expect(componentStyles.root).toHaveBeenCalledTimes(1);
   });
 
@@ -107,7 +110,7 @@ describe('resolveStyles', () => {
     const { classes: secondClasses } = resolveStyles(options, resolvedVariables, renderStyles);
 
     expect(classes['root']).toBeDefined();
-    expect(renderStyles).toHaveBeenCalledWith({ color: 'red' });
+    expect(renderStyles).toHaveBeenCalledWith(expect.objectContaining({ color: 'red' }));
     expect(secondClasses['root']).toBeDefined();
     expect(renderStyles).toHaveBeenCalledTimes(1);
   });
@@ -121,9 +124,9 @@ describe('resolveStyles', () => {
     const { resolvedStyles } = resolveStyles(options, resolvedVariables);
     const { resolvedStyles: secondResolvedStyles } = resolveStyles(options, resolvedVariables);
 
-    expect(resolvedStyles.root).toMatchObject({ color: 'red' });
+    expect(resolvedStyles.root).toMatchObject(expect.objectContaining({ color: 'red' }));
     expect(componentStyles.root).toHaveBeenCalledTimes(1);
-    expect(secondResolvedStyles.root).toMatchObject({ color: 'red' });
+    expect(secondResolvedStyles.root).toMatchObject(expect.objectContaining({ color: 'red' }));
     expect(componentStyles.root).toHaveBeenCalledTimes(1);
   });
 
@@ -137,7 +140,7 @@ describe('resolveStyles', () => {
     const { classes: secondClasses } = resolveStyles(options, resolvedVariables, renderStyles);
 
     expect(classes['root']).toBeDefined();
-    expect(renderStyles).toHaveBeenCalledWith({ color: 'red' });
+    expect(renderStyles).toHaveBeenCalledWith(expect.objectContaining({ color: 'red' }));
     expect(secondClasses['root']).toBeDefined();
     expect(renderStyles).toHaveBeenCalledTimes(1);
   });
@@ -149,13 +152,11 @@ describe('resolveStyles', () => {
       props: { primary: true }
     });
     const { resolvedStyles } = resolveStyles(options, resolvedVariables);
+    const { resolvedStyles: secondResolvedStyles } = resolveStyles({ ...options, props: { primary: false } }, resolvedVariables);
 
-    options.props = { primary: false };
-    const { resolvedStyles: secondResolvedStyles } = resolveStyles(options, resolvedVariables);
-
-    expect(resolvedStyles.root).toMatchObject({ color: 'red' });
+    expect(resolvedStyles.root).toMatchObject(expect.objectContaining({ color: 'red' }));
     expect(componentStyles.root).toHaveBeenCalledTimes(1);
-    expect(secondResolvedStyles.root).toMatchObject({ color: 'red' });
+    expect(secondResolvedStyles.root).toMatchObject(expect.objectContaining({ color: 'red' }));
     expect(componentStyles.root).toHaveBeenCalledTimes(2);
   });
 
@@ -171,7 +172,7 @@ describe('resolveStyles', () => {
     const { classes: secondClasses } = resolveStyles(options, resolvedVariables, renderStyles);
 
     expect(classes['root']).toBeDefined();
-    expect(renderStyles).toHaveBeenCalledWith({ color: 'red' });
+    expect(renderStyles).toHaveBeenCalledWith(expect.objectContaining({ color: 'red' }));
     expect(secondClasses['root']).toBeDefined();
     expect(renderStyles).toHaveBeenCalledTimes(2);
   });
@@ -179,26 +180,26 @@ describe('resolveStyles', () => {
   test('does not cache styles if caching is disabled', () => {
     spyOn(componentStyles, 'root').and.callThrough();
     const options = resolveStylesOptions({
-      performance: { ...defaultPerformanceOptions, enableStylesCaching: false }
+      performance: { enableStylesCaching: false }
     });
     const { resolvedStyles } = resolveStyles(options, resolvedVariables);
     const { resolvedStyles: secondResolvedStyles } = resolveStyles(options, resolvedVariables);
 
-    expect(resolvedStyles.root).toMatchObject({ color: 'red' });
-    expect(secondResolvedStyles.root).toMatchObject({ color: 'red' });
+    expect(resolvedStyles.root).toMatchObject(expect.objectContaining({ color: 'red' }));
+    expect(secondResolvedStyles.root).toMatchObject(expect.objectContaining({ color: 'red' }));
     expect(componentStyles.root).toHaveBeenCalledTimes(2);
   });
 
   test('does not cache classes if caching is disabled', () => {
     const renderStyles = jest.fn().mockReturnValue('a');
     const options = resolveStylesOptions({
-      performance: { ...defaultPerformanceOptions, enableStylesCaching: false }
+      performance: { enableStylesCaching: false }
     });
     const { classes } = resolveStyles(options, resolvedVariables, renderStyles);
     const { classes: secondClasses } = resolveStyles(options, resolvedVariables, renderStyles);
 
     expect(classes['root']).toBeDefined();
-    expect(renderStyles).toHaveBeenCalledWith({ color: 'red' });
+    expect(renderStyles).toHaveBeenCalledWith(expect.objectContaining({ color: 'red' }));
     expect(secondClasses['root']).toBeDefined();
     expect(renderStyles).toHaveBeenCalledTimes(2);
   });
@@ -222,7 +223,7 @@ describe('resolveStyles', () => {
     _.forEach(propsInlineOverrides, (props, idx) => {
       const options = resolveStylesOptions({
         props,
-        performance: { ...defaultPerformanceOptions, enableStylesCaching: false }
+        performance: { enableStylesCaching: false }
       });
 
       const { resolvedStyles } = resolveStyles(options, resolvedVariables);
@@ -249,7 +250,7 @@ describe('resolveStyles', () => {
     _.forEach(propsInlineOverrides, props => {
       const options = resolveStylesOptions({
         props,
-        performance: { ...defaultPerformanceOptions, enableStylesCaching: false }
+        performance: { enableStylesCaching: false }
       });
       const { classes } = resolveStyles(options, resolvedVariables, renderStyles);
       const { classes: secondClasses } = resolveStyles(options, resolvedVariables, renderStyles);
@@ -259,5 +260,77 @@ describe('resolveStyles', () => {
     });
 
     expect(renderStyles).toHaveBeenCalledTimes(propsInlineOverridesSize * 2);
+  });
+
+  test('computes new styles when "rtl" changes', () => {
+    const renderStyles = jest.fn().mockImplementation((style: ICSSInJSStyle) => style.content);
+
+    const ltrOptions = resolveStylesOptions({ rtl: false });
+    const rtlOptions = resolveStylesOptions({ rtl: true });
+
+    const ltrStyles = resolveStyles(ltrOptions, resolvedVariables, renderStyles);
+    const rtlStyles = resolveStyles(rtlOptions, resolvedVariables, renderStyles);
+
+    expect(ltrStyles).toHaveProperty('resolvedStyles.root.content', expect.stringMatching(/rtl:false/));
+    expect(ltrStyles).toHaveProperty('classes.root', expect.stringMatching(/rtl:false/));
+    expect(renderStyles).toHaveBeenCalledTimes(1);
+
+    expect(rtlStyles).toHaveProperty('resolvedStyles.root.content', expect.stringMatching(/rtl:true/));
+    expect(rtlStyles).toHaveProperty('classes.root', expect.stringMatching(/rtl:true/));
+    expect(renderStyles).toHaveBeenCalledTimes(2);
+  });
+
+  describe('enableHardVariablesCaching', () => {
+    test('avoids "classes" computation when enabled', () => {
+      const renderStyles = jest.fn().mockReturnValue('a');
+      const options = resolveStylesOptions({
+        props: { variables: { isFoo: true, isBar: null, isBaz: undefined } },
+        performance: { enableHardVariablesCaching: true }
+      });
+
+      expect(resolveStyles(options, resolvedVariables, renderStyles)).toHaveProperty('classes.root', 'a');
+      expect(resolveStyles(options, resolvedVariables, renderStyles)).toHaveProperty('classes.root', 'a');
+      expect(renderStyles).toHaveBeenCalledTimes(1);
+    });
+
+    test('avoids "styles" computation when enabled', () => {
+      spyOn(componentStyles, 'root').and.callThrough();
+      const options = resolveStylesOptions({
+        props: { variables: { isFoo: true, isBar: null, isBaz: undefined } },
+        performance: { enableHardVariablesCaching: true }
+      });
+
+      expect(resolveStyles(options, resolvedVariables)).toHaveProperty('resolvedStyles.root');
+      expect(resolveStyles(options, resolvedVariables)).toHaveProperty('resolvedStyles.root');
+      expect(componentStyles.root).toHaveBeenCalledTimes(1);
+    });
+
+    test('requires "enableStylesCaching" to be enabled', () => {
+      const options = resolveStylesOptions({
+        performance: { enableStylesCaching: false, enableHardVariablesCaching: true }
+      });
+
+      expect(() => resolveStyles(options, resolvedVariables)).toThrowError(/Please check your "performance" settings on "Provider"/);
+    });
+
+    test('when enabled only plain objects can be passed as "variables"', () => {
+      const options = resolveStylesOptions({
+        props: { variables: () => {} },
+        performance: { enableHardVariablesCaching: true }
+      });
+
+      expect(() => resolveStyles(options, resolvedVariables)).toThrowError(/With "enableHardVariablesCaching" only plain objects/);
+    });
+
+    test('when enabled only boolean or nil properties can be passed to "variables"', () => {
+      const options = resolveStylesOptions({
+        props: { variables: { foo: 'bar' } },
+        performance: { enableHardVariablesCaching: true }
+      });
+
+      expect(() => resolveStyles(options, resolvedVariables)).toThrowError(
+        /With "enableHardVariablesCaching" only boolean or nil properties/
+      );
+    });
   });
 });

--- a/packages/fluentui/react/src/components/Animation/Animation.tsx
+++ b/packages/fluentui/react/src/components/Animation/Animation.tsx
@@ -199,7 +199,8 @@ const Animation: React.FC<AnimationProps> & {
       performance: {
         enableSanitizeCssPlugin: false,
         enableStylesCaching: false,
-        enableVariablesCaching: false
+        enableVariablesCaching: false,
+        enableHardVariablesCaching: false
       },
       saveDebug: _.noop,
       theme: context.theme

--- a/packages/fluentui/react/src/components/Animation/Animation.tsx
+++ b/packages/fluentui/react/src/components/Animation/Animation.tsx
@@ -200,7 +200,7 @@ const Animation: React.FC<AnimationProps> & {
         enableSanitizeCssPlugin: false,
         enableStylesCaching: false,
         enableVariablesCaching: false,
-        enableHardVariablesCaching: false
+        enableBooleanVariablesCaching: false
       },
       saveDebug: _.noop,
       theme: context.theme

--- a/packages/fluentui/react/src/utils/mergeProviderContexts.ts
+++ b/packages/fluentui/react/src/utils/mergeProviderContexts.ts
@@ -65,7 +65,8 @@ const mergeProviderContexts = (...contexts: (ProviderContextInput | ProviderCont
     performance: {
       enableSanitizeCssPlugin: process.env.NODE_ENV !== 'production',
       enableStylesCaching: true,
-      enableVariablesCaching: true
+      enableVariablesCaching: true,
+      enableHardVariablesCaching: false
     },
     telemetry: undefined,
     renderer: undefined

--- a/packages/fluentui/react/src/utils/mergeProviderContexts.ts
+++ b/packages/fluentui/react/src/utils/mergeProviderContexts.ts
@@ -66,7 +66,7 @@ const mergeProviderContexts = (...contexts: (ProviderContextInput | ProviderCont
       enableSanitizeCssPlugin: process.env.NODE_ENV !== 'production',
       enableStylesCaching: true,
       enableVariablesCaching: true,
-      enableHardVariablesCaching: false
+      enableBooleanVariablesCaching: false
     },
     telemetry: undefined,
     renderer: undefined

--- a/packages/fluentui/react/src/utils/renderComponent.tsx
+++ b/packages/fluentui/react/src/utils/renderComponent.tsx
@@ -77,7 +77,7 @@ const renderComponent = <P extends {}>(config: RenderConfig<P>, context?: Provid
       ...context.performance,
       // we cannot enable caching for class components
       enableStylesCaching: false,
-      enableHardVariablesCaching: false
+      enableBooleanVariablesCaching: false
     }
   });
 

--- a/packages/fluentui/react/src/utils/renderComponent.tsx
+++ b/packages/fluentui/react/src/utils/renderComponent.tsx
@@ -75,7 +75,9 @@ const renderComponent = <P extends {}>(config: RenderConfig<P>, context?: Provid
     theme: context.theme || emptyTheme,
     performance: {
       ...context.performance,
-      enableStylesCaching: false // we cannot enable caching for class components
+      // we cannot enable caching for class components
+      enableStylesCaching: false,
+      enableHardVariablesCaching: false
     }
   });
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

### WAT? 😱

This PR adds `enableBooleanVariablesCaching` which is disabled by default. It allows to handle styles caching for cases when boolean variables are used:

```tsx
<Provider performance={{ enableBooleanVariablesCaching: true }}>
  <Button variables={{ isFoo: true }} />
</Provider>
```

### Limitations 💔

We use `JSON.stringify()` for the implementation and it means that boolean variables should go in the same order, i.e. `Button`s below will create different cache entries:

```tsx
<>
  <Button variables={{ isFoo: true, isBar: true }} />
  <Button variables={{ isBar: true, isFoo: true }} />
</>
```

To avoid this the order should be always the same, proposed solution for customers: enforce the alphabetic order via ESLint rules.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12073)
