### PR TITLE
Fluent: Remove bundle all packages task

### DIFF
--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -31,4 +31,4 @@ require('./scripts/gulp/tasks/test-circulars');
 require('./scripts/gulp/tasks/test-dependencies');
 
 // global tasks
-task('build', parallel('bundle:all-packages', 'build:docs'));
+task('build', parallel('build:docs'));

--- a/scripts/gulp/tasks/bundle.ts
+++ b/scripts/gulp/tasks/bundle.ts
@@ -89,8 +89,3 @@ task(
   series('bundle:package:clean', parallel('bundle:package:commonjs', 'bundle:package:es', 'bundle:package:types'))
 );
 task('bundle:package', series('bundle:package:no-umd', 'bundle:package:umd'));
-
-task('bundle:all-packages', async () => {
-  await sh('lerna run build --scope @fluentui/*');
-  return del(`${config.paths.packages()}/*/dist/dts`);
-});

--- a/scripts/gulp/tasks/stats.ts
+++ b/scripts/gulp/tasks/stats.ts
@@ -127,7 +127,7 @@ task('stats:build:bundle', async () => {
   writeCurrentStats(currentStatsFilePath, results);
 });
 
-task('stats', series(parallel('bundle:all-packages', 'build:docs:component-info'), 'stats:build:bundle'));
+task('stats', series(parallel('build:docs:component-info'), 'stats:build:bundle'));
 
 function readSummaryPerfStats() {
   return _.chain(require(paths.perfDist('result.json')))

--- a/scripts/gulp/tasks/test-circulars/index.ts
+++ b/scripts/gulp/tasks/test-circulars/index.ts
@@ -35,4 +35,4 @@ task('test:circulars:run', done => {
   });
 });
 
-task('test:circulars', series('bundle:all-packages', 'test:circulars:run'));
+task('test:circulars', series('test:circulars:run'));


### PR DESCRIPTION
…with yarn build.

#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Remove fluent's `bundle:all-packages` script since it is now redundant with `yarn build` and is occasionally causing build errors in pipelines.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12074)