### PR TITLE
Fix Fluent UI's snapshot script

### DIFF
--- a/packages/fluentui/playground/package.json
+++ b/packages/fluentui/playground/package.json
@@ -31,7 +31,7 @@
     "start": "just-scripts storybook:start",
     "start-test": "just-scripts test:watch",
     "test": "just-scripts test",
-    "update-snapshots": "just-scripts jest:snapshots"
+    "update-snapshots": "just-scripts jest -u"
   },
   "dependencies": {
     "@fluentui/react-theming": "^0.44.0",

--- a/packages/fluentui/playground/package.json
+++ b/packages/fluentui/playground/package.json
@@ -30,8 +30,7 @@
     "perf": "just-scripts e2e:perf",
     "start": "just-scripts storybook:start",
     "start-test": "just-scripts test:watch",
-    "test": "just-scripts test",
-    "update-snapshots": "just-scripts jest -u"
+    "test": "just-scripts test"
   },
   "dependencies": {
     "@fluentui/react-theming": "^0.44.0",

--- a/packages/fluentui/react-theming/package.json
+++ b/packages/fluentui/react-theming/package.json
@@ -28,8 +28,7 @@
     "lint:fix": "yarn lint:eslint --fix && yarn lint:old --fix",
     "lint:old": "tslint -t stylish -p .",
     "start-test": "just-scripts test:watch",
-    "test": "just-scripts test",
-    "update-snapshots": "just-scripts jest -u"
+    "test": "just-scripts test"
   },
   "dependencies": {
     "@types/classnames": "^2.2.9",

--- a/packages/fluentui/react-theming/package.json
+++ b/packages/fluentui/react-theming/package.json
@@ -29,7 +29,7 @@
     "lint:old": "tslint -t stylish -p .",
     "start-test": "just-scripts test:watch",
     "test": "just-scripts test",
-    "update-snapshots": "just-scripts jest:snapshots"
+    "update-snapshots": "just-scripts jest -u"
   },
   "dependencies": {
     "@types/classnames": "^2.2.9",


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: N/A
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Running `yarn update-snapshots` was failing on what I assume to be usage of outdated `jest:snapshots`. This PR passes the `-u` option instead, which is what's used elsewhere in the repo.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12087)