### PR TITLE
chore: Update FluentUI github links

### DIFF
--- a/packages/fluentui/ability-attributes/package.json
+++ b/packages/fluentui/ability-attributes/package.json
@@ -3,7 +3,7 @@
   "description": "Accessibility attributes schema for Fluent UI",
   "version": "0.44.0",
   "author": "Marat Abdullin <marata@microsoft.com>",
-  "bugs": "https://github.com/microsoft/fluent-ui-react/issues",
+  "bugs": "https://github.com/OfficeDev/office-ui-fabric-react/issues",
   "dependencies": {
     "ability-attributes": "^0.0.8"
   },
@@ -13,7 +13,7 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/microsoft/fluent-ui-react/tree/master/packages/ability-attributes",
+  "homepage": "https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/fluentui/ability-attributes",
   "jsnext:main": "dist/es/index.js",
   "license": "MIT",
   "main": "dist/commonjs/index.js",
@@ -21,7 +21,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "microsoft/fluent-ui-react.git",
+  "repository": "OfficeDev/office-ui-fabric-react.git",
   "scripts": {
     "build": "npm run schema && gulp bundle:package:no-umd",
     "clean": "gulp bundle:package:clean",

--- a/packages/fluentui/accessibility/package.json
+++ b/packages/fluentui/accessibility/package.json
@@ -3,7 +3,7 @@
   "description": "A set of reusable framework accessibility behaviours.",
   "version": "0.44.0",
   "author": "Oleksandr Fediashov <olfedias@microsoft.com>",
-  "bugs": "https://github.com/microsoft/fluent-ui-react/issues",
+  "bugs": "https://github.com/OfficeDev/office-ui-fabric-react/issues",
   "dependencies": {
     "@babel/runtime": "^7.7.6",
     "keyboard-key": "1.0.1",
@@ -17,7 +17,7 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/microsoft/fluent-ui-react/tree/master/packages/accessibility",
+  "homepage": "https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/fluentui/accessibility",
   "jsnext:main": "dist/es/index.js",
   "license": "MIT",
   "main": "dist/commonjs/index.js",
@@ -25,7 +25,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "microsoft/fluent-ui-react.git",
+  "repository": "OfficeDev/office-ui-fabric-react.git",
   "scripts": {
     "build": "gulp bundle:package:no-umd",
     "clean": "gulp bundle:package:clean",

--- a/packages/fluentui/code-sandbox/package.json
+++ b/packages/fluentui/code-sandbox/package.json
@@ -3,7 +3,7 @@
   "description": "Fluent UI tools for CodeSandbox.",
   "version": "0.44.0",
   "author": "Oleksandr Fediashov <a@fedyashov.com>",
-  "bugs": "https://github.com/microsoft/fluent-ui-react/issues",
+  "bugs": "https://github.com/OfficeDev/office-ui-fabric-react/issues",
   "dependencies": {
     "@fluentui/docs-components": "^0.44.0"
   },
@@ -13,7 +13,7 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/microsoft/fluent-ui-react/tree/master/packages/code-sandbox",
+  "homepage": "https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/fluentui/code-sandbox",
   "jsnext:main": "dist/es/index.js",
   "license": "MIT",
   "main": "dist/commonjs/index.js",
@@ -26,7 +26,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "microsoft/fluent-ui-react.git",
+  "repository": "OfficeDev/office-ui-fabric-react.git",
   "scripts": {
     "build": "gulp bundle:package:no-umd",
     "clean": "gulp bundle:package:clean",

--- a/packages/fluentui/code-sandbox/src/SandboxApp.tsx
+++ b/packages/fluentui/code-sandbox/src/SandboxApp.tsx
@@ -39,11 +39,11 @@ const SandboxApp: React.FunctionComponent = props => {
           <Header>Fluent UI @ {pkg.version}</Header>
           <p>
             This example is powered by Fluent UI, check{' '}
-            <Text as="a" href="https://microsoft.github.io/fluent-ui-react/">
+            <Text as="a" href="https://aka.ms/fluent-ui">
               our docs
             </Text>{' '}
             and{' '}
-            <Text as="a" href="https://github.com/microsoft/fluent-ui-react">
+            <Text as="a" href="https://github.com/OfficeDev/office-ui-fabric-react">
               GitHub
             </Text>
             .

--- a/packages/fluentui/docs-components/package.json
+++ b/packages/fluentui/docs-components/package.json
@@ -3,7 +3,7 @@
   "description": "A set of React components to build docs sites.",
   "version": "0.44.0",
   "author": "Oleksandr Fediashov <a@fedyashov.com>",
-  "bugs": "https://github.com/microsoft/fluent-ui-react/issues",
+  "bugs": "https://github.com/OfficeDev/office-ui-fabric-react/issues",
   "dependencies": {
     "@babel/runtime": "^7.7.6",
     "copy-to-clipboard": "^3.2.0",
@@ -14,7 +14,7 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/microsoft/fluent-ui-react/tree/master/packages/docs-components",
+  "homepage": "https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/fluentui/docs-components",
   "jsnext:main": "dist/es/index.js",
   "license": "MIT",
   "main": "dist/commonjs/index.js",
@@ -27,7 +27,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "microsoft/fluent-ui-react.git",
+  "repository": "OfficeDev/office-ui-fabric-react.git",
   "scripts": {
     "build": "gulp bundle:package:no-umd",
     "clean": "gulp bundle:package:clean",

--- a/packages/fluentui/docs/src/views/AccessibilityBehaviors.tsx
+++ b/packages/fluentui/docs/src/views/AccessibilityBehaviors.tsx
@@ -203,7 +203,7 @@ export default () => (
     <CodeSnippet label="App.jsx" value={`<Menu accessibility={overridenMenuBehavior} />`} />
     <p>
       All Fluent UI behaviors implementations can be found on the{' '}
-      {link('GitHub', 'https://github.com/microsoft/fluent-ui-react/tree/master/packages/react/src/utils/accessibility/Behaviors')}.
+      {link('GitHub', 'https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/fluentui/accessibility/src/behaviors')}.
     </p>
     <Header as="h4" content="Available Behaviors" />
     <p>

--- a/packages/fluentui/docs/src/views/AutoFocusZoneDoc.tsx
+++ b/packages/fluentui/docs/src/views/AutoFocusZoneDoc.tsx
@@ -34,7 +34,7 @@ export default () => (
       {code('AutoFocusZone')}'s props which can be applied to {code('autoFocus')} prop (
       {link(
         'lookup for API on GitHub',
-        'https://github.com/microsoft/fluent-ui-react/blob/master/packages/react/src/utils/accessibility/AutoFocusZone/AutoFocusZone.types.tsx'
+        'https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/fluentui/react-bindings/src/FocusZone/AutoFocusZone.types.tsx'
       )}
       ):
     </p>
@@ -67,7 +67,7 @@ export default () => (
       {code('AutoFocusZone')} code on{' '}
       {link(
         'GitHub.',
-        'https://github.com/microsoft/fluent-ui-react/blob/master/packages/react/src/utils/accessibility/FocusZone/AutoFocusZone.tsx'
+        'https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/fluentui/react-bindings/src/FocusZone/AutoFocusZone.tsx'
       )}
     </p>
   </DocPage>

--- a/packages/fluentui/docs/src/views/FocusTrapZoneDoc.tsx
+++ b/packages/fluentui/docs/src/views/FocusTrapZoneDoc.tsx
@@ -40,7 +40,7 @@ export default () => (
       {code('FocusTrapZone')}'s props which can be applied to {code('trapFocus')} prop (
       {link(
         'lookup for API on GitHub',
-        'https://github.com/microsoft/fluent-ui-react/blob/master/packages/react/src/utils/accessibility/FocusTrapZone/FocusTrapZone.types.tsx'
+        'https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/fluentui/react-bindings/src/FocusZone/FocusTrapZone.types.tsx'
       )}
       ):
     </p>
@@ -78,7 +78,7 @@ export default () => (
       {code('FocusTrapZone')} code on{' '}
       {link(
         'GitHub.',
-        'https://github.com/microsoft/fluent-ui-react/blob/master/packages/react/src/utils/accessibility/FocusZone/FocusTrapZone.tsx'
+        'https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/fluentui/react-bindings/src/FocusZone/FocusTrapZone.tsx'
       )}
     </p>
   </DocPage>

--- a/packages/fluentui/docs/src/views/FocusZoneDoc.tsx
+++ b/packages/fluentui/docs/src/views/FocusZoneDoc.tsx
@@ -116,7 +116,7 @@ export default () => (
       The following props can be applied (
       {link(
         'lookup for API on GitHub',
-        'https://github.com/microsoft/fluent-ui-react/blob/master/packages/react/src/utils/accessibility/FocusZone/FocusZone.types.ts'
+        'https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/fluentui/react-bindings/src/FocusZone/FocusZone.types.ts'
       )}
       ):
     </p>
@@ -164,7 +164,7 @@ export default () => (
       {code('FocusZone')} code on{' '}
       {link(
         'GitHub.',
-        'https://github.com/microsoft/fluent-ui-react/blob/master/packages/react/src/utils/accessibility/FocusZone/FocusZone.tsx'
+        'https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/fluentui/react-bindings/src/FocusZone/FocusZone.tsx'
       )}
     </p>
   </DocPage>

--- a/packages/fluentui/eslint-plugin/rules/no-visibility-modifiers/index.js
+++ b/packages/fluentui/eslint-plugin/rules/no-visibility-modifiers/index.js
@@ -3,7 +3,7 @@ const isTypeScriptFile = require('../../utils/isTypeScriptFile');
 const { AST_NODE_TYPES, ESLintUtils } = require('@typescript-eslint/experimental-utils');
 
 const createRule = ESLintUtils.RuleCreator(
-  name => `https://github.com/microsoft/fluent-ui-react/tree/master/packages/eslint-plugin/rules/${name}/index.js`
+  name => `https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/fluentui/eslint-plugin/rules/${name}/index.js`
 );
 
 module.exports = createRule({

--- a/packages/fluentui/playground/package.json
+++ b/packages/fluentui/playground/package.json
@@ -2,13 +2,13 @@
   "name": "@fluentui/playground",
   "version": "0.44.0",
   "description": "> TODO: description",
-  "homepage": "https://github.com/microsoft/fluent-ui#readme",
+  "homepage": "https://github.com/OfficeDev/office-ui-fabric-react",
   "bugs": {
-    "url": "https://github.com/microsoft/fluent-ui/issues"
+    "url": "https://github.com/OfficeDev/office-ui-fabric-react/issues"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/microsoft/fluent-ui.git"
+    "url": "git@github.com:OfficeDev/office-ui-fabric-react.git"
   },
   "license": "ISC",
   "author": "JD Huntington <jdh@microsoft.com>",

--- a/packages/fluentui/playground/src/components/Icon/README.md
+++ b/packages/fluentui/playground/src/components/Icon/README.md
@@ -481,12 +481,10 @@ type FontIconSpec = ObjectOrFunc<{
 
 Below are wiki and code references into this process:
 
-- [SVG icon processing](https://github.com/microsoft/fluent-ui-react/blob/21c2f9e3e495b3094e0db4610e9f8834cdc135b0/packages/react/src/themes/teams/components/Icon/svg/ProcessedIcons/process-icons.sh#L36)
+- [SVG icon processing](https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/fluentui/react/src/themes/teams/components/Icon/svg/ProcessedIcons/process-icons.sh#L36)
 - [Instructions on adding new SVG Icon](https://github.com/microsoft/fluent-ui-react/pull/585)
-- [Font icon registration into the theme (fontAwesome theme example)](https://github.com/microsoft/fluent-ui-react/blob/feat/generate-css/src/themes/teams/components/Icon/fontAwesomeIconStyles.ts)
-- [Font vs SVG icon rendering](https://github.com/microsoft/fluent-ui-react/blob/master/packages/react/src/themes/teams/components/Icon/iconStyles.ts)
-- [Icon styles as part of theme component styles](https://github.com/microsoft/fluent-ui-react/blob/de10e334fc039370c4fe4b425050327d57f3f515/packages/react/src/themes/teams/componentStyles.ts#L51)
-- [Merging icons as part of theme](https://github.com/microsoft/fluent-ui-react/blob/feat/generate-css/src/themes/teams/index.ts)
+- [Font vs SVG icon rendering](https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/fluentui/react/src/themes/teams/components/Icon/iconStyles.ts)
+- [Icon styles as part of theme component styles](https://github.com/OfficeDev/office-ui-fabric-react/blob/15ad5f0b98156117d738f46ae4f5490c86027bce/packages/fluentui/react/src/themes/teams/componentStyles.ts#L47)
 
 > - TODO: Decide on recommended thing to do. Leaning towards Fluent UI approach but worried about perf implications regarding icon definitions.
 > - TODO: Discuss how to handle font loading if we put icons in the theme.

--- a/packages/fluentui/react-bindings/package.json
+++ b/packages/fluentui/react-bindings/package.json
@@ -3,7 +3,7 @@
   "description": "A set of components and hooks to build components libraries and UI kits.",
   "version": "0.44.0",
   "author": "Oleksandr Fediashov <a@fedyashov.com>",
-  "bugs": "https://github.com/microsoft/fluent-ui-react/issues",
+  "bugs": "https://github.com/OfficeDev/office-ui-fabric-react/issues",
   "dependencies": {
     "@babel/runtime": "^7.7.6",
     "@fluentui/accessibility": "^0.44.0",
@@ -22,7 +22,7 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/microsoft/fluent-ui-react/tree/master/packages/react-bindings",
+  "homepage": "https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/fluentui/react-bindings",
   "jsnext:main": "dist/es/index.js",
   "license": "MIT",
   "main": "dist/commonjs/index.js",
@@ -34,7 +34,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "microsoft/fluent-ui-react.git",
+  "repository": "OfficeDev/office-ui-fabric-react.git",
   "scripts": {
     "build": "gulp bundle:package:no-umd",
     "clean": "gulp bundle:package:clean",

--- a/packages/fluentui/react-component-event-listener/package.json
+++ b/packages/fluentui/react-component-event-listener/package.json
@@ -3,7 +3,7 @@
   "description": "React components for binding events on the global scope.",
   "version": "0.44.0",
   "author": "Oleksandr Fediashov <a@fedyashov.com>",
-  "bugs": "https://github.com/microsoft/fluent-ui-react/issues",
+  "bugs": "https://github.com/OfficeDev/office-ui-fabric-react/issues",
   "dependencies": {
     "@babel/runtime": "^7.7.6",
     "prop-types": "^15.7.2"
@@ -18,7 +18,7 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/microsoft/fluent-ui-react/tree/master/packages/react-component-event-listener",
+  "homepage": "https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/fluentui/react-component-event-listener",
   "jsnext:main": "dist/es/index.js",
   "license": "MIT",
   "main": "dist/commonjs/index.js",
@@ -30,7 +30,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "microsoft/fluent-ui-react.git",
+  "repository": "OfficeDev/office-ui-fabric-react.git",
   "scripts": {
     "build": "gulp bundle:package:no-umd",
     "clean": "gulp bundle:package:clean",

--- a/packages/fluentui/react-component-nesting-registry/package.json
+++ b/packages/fluentui/react-component-nesting-registry/package.json
@@ -3,7 +3,7 @@
   "description": "Registers a DOM nodes within a context.",
   "version": "0.44.0",
   "author": "Oleksandr Fediashov <a@fedyashov.com>",
-  "bugs": "https://github.com/microsoft/fluent-ui-react/issues",
+  "bugs": "https://github.com/OfficeDev/office-ui-fabric-react/issues",
   "dependencies": {
     "@babel/runtime": "^7.7.6",
     "prop-types": "^15.7.2"
@@ -16,7 +16,7 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/microsoft/fluent-ui-react/tree/master/packages/react-component-nesting-registry",
+  "homepage": "https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/fluentui/react-component-nesting-registry",
   "jsnext:main": "dist/es/index.js",
   "license": "MIT",
   "main": "dist/commonjs/index.js",
@@ -28,7 +28,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "microsoft/fluent-ui-react.git",
+  "repository": "OfficeDev/office-ui-fabric-react.git",
   "scripts": {
     "build": "gulp bundle:package:no-umd",
     "clean": "gulp bundle:package:clean",

--- a/packages/fluentui/react-component-ref/package.json
+++ b/packages/fluentui/react-component-ref/package.json
@@ -3,7 +3,7 @@
   "description": "A set of components and utils to deal with React refs.",
   "version": "0.44.0",
   "author": "Oleksandr Fediashov <olfedias@microsoft.com>",
-  "bugs": "https://github.com/microsoft/fluent-ui-react/issues",
+  "bugs": "https://github.com/OfficeDev/office-ui-fabric-react/issues",
   "dependencies": {
     "@babel/runtime": "^7.7.6",
     "prop-types": "^15.7.2",
@@ -18,7 +18,7 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/microsoft/fluent-ui-react/tree/master/packages/react-component-ref",
+  "homepage": "https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/fluentui/react-component-ref",
   "jsnext:main": "dist/es/index.js",
   "license": "MIT",
   "main": "dist/commonjs/index.js",
@@ -30,7 +30,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "microsoft/fluent-ui-react.git",
+  "repository": "OfficeDev/office-ui-fabric-react.git",
   "scripts": {
     "build": "gulp bundle:package:no-umd",
     "clean": "gulp bundle:package:clean",

--- a/packages/fluentui/react-context-selector/package.json
+++ b/packages/fluentui/react-context-selector/package.json
@@ -3,7 +3,7 @@
   "description": "React useContextSelector & useContextSelectors hooks in userland",
   "version": "0.44.0",
   "author": "Oleksandr Fediashov <a@fedyashov.com>",
-  "bugs": "https://github.com/microsoft/fluent-ui-react/issues",
+  "bugs": "https://github.com/OfficeDev/office-ui-fabric-react/issues",
   "dependencies": {
     "@babel/runtime": "^7.7.6"
   },
@@ -21,7 +21,7 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/microsoft/fluent-ui-react/tree/master/packages/react-context-selector",
+  "homepage": "https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/fluentui/react-context-selector",
   "jsnext:main": "dist/es/index.js",
   "license": "MIT",
   "main": "dist/commonjs/index.js",
@@ -29,7 +29,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "microsoft/fluent-ui-react.git",
+  "repository": "OfficeDev/office-ui-fabric-react.git",
   "scripts": {
     "build": "gulp bundle:package:no-umd",
     "clean": "gulp bundle:package:clean",

--- a/packages/fluentui/react-proptypes/package.json
+++ b/packages/fluentui/react-proptypes/package.json
@@ -3,7 +3,7 @@
   "description": "Set of custom reusable PropTypes for React components, some of them are specific for Fluent UI.",
   "version": "0.44.0",
   "author": "Oleksandr Fediashov <olfedias@microsoft.com>",
-  "bugs": "https://github.com/microsoft/fluent-ui-react/issues",
+  "bugs": "https://github.com/OfficeDev/office-ui-fabric-react/issues",
   "dependencies": {
     "@babel/runtime": "^7.7.6",
     "lodash": "^4.17.15",
@@ -17,7 +17,7 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/microsoft/fluent-ui-react/tree/master/packages/react-proptypes",
+  "homepage": "https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/fluentui/react-proptypes",
   "jsnext:main": "dist/es/index.js",
   "license": "MIT",
   "main": "dist/commonjs/index.js",
@@ -25,7 +25,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "microsoft/fluent-ui-react.git",
+  "repository": "OfficeDev/office-ui-fabric-react.git",
   "scripts": {
     "build": "gulp bundle:package:no-umd",
     "clean": "gulp bundle:package:clean",

--- a/packages/fluentui/react-theming/package.json
+++ b/packages/fluentui/react-theming/package.json
@@ -2,14 +2,11 @@
   "name": "@fluentui/react-theming",
   "version": "0.44.0",
   "description": "> TODO: description",
-  "homepage": "https://github.com/microsoft/fluent-ui#readme",
+  "homepage": "https://github.com/OfficeDev/office-ui-fabric-react",
   "bugs": {
-    "url": "https://github.com/microsoft/fluent-ui/issues"
+    "url": "https://github.com/OfficeDev/office-ui-fabric-react/issues"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/microsoft/fluent-ui.git"
-  },
+  "repository": "OfficeDev/office-ui-fabric-react.git",
   "license": "MIT",
   "files": [
     "lib"

--- a/packages/fluentui/react/package.json
+++ b/packages/fluentui/react/package.json
@@ -45,7 +45,7 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/OfficeDev/office-ui-fabric-react",
+  "homepage": "https://github.com/microsoft/fluent-ui-react/tree/master/packages/react",
   "jsnext:main": "dist/es/index.js",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/packages/fluentui/react/package.json
+++ b/packages/fluentui/react/package.json
@@ -3,7 +3,7 @@
   "description": "A themable React component library.",
   "version": "0.44.0",
   "author": "Levi Thomason <me@levithomason.com>",
-  "bugs": "https://github.com/microsoft/fluent-ui-react/issues",
+  "bugs": "https://github.com/OfficeDev/office-ui-fabric-react/issues",
   "dependencies": {
     "@babel/runtime": "^7.7.6",
     "@fluentui/accessibility": "^0.44.0",
@@ -45,7 +45,7 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/microsoft/fluent-ui-react#readme",
+  "homepage": "https://github.com/OfficeDev/office-ui-fabric-react",
   "jsnext:main": "dist/es/index.js",
   "license": "MIT",
   "main": "dist/commonjs/index.js",
@@ -57,7 +57,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "microsoft/fluent-ui-react.git",
+  "repository": "OfficeDev/office-ui-fabric-react.git",
   "scripts": {
     "build": "gulp bundle:package",
     "clean": "gulp bundle:package:clean",

--- a/packages/fluentui/react/package.json
+++ b/packages/fluentui/react/package.json
@@ -45,7 +45,7 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/microsoft/fluent-ui-react/tree/master/packages/react",
+  "homepage": "https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/fluentui/react",
   "jsnext:main": "dist/es/index.js",
   "license": "MIT",
   "main": "dist/commonjs/index.js",

--- a/packages/fluentui/react/src/utils/constants.ts
+++ b/packages/fluentui/react/src/utils/constants.ts
@@ -1,9 +1,9 @@
-const docSiteUrl = 'https://microsoft.github.io/fluent-ui-react';
+const docSiteUrl = 'https://fluentsite.z22.web.core.windows.net';
 
 const constants = {
   docSiteUrl,
   quickStartUrl: `${docSiteUrl}/quick-start`,
-  repoURL: 'https://github.com/microsoft/fluent-ui-react',
+  repoURL: 'https://github.com/OfficeDev/office-ui-fabric-react',
   typeOrder: ['component', 'behavior']
 };
 

--- a/packages/fluentui/state/README.md
+++ b/packages/fluentui/state/README.md
@@ -46,4 +46,4 @@ const manager = createInputManager({ state: { value: 'Hello world!' } });
 
 # Usage with React
 
-We provide React bindings under [`@fluentui/react-bindings`](https://github.com/microsoft/fluent-ui-react/tree/master/packages/react-bindings).
+We provide React bindings under [`@fluentui/react-bindings`](https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/fluentui/react-bindings).

--- a/packages/fluentui/state/package.json
+++ b/packages/fluentui/state/package.json
@@ -3,7 +3,7 @@
   "description": "A set of utils to create framework agnostic and reusable state managers",
   "version": "0.44.0",
   "author": "Oleksandr Fediashov <a@fedyashov.com>",
-  "bugs": "https://github.com/microsoft/fluent-ui-react/issues",
+  "bugs": "https://github.com/OfficeDev/office-ui-fabric-react/issues",
   "dependencies": {
     "@babel/runtime": "^7.7.6"
   },
@@ -15,7 +15,7 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/microsoft/fluent-ui-react/tree/master/packages/state",
+  "homepage": "https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/fluentui/state",
   "jsnext:main": "dist/es/index.js",
   "license": "MIT",
   "main": "dist/commonjs/index.js",
@@ -23,7 +23,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "microsoft/fluent-ui-react.git",
+  "repository": "OfficeDev/office-ui-fabric-react.git",
   "scripts": {
     "build": "gulp bundle:package:no-umd",
     "clean": "gulp bundle:package:clean",

--- a/packages/fluentui/styles/package.json
+++ b/packages/fluentui/styles/package.json
@@ -3,7 +3,7 @@
   "description": "A set of styling utilities for CSS-in-JS.",
   "version": "0.44.0",
   "author": "Marija Najdova <mnajdova@gmail.com>",
-  "bugs": "https://github.com/microsoft/fluent-ui-react/issues",
+  "bugs": "https://github.com/OfficeDev/office-ui-fabric-react/issues",
   "dependencies": {
     "@babel/runtime": "^7.7.6",
     "csstype": "^2.6.7",
@@ -17,7 +17,7 @@
   "files": [
     "dist"
   ],
-  "homepage": "https://github.com/microsoft/fluent-ui-react/tree/master/packages/styles",
+  "homepage": "https://github.com/OfficeDev/office-ui-fabric-react/tree/master/packages/fluentui/styles",
   "jsnext:main": "dist/es/index.js",
   "license": "MIT",
   "main": "dist/commonjs/index.js",
@@ -25,7 +25,7 @@
   "publishConfig": {
     "access": "public"
   },
-  "repository": "microsoft/fluent-ui-react.git",
+  "repository": "OfficeDev/office-ui-fabric-react.git",
   "scripts": {
     "build": "gulp bundle:package:no-umd",
     "clean": "gulp bundle:package:clean",

--- a/scripts/dangerjs/checkChangelog.ts
+++ b/scripts/dangerjs/checkChangelog.ts
@@ -19,8 +19,8 @@ const hasAddedLinesAfterVersionInChangelog = async (danger: DangerDSLType): Prom
 };
 
 const getMalformedChangelogEntries = async (danger: DangerDSLType): Promise<string[]> => {
-  // +- description @githubname ([#DDDD](https://github.com/microsoft/fluent-ui-react/pull/DDDD))
-  const validEntry = /^\+- .*@\S+ \(\[#(\d+)]\(https:\/\/github\.com\/microsoft\/fluent-ui-react\/pull\/\1\)\)$/;
+  // +- description @githubname ([#DDDD](https://github.com/OfficeDev/office-ui-fabric-react/pull/DDDD))
+  const validEntry = /^\+- .*@\S+ \(\[#(\d+)]\(https:\/\/github\.com\/OfficeDev\/office-ui-fabric-react\/pull\/\1\)\)$/;
 
   const addedLines = await getAddedLinesFromChangelog(danger);
 
@@ -56,7 +56,7 @@ export default async ({ danger, fail, warn }: DangerJS) => {
       malformedChangelogEntries.forEach(entry => {
         fail(`Invalid entry format in ${CHANGELOG_FILE}: >${entry}<
 
-The correct format is: \`- description @githubname ([#DDDD](https://github.com/microsoft/fluent-ui-react/pull/DDDD)\``);
+The correct format is: \`- description @githubname ([#DDDD](https://github.com/OfficeDev/office-ui-fabric-react/pull/DDDD)\``);
       });
 
       const hasLine = await hasAddedLinesAfterVersionInChangelog(danger);


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Follow up after FluentUI code move to Fabric repo - update all the github links.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12076)