### PR TITLE
Change some jobs to default agent pool

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -7,10 +7,9 @@ trigger:
 variables:
   - group: fabric-variables
 
-pool: 'Self Host Ubuntu'
-
 jobs:
   - job: Build
+    pool: 'Self Host Ubuntu'
     steps:
       - template: azure-pipelines.tools.yml
 
@@ -62,6 +61,8 @@ jobs:
 
   - job: Validate
     dependsOn: Build
+    pool:
+      vmImage: 'Ubuntu 18.04'
     steps:
       # No need for checkout since we're using build artifacts.
       - checkout: none
@@ -93,6 +94,8 @@ jobs:
 
   - job: ValidateFluent
     dependsOn: Build
+    pool:
+      vmImage: 'Ubuntu 18.04'
     steps:
       # No need for checkout since we're using build artifacts.
       - checkout: none
@@ -138,6 +141,8 @@ jobs:
 
   - job: Deploy
     dependsOn: Build
+    pool:
+      vmImage: 'Ubuntu 18.04'
     steps:
       # No need for checkout since we're using build artifacts.
       - checkout: none
@@ -170,6 +175,7 @@ jobs:
 
   - job: Screener
     dependsOn: Build
+    pool: 'Self Host Ubuntu'
     steps:
       # No need for checkout since we're using build artifacts.
       - checkout: none


### PR DESCRIPTION
Reduce load on our agents by moving Validate, ValidateFluent, and Deploy jobs to the default agent pool. Build and Screener jobs continue to use our custom VMs.

![image](https://user-images.githubusercontent.com/5864305/75373102-7d53f800-587e-11ea-8df3-fd15fcddf612.png)

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12082)