### PR TITLE
Slider: allow setting id

### DIFF
--- a/change/office-ui-fabric-react-2020-02-26-11-02-33-xgao-slider-id.json
+++ b/change/office-ui-fabric-react-2020-02-26-11-02-33-xgao-slider-id.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Slider: allow setting id on slider",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "861f94c69a85c7c31af3901734237ac562e892bb",
+  "dependentChangeType": "patch",
+  "date": "2020-02-26T19:02:33.105Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.base.tsx
@@ -89,6 +89,7 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
         )}
         <div className={classNames.container}>
           <div
+            id={this._id}
             aria-valuenow={value}
             aria-valuemin={min}
             aria-valuemax={max}
@@ -100,7 +101,6 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
             {...onKeyDownProp}
             {...divButtonProps}
             className={css(classNames.slideBox, buttonProps!.className)}
-            id={this._id}
             role="slider"
             tabIndex={disabled ? undefined : 0}
             data-is-focusable={!disabled}

--- a/packages/office-ui-fabric-react/src/components/Slider/Slider.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Slider/Slider.test.tsx
@@ -3,13 +3,22 @@ import * as ReactDOM from 'react-dom';
 import * as renderer from 'react-test-renderer';
 import * as ReactTestUtils from 'react-dom/test-utils';
 
-import { mount } from 'enzyme';
+import { mount, ReactWrapper } from 'enzyme';
 import { Slider } from './Slider';
 import { ISlider } from './Slider.types';
 import { ONKEYDOWN_TIMEOUT_DURATION } from './Slider.base';
 import { KeyCodes } from '../../Utilities';
 
 describe('Slider', () => {
+  let wrapper: ReactWrapper | undefined;
+
+  afterEach(() => {
+    if (wrapper) {
+      wrapper.unmount();
+      wrapper = undefined;
+    }
+  });
+
   it('renders correctly', () => {
     const component = renderer.create(<Slider label="I am a slider" />);
     const tree = component.toJSON();
@@ -23,7 +32,7 @@ describe('Slider', () => {
       changedValue = val;
     };
 
-    const wrapper = mount(<Slider onChange={onChange} />);
+    wrapper = mount(<Slider onChange={onChange} />);
 
     const sliderLine = wrapper.find('.ms-Slider-line');
     const sliderThumb = wrapper.find('.ms-Slider-slideBox');
@@ -58,9 +67,9 @@ describe('Slider', () => {
   });
 
   it('has type=button on all buttons', () => {
-    const component = mount(<Slider />);
+    wrapper = mount(<Slider />);
 
-    component.find('button').forEach(button => {
+    wrapper.find('button').forEach(button => {
       expect(button.prop('type')).toEqual('button');
     });
   });
@@ -68,44 +77,52 @@ describe('Slider', () => {
   it('can provide the current value', () => {
     const slider = React.createRef<ISlider>();
 
-    mount(<Slider label="slider" defaultValue={12} min={0} max={100} componentRef={slider} />);
+    wrapper = mount(<Slider label="slider" defaultValue={12} min={0} max={100} componentRef={slider} />);
     expect(slider.current!.value).toEqual(12);
+  });
+
+  it('can set id on slider', () => {
+    wrapper = mount(<Slider buttonProps={{ id: 'test_id' }} />);
+
+    const sliderSlideBox = wrapper.find('.ms-Slider-slideBox');
+    expect(sliderSlideBox.getDOMNode().id).toEqual('test_id');
   });
 
   it('should be able to handler zero default value', () => {
     const slider = React.createRef<ISlider>();
 
-    mount(<Slider label="slider" defaultValue={0} min={-100} max={100} componentRef={slider} />);
+    wrapper = mount(<Slider label="slider" defaultValue={0} min={-100} max={100} componentRef={slider} />);
     expect(slider.current!.value).toEqual(0);
   });
 
   it('should be able to handler zero value', () => {
     const slider = React.createRef<ISlider>();
 
-    mount(<Slider label="slider" value={0} min={-100} max={100} componentRef={slider} />);
+    wrapper = mount(<Slider label="slider" value={0} min={-100} max={100} componentRef={slider} />);
     expect(slider.current!.value).toEqual(0);
   });
 
   it('renders correct aria-valuetext', () => {
-    let component = mount(<Slider />);
+    wrapper = mount(<Slider />);
 
-    expect(component.find('.ms-Slider-slideBox').prop('aria-valuetext')).toEqual('0');
+    expect(wrapper.find('.ms-Slider-slideBox').prop('aria-valuetext')).toEqual('0');
 
     const values = ['small', 'medium', 'large'];
     const selected = 1;
     const getTextValue = (value: number) => values[value];
 
-    component = mount(<Slider value={selected} ariaValueText={getTextValue} />);
+    wrapper.unmount();
+    wrapper = mount(<Slider value={selected} ariaValueText={getTextValue} />);
 
-    expect(component.find('.ms-Slider-slideBox').prop('aria-valuetext')).toEqual(values[selected]);
+    expect(wrapper.find('.ms-Slider-slideBox').prop('aria-valuetext')).toEqual(values[selected]);
   });
 
   it('formats the value when a format function is passed', () => {
     const value = 10;
     const valueFormat = (val: any) => `${val}%`;
-    const component = mount(<Slider value={value} min={0} max={100} showValue={true} valueFormat={valueFormat} />);
+    wrapper = mount(<Slider value={value} min={0} max={100} showValue={true} valueFormat={valueFormat} />);
 
-    expect(component.find('label.ms-Label.ms-Slider-value').text()).toEqual(valueFormat(value));
+    expect(wrapper.find('label.ms-Label.ms-Slider-value').text()).toEqual(valueFormat(value));
   });
 
   it('calls onChanged after keyboard event', () => {


### PR DESCRIPTION
#### Pull request checklist

- [X] Addresses an existing issue: Fixes #12080
- [X] Include a change request file using `$ yarn change`

#### Description of changes
Allow setting `id` instead of only letting `id` be generated internally.
Added unit test along with cleaning up mounted react wrapper.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12085)