### PR TITLE
Fix test-projects cleanup

### DIFF
--- a/scripts/gulp/tasks/test-projects.ts
+++ b/scripts/gulp/tasks/test-projects.ts
@@ -1,12 +1,11 @@
 import express from 'express';
-import fs from 'fs';
+import fs from 'fs-extra';
 import { series, task } from 'gulp';
 import { rollup as lernaAliases } from 'lerna-alias';
 import path from 'path';
 import portfinder from 'portfinder';
 import puppeteer from 'puppeteer';
 import sh from '../sh';
-import del from 'del';
 
 import config from '../../config';
 import tmp from 'tmp';
@@ -17,6 +16,13 @@ type PackedPackages = Record<string, string>;
 
 const { paths } = config;
 
+// Clean up created files/folders on exit, even after exceptions
+// (will not catch SIGINT on windows)
+tmp.setGracefulCleanup();
+
+/** Shared packed packages between tests since they're not modified by any test */
+let packedPackages: PackedPackages;
+
 const log = (context: string) => (message: string) => {
   console.log();
   console.log('='.repeat(80));
@@ -24,9 +30,11 @@ const log = (context: string) => (message: string) => {
   console.log('='.repeat(80));
 };
 
-export const runIn = targetPath => cmd => sh(cmd, targetPath);
+const createTempDir = (prefix: string): string => {
+  return tmp.dirSync({ prefix, unsafeCleanup: true }).name;
+};
 
-const addResolutionPathsForProjectPackages = async (testProjectDir: string, packedPackages: PackedPackages) => {
+const addResolutionPathsForProjectPackages = async (testProjectDir: string) => {
   const packageJsonPath = path.resolve(testProjectDir, 'package.json');
   const packageJson = require(packageJsonPath);
 
@@ -35,41 +43,53 @@ const addResolutionPathsForProjectPackages = async (testProjectDir: string, pack
     packageJson.resolutions[`**/${packageName}`] = `file:${packedPackages[packageName]}`;
   });
 
-  fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
+  fs.writeJSONSync(packageJsonPath, packageJson, { spaces: 2 });
 };
 
-const packProjectPackages = async (logger: Function): Promise<PackedPackages> => {
-  // packages/react/src -> packages/react,
+const packProjectPackages = async (logger: Function): Promise<void> => {
+  if (packedPackages) {
+    logger(`✔️ Packages already packed`);
+    return;
+  }
+
+  packedPackages = {};
+
+  // packages/fluentui/react/src -> packages/fluentui/react,
   // as lernaAliases append 'src' by default
   const projectPackages = lernaAliases({ sourceDirectory: false });
 
-  // We don't want to pack a package with our dev tools
-  delete projectPackages['@fluentui/digest'];
-  delete projectPackages['@fluentui/docs'];
-  delete projectPackages['@fluentui/e2e'];
-  delete projectPackages['@fluentui/eslint-plugin'];
-  delete projectPackages['@uifabric/build'];
-  delete projectPackages['@fluentui/perf'];
-  delete projectPackages['@fluentui/perf-test'];
-  delete projectPackages['@fluentui/scripts'];
+  const tmpDirectory = createTempDir('project-packed-');
+  logger(`✔️ Temporary directory for packed packages was created: ${tmpDirectory}`);
+
+  const excludedPkgs = [
+    '@fluentui/digest',
+    '@fluentui/docs',
+    '@fluentui/e2e',
+    '@fluentui/eslint-plugin',
+    '@fluentui/perf',
+    '@fluentui/perf-test'
+  ];
+  for (const [pkg, pkgPath] of Object.entries(projectPackages)) {
+    // Don't pack fabric packages or dev tools
+    if (path.basename(path.dirname(pkgPath)) !== 'fluentui' || excludedPkgs.includes(pkg)) {
+      delete projectPackages[pkg];
+    }
+  }
 
   await Promise.all(
-    Object.keys(projectPackages).map(async (packageName: string) => {
-      const filename = tmp.tmpNameSync({ prefix: `project-`, postfix: '.tgz' });
-      const directory = projectPackages[packageName];
+    Object.entries(projectPackages).map(async ([packageName, packagePath]) => {
+      const filename = path.join(tmpDirectory, path.basename(packageName)) + '.tgz';
 
-      await runIn(directory)(`yarn pack --filename ${filename}`);
-      logger(`✔️Package "${packageName}" was packed to ${filename}`);
+      await sh(`yarn pack --filename ${filename}`, packagePath);
+      logger(`✔️ Package "${packageName}" was packed to ${filename}`);
 
-      projectPackages[packageName] = filename;
+      packedPackages[packageName] = filename;
     })
   );
-
-  return projectPackages;
 };
 
-const createReactApp = async (atTempDirectory: string, appName: string): Promise<string> => {
-  const atDirectorySubpath = paths.withRootAt(atTempDirectory);
+const createReactApp = async (tmpDirectory: string, appName: string): Promise<string> => {
+  const atDirectorySubpath = paths.withRootAt(tmpDirectory);
 
   // we need this temp sibling project to install create-react-app util without polluting
   // global state, as well as the scope of test project
@@ -80,14 +100,14 @@ const createReactApp = async (atTempDirectory: string, appName: string): Promise
 
   try {
     // restoring bits of create-react-app inside util project
-    await runIn(tempUtilProjectPath)('yarn add create-react-app');
+    await sh('yarn add create-react-app', tempUtilProjectPath);
 
     // create test project with util's create-react-app
     fs.mkdirSync(appProjectPath);
-    await runIn(tempUtilProjectPath)(`yarn create-react-app ${appProjectPath} --typescript`);
+    await sh(`yarn create-react-app ${appProjectPath} --typescript`, tempUtilProjectPath);
   } finally {
     // remove temp util directory
-    del.sync(tempUtilProjectPath, { force: true });
+    fs.removeSync(tempUtilProjectPath);
   }
 
   return appProjectPath;
@@ -110,7 +130,7 @@ const performBrowserTest = async (publicDirectory: string, listenPort: number) =
 
   const browser = await puppeteer.launch(safeLaunchOptions());
   const page = await browser.newPage();
-  let error: Error;
+  let error: Error | undefined;
 
   page.on('console', message => {
     if (message.type() === 'error') {
@@ -139,37 +159,40 @@ task('test:projects:cra-ts', async () => {
   const logger = log('test:projects:cra-ts');
   const scaffoldPath = paths.base.bind(null, 'scripts/gulp/tasks/test-projects/cra');
 
+  const tmpDirectory = createTempDir('project-cra-');
+  logger(`✔️ Temporary directory was created: ${tmpDirectory}`);
+
   logger('STEP 1. Create test React project with TSX scripts..');
 
-  const testAppPath = paths.withRootAt(await createReactApp(tmp.dirSync({ prefix: 'project-' }).name, 'test-app'));
+  const testAppPath = paths.withRootAt(await createReactApp(tmpDirectory, 'test-app'));
 
-  const runInTestApp = runIn(testAppPath());
+  throw 'hi';
   logger(`Test React project is successfully created: ${testAppPath()}`);
 
   logger('STEP 2. Add Fluent UI dependency to test project..');
 
-  const packedPackages = await packProjectPackages(logger);
-  await addResolutionPathsForProjectPackages(testAppPath(), packedPackages);
-  await runInTestApp(`yarn add ${packedPackages['@fluentui/react']}`);
-  logger(`✔️Fluent UI packages were added to dependencies`);
+  await packProjectPackages(logger);
+  await addResolutionPathsForProjectPackages(testAppPath());
+  await sh(`yarn add ${packedPackages['@fluentui/react']}`, testAppPath());
+  logger(`✔️ Fluent UI packages were added to dependencies`);
 
   logger("STEP 3. Reference Fluent UI components in test project's App.tsx");
   fs.copyFileSync(scaffoldPath('App.tsx'), testAppPath('src', 'App.tsx'));
 
   logger('STEP 4. Build test project..');
-  await runInTestApp(`yarn build`);
+  await sh(`yarn build`, testAppPath());
 
   await performBrowserTest(testAppPath('build'), await portfinder.getPortPromise());
-  logger(`✔️Browser test was passed`);
+  logger(`✔️ Browser test was passed`);
 });
 
 task('test:projects:rollup', async () => {
   const logger = log('test:projects:rollup');
 
   const scaffoldPath = paths.base.bind(null, 'scripts/gulp/tasks/test-projects/rollup');
-  const tmpDirectory = tmp.dirSync({ prefix: 'project-' }).name;
+  const tmpDirectory = createTempDir('project-rollup-');
 
-  logger(`✔️Temporary directory was created: ${tmpDirectory}`);
+  logger(`✔️ Temporary directory was created: ${tmpDirectory}`);
 
   const dependencies = [
     'rollup',
@@ -180,79 +203,79 @@ task('test:projects:rollup', async () => {
     'react',
     'react-dom'
   ].join(' ');
-  await runIn(tmpDirectory)(`yarn add ${dependencies}`);
-  logger(`✔️Dependencies were installed`);
+  await sh(`yarn add ${dependencies}`, tmpDirectory);
+  logger(`✔️ Dependencies were installed`);
 
-  const packedPackages = await packProjectPackages(logger);
-  await addResolutionPathsForProjectPackages(tmpDirectory, packedPackages);
-  await runIn(tmpDirectory)(`yarn add ${packedPackages['@fluentui/react']}`);
-  logger(`✔️Fluent UI packages were added to dependencies`);
+  await packProjectPackages(logger);
+  await addResolutionPathsForProjectPackages(tmpDirectory);
+  await sh(`yarn add ${packedPackages['@fluentui/react']}`, tmpDirectory);
+  logger(`✔️ Fluent UI packages were added to dependencies`);
 
   fs.copyFileSync(scaffoldPath('app.js'), path.resolve(tmpDirectory, 'app.js'));
   fs.copyFileSync(scaffoldPath('rollup.config.js'), path.resolve(tmpDirectory, 'rollup.config.js'));
   fs.copyFileSync(scaffoldPath('index.html'), path.resolve(tmpDirectory, 'index.html'));
-  logger(`✔️Source and bundler's config were created`);
+  logger(`✔️ Source and bundler's config were created`);
 
-  await runIn(tmpDirectory)(`yarn rollup -c`);
-  logger(`✔️Example project was successfully built: ${tmpDirectory}`);
+  await sh(`yarn rollup -c`, tmpDirectory);
+  logger(`✔️ Example project was successfully built: ${tmpDirectory}`);
 
   await performBrowserTest(tmpDirectory, await portfinder.getPortPromise());
-  logger(`✔️Browser test was passed`);
+  logger(`✔️ Browser test was passed`);
 });
 
 task('test:projects:nextjs', async () => {
   const logger = log('test:projects:nextjs');
 
   const scaffoldPath = paths.base.bind(null, 'scripts/gulp/tasks/test-projects/nextjs');
-  const tmpDirectory = tmp.dirSync({ prefix: 'project-' }).name;
+  const tmpDirectory = createTempDir('project-nextjs-');
 
-  logger(`✔️Temporary directory was created: ${tmpDirectory}`);
+  logger(`✔️ Temporary directory was created: ${tmpDirectory}`);
 
   const dependencies = ['next', 'react', 'react-dom'].join(' ');
-  await runIn(tmpDirectory)(`yarn add ${dependencies}`);
-  logger(`✔️Dependencies were installed`);
+  await sh(`yarn add ${dependencies}`, tmpDirectory);
+  logger(`✔️ Dependencies were installed`);
 
-  const packedPackages = await packProjectPackages(logger);
-  await addResolutionPathsForProjectPackages(tmpDirectory, packedPackages);
-  await runIn(tmpDirectory)(`yarn add ${packedPackages['@fluentui/react']}`);
-  logger(`✔️Fluent UI packages were added to dependencies`);
+  await packProjectPackages(logger);
+  await addResolutionPathsForProjectPackages(tmpDirectory);
+  await sh(`yarn add ${packedPackages['@fluentui/react']}`, tmpDirectory);
+  logger(`✔️ Fluent UI packages were added to dependencies`);
 
   fs.mkdirSync(path.resolve(tmpDirectory, 'pages'));
   fs.copyFileSync(scaffoldPath('index.js'), path.resolve(tmpDirectory, 'pages', 'index.js'));
-  logger(`✔️Source and bundler's config were created`);
+  logger(`✔️ Source and bundler's config were created`);
 
-  await runIn(tmpDirectory)(`yarn next build`);
-  await runIn(tmpDirectory)(`yarn next export`);
-  logger(`✔️Example project was successfully built: ${tmpDirectory}`);
+  await sh(`yarn next build`, tmpDirectory);
+  await sh(`yarn next export`, tmpDirectory);
+  logger(`✔️ Example project was successfully built: ${tmpDirectory}`);
 
   await performBrowserTest(path.resolve(tmpDirectory, 'out'), await portfinder.getPortPromise());
-  logger(`✔️Browser test was passed`);
+  logger(`✔️ Browser test was passed`);
 });
 
 task('test:projects:typings', async () => {
   const logger = log('test:projects:typings');
 
   const scaffoldPath = paths.base.bind(null, 'scripts/gulp/tasks/test-projects/typings');
-  const tmpDirectory = tmp.dirSync({ prefix: 'project-' }).name;
+  const tmpDirectory = createTempDir('project-typings-');
 
-  logger(`✔️Temporary directory was created: ${tmpDirectory}`);
+  logger(`✔️ Temporary directory was created: ${tmpDirectory}`);
 
   const dependencies = ['@types/react', '@types/react-dom', 'react', 'react-dom', 'typescript'].join(' ');
-  await runIn(tmpDirectory)(`yarn add ${dependencies}`);
-  logger(`✔️Dependencies were installed`);
+  await sh(`yarn add ${dependencies}`, tmpDirectory);
+  logger(`✔️ Dependencies were installed`);
 
-  const packedPackages = await packProjectPackages(logger);
-  await addResolutionPathsForProjectPackages(tmpDirectory, packedPackages);
-  await runIn(tmpDirectory)(`yarn add ${packedPackages['@fluentui/react']}`);
-  logger(`✔️Fluent UI packages were added to dependencies`);
+  await packProjectPackages(logger);
+  await addResolutionPathsForProjectPackages(tmpDirectory);
+  await sh(`yarn add ${packedPackages['@fluentui/react']}`, tmpDirectory);
+  logger(`✔️ Fluent UI packages were added to dependencies`);
 
   fs.mkdirSync(path.resolve(tmpDirectory, 'src'));
   fs.copyFileSync(scaffoldPath('index.tsx'), path.resolve(tmpDirectory, 'src/index.tsx'));
   fs.copyFileSync(scaffoldPath('tsconfig.json'), path.resolve(tmpDirectory, 'tsconfig.json'));
-  logger(`✔️Source and configs were copied`);
+  logger(`✔️ Source and configs were copied`);
 
-  await runIn(tmpDirectory)(`yarn tsc --noEmit`);
-  logger(`✔️Example project was successfully built: ${tmpDirectory}`);
+  await sh(`yarn tsc --noEmit`, tmpDirectory);
+  logger(`✔️ Example project was successfully built: ${tmpDirectory}`);
 });
 
 task('test:projects', series('test:projects:cra-ts', 'test:projects:nextjs', 'test:projects:rollup', 'test:projects:typings'));

--- a/scripts/gulp/tasks/test-projects.ts
+++ b/scripts/gulp/tasks/test-projects.ts
@@ -166,7 +166,6 @@ task('test:projects:cra-ts', async () => {
 
   const testAppPath = paths.withRootAt(await createReactApp(tmpDirectory, 'test-app'));
 
-  throw 'hi';
   logger(`Test React project is successfully created: ${testAppPath()}`);
 
   logger('STEP 2. Add Fluent UI dependency to test project..');

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -52,6 +52,7 @@
     "@types/node": "^10.3.2",
     "@types/prompts": "^2.0.3",
     "@types/puppeteer": "1.12.3",
+    "@types/tmp": "^0.1.0",
     "@types/webpack-dev-middleware": "^2.0.1",
     "@types/webpack-env": "1.15.1",
     "@types/webpack-hot-middleware": "^2.16.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4298,6 +4298,11 @@
   dependencies:
     "@types/node" "*"
 
+"@types/tmp@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@types/tmp/-/tmp-0.1.0.tgz#19cf73a7bcf641965485119726397a096f0049bd"
+  integrity sha512-6IwZ9HzWbCq6XoQWhxLpDjuADodH/MKXRUIDFudvgjcVdjFknvmR+DNsoUeer4XPrEnrZs04Jj+kfV9pFsrhmA==
+
 "@types/uglify-js@*":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@types/uglify-js/-/uglify-js-3.0.4.tgz#96beae23df6f561862a830b4288a49e86baac082"


### PR DESCRIPTION
Ensure that fluent test-projects cleans up after itself to help prevent the VMs from running out of space.

Also update test-projects to only pack the packages once (instead of doing it for every type of project test) and exclude fabric packages.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12089)