### PR TITLE
Remove "unused" vertical-align declarations on Button & Button w/ Icon

### DIFF
--- a/change/@uifabric-experiments-2020-02-26-20-13-55-keco-button-vertical-align.json
+++ b/change/@uifabric-experiments-2020-02-26-20-13-55-keco-button-vertical-align.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Update snapshots",
+  "packageName": "@uifabric/experiments",
+  "email": "KevinTCoughlin@users.noreply.github.com",
+  "commit": "3e9562ca49b5e9b3eeb5a789edcbf6c03b5eb885",
+  "dependentChangeType": "patch",
+  "date": "2020-02-27T04:13:55.006Z"
+}

--- a/change/office-ui-fabric-react-2020-02-26-16-06-26-keco-button-vertical-align.json
+++ b/change/office-ui-fabric-react-2020-02-26-16-06-26-keco-button-vertical-align.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Remove vertical-align flagged as unused",
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com",
+  "commit": "a3c34a50545050573127b7c1c0c451fbf610ba8c",
+  "dependentChangeType": "patch",
+  "date": "2020-02-27T00:06:26.350Z"
+}

--- a/packages/experiments/src/components/MicroFeedback/__snapshots__/MicroFeedback.test.tsx.snap
+++ b/packages/experiments/src/components/MicroFeedback/__snapshots__/MicroFeedback.test.tsx.snap
@@ -76,7 +76,6 @@ exports[`MicroFeedback renders correctly with inline prop set 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
               width: 32px;
             }
             &::-moz-focus-inner {
@@ -165,7 +164,6 @@ exports[`MicroFeedback renders correctly with inline prop set 1`] = `
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="Like"
             role="presentation"
@@ -208,7 +206,6 @@ exports[`MicroFeedback renders correctly with inline prop set 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
               width: 32px;
             }
             &::-moz-focus-inner {
@@ -297,7 +294,6 @@ exports[`MicroFeedback renders correctly with inline prop set 1`] = `
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="Dislike"
             role="presentation"
@@ -392,7 +388,6 @@ exports[`MicroFeedback renders correctly with no props 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
               width: 32px;
             }
             &::-moz-focus-inner {
@@ -481,7 +476,6 @@ exports[`MicroFeedback renders correctly with no props 1`] = `
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="Like"
             role="presentation"
@@ -524,7 +518,6 @@ exports[`MicroFeedback renders correctly with no props 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
               width: 32px;
             }
             &::-moz-focus-inner {
@@ -613,7 +606,6 @@ exports[`MicroFeedback renders correctly with no props 1`] = `
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="Dislike"
             role="presentation"

--- a/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
+++ b/packages/experiments/src/components/Pagination/__snapshots__/Pagination.test.tsx.snap
@@ -44,7 +44,6 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
             width: 32px;
           }
           &::-moz-focus-inner {
@@ -133,7 +132,6 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
                 margin-right: 4px;
                 margin-top: 0;
                 text-align: center;
-                vertical-align: middle;
               }
           data-icon-name="Previous"
           role="presentation"
@@ -179,7 +177,6 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
             width: 32px;
           }
           &::-moz-focus-inner {
@@ -268,7 +265,6 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
                 margin-right: 4px;
                 margin-top: 0;
                 text-align: center;
-                vertical-align: middle;
               }
           data-icon-name="CaretSolidLeft"
           role="presentation"
@@ -845,7 +841,6 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
             width: 32px;
           }
           &::-moz-focus-inner {
@@ -935,7 +930,6 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
                 margin-right: 4px;
                 margin-top: 0;
                 text-align: center;
-                vertical-align: middle;
               }
           data-icon-name="CaretSolidRight"
           role="presentation"
@@ -989,7 +983,6 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
               width: 32px;
             }
             &::-moz-focus-inner {
@@ -1079,7 +1072,6 @@ exports[`Pagination render buttons Pagination correctly 1`] = `
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="Next"
             role="presentation"
@@ -1146,7 +1138,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
           width: 32px;
         }
         &::-moz-focus-inner {
@@ -1235,7 +1226,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
               margin-right: 4px;
               margin-top: 0;
               text-align: center;
-              vertical-align: middle;
             }
         data-icon-name="Previous"
         role="presentation"
@@ -1281,7 +1271,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
           width: 32px;
         }
         &::-moz-focus-inner {
@@ -1370,7 +1359,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
               margin-right: 4px;
               margin-top: 0;
               text-align: center;
-              vertical-align: middle;
             }
         data-icon-name="CaretSolidLeft"
         role="presentation"
@@ -1622,7 +1610,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
               text-decoration: none;
               top: 0px;
               user-select: none;
-              vertical-align: top;
               width: 32px;
             }
             &::-moz-focus-inner {
@@ -1729,7 +1716,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="ChevronDown"
             role="presentation"
@@ -1782,7 +1768,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
           width: 32px;
         }
         &::-moz-focus-inner {
@@ -1871,7 +1856,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
               margin-right: 4px;
               margin-top: 0;
               text-align: center;
-              vertical-align: middle;
             }
         data-icon-name="CaretSolidRight"
         role="presentation"
@@ -1913,7 +1897,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
           width: 32px;
         }
         &::-moz-focus-inner {
@@ -2002,7 +1985,6 @@ exports[`Pagination render comboBox Pagination correctly 1`] = `
               margin-right: 4px;
               margin-top: 0;
               text-align: center;
-              vertical-align: middle;
             }
         data-icon-name="Next"
         role="presentation"

--- a/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
+++ b/packages/experiments/src/components/SelectedItemsList/SelectedPeopleList/__snapshots__/SelectedPeopleList.test.tsx.snap
@@ -68,7 +68,6 @@ Array [
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
               width: 44px;
             }
             &::-moz-focus-inner {
@@ -158,7 +157,6 @@ Array [
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
                 @media screen and (-ms-high-contrast: active){& {
                   color: HighlightText;
@@ -405,7 +403,6 @@ Array [
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
               width: 33px;
             }
             &::-moz-focus-inner {
@@ -495,7 +492,6 @@ Array [
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
                 @media screen and (-ms-high-contrast: active){& {
                   color: HighlightText;
@@ -581,7 +577,6 @@ Array [
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
               width: 44px;
             }
             &::-moz-focus-inner {
@@ -671,7 +666,6 @@ Array [
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
                 @media screen and (-ms-high-contrast: active){& {
                   color: HighlightText;
@@ -918,7 +912,6 @@ Array [
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
               width: 33px;
             }
             &::-moz-focus-inner {
@@ -1008,7 +1001,6 @@ Array [
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
                 @media screen and (-ms-high-contrast: active){& {
                   color: HighlightText;

--- a/packages/office-ui-fabric-react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Breadcrumb/__snapshots__/Breadcrumb.test.tsx.snap
@@ -105,7 +105,6 @@ exports[`Breadcrumb rendering renders  correctly with custom overflow icon 1`] =
                       text-decoration: none;
                       text-overflow: ellipsis;
                       user-select: none;
-                      vertical-align: top;
                       white-space: nowrap;
                       width: auto;
                     }
@@ -1292,7 +1291,6 @@ exports[`Breadcrumb rendering renders correctly with maxDisplayedItems and overf
                       text-decoration: none;
                       text-overflow: ellipsis;
                       user-select: none;
-                      vertical-align: top;
                       white-space: nowrap;
                       width: auto;
                     }
@@ -1400,7 +1398,6 @@ exports[`Breadcrumb rendering renders correctly with maxDisplayedItems and overf
                           margin-right: 4px;
                           margin-top: 0;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="More"
                     role="presentation"
@@ -1528,7 +1525,6 @@ exports[`Breadcrumb rendering renders correctly with maxDisplayedItems and overf
                       text-decoration: none;
                       text-overflow: ellipsis;
                       user-select: none;
-                      vertical-align: top;
                       white-space: nowrap;
                       width: auto;
                     }
@@ -1636,7 +1632,6 @@ exports[`Breadcrumb rendering renders correctly with maxDisplayedItems and overf
                           margin-right: 4px;
                           margin-top: 0;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="More"
                     role="presentation"
@@ -1764,7 +1759,6 @@ exports[`Breadcrumb rendering renders correctly with overflow 1`] = `
                       text-decoration: none;
                       text-overflow: ellipsis;
                       user-select: none;
-                      vertical-align: top;
                       white-space: nowrap;
                       width: auto;
                     }
@@ -1872,7 +1866,6 @@ exports[`Breadcrumb rendering renders correctly with overflow 1`] = `
                           margin-right: 4px;
                           margin-top: 0;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="More"
                     role="presentation"
@@ -2264,7 +2257,6 @@ exports[`Breadcrumb rendering renders correctly with overflow and overflowIndex 
                       text-decoration: none;
                       text-overflow: ellipsis;
                       user-select: none;
-                      vertical-align: top;
                       white-space: nowrap;
                       width: auto;
                     }
@@ -2372,7 +2364,6 @@ exports[`Breadcrumb rendering renders correctly with overflow and overflowIndex 
                           margin-right: 4px;
                           margin-top: 0;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="More"
                     role="presentation"

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.styles.ts
@@ -13,7 +13,6 @@ const iconStyle = (fontSize?: string | number): IRawStyle => {
     height: '16px',
     lineHeight: '16px',
     textAlign: 'center',
-    verticalAlign: 'middle',
     flexShrink: 0
   };
 };
@@ -51,7 +50,6 @@ export const getStyles = memoizeFunction(
           textDecoration: 'none',
           textAlign: 'center',
           cursor: 'pointer',
-          verticalAlign: 'top',
           padding: '0 16px',
           borderRadius: effects.roundedCorner2,
 

--- a/packages/office-ui-fabric-react/src/components/Button/__snapshots__/Button.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Button/__snapshots__/Button.deprecated.test.tsx.snap
@@ -32,7 +32,6 @@ exports[`Button renders CompoundButton correctly 1`] = `
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
       }
       &::-moz-focus-inner {
         border: 0;

--- a/packages/office-ui-fabric-react/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -29,7 +29,6 @@ exports[`Button renders ActionButton correctly 1`] = `
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
       }
       &::-moz-focus-inner {
         border: 0;
@@ -155,7 +154,6 @@ exports[`Button renders CommandBarButton correctly 1`] = `
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
       }
       &::-moz-focus-inner {
         border: 0;
@@ -258,7 +256,6 @@ exports[`Button renders CommandBarButton correctly 1`] = `
             margin-right: 4px;
             margin-top: 0;
             text-align: center;
-            vertical-align: middle;
           }
       data-icon-name="Add"
       role="presentation"
@@ -322,7 +319,6 @@ exports[`Button renders CommandBarButton correctly 1`] = `
             margin-right: 4px;
             margin-top: 0;
             text-align: center;
-            vertical-align: middle;
           }
       data-icon-name="ChevronDown"
       role="presentation"
@@ -370,7 +366,6 @@ exports[`Button renders CompoundButton correctly 1`] = `
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
       }
       &::-moz-focus-inner {
         border: 0;
@@ -520,7 +515,6 @@ exports[`Button renders DefaultButton correctly 1`] = `
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
       }
       &::-moz-focus-inner {
         border: 0;
@@ -640,7 +634,6 @@ exports[`Button renders IconButton correctly 1`] = `
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
         width: 32px;
       }
       &::-moz-focus-inner {
@@ -730,7 +723,6 @@ exports[`Button renders IconButton correctly 1`] = `
             margin-right: 4px;
             margin-top: 0;
             text-align: center;
-            vertical-align: middle;
           }
       data-icon-name="Emoji2"
       role="presentation"
@@ -776,7 +768,6 @@ exports[`Button renders a DefaultButton with a keytip correctly 1`] = `
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
       }
       &::-moz-focus-inner {
         border: 0;

--- a/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ComboBox/__snapshots__/ComboBox.test.tsx.snap
@@ -233,7 +233,6 @@ exports[`ComboBox Renders correctly 1`] = `
             text-decoration: none;
             top: 0px;
             user-select: none;
-            vertical-align: top;
             width: 32px;
           }
           &::-moz-focus-inner {
@@ -340,7 +339,6 @@ exports[`ComboBox Renders correctly 1`] = `
                 margin-right: 4px;
                 margin-top: 0;
                 text-align: center;
-                vertical-align: middle;
               }
           data-icon-name="ChevronDown"
           role="presentation"
@@ -603,7 +601,6 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
             text-decoration: none;
             top: 0px;
             user-select: none;
-            vertical-align: top;
             width: 32px;
           }
           &::-moz-focus-inner {
@@ -710,7 +707,6 @@ exports[`ComboBox renders with a Keytip correctly 1`] = `
                 margin-right: 4px;
                 margin-top: 0;
                 text-align: center;
-                vertical-align: middle;
               }
           data-icon-name="ChevronDown"
           role="presentation"

--- a/packages/office-ui-fabric-react/src/components/CommandBar/__snapshots__/CommandBar.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/__snapshots__/CommandBar.deprecated.test.tsx.snap
@@ -97,7 +97,6 @@ exports[`CommandBar renders commands correctly 1`] = `
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -241,7 +240,6 @@ exports[`CommandBar renders commands correctly 1`] = `
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;

--- a/packages/office-ui-fabric-react/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/CommandBar/__snapshots__/CommandBar.test.tsx.snap
@@ -97,7 +97,6 @@ exports[`CommandBar renders commands correctly 1`] = `
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -240,7 +239,6 @@ exports[`CommandBar renders commands correctly 1`] = `
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -448,7 +446,6 @@ exports[`CommandBar renders empty farItems correctly 1`] = `
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -591,7 +588,6 @@ exports[`CommandBar renders empty farItems correctly 1`] = `
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/__snapshots__/ContextualMenu.test.tsx.snap
@@ -33,7 +33,6 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
       }
       &::-moz-focus-inner {
         border: 0;
@@ -121,7 +120,6 @@ exports[`ContextualMenu ContextualMenu snapshot ContextualMenu should be present
             margin-right: 4px;
             margin-top: 0;
             text-align: center;
-            vertical-align: middle;
           }
       data-icon-name="ChevronDown"
       role="presentation"

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.styles.ts
@@ -70,6 +70,7 @@ export const getStyles = (props: INavStyleProps): INavStyles => {
       {
         margin: '0 4px',
         overflow: 'hidden',
+        verticalAlign: 'middle',
         textAlign: 'left',
         textOverflow: 'ellipsis'
       }

--- a/packages/office-ui-fabric-react/src/components/Nav/Nav.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Nav/Nav.styles.ts
@@ -70,7 +70,6 @@ export const getStyles = (props: INavStyleProps): INavStyles => {
       {
         margin: '0 4px',
         overflow: 'hidden',
-        verticalAlign: 'middle',
         textAlign: 'left',
         textOverflow: 'ellipsis'
       }

--- a/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Nav/__snapshots__/Nav.test.tsx.snap
@@ -114,7 +114,6 @@ exports[`Nav renders Nav correctly 1`] = `
                       text-decoration: none;
                       text-overflow: ellipsis;
                       user-select: none;
-                      vertical-align: top;
                       white-space: nowrap;
                       width: 100%;
                     }

--- a/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Panel/__snapshots__/Panel.test.tsx.snap
@@ -252,7 +252,6 @@ exports[`Panel renders Panel correctly 1`] = `
                       text-align: center;
                       text-decoration: none;
                       user-select: none;
-                      vertical-align: top;
                       width: 32px;
                     }
                     &::-moz-focus-inner {
@@ -342,7 +341,6 @@ exports[`Panel renders Panel correctly 1`] = `
                           margin-right: 4px;
                           margin-top: 0;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="Cancel"
                     role="presentation"

--- a/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.deprecated.test.tsx.snap
@@ -73,7 +73,6 @@ exports[`Pivot renders link Pivot correctly 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -241,7 +240,6 @@ exports[`Pivot renders link Pivot correctly 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;

--- a/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Pivot/__snapshots__/Pivot.test.tsx.snap
@@ -73,7 +73,6 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -241,7 +240,6 @@ exports[`Pivot renders Pivot correctly when itemCount is a string 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -464,7 +462,6 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -632,7 +629,6 @@ exports[`Pivot renders Pivot correctly with custom className 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -844,7 +840,6 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -1012,7 +1007,6 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -1182,7 +1176,6 @@ exports[`Pivot renders Pivot correctly with icon, text and count 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -1416,7 +1409,6 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -1584,7 +1576,6 @@ exports[`Pivot renders large link Pivot correctly 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -2190,7 +2181,6 @@ exports[`Pivot renders link Pivot correctly 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -2358,7 +2348,6 @@ exports[`Pivot renders link Pivot correctly 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -2962,7 +2951,6 @@ exports[`Pivot supports JSX expressions 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -3121,7 +3109,6 @@ exports[`Pivot supports JSX expressions 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;

--- a/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
@@ -168,7 +168,6 @@ exports[`SpinButton renders SpinButton correctly 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
               width: 23px;
             }
             &::-moz-focus-inner {
@@ -269,7 +268,6 @@ exports[`SpinButton renders SpinButton correctly 1`] = `
                   margin-right: 0px;
                   margin-top: 0px;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="ChevronUpSmall"
             role="presentation"
@@ -311,7 +309,6 @@ exports[`SpinButton renders SpinButton correctly 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
               width: 23px;
             }
             &::-moz-focus-inner {
@@ -412,7 +409,6 @@ exports[`SpinButton renders SpinButton correctly 1`] = `
                   margin-right: 0px;
                   margin-top: 0px;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="ChevronDownSmall"
             role="presentation"
@@ -601,7 +597,6 @@ exports[`SpinButton renders SpinButton correctly with values that the user passe
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
               width: 23px;
             }
             &::-moz-focus-inner {
@@ -702,7 +697,6 @@ exports[`SpinButton renders SpinButton correctly with values that the user passe
                   margin-right: 0px;
                   margin-top: 0px;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="ChevronUpSmall"
             role="presentation"
@@ -744,7 +738,6 @@ exports[`SpinButton renders SpinButton correctly with values that the user passe
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
               width: 23px;
             }
             &::-moz-focus-inner {
@@ -845,7 +838,6 @@ exports[`SpinButton renders SpinButton correctly with values that the user passe
                   margin-right: 0px;
                   margin-top: 0px;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="ChevronDownSmall"
             role="presentation"

--- a/packages/office-ui-fabric-react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SwatchColorPicker/__snapshots__/SwatchColorPicker.test.tsx.snap
@@ -82,7 +82,6 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 20px;
                 }
                 &::-moz-focus-inner {
@@ -252,7 +251,6 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 20px;
                 }
                 &::-moz-focus-inner {
@@ -422,7 +420,6 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 20px;
                 }
                 &::-moz-focus-inner {
@@ -592,7 +589,6 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 20px;
                 }
                 &::-moz-focus-inner {
@@ -766,7 +762,6 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 20px;
                 }
                 &::-moz-focus-inner {
@@ -936,7 +931,6 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 20px;
                 }
                 &::-moz-focus-inner {
@@ -1106,7 +1100,6 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 20px;
                 }
                 &::-moz-focus-inner {
@@ -1276,7 +1269,6 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 20px;
                 }
                 &::-moz-focus-inner {
@@ -1450,7 +1442,6 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 20px;
                 }
                 &::-moz-focus-inner {
@@ -1620,7 +1611,6 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 20px;
                 }
                 &::-moz-focus-inner {
@@ -1790,7 +1780,6 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 20px;
                 }
                 &::-moz-focus-inner {
@@ -1960,7 +1949,6 @@ exports[`SwatchColorPicker renders SwatchColorPicker correctly 1`] = `
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 20px;
                 }
                 &::-moz-focus-inner {

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.deprecated.test.tsx.snap
@@ -187,7 +187,6 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   white-space: nowrap;
                 }
                 &::-moz-focus-inner {
@@ -322,7 +321,6 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   white-space: nowrap;
                 }
                 &::-moz-focus-inner {
@@ -477,7 +475,6 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
               text-decoration: none;
               top: 0px;
               user-select: none;
-              vertical-align: top;
               width: 32px;
             }
             &::-moz-focus-inner {
@@ -571,7 +568,6 @@ exports[`TeachingBubble renders renders with hasCloseIcon which is deprecated 1`
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="Cancel"
             role="presentation"

--- a/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/TeachingBubble/__snapshots__/TeachingBubble.test.tsx.snap
@@ -455,7 +455,6 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   white-space: nowrap;
                 }
                 &::-moz-focus-inner {
@@ -590,7 +589,6 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   white-space: nowrap;
                 }
                 &::-moz-focus-inner {
@@ -745,7 +743,6 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
               text-decoration: none;
               top: 0px;
               user-select: none;
-              vertical-align: top;
               width: 32px;
             }
             &::-moz-focus-inner {
@@ -839,7 +836,6 @@ exports[`TeachingBubble renders TeachingBubbleContent with buttons correctly 1`]
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="Cancel"
             role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.LazyLoading.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.LazyLoading.Example.tsx.shot
@@ -66,7 +66,6 @@ exports[`Component Examples renders Announced.LazyLoading.Example.tsx correctly 
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
           width: 150px;
         }
         &::-moz-focus-inner {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.QuickActions.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.QuickActions.Example.tsx.shot
@@ -1599,7 +1599,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                       text-align: center;
                                       text-decoration: none;
                                       user-select: none;
-                                      vertical-align: top;
                                       width: auto;
                                     }
                                     &::-moz-focus-inner {
@@ -1689,7 +1688,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                           margin-right: 4px;
                                           margin-top: 0;
                                           text-align: center;
-                                          vertical-align: middle;
                                         }
                                     data-icon-name="MoreVertical"
                                     role="presentation"
@@ -2319,7 +2317,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                       text-align: center;
                                       text-decoration: none;
                                       user-select: none;
-                                      vertical-align: top;
                                       width: auto;
                                     }
                                     &::-moz-focus-inner {
@@ -2409,7 +2406,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                           margin-right: 4px;
                                           margin-top: 0;
                                           text-align: center;
-                                          vertical-align: middle;
                                         }
                                     data-icon-name="MoreVertical"
                                     role="presentation"
@@ -3039,7 +3035,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                       text-align: center;
                                       text-decoration: none;
                                       user-select: none;
-                                      vertical-align: top;
                                       width: auto;
                                     }
                                     &::-moz-focus-inner {
@@ -3129,7 +3124,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                           margin-right: 4px;
                                           margin-top: 0;
                                           text-align: center;
-                                          vertical-align: middle;
                                         }
                                     data-icon-name="MoreVertical"
                                     role="presentation"
@@ -3759,7 +3753,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                       text-align: center;
                                       text-decoration: none;
                                       user-select: none;
-                                      vertical-align: top;
                                       width: auto;
                                     }
                                     &::-moz-focus-inner {
@@ -3849,7 +3842,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                           margin-right: 4px;
                                           margin-top: 0;
                                           text-align: center;
-                                          vertical-align: middle;
                                         }
                                     data-icon-name="MoreVertical"
                                     role="presentation"
@@ -4479,7 +4471,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                       text-align: center;
                                       text-decoration: none;
                                       user-select: none;
-                                      vertical-align: top;
                                       width: auto;
                                     }
                                     &::-moz-focus-inner {
@@ -4569,7 +4560,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                           margin-right: 4px;
                                           margin-top: 0;
                                           text-align: center;
-                                          vertical-align: middle;
                                         }
                                     data-icon-name="MoreVertical"
                                     role="presentation"
@@ -5199,7 +5189,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                       text-align: center;
                                       text-decoration: none;
                                       user-select: none;
-                                      vertical-align: top;
                                       width: auto;
                                     }
                                     &::-moz-focus-inner {
@@ -5289,7 +5278,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                           margin-right: 4px;
                                           margin-top: 0;
                                           text-align: center;
-                                          vertical-align: middle;
                                         }
                                     data-icon-name="MoreVertical"
                                     role="presentation"
@@ -5919,7 +5907,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                       text-align: center;
                                       text-decoration: none;
                                       user-select: none;
-                                      vertical-align: top;
                                       width: auto;
                                     }
                                     &::-moz-focus-inner {
@@ -6009,7 +5996,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                           margin-right: 4px;
                                           margin-top: 0;
                                           text-align: center;
-                                          vertical-align: middle;
                                         }
                                     data-icon-name="MoreVertical"
                                     role="presentation"
@@ -6639,7 +6625,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                       text-align: center;
                                       text-decoration: none;
                                       user-select: none;
-                                      vertical-align: top;
                                       width: auto;
                                     }
                                     &::-moz-focus-inner {
@@ -6729,7 +6714,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                           margin-right: 4px;
                                           margin-top: 0;
                                           text-align: center;
-                                          vertical-align: middle;
                                         }
                                     data-icon-name="MoreVertical"
                                     role="presentation"
@@ -7359,7 +7343,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                       text-align: center;
                                       text-decoration: none;
                                       user-select: none;
-                                      vertical-align: top;
                                       width: auto;
                                     }
                                     &::-moz-focus-inner {
@@ -7449,7 +7432,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                           margin-right: 4px;
                                           margin-top: 0;
                                           text-align: center;
-                                          vertical-align: middle;
                                         }
                                     data-icon-name="MoreVertical"
                                     role="presentation"
@@ -8079,7 +8061,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                       text-align: center;
                                       text-decoration: none;
                                       user-select: none;
-                                      vertical-align: top;
                                       width: auto;
                                     }
                                     &::-moz-focus-inner {
@@ -8169,7 +8150,6 @@ exports[`Component Examples renders Announced.QuickActions.Example.tsx correctly
                                           margin-right: 4px;
                                           margin-top: 0;
                                           text-align: center;
-                                          vertical-align: middle;
                                         }
                                     data-icon-name="MoreVertical"
                                     role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Basic.Example.tsx.shot
@@ -138,7 +138,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         text-decoration: none;
                         text-overflow: ellipsis;
                         user-select: none;
-                        vertical-align: top;
                         white-space: nowrap;
                         width: auto;
                       }
@@ -246,7 +245,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                             margin-right: 4px;
                             margin-top: 0;
                             text-align: center;
-                            vertical-align: middle;
                           }
                       data-icon-name="More"
                       role="presentation"
@@ -814,7 +812,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                         text-decoration: none;
                         text-overflow: ellipsis;
                         user-select: none;
-                        vertical-align: top;
                         white-space: nowrap;
                         width: auto;
                       }
@@ -922,7 +919,6 @@ exports[`Component Examples renders Breadcrumb.Basic.Example.tsx correctly 1`] =
                             margin-right: 4px;
                             margin-top: 0;
                             text-align: center;
-                            vertical-align: middle;
                           }
                       data-icon-name="More"
                       role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Collapsing.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Collapsing.Example.tsx.shot
@@ -1101,7 +1101,6 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         text-decoration: none;
                         text-overflow: ellipsis;
                         user-select: none;
-                        vertical-align: top;
                         white-space: nowrap;
                         width: auto;
                       }
@@ -1209,7 +1208,6 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                             margin-right: 4px;
                             margin-top: 0;
                             text-align: center;
-                            vertical-align: middle;
                           }
                       data-icon-name="More"
                       role="presentation"
@@ -1938,7 +1936,6 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                         text-decoration: none;
                         text-overflow: ellipsis;
                         user-select: none;
-                        vertical-align: top;
                         white-space: nowrap;
                         width: auto;
                       }
@@ -2046,7 +2043,6 @@ exports[`Component Examples renders Breadcrumb.Collapsing.Example.tsx correctly 
                             margin-right: 4px;
                             margin-top: 0;
                             text-align: center;
-                            vertical-align: middle;
                           }
                       data-icon-name="More"
                       role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Breadcrumb.Static.Example.tsx.shot
@@ -114,7 +114,6 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                         text-decoration: none;
                         text-overflow: ellipsis;
                         user-select: none;
-                        vertical-align: top;
                         white-space: nowrap;
                         width: auto;
                       }
@@ -222,7 +221,6 @@ exports[`Component Examples renders Breadcrumb.Static.Example.tsx correctly 1`] 
                             margin-right: 4px;
                             margin-top: 0;
                             text-align: center;
-                            vertical-align: middle;
                           }
                       data-icon-name="More"
                       role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Action.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Action.Example.tsx.shot
@@ -29,7 +29,6 @@ exports[`Component Examples renders Button.Action.Example.tsx correctly 1`] = `
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
       }
       &::-moz-focus-inner {
         border: 0;
@@ -122,7 +121,6 @@ exports[`Component Examples renders Button.Action.Example.tsx correctly 1`] = `
             margin-right: 4px;
             margin-top: 0;
             text-align: center;
-            vertical-align: middle;
           }
       data-icon-name="AddFriend"
       role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Anchor.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Anchor.Example.tsx.shot
@@ -29,7 +29,6 @@ exports[`Component Examples renders Button.Anchor.Example.tsx correctly 1`] = `
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
       }
       &::-moz-focus-inner {
         border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Command.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Command.Example.tsx.shot
@@ -33,7 +33,6 @@ exports[`Component Examples renders Button.Command.Example.tsx correctly 1`] = `
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
       }
       &::-moz-focus-inner {
         border: 0;
@@ -126,7 +125,6 @@ exports[`Component Examples renders Button.Command.Example.tsx correctly 1`] = `
             margin-right: 4px;
             margin-top: 0;
             text-align: center;
-            vertical-align: middle;
           }
       data-icon-name="Add"
       role="presentation"
@@ -189,7 +187,6 @@ exports[`Component Examples renders Button.Command.Example.tsx correctly 1`] = `
             margin-right: 4px;
             margin-top: 0;
             text-align: center;
-            vertical-align: middle;
           }
       data-icon-name="ChevronDown"
       role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CommandBar.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CommandBar.Example.tsx.shot
@@ -53,7 +53,6 @@ exports[`Component Examples renders Button.CommandBar.Example.tsx correctly 1`] 
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;
@@ -156,7 +155,6 @@ exports[`Component Examples renders Button.CommandBar.Example.tsx correctly 1`] 
               margin-right: 4px;
               margin-top: 0;
               text-align: center;
-              vertical-align: middle;
             }
         data-icon-name="Add"
         role="presentation"
@@ -220,7 +218,6 @@ exports[`Component Examples renders Button.CommandBar.Example.tsx correctly 1`] 
               margin-right: 4px;
               margin-top: 0;
               text-align: center;
-              vertical-align: middle;
             }
         data-icon-name="ChevronDown"
         role="presentation"
@@ -261,7 +258,6 @@ exports[`Component Examples renders Button.CommandBar.Example.tsx correctly 1`] 
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;
@@ -364,7 +360,6 @@ exports[`Component Examples renders Button.CommandBar.Example.tsx correctly 1`] 
               margin-right: 4px;
               margin-top: 0;
               text-align: center;
-              vertical-align: middle;
             }
         data-icon-name="Mail"
         role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Compound.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Compound.Example.tsx.shot
@@ -53,7 +53,6 @@ exports[`Component Examples renders Button.Compound.Example.tsx correctly 1`] = 
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;
@@ -203,7 +202,6 @@ exports[`Component Examples renders Button.Compound.Example.tsx correctly 1`] = 
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.ContextualMenu.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.ContextualMenu.Example.tsx.shot
@@ -33,7 +33,6 @@ exports[`Component Examples renders Button.ContextualMenu.Example.tsx correctly 
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
       }
       &::-moz-focus-inner {
         border: 0;
@@ -121,7 +120,6 @@ exports[`Component Examples renders Button.ContextualMenu.Example.tsx correctly 
             margin-right: 4px;
             margin-top: 0;
             text-align: center;
-            vertical-align: middle;
           }
       data-icon-name="Add"
       role="presentation"
@@ -184,7 +182,6 @@ exports[`Component Examples renders Button.ContextualMenu.Example.tsx correctly 
             margin-right: 4px;
             margin-top: 0;
             text-align: center;
-            vertical-align: middle;
           }
       data-icon-name="ChevronDown"
       role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CustomSplit.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CustomSplit.Example.tsx.shot
@@ -143,7 +143,6 @@ exports[`Component Examples renders Button.CustomSplit.Example.tsx correctly 1`]
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
               width: auto;
             }
             &::-moz-focus-inner {
@@ -232,7 +231,6 @@ exports[`Component Examples renders Button.CustomSplit.Example.tsx correctly 1`]
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="Add"
             role="presentation"
@@ -328,7 +326,6 @@ exports[`Component Examples renders Button.CustomSplit.Example.tsx correctly 1`]
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
                 {
                   flex-shrink: 0;
@@ -340,7 +337,6 @@ exports[`Component Examples renders Button.CustomSplit.Example.tsx correctly 1`]
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="ChevronDown"
             role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Default.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Default.Example.tsx.shot
@@ -50,7 +50,6 @@ exports[`Component Examples renders Button.Default.Example.tsx correctly 1`] = `
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;
@@ -167,7 +166,6 @@ exports[`Component Examples renders Button.Default.Example.tsx correctly 1`] = `
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Icon.Example.tsx.shot
@@ -51,7 +51,6 @@ exports[`Component Examples renders Button.Icon.Example.tsx correctly 1`] = `
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
             width: 32px;
           }
           &::-moz-focus-inner {
@@ -141,7 +140,6 @@ exports[`Component Examples renders Button.Icon.Example.tsx correctly 1`] = `
                 margin-right: 4px;
                 margin-top: 0;
                 text-align: center;
-                vertical-align: middle;
               }
           data-icon-name="Emoji2"
           role="presentation"
@@ -187,7 +185,6 @@ exports[`Component Examples renders Button.Icon.Example.tsx correctly 1`] = `
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
             width: auto;
           }
           &::-moz-focus-inner {
@@ -277,7 +274,6 @@ exports[`Component Examples renders Button.Icon.Example.tsx correctly 1`] = `
                 margin-right: 4px;
                 margin-top: 0;
                 text-align: center;
-                vertical-align: middle;
               }
           data-icon-name="Emoji2"
           role="presentation"
@@ -315,7 +311,6 @@ exports[`Component Examples renders Button.Icon.Example.tsx correctly 1`] = `
                 margin-right: 4px;
                 margin-top: 0;
                 text-align: center;
-                vertical-align: middle;
               }
           data-icon-name="ChevronDown"
           role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.ScreenReader.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.ScreenReader.Example.tsx.shot
@@ -31,7 +31,6 @@ exports[`Component Examples renders Button.ScreenReader.Example.tsx correctly 1`
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
       }
       &::-moz-focus-inner {
         border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Split.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Split.Example.tsx.shot
@@ -154,7 +154,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;
@@ -333,7 +332,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                     margin-right: 4px;
                     margin-top: 0;
                     text-align: center;
-                    vertical-align: middle;
                   }
                   {
                     flex-shrink: 0;
@@ -345,7 +343,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                     margin-right: 4px;
                     margin-top: 0;
                     text-align: center;
-                    vertical-align: middle;
                   }
               data-icon-name="ChevronDown"
               role="presentation"
@@ -490,7 +487,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;
@@ -688,7 +684,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                     margin-right: 4px;
                     margin-top: 0;
                     text-align: center;
-                    vertical-align: middle;
                   }
                   {
                     flex-shrink: 0;
@@ -700,7 +695,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                     margin-right: 4px;
                     margin-top: 0;
                     text-align: center;
-                    vertical-align: middle;
                   }
               data-icon-name="ChevronDown"
               role="presentation"
@@ -848,7 +842,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;
@@ -1027,7 +1020,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                     margin-right: 4px;
                     margin-top: 0;
                     text-align: center;
-                    vertical-align: middle;
                   }
                   {
                     flex-shrink: 0;
@@ -1039,7 +1031,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                     margin-right: 4px;
                     margin-top: 0;
                     text-align: center;
-                    vertical-align: middle;
                   }
               data-icon-name="ChevronDown"
               role="presentation"
@@ -1177,7 +1168,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;
@@ -1371,7 +1361,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                     margin-right: 4px;
                     margin-top: 0;
                     text-align: center;
-                    vertical-align: middle;
                   }
                   {
                     flex-shrink: 0;
@@ -1383,7 +1372,6 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
                     margin-right: 4px;
                     margin-top: 0;
                     text-align: center;
-                    vertical-align: middle;
                   }
               data-icon-name="ChevronDown"
               role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Toggle.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Toggle.Example.tsx.shot
@@ -30,7 +30,6 @@ exports[`Component Examples renders Button.Toggle.Example.tsx correctly 1`] = `
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
       }
       &::-moz-focus-inner {
         border: 0;
@@ -118,7 +117,6 @@ exports[`Component Examples renders Button.Toggle.Example.tsx correctly 1`] = `
             margin-right: 4px;
             margin-top: 0;
             text-align: center;
-            vertical-align: middle;
           }
       data-icon-name="Volume3"
       role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Calendar.Button.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Calendar.Button.Example.tsx.shot
@@ -31,7 +31,6 @@ exports[`Component Examples renders Calendar.Button.Example.tsx correctly 1`] = 
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Basic.Example.tsx.shot
@@ -44,7 +44,6 @@ exports[`Component Examples renders Callout.Basic.Example.tsx correctly 1`] = `
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Cover.Example.tsx.shot
@@ -265,7 +265,6 @@ Array [
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Directional.Example.tsx.shot
@@ -952,7 +952,6 @@ Array [
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
             width: 100%;
           }
           &::-moz-focus-inner {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.FocusTrap.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.FocusTrap.Example.tsx.shot
@@ -44,7 +44,6 @@ exports[`Component Examples renders Callout.FocusTrap.Example.tsx correctly 1`] 
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Status.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Callout.Status.Example.tsx.shot
@@ -44,7 +44,6 @@ exports[`Component Examples renders Callout.Status.Example.tsx correctly 1`] = `
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Coachmark.Basic.Example.tsx.shot
@@ -257,7 +257,6 @@ exports[`Component Examples renders Coachmark.Basic.Example.tsx correctly 1`] = 
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Basic.Example.tsx.shot
@@ -295,7 +295,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                 text-decoration: none;
                 top: 0px;
                 user-select: none;
-                vertical-align: top;
                 width: 32px;
               }
               &::-moz-focus-inner {
@@ -402,7 +401,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                     margin-right: 4px;
                     margin-top: 0;
                     text-align: center;
-                    vertical-align: middle;
                   }
               data-icon-name="ChevronDown"
               role="presentation"
@@ -455,7 +453,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;
@@ -849,7 +846,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               text-decoration: none;
               top: 0px;
               user-select: none;
-              vertical-align: top;
               width: 32px;
             }
             &::-moz-focus-inner {
@@ -956,7 +952,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="ChevronDown"
             role="presentation"
@@ -1243,7 +1238,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               text-decoration: none;
               top: 0px;
               user-select: none;
-              vertical-align: top;
               width: 32px;
             }
             &::-moz-focus-inner {
@@ -1350,7 +1344,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="ChevronDown"
             role="presentation"
@@ -1636,7 +1629,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               text-decoration: none;
               top: 0px;
               user-select: none;
-              vertical-align: top;
               width: 32px;
             }
             &::-moz-focus-inner {
@@ -1743,7 +1735,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="ChevronDown"
             role="presentation"
@@ -1976,7 +1967,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                           text-align: left;
                           text-decoration: none;
                           user-select: none;
-                          vertical-align: top;
                           width: 100%;
                           word-wrap: break-word;
                         }
@@ -2134,7 +2124,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                           text-align: left;
                           text-decoration: none;
                           user-select: none;
-                          vertical-align: top;
                           width: 100%;
                           word-wrap: break-word;
                         }
@@ -2294,7 +2283,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                           text-align: left;
                           text-decoration: none;
                           user-select: none;
-                          vertical-align: top;
                           width: 100%;
                           word-wrap: break-word;
                         }
@@ -2451,7 +2439,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                           text-align: left;
                           text-decoration: none;
                           user-select: none;
-                          vertical-align: top;
                           width: 100%;
                           word-wrap: break-word;
                         }
@@ -2657,7 +2644,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                           text-align: left;
                           text-decoration: none;
                           user-select: none;
-                          vertical-align: top;
                           width: 100%;
                           word-wrap: break-word;
                         }
@@ -2817,7 +2803,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                           text-align: left;
                           text-decoration: none;
                           user-select: none;
-                          vertical-align: top;
                           width: 100%;
                           word-wrap: break-word;
                         }
@@ -2962,7 +2947,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                           text-align: left;
                           text-decoration: none;
                           user-select: none;
-                          vertical-align: top;
                           width: 100%;
                           word-wrap: break-word;
                         }
@@ -3119,7 +3103,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                           text-align: left;
                           text-decoration: none;
                           user-select: none;
-                          vertical-align: top;
                           width: 100%;
                           word-wrap: break-word;
                         }
@@ -3276,7 +3259,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                           text-align: left;
                           text-decoration: none;
                           user-select: none;
-                          vertical-align: top;
                           width: 100%;
                           word-wrap: break-word;
                         }
@@ -3433,7 +3415,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                           text-align: left;
                           text-decoration: none;
                           user-select: none;
-                          vertical-align: top;
                           width: 100%;
                           word-wrap: break-word;
                         }
@@ -3773,7 +3754,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               text-decoration: none;
               top: 0px;
               user-select: none;
-              vertical-align: top;
               width: 32px;
             }
             &::-moz-focus-inner {
@@ -3880,7 +3860,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="ChevronDown"
             role="presentation"
@@ -4177,7 +4156,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               text-decoration: none;
               top: 0px;
               user-select: none;
-              vertical-align: top;
               width: 32px;
             }
             &::-moz-focus-inner {
@@ -4284,7 +4262,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="ChevronDown"
             role="presentation"
@@ -4514,7 +4491,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
               text-decoration: none;
               top: 0px;
               user-select: none;
-              vertical-align: top;
               width: 32px;
             }
             &::-moz-focus-inner {
@@ -4614,7 +4590,6 @@ exports[`Component Examples renders ComboBox.Basic.Example.tsx correctly 1`] = `
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="ChevronDown"
             role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Controlled.Example.tsx.shot
@@ -292,7 +292,6 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
               text-decoration: none;
               top: 0px;
               user-select: none;
-              vertical-align: top;
               width: 32px;
             }
             &::-moz-focus-inner {
@@ -399,7 +398,6 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="ChevronDown"
             role="presentation"
@@ -686,7 +684,6 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
               text-decoration: none;
               top: 0px;
               user-select: none;
-              vertical-align: top;
               width: 32px;
             }
             &::-moz-focus-inner {
@@ -793,7 +790,6 @@ exports[`Component Examples renders ComboBox.Controlled.Example.tsx correctly 1`
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="ChevronDown"
             role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.CustomStyled.Example.tsx.shot
@@ -296,7 +296,6 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
               text-decoration: none;
               top: 0px;
               user-select: none;
-              vertical-align: top;
               width: 32px;
             }
             &::-moz-focus-inner {
@@ -403,7 +402,6 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="ChevronDown"
             role="presentation"
@@ -689,7 +687,6 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
               text-decoration: none;
               top: 0px;
               user-select: none;
-              vertical-align: top;
               width: 32px;
             }
             &::-moz-focus-inner {
@@ -796,7 +793,6 @@ exports[`Component Examples renders ComboBox.CustomStyled.Example.tsx correctly 
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="ChevronDown"
             role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Toggles.Example.tsx.shot
@@ -293,7 +293,6 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
               text-decoration: none;
               top: 0px;
               user-select: none;
-              vertical-align: top;
               width: 32px;
             }
             &::-moz-focus-inner {
@@ -400,7 +399,6 @@ exports[`Component Examples renders ComboBox.Toggles.Example.tsx correctly 1`] =
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="ChevronDown"
             role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ComboBox.Virtualized.Example.tsx.shot
@@ -288,7 +288,6 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
               text-decoration: none;
               top: 0px;
               user-select: none;
-              vertical-align: top;
               width: 32px;
             }
             &::-moz-focus-inner {
@@ -395,7 +394,6 @@ exports[`Component Examples renders ComboBox.Virtualized.Example.tsx correctly 1
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="ChevronDown"
             role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.Basic.Example.tsx.shot
@@ -101,7 +101,6 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                       text-align: center;
                       text-decoration: none;
                       user-select: none;
-                      vertical-align: top;
                     }
                     &::-moz-focus-inner {
                       border: 0;
@@ -205,7 +204,6 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                           margin-right: 4px;
                           margin-top: 0;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="Add"
                     role="presentation"
@@ -270,7 +268,6 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                           margin-right: 4px;
                           margin-top: 0;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="ChevronDown"
                     role="presentation"
@@ -322,7 +319,6 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                       text-align: center;
                       text-decoration: none;
                       user-select: none;
-                      vertical-align: top;
                     }
                     &::-moz-focus-inner {
                       border: 0;
@@ -426,7 +422,6 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                           margin-right: 4px;
                           margin-top: 0;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="Upload"
                     role="presentation"
@@ -504,7 +499,6 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                       text-align: center;
                       text-decoration: none;
                       user-select: none;
-                      vertical-align: top;
                     }
                     &::-moz-focus-inner {
                       border: 0;
@@ -608,7 +602,6 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                           margin-right: 4px;
                           margin-top: 0;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="Share"
                     role="presentation"
@@ -686,7 +679,6 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                       text-align: center;
                       text-decoration: none;
                       user-select: none;
-                      vertical-align: top;
                     }
                     &::-moz-focus-inner {
                       border: 0;
@@ -790,7 +782,6 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                           margin-right: 4px;
                           margin-top: 0;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="Download"
                     role="presentation"
@@ -872,7 +863,6 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                       text-align: center;
                       text-decoration: none;
                       user-select: none;
-                      vertical-align: top;
                     }
                     &::-moz-focus-inner {
                       border: 0;
@@ -976,7 +966,6 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                           margin-right: 4px;
                           margin-top: 0;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="More"
                     role="presentation"
@@ -1055,7 +1044,6 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                         text-align: center;
                         text-decoration: none;
                         user-select: none;
-                        vertical-align: top;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1159,7 +1147,6 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                             margin-right: 4px;
                             margin-top: 0;
                             text-align: center;
-                            vertical-align: middle;
                           }
                       data-icon-name="Tiles"
                       role="presentation"
@@ -1225,7 +1212,6 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                         text-align: center;
                         text-decoration: none;
                         user-select: none;
-                        vertical-align: top;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1329,7 +1315,6 @@ exports[`Component Examples renders CommandBar.Basic.Example.tsx correctly 1`] =
                             margin-right: 4px;
                             margin-top: 0;
                             text-align: center;
-                            vertical-align: middle;
                           }
                       data-icon-name="Info"
                       role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.ButtonAs.Example.tsx.shot
@@ -100,7 +100,6 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -204,7 +203,6 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Add"
                   role="presentation"
@@ -269,7 +267,6 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="ChevronDown"
                   role="presentation"
@@ -321,7 +318,6 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -425,7 +421,6 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Upload"
                   role="presentation"
@@ -503,7 +498,6 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -607,7 +601,6 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Share"
                   role="presentation"
@@ -685,7 +678,6 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -789,7 +781,6 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Download"
                   role="presentation"
@@ -871,7 +862,6 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -975,7 +965,6 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="More"
                   role="presentation"
@@ -1054,7 +1043,6 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                       text-align: center;
                       text-decoration: none;
                       user-select: none;
-                      vertical-align: top;
                     }
                     &::-moz-focus-inner {
                       border: 0;
@@ -1158,7 +1146,6 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                           margin-right: 4px;
                           margin-top: 0;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="Tiles"
                     role="presentation"
@@ -1224,7 +1211,6 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                       text-align: center;
                       text-decoration: none;
                       user-select: none;
-                      vertical-align: top;
                     }
                     &::-moz-focus-inner {
                       border: 0;
@@ -1328,7 +1314,6 @@ exports[`Component Examples renders CommandBar.ButtonAs.Example.tsx correctly 1`
                           margin-right: 4px;
                           margin-top: 0;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="Info"
                     role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.CommandBarButtonAs.Example.tsx.shot
@@ -96,7 +96,6 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -200,7 +199,6 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Add"
                   role="presentation"
@@ -278,7 +276,6 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -382,7 +379,6 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Upload"
                   role="presentation"
@@ -461,7 +457,6 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                       text-align: center;
                       text-decoration: none;
                       user-select: none;
-                      vertical-align: top;
                     }
                     &::-moz-focus-inner {
                       border: 0;
@@ -565,7 +560,6 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                           margin-right: 4px;
                           margin-top: 0;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="Share"
                     role="presentation"
@@ -1001,7 +995,6 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                                                   text-decoration: none;
                                                   top: 0px;
                                                   user-select: none;
-                                                  vertical-align: top;
                                                   width: 32px;
                                                 }
                                                 &::-moz-focus-inner {
@@ -1096,7 +1089,6 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                                                       margin-right: 4px;
                                                       margin-top: 0;
                                                       text-align: center;
-                                                      vertical-align: middle;
                                                     }
                                                 data-icon-name="Cancel"
                                                 role="presentation"
@@ -1185,7 +1177,6 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -1289,7 +1280,6 @@ exports[`Component Examples renders CommandBar.CommandBarButtonAs.Example.tsx co
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Download"
                   role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
@@ -183,7 +183,6 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                           text-align: center;
                           text-decoration: none;
                           user-select: none;
-                          vertical-align: top;
                         }
                         &::-moz-focus-inner {
                           border: 0;
@@ -287,7 +286,6 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                               margin-right: 4px;
                               margin-top: 0;
                               text-align: center;
-                              vertical-align: middle;
                             }
                         data-icon-name="Add"
                         role="presentation"
@@ -426,7 +424,6 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                               margin-right: 4px;
                               margin-top: 0;
                               text-align: center;
-                              vertical-align: middle;
                             }
                             {
                               color: #605e5c;
@@ -439,7 +436,6 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                               margin-right: 4px;
                               margin-top: 0;
                               text-align: center;
-                              vertical-align: middle;
                             }
                         data-icon-name="ChevronDown"
                         role="presentation"
@@ -586,7 +582,6 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                           text-align: center;
                           text-decoration: none;
                           user-select: none;
-                          vertical-align: top;
                         }
                         &::-moz-focus-inner {
                           border: 0;
@@ -679,7 +674,6 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                               margin-right: 4px;
                               margin-top: 0;
                               text-align: center;
-                              vertical-align: middle;
                             }
                         data-icon-name="Upload"
                         role="presentation"
@@ -833,7 +827,6 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                               margin-right: 4px;
                               margin-top: 0;
                               text-align: center;
-                              vertical-align: middle;
                             }
                             {
                               color: #605e5c;
@@ -846,7 +839,6 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                               margin-right: 4px;
                               margin-top: 0;
                               text-align: center;
-                              vertical-align: middle;
                             }
                         data-icon-name="ChevronDown"
                         role="presentation"
@@ -920,7 +912,6 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                       text-align: center;
                       text-decoration: none;
                       user-select: none;
-                      vertical-align: top;
                     }
                     &::-moz-focus-inner {
                       border: 0;
@@ -1013,7 +1004,6 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                           margin-right: 4px;
                           margin-top: 0;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="Share"
                     role="presentation"
@@ -1108,7 +1098,6 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                         text-align: center;
                         text-decoration: none;
                         user-select: none;
-                        vertical-align: top;
                       }
                       &::-moz-focus-inner {
                         border: 0;
@@ -1201,7 +1190,6 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                             margin-right: 4px;
                             margin-top: 0;
                             text-align: center;
-                            vertical-align: middle;
                           }
                       data-icon-name="Download"
                       role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Checkmarks.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Checkmarks.Example.tsx.shot
@@ -33,7 +33,6 @@ exports[`Component Examples renders ContextualMenu.Checkmarks.Example.tsx correc
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
       }
       &::-moz-focus-inner {
         border: 0;
@@ -146,7 +145,6 @@ exports[`Component Examples renders ContextualMenu.Checkmarks.Example.tsx correc
             margin-right: 4px;
             margin-top: 0;
             text-align: center;
-            vertical-align: middle;
           }
       data-icon-name="ChevronDown"
       role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.CustomMenuItem.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.CustomMenuItem.Example.tsx.shot
@@ -33,7 +33,6 @@ exports[`Component Examples renders ContextualMenu.CustomMenuItem.Example.tsx co
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
       }
       &::-moz-focus-inner {
         border: 0;
@@ -146,7 +145,6 @@ exports[`Component Examples renders ContextualMenu.CustomMenuItem.Example.tsx co
             margin-right: 4px;
             margin-top: 0;
             text-align: center;
-            vertical-align: middle;
           }
       data-icon-name="ChevronDown"
       role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.CustomMenuList.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.CustomMenuList.Example.tsx.shot
@@ -33,7 +33,6 @@ exports[`Component Examples renders ContextualMenu.CustomMenuList.Example.tsx co
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
       }
       &::-moz-focus-inner {
         border: 0;
@@ -146,7 +145,6 @@ exports[`Component Examples renders ContextualMenu.CustomMenuList.Example.tsx co
             margin-right: 4px;
             margin-top: 0;
             text-align: center;
-            vertical-align: middle;
           }
       data-icon-name="ChevronDown"
       role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Customization.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Customization.Example.tsx.shot
@@ -34,7 +34,6 @@ exports[`Component Examples renders ContextualMenu.Customization.Example.tsx cor
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
       }
       &::-moz-focus-inner {
         border: 0;
@@ -147,7 +146,6 @@ exports[`Component Examples renders ContextualMenu.Customization.Example.tsx cor
             margin-right: 4px;
             margin-top: 0;
             text-align: center;
-            vertical-align: middle;
           }
       data-icon-name="ChevronDown"
       role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.CustomizationWithNoWrap.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.CustomizationWithNoWrap.Example.tsx.shot
@@ -34,7 +34,6 @@ exports[`Component Examples renders ContextualMenu.CustomizationWithNoWrap.Examp
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
       }
       &::-moz-focus-inner {
         border: 0;
@@ -147,7 +146,6 @@ exports[`Component Examples renders ContextualMenu.CustomizationWithNoWrap.Examp
             margin-right: 4px;
             margin-top: 0;
             text-align: center;
-            vertical-align: middle;
           }
       data-icon-name="ChevronDown"
       role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Default.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Default.Example.tsx.shot
@@ -33,7 +33,6 @@ exports[`Component Examples renders ContextualMenu.Default.Example.tsx correctly
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
       }
       &::-moz-focus-inner {
         border: 0;
@@ -146,7 +145,6 @@ exports[`Component Examples renders ContextualMenu.Default.Example.tsx correctly
             margin-right: 4px;
             margin-top: 0;
             text-align: center;
-            vertical-align: middle;
           }
       data-icon-name="ChevronDown"
       role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Directional.Example.tsx.shot
@@ -400,7 +400,6 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;
@@ -513,7 +512,6 @@ exports[`Component Examples renders ContextualMenu.Directional.Example.tsx corre
                 margin-right: 4px;
                 margin-top: 0;
                 text-align: center;
-                vertical-align: middle;
               }
           data-icon-name="ChevronDown"
           role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Header.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Header.Example.tsx.shot
@@ -33,7 +33,6 @@ exports[`Component Examples renders ContextualMenu.Header.Example.tsx correctly 
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
       }
       &::-moz-focus-inner {
         border: 0;
@@ -146,7 +145,6 @@ exports[`Component Examples renders ContextualMenu.Header.Example.tsx correctly 
             margin-right: 4px;
             margin-top: 0;
             text-align: center;
-            vertical-align: middle;
           }
       data-icon-name="ChevronDown"
       role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Icon.Example.tsx.shot
@@ -34,7 +34,6 @@ exports[`Component Examples renders ContextualMenu.Icon.Example.tsx correctly 1`
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;
@@ -147,7 +146,6 @@ exports[`Component Examples renders ContextualMenu.Icon.Example.tsx correctly 1`
               margin-right: 4px;
               margin-top: 0;
               text-align: center;
-              vertical-align: middle;
             }
         data-icon-name="ChevronDown"
         role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Icon.SecondaryText.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Icon.SecondaryText.Example.tsx.shot
@@ -33,7 +33,6 @@ exports[`Component Examples renders ContextualMenu.Icon.SecondaryText.Example.ts
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
       }
       &::-moz-focus-inner {
         border: 0;
@@ -146,7 +145,6 @@ exports[`Component Examples renders ContextualMenu.Icon.SecondaryText.Example.ts
             margin-right: 4px;
             margin-top: 0;
             text-align: center;
-            vertical-align: middle;
           }
       data-icon-name="ChevronDown"
       role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Persisted.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Persisted.Example.tsx.shot
@@ -33,7 +33,6 @@ exports[`Component Examples renders ContextualMenu.Persisted.Example.tsx correct
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
       }
       &::-moz-focus-inner {
         border: 0;
@@ -146,7 +145,6 @@ exports[`Component Examples renders ContextualMenu.Persisted.Example.tsx correct
             margin-right: 4px;
             margin-top: 0;
             text-align: center;
-            vertical-align: middle;
           }
       data-icon-name="ChevronDown"
       role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.ScrollBar.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.ScrollBar.Example.tsx.shot
@@ -33,7 +33,6 @@ exports[`Component Examples renders ContextualMenu.ScrollBar.Example.tsx correct
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
       }
       &::-moz-focus-inner {
         border: 0;
@@ -146,7 +145,6 @@ exports[`Component Examples renders ContextualMenu.ScrollBar.Example.tsx correct
             margin-right: 4px;
             margin-top: 0;
             text-align: center;
-            vertical-align: middle;
           }
       data-icon-name="ChevronDown"
       role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Section.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Section.Example.tsx.shot
@@ -33,7 +33,6 @@ exports[`Component Examples renders ContextualMenu.Section.Example.tsx correctly
         text-align: center;
         text-decoration: none;
         user-select: none;
-        vertical-align: top;
       }
       &::-moz-focus-inner {
         border: 0;
@@ -146,7 +145,6 @@ exports[`Component Examples renders ContextualMenu.Section.Example.tsx correctly
             margin-right: 4px;
             margin-top: 0;
             text-align: center;
-            vertical-align: middle;
           }
       data-icon-name="ChevronDown"
       role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ContextualMenu.Submenu.Example.tsx.shot
@@ -206,7 +206,6 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;
@@ -319,7 +318,6 @@ exports[`Component Examples renders ContextualMenu.Submenu.Example.tsx correctly
               margin-right: 4px;
               margin-top: 0;
               text-align: center;
-              vertical-align: middle;
             }
         data-icon-name="ChevronDown"
         role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Format.Example.tsx.shot
@@ -273,7 +273,6 @@ exports[`Component Examples renders DatePicker.Format.Example.tsx correctly 1`] 
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DatePicker.Input.Example.tsx.shot
@@ -273,7 +273,6 @@ exports[`Component Examples renders DatePicker.Input.Example.tsx correctly 1`] =
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Advanced.Example.tsx.shot
@@ -103,7 +103,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                       text-align: center;
                       text-decoration: none;
                       user-select: none;
-                      vertical-align: top;
                     }
                     &::-moz-focus-inner {
                       border: 0;
@@ -207,7 +206,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           margin-right: 4px;
                           margin-top: 0;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="Add"
                     role="presentation"
@@ -285,7 +283,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                       text-align: center;
                       text-decoration: none;
                       user-select: none;
-                      vertical-align: top;
                     }
                     &::-moz-focus-inner {
                       border: 0;
@@ -389,7 +386,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           margin-right: 4px;
                           margin-top: 0;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="Delete"
                     role="presentation"
@@ -471,7 +467,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                       text-align: center;
                       text-decoration: none;
                       user-select: none;
-                      vertical-align: top;
                     }
                     &::-moz-focus-inner {
                       border: 0;
@@ -575,7 +570,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           margin-right: 4px;
                           margin-top: 0;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="Settings"
                     role="presentation"
@@ -640,7 +634,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                           margin-right: 4px;
                           margin-top: 0;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="ChevronDown"
                     role="presentation"
@@ -706,7 +699,6 @@ exports[`Component Examples renders DetailsList.Advanced.Example.tsx correctly 1
                       text-align: center;
                       text-decoration: none;
                       user-select: none;
-                      vertical-align: top;
                     }
                     &::-moz-focus-inner {
                       border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.Grouped.Example.tsx.shot
@@ -42,7 +42,6 @@ exports[`Component Examples renders DetailsList.Grouped.Example.tsx correctly 1`
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Basic.Example.tsx.shot
@@ -172,7 +172,6 @@ exports[`Component Examples renders Dialog.Basic.Example.tsx correctly 1`] = `
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Blocking.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Blocking.Example.tsx.shot
@@ -172,7 +172,6 @@ exports[`Component Examples renders Dialog.Blocking.Example.tsx correctly 1`] = 
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.LargeHeader.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.LargeHeader.Example.tsx.shot
@@ -30,7 +30,6 @@ exports[`Component Examples renders Dialog.LargeHeader.Example.tsx correctly 1`]
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Modeless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.Modeless.Example.tsx.shot
@@ -179,7 +179,6 @@ exports[`Component Examples renders Dialog.Modeless.Example.tsx correctly 1`] = 
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;
@@ -296,7 +295,6 @@ exports[`Component Examples renders Dialog.Modeless.Example.tsx correctly 1`] = 
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.TopOffsetFixed.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dialog.TopOffsetFixed.Example.tsx.shot
@@ -30,7 +30,6 @@ exports[`Component Examples renders Dialog.TopOffsetFixed.Example.tsx correctly 
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
@@ -717,7 +717,6 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
               width: 32px;
             }
             &::-moz-focus-inner {
@@ -806,7 +805,6 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="Share"
             role="presentation"
@@ -868,7 +866,6 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
               width: 32px;
             }
             &::-moz-focus-inner {
@@ -957,7 +954,6 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="Pin"
             role="presentation"
@@ -1019,7 +1015,6 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
               width: 32px;
             }
             &::-moz-focus-inner {
@@ -1108,7 +1103,6 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="Ringer"
             role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Custom.Example.tsx.shot
@@ -323,7 +323,6 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
               width: 32px;
             }
             &::-moz-focus-inner {
@@ -413,7 +412,6 @@ exports[`Component Examples renders Dropdown.Custom.Example.tsx correctly 1`] = 
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="Info"
             role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Dropdown.Required.Example.tsx.shot
@@ -291,7 +291,6 @@ exports[`Component Examples renders Dropdown.Required.Example.tsx correctly 1`] 
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Basic.Example.tsx.shot
@@ -110,7 +110,6 @@ exports[`Component Examples renders ExtendedPeoplePicker.Basic.Example.tsx corre
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ExtendedPeoplePicker.Controlled.Example.tsx.shot
@@ -110,7 +110,6 @@ exports[`Component Examples renders ExtendedPeoplePicker.Controlled.Example.tsx 
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -95,7 +95,6 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -95,7 +95,6 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.DialogInPanel.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.DialogInPanel.Example.tsx.shot
@@ -30,7 +30,6 @@ exports[`Component Examples renders FocusTrapZone.DialogInPanel.Example.tsx corr
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.FocusZone.Example.tsx.shot
@@ -280,7 +280,6 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;
@@ -397,7 +396,6 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;
@@ -514,7 +512,6 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;
@@ -633,7 +630,6 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;
@@ -788,7 +784,6 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;
@@ -905,7 +900,6 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;
@@ -1022,7 +1016,6 @@ exports[`Component Examples renders FocusTrapZone.FocusZone.Example.tsx correctl
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Nested.Example.tsx.shot
@@ -243,7 +243,6 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -574,7 +573,6 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -905,7 +903,6 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                       text-align: center;
                       text-decoration: none;
                       user-select: none;
-                      vertical-align: top;
                     }
                     &::-moz-focus-inner {
                       border: 0;
@@ -1249,7 +1246,6 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                       text-align: center;
                       text-decoration: none;
                       user-select: none;
-                      vertical-align: top;
                     }
                     &::-moz-focus-inner {
                       border: 0;
@@ -1605,7 +1601,6 @@ exports[`Component Examples renders FocusTrapZone.Nested.Example.tsx correctly 1
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                 }
                 &::-moz-focus-inner {
                   border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Disabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Disabled.Example.tsx.shot
@@ -87,7 +87,6 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -204,7 +203,6 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -462,7 +460,6 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -581,7 +578,6 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;
@@ -734,7 +730,6 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -851,7 +846,6 @@ exports[`Component Examples renders FocusZone.Disabled.Example.tsx correctly 1`]
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.HorizontalMenu.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.HorizontalMenu.Example.tsx.shot
@@ -41,7 +41,6 @@ exports[`Component Examples renders FocusZone.HorizontalMenu.Example.tsx correct
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;
@@ -159,7 +158,6 @@ exports[`Component Examples renders FocusZone.HorizontalMenu.Example.tsx correct
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;
@@ -277,7 +275,6 @@ exports[`Component Examples renders FocusZone.HorizontalMenu.Example.tsx correct
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;
@@ -395,7 +392,6 @@ exports[`Component Examples renders FocusZone.HorizontalMenu.Example.tsx correct
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;
@@ -513,7 +509,6 @@ exports[`Component Examples renders FocusZone.HorizontalMenu.Example.tsx correct
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
@@ -87,7 +87,6 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -204,7 +203,6 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -462,7 +460,6 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -662,7 +659,6 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -841,7 +837,6 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                       margin-right: 4px;
                       margin-top: 0;
                       text-align: center;
-                      vertical-align: middle;
                     }
                     {
                       flex-shrink: 0;
@@ -853,7 +848,6 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                       margin-right: 4px;
                       margin-top: 0;
                       text-align: center;
-                      vertical-align: middle;
                     }
                 data-icon-name="ChevronDown"
                 role="presentation"
@@ -951,7 +945,6 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -1068,7 +1061,6 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -1326,7 +1318,6 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.EventListenerTarget.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/HoverCard.EventListenerTarget.Example.tsx.shot
@@ -65,7 +65,6 @@ exports[`Component Examples renders HoverCard.EventListenerTarget.Example.tsx co
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
             width: 32px;
           }
           &::-moz-focus-inner {
@@ -155,7 +154,6 @@ exports[`Component Examples renders HoverCard.EventListenerTarget.Example.tsx co
                 margin-right: 4px;
                 margin-top: 0;
                 text-align: center;
-                vertical-align: middle;
               }
           data-icon-name="Emoji2"
           role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -78,7 +78,6 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;
@@ -249,7 +248,6 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;
@@ -410,7 +408,6 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;
@@ -744,7 +741,6 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                         text-align: center;
                         text-decoration: none;
                         user-select: none;
-                        vertical-align: top;
                         width: 23px;
                       }
                       &::-moz-focus-inner {
@@ -845,7 +841,6 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                             margin-right: 0px;
                             margin-top: 0px;
                             text-align: center;
-                            vertical-align: middle;
                           }
                       data-icon-name="ChevronUpSmall"
                       role="presentation"
@@ -887,7 +882,6 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                         text-align: center;
                         text-decoration: none;
                         user-select: none;
-                        vertical-align: top;
                         width: 23px;
                       }
                       &::-moz-focus-inner {
@@ -988,7 +982,6 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                             margin-right: 0px;
                             margin-top: 0px;
                             text-align: center;
-                            vertical-align: middle;
                           }
                       data-icon-name="ChevronDownSmall"
                       role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
@@ -55,7 +55,6 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;
@@ -178,7 +177,6 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;
@@ -332,7 +330,6 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;
@@ -447,7 +444,6 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
                 margin-right: 4px;
                 margin-top: 0;
                 text-align: center;
-                vertical-align: middle;
               }
           data-icon-name="ChevronDown"
           role="presentation"
@@ -575,7 +571,6 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;
@@ -754,7 +749,6 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
                     margin-right: 4px;
                     margin-top: 0;
                     text-align: center;
-                    vertical-align: middle;
                   }
                   {
                     flex-shrink: 0;
@@ -766,7 +760,6 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
                     margin-right: 4px;
                     margin-top: 0;
                     text-align: center;
-                    vertical-align: middle;
                   }
               data-icon-name="ChevronDown"
               role="presentation"
@@ -826,7 +819,6 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;
@@ -949,7 +941,6 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;
@@ -1217,7 +1208,6 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.CommandBar.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.CommandBar.Example.tsx.shot
@@ -103,7 +103,6 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
                       text-align: center;
                       text-decoration: none;
                       user-select: none;
-                      vertical-align: top;
                     }
                     &::-moz-focus-inner {
                       border: 0;
@@ -209,7 +208,6 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
                           margin-right: 4px;
                           margin-top: 0;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="Add"
                     role="presentation"
@@ -288,7 +286,6 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
                       text-align: center;
                       text-decoration: none;
                       user-select: none;
-                      vertical-align: top;
                     }
                     &::-moz-focus-inner {
                       border: 0;
@@ -394,7 +391,6 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
                           margin-right: 4px;
                           margin-top: 0;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="Upload"
                     role="presentation"
@@ -491,7 +487,6 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
                       text-align: center;
                       text-decoration: none;
                       user-select: none;
-                      vertical-align: top;
                     }
                     &::-moz-focus-inner {
                       border: 0;
@@ -597,7 +592,6 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
                           margin-right: 4px;
                           margin-top: 0;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="SortLines"
                     role="presentation"
@@ -662,7 +656,6 @@ exports[`Component Examples renders Keytips.CommandBar.Example.tsx correctly 1`]
                           margin-right: 4px;
                           margin-top: 0;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="ChevronDown"
                     role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Dynamic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Dynamic.Example.tsx.shot
@@ -34,7 +34,6 @@ exports[`Component Examples renders Keytips.Dynamic.Example.tsx correctly 1`] = 
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;
@@ -154,7 +153,6 @@ exports[`Component Examples renders Keytips.Dynamic.Example.tsx correctly 1`] = 
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;
@@ -275,7 +273,6 @@ exports[`Component Examples renders Keytips.Dynamic.Example.tsx correctly 1`] = 
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Overflow.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Overflow.Example.tsx.shot
@@ -61,7 +61,6 @@ exports[`Component Examples renders Keytips.Overflow.Example.tsx correctly 1`] =
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -205,7 +204,6 @@ exports[`Component Examples renders Keytips.Overflow.Example.tsx correctly 1`] =
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -349,7 +347,6 @@ exports[`Component Examples renders Keytips.Overflow.Example.tsx correctly 1`] =
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -497,7 +494,6 @@ exports[`Component Examples renders Keytips.Overflow.Example.tsx correctly 1`] =
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -602,7 +598,6 @@ exports[`Component Examples renders Keytips.Overflow.Example.tsx correctly 1`] =
                   margin-right: 4px;
                   margin-top: 0;
                   text-align: center;
-                  vertical-align: middle;
                 }
             data-icon-name="More"
             role="presentation"
@@ -649,7 +644,6 @@ exports[`Component Examples renders Keytips.Overflow.Example.tsx correctly 1`] =
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.NestedLayers.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Layer.NestedLayers.Example.tsx.shot
@@ -30,7 +30,6 @@ exports[`Component Examples renders Layer.NestedLayers.Example.tsx correctly 1`]
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Basic.Example.tsx.shot
@@ -173,7 +173,6 @@ exports[`Component Examples renders Modal.Basic.Example.tsx correctly 1`] = `
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Modeless.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Modal.Modeless.Example.tsx.shot
@@ -175,7 +175,6 @@ exports[`Component Examples renders Modal.Modeless.Example.tsx correctly 1`] = `
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Basic.Example.tsx.shot
@@ -202,7 +202,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                       text-decoration: none;
                       text-overflow: ellipsis;
                       user-select: none;
-                      vertical-align: top;
                       white-space: nowrap;
                       width: 100%;
                     }
@@ -368,7 +367,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                           text-decoration: none;
                           text-overflow: ellipsis;
                           user-select: none;
-                          vertical-align: top;
                           white-space: nowrap;
                           width: 100%;
                         }
@@ -526,7 +524,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                           text-decoration: none;
                           text-overflow: ellipsis;
                           user-select: none;
-                          vertical-align: top;
                           white-space: nowrap;
                           width: 100%;
                         }
@@ -671,7 +668,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                       text-decoration: none;
                       text-overflow: ellipsis;
                       user-select: none;
-                      vertical-align: top;
                       white-space: nowrap;
                       width: 100%;
                     }
@@ -834,7 +830,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                       text-decoration: none;
                       text-overflow: ellipsis;
                       user-select: none;
-                      vertical-align: top;
                       white-space: nowrap;
                       width: 100%;
                     }
@@ -992,7 +987,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                       text-decoration: none;
                       text-overflow: ellipsis;
                       user-select: none;
-                      vertical-align: top;
                       white-space: nowrap;
                       width: 100%;
                     }
@@ -1132,7 +1126,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                       text-decoration: none;
                       text-overflow: ellipsis;
                       user-select: none;
-                      vertical-align: top;
                       white-space: nowrap;
                       width: 100%;
                     }
@@ -1285,7 +1278,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                       text-decoration: none;
                       text-overflow: ellipsis;
                       user-select: none;
-                      vertical-align: top;
                       white-space: nowrap;
                       width: 100%;
                     }
@@ -1392,7 +1384,6 @@ exports[`Component Examples renders Nav.Basic.Example.tsx correctly 1`] = `
                           margin-right: 4px;
                           margin-top: 0;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="News"
                     role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.CustomGroupHeaders.Example.tsx.shot
@@ -118,7 +118,6 @@ exports[`Component Examples renders Nav.CustomGroupHeaders.Example.tsx correctly
                       text-decoration: none;
                       text-overflow: ellipsis;
                       user-select: none;
-                      vertical-align: top;
                       white-space: nowrap;
                       width: 100%;
                     }
@@ -271,7 +270,6 @@ exports[`Component Examples renders Nav.CustomGroupHeaders.Example.tsx correctly
                       text-decoration: none;
                       text-overflow: ellipsis;
                       user-select: none;
-                      vertical-align: top;
                       white-space: nowrap;
                       width: 100%;
                     }
@@ -464,7 +462,6 @@ exports[`Component Examples renders Nav.CustomGroupHeaders.Example.tsx correctly
                       text-decoration: none;
                       text-overflow: ellipsis;
                       user-select: none;
-                      vertical-align: top;
                       white-space: nowrap;
                       width: 100%;
                     }
@@ -617,7 +614,6 @@ exports[`Component Examples renders Nav.CustomGroupHeaders.Example.tsx correctly
                       text-decoration: none;
                       text-overflow: ellipsis;
                       user-select: none;
-                      vertical-align: top;
                       white-space: nowrap;
                       width: 100%;
                     }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Nested.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Nav.Nested.Example.tsx.shot
@@ -196,7 +196,6 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
                       text-decoration: none;
                       text-overflow: ellipsis;
                       user-select: none;
-                      vertical-align: top;
                       white-space: nowrap;
                       width: 100%;
                     }
@@ -430,7 +429,6 @@ exports[`Component Examples renders Nav.Nested.Example.tsx correctly 1`] = `
                       text-decoration: none;
                       text-overflow: ellipsis;
                       user-select: none;
-                      vertical-align: top;
                       white-space: nowrap;
                       width: 100%;
                     }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Basic.Example.tsx.shot
@@ -290,7 +290,6 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
             width: auto;
           }
           &::-moz-focus-inner {
@@ -381,7 +380,6 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
                 margin-right: 4px;
                 margin-top: 0;
                 text-align: center;
-                vertical-align: middle;
               }
           data-icon-name="More"
           role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Custom.Example.tsx.shot
@@ -213,7 +213,6 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;
@@ -317,7 +316,6 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
                 margin-right: 4px;
                 margin-top: 0;
                 text-align: center;
-                vertical-align: middle;
               }
           data-icon-name="Add"
           role="presentation"
@@ -381,7 +379,6 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
                 margin-right: 4px;
                 margin-top: 0;
                 text-align: center;
-                vertical-align: middle;
               }
           data-icon-name="ChevronDown"
           role="presentation"
@@ -431,7 +428,6 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;
@@ -535,7 +531,6 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
                 margin-right: 4px;
                 margin-top: 0;
                 text-align: center;
-                vertical-align: middle;
               }
           data-icon-name="Upload"
           role="presentation"
@@ -610,7 +605,6 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;
@@ -714,7 +708,6 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
                 margin-right: 4px;
                 margin-top: 0;
                 text-align: center;
-                vertical-align: middle;
               }
           data-icon-name="Share"
           role="presentation"
@@ -796,7 +789,6 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;
@@ -900,7 +892,6 @@ exports[`Component Examples renders OverflowSet.Custom.Example.tsx correctly 1`]
                 margin-right: 4px;
                 margin-top: 0;
                 text-align: center;
-                vertical-align: middle;
               }
           data-icon-name="More"
           role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Vertical.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Vertical.Example.tsx.shot
@@ -58,7 +58,6 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;
@@ -162,7 +161,6 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
                 margin-right: 4px;
                 margin-top: 0;
                 text-align: center;
-                vertical-align: middle;
               }
           data-icon-name="Add"
           role="presentation"
@@ -213,7 +211,6 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;
@@ -317,7 +314,6 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
                 margin-right: 4px;
                 margin-top: 0;
                 text-align: center;
-                vertical-align: middle;
               }
           data-icon-name="Upload"
           role="presentation"
@@ -368,7 +364,6 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;
@@ -472,7 +467,6 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
                 margin-right: 4px;
                 margin-top: 0;
                 text-align: center;
-                vertical-align: middle;
               }
           data-icon-name="Share"
           role="presentation"
@@ -526,7 +520,6 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;
@@ -631,7 +624,6 @@ exports[`Component Examples renders OverflowSet.Vertical.Example.tsx correctly 1
                 margin-right: 4px;
                 margin-top: 0;
                 text-align: center;
-                vertical-align: middle;
               }
           data-icon-name="More"
           role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Overlay.Dark.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Overlay.Dark.Example.tsx.shot
@@ -30,7 +30,6 @@ exports[`Component Examples renders Overlay.Dark.Example.tsx correctly 1`] = `
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Overlay.Light.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Overlay.Light.Example.tsx.shot
@@ -30,7 +30,6 @@ exports[`Component Examples renders Overlay.Light.Example.tsx correctly 1`] = `
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.Controlled.Example.tsx.shot
@@ -135,7 +135,6 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -524,7 +523,6 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -907,7 +905,6 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -1296,7 +1293,6 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -1698,7 +1694,6 @@ exports[`Component Examples renders PeoplePicker.Controlled.Example.tsx correctl
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/PeoplePicker.PreselectedItems.Example.tsx.shot
@@ -423,7 +423,6 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
                       text-align: center;
                       text-decoration: none;
                       user-select: none;
-                      vertical-align: top;
                       width: 24px;
                     }
                     &::-moz-focus-inner {
@@ -508,7 +507,6 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
                           margin-top: 0;
                           speak: none;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="Cancel"
                   >
@@ -875,7 +873,6 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
                       text-align: center;
                       text-decoration: none;
                       user-select: none;
-                      vertical-align: top;
                       width: 24px;
                     }
                     &::-moz-focus-inner {
@@ -960,7 +957,6 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
                           margin-top: 0;
                           speak: none;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="Cancel"
                   >
@@ -1327,7 +1323,6 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
                       text-align: center;
                       text-decoration: none;
                       user-select: none;
-                      vertical-align: top;
                       width: 24px;
                     }
                     &::-moz-focus-inner {
@@ -1412,7 +1407,6 @@ exports[`Component Examples renders PeoplePicker.PreselectedItems.Example.tsx co
                           margin-top: 0;
                           speak: none;
                           text-align: center;
-                          vertical-align: middle;
                         }
                     data-icon-name="Cancel"
                   >

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Basic.Example.tsx.shot
@@ -74,7 +74,6 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -244,7 +243,6 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;
@@ -402,7 +400,6 @@ exports[`Component Examples renders Pivot.Basic.Example.tsx correctly 1`] = `
               text-align: center;
               text-decoration: none;
               user-select: none;
-              vertical-align: top;
             }
             &::-moz-focus-inner {
               border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.IconCount.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.IconCount.Example.tsx.shot
@@ -75,7 +75,6 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;
@@ -278,7 +277,6 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;
@@ -459,7 +457,6 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;
@@ -640,7 +637,6 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;
@@ -833,7 +829,6 @@ exports[`Component Examples renders Pivot.IconCount.Example.tsx correctly 1`] = 
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Large.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Large.Example.tsx.shot
@@ -76,7 +76,6 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;
@@ -244,7 +243,6 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;
@@ -402,7 +400,6 @@ exports[`Component Examples renders Pivot.Large.Example.tsx correctly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Override.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Override.Example.tsx.shot
@@ -75,7 +75,6 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;
@@ -243,7 +242,6 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;
@@ -401,7 +399,6 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;
@@ -592,7 +589,6 @@ exports[`Component Examples renders Pivot.Override.Example.tsx correctly 1`] = `
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Remove.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Remove.Example.tsx.shot
@@ -838,7 +838,6 @@ exports[`Component Examples renders Pivot.Remove.Example.tsx correctly 1`] = `
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Separate.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.Separate.Example.tsx.shot
@@ -87,7 +87,6 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;
@@ -255,7 +254,6 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;
@@ -413,7 +411,6 @@ exports[`Component Examples renders Pivot.Separate.Example.tsx correctly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
               }
               &::-moz-focus-inner {
                 border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.SeparateNoSelectedKey.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Pivot.SeparateNoSelectedKey.Example.tsx.shot
@@ -96,7 +96,6 @@ exports[`Component Examples renders Pivot.SeparateNoSelectedKey.Example.tsx corr
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -254,7 +253,6 @@ exports[`Component Examples renders Pivot.SeparateNoSelectedKey.Example.tsx corr
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -412,7 +410,6 @@ exports[`Component Examples renders Pivot.SeparateNoSelectedKey.Example.tsx corr
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                 }
                 &::-moz-focus-inner {
                   border: 0;
@@ -569,7 +566,6 @@ exports[`Component Examples renders Pivot.SeparateNoSelectedKey.Example.tsx corr
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;
@@ -657,7 +653,6 @@ exports[`Component Examples renders Pivot.SeparateNoSelectedKey.Example.tsx corr
                 margin-right: 4px;
                 margin-top: 0;
                 text-align: center;
-                vertical-align: middle;
               }
           data-icon-name="Settings"
           role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.ButtonControlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Rating.ButtonControlled.Example.tsx.shot
@@ -776,7 +776,6 @@ exports[`Component Examples renders Rating.ButtonControlled.Example.tsx correctl
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.OverflowSet.Example.tsx.shot
@@ -79,7 +79,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -183,7 +182,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Add"
                   role="presentation"
@@ -258,7 +256,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -362,7 +359,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Share"
                   role="presentation"
@@ -437,7 +433,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -541,7 +536,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Upload"
                   role="presentation"
@@ -616,7 +610,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -720,7 +713,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Add"
                   role="presentation"
@@ -795,7 +787,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -899,7 +890,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Share"
                   role="presentation"
@@ -974,7 +964,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -1078,7 +1067,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Upload"
                   role="presentation"
@@ -1153,7 +1141,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -1257,7 +1244,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Add"
                   role="presentation"
@@ -1332,7 +1318,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -1436,7 +1421,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Share"
                   role="presentation"
@@ -1511,7 +1495,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -1615,7 +1598,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Upload"
                   role="presentation"
@@ -1690,7 +1672,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -1794,7 +1775,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Add"
                   role="presentation"
@@ -1869,7 +1849,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -1973,7 +1952,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Share"
                   role="presentation"
@@ -2048,7 +2026,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -2152,7 +2129,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Upload"
                   role="presentation"
@@ -2227,7 +2203,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -2331,7 +2306,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Add"
                   role="presentation"
@@ -2406,7 +2380,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -2510,7 +2483,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Share"
                   role="presentation"
@@ -2585,7 +2557,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -2689,7 +2660,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Upload"
                   role="presentation"
@@ -2764,7 +2734,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -2868,7 +2837,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Add"
                   role="presentation"
@@ -2943,7 +2911,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -3047,7 +3014,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Share"
                   role="presentation"
@@ -3122,7 +3088,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -3226,7 +3191,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Upload"
                   role="presentation"
@@ -3301,7 +3265,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -3405,7 +3368,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Add"
                   role="presentation"
@@ -3480,7 +3442,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                   }
                   &::-moz-focus-inner {
                     border: 0;
@@ -3584,7 +3545,6 @@ exports[`Component Examples renders ResizeGroup.OverflowSet.Example.tsx correctl
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Share"
                   role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.VerticalOverflowSet.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ResizeGroup.VerticalOverflowSet.Example.tsx.shot
@@ -81,7 +81,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 100px;
                 }
                 &::-moz-focus-inner {
@@ -186,7 +185,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                       margin-right: 4px;
                       margin-top: 0;
                       text-align: center;
-                      vertical-align: middle;
                     }
                 data-icon-name="Add"
                 role="presentation"
@@ -261,7 +259,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 100px;
                 }
                 &::-moz-focus-inner {
@@ -366,7 +363,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                       margin-right: 4px;
                       margin-top: 0;
                       text-align: center;
-                      vertical-align: middle;
                     }
                 data-icon-name="Share"
                 role="presentation"
@@ -441,7 +437,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 100px;
                 }
                 &::-moz-focus-inner {
@@ -546,7 +541,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                       margin-right: 4px;
                       margin-top: 0;
                       text-align: center;
-                      vertical-align: middle;
                     }
                 data-icon-name="Upload"
                 role="presentation"
@@ -621,7 +615,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 100px;
                 }
                 &::-moz-focus-inner {
@@ -726,7 +719,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                       margin-right: 4px;
                       margin-top: 0;
                       text-align: center;
-                      vertical-align: middle;
                     }
                 data-icon-name="Add"
                 role="presentation"
@@ -801,7 +793,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 100px;
                 }
                 &::-moz-focus-inner {
@@ -906,7 +897,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                       margin-right: 4px;
                       margin-top: 0;
                       text-align: center;
-                      vertical-align: middle;
                     }
                 data-icon-name="Share"
                 role="presentation"
@@ -981,7 +971,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 100px;
                 }
                 &::-moz-focus-inner {
@@ -1086,7 +1075,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                       margin-right: 4px;
                       margin-top: 0;
                       text-align: center;
-                      vertical-align: middle;
                     }
                 data-icon-name="Upload"
                 role="presentation"
@@ -1161,7 +1149,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 100px;
                 }
                 &::-moz-focus-inner {
@@ -1266,7 +1253,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                       margin-right: 4px;
                       margin-top: 0;
                       text-align: center;
-                      vertical-align: middle;
                     }
                 data-icon-name="Add"
                 role="presentation"
@@ -1341,7 +1327,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 100px;
                 }
                 &::-moz-focus-inner {
@@ -1446,7 +1431,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                       margin-right: 4px;
                       margin-top: 0;
                       text-align: center;
-                      vertical-align: middle;
                     }
                 data-icon-name="Share"
                 role="presentation"
@@ -1521,7 +1505,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 100px;
                 }
                 &::-moz-focus-inner {
@@ -1626,7 +1609,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                       margin-right: 4px;
                       margin-top: 0;
                       text-align: center;
-                      vertical-align: middle;
                     }
                 data-icon-name="Upload"
                 role="presentation"
@@ -1701,7 +1683,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 100px;
                 }
                 &::-moz-focus-inner {
@@ -1806,7 +1787,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                       margin-right: 4px;
                       margin-top: 0;
                       text-align: center;
-                      vertical-align: middle;
                     }
                 data-icon-name="Add"
                 role="presentation"
@@ -1881,7 +1861,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 100px;
                 }
                 &::-moz-focus-inner {
@@ -1986,7 +1965,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                       margin-right: 4px;
                       margin-top: 0;
                       text-align: center;
-                      vertical-align: middle;
                     }
                 data-icon-name="Share"
                 role="presentation"
@@ -2061,7 +2039,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 100px;
                 }
                 &::-moz-focus-inner {
@@ -2166,7 +2143,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                       margin-right: 4px;
                       margin-top: 0;
                       text-align: center;
-                      vertical-align: middle;
                     }
                 data-icon-name="Upload"
                 role="presentation"
@@ -2241,7 +2217,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 100px;
                 }
                 &::-moz-focus-inner {
@@ -2346,7 +2321,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                       margin-right: 4px;
                       margin-top: 0;
                       text-align: center;
-                      vertical-align: middle;
                     }
                 data-icon-name="Add"
                 role="presentation"
@@ -2421,7 +2395,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 100px;
                 }
                 &::-moz-focus-inner {
@@ -2526,7 +2499,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                       margin-right: 4px;
                       margin-top: 0;
                       text-align: center;
-                      vertical-align: middle;
                     }
                 data-icon-name="Share"
                 role="presentation"
@@ -2601,7 +2573,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 100px;
                 }
                 &::-moz-focus-inner {
@@ -2706,7 +2677,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                       margin-right: 4px;
                       margin-top: 0;
                       text-align: center;
-                      vertical-align: middle;
                     }
                 data-icon-name="Upload"
                 role="presentation"
@@ -2781,7 +2751,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 100px;
                 }
                 &::-moz-focus-inner {
@@ -2886,7 +2855,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                       margin-right: 4px;
                       margin-top: 0;
                       text-align: center;
-                      vertical-align: middle;
                     }
                 data-icon-name="Add"
                 role="presentation"
@@ -2961,7 +2929,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 100px;
                 }
                 &::-moz-focus-inner {
@@ -3066,7 +3033,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                       margin-right: 4px;
                       margin-top: 0;
                       text-align: center;
-                      vertical-align: middle;
                     }
                 data-icon-name="Share"
                 role="presentation"
@@ -3141,7 +3107,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 100px;
                 }
                 &::-moz-focus-inner {
@@ -3246,7 +3211,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                       margin-right: 4px;
                       margin-top: 0;
                       text-align: center;
-                      vertical-align: middle;
                     }
                 data-icon-name="Upload"
                 role="presentation"
@@ -3321,7 +3285,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 100px;
                 }
                 &::-moz-focus-inner {
@@ -3426,7 +3389,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                       margin-right: 4px;
                       margin-top: 0;
                       text-align: center;
-                      vertical-align: middle;
                     }
                 data-icon-name="Add"
                 role="presentation"
@@ -3501,7 +3463,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                   text-align: center;
                   text-decoration: none;
                   user-select: none;
-                  vertical-align: top;
                   width: 100px;
                 }
                 &::-moz-focus-inner {
@@ -3606,7 +3567,6 @@ exports[`Component Examples renders ResizeGroup.VerticalOverflowSet.Example.tsx 
                       margin-right: 4px;
                       margin-top: 0;
                       text-align: center;
-                      vertical-align: middle;
                     }
                 data-icon-name="Share"
                 role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SelectedPeopleList.Controlled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SelectedPeopleList.Controlled.Example.tsx.shot
@@ -31,7 +31,6 @@ exports[`Component Examples renders SelectedPeopleList.Controlled.Example.tsx co
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;
@@ -220,7 +219,6 @@ exports[`Component Examples renders SelectedPeopleList.Controlled.Example.tsx co
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 32px;
                   }
                   &::-moz-focus-inner {
@@ -309,7 +307,6 @@ exports[`Component Examples renders SelectedPeopleList.Controlled.Example.tsx co
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Add"
                   role="presentation"
@@ -539,7 +536,6 @@ exports[`Component Examples renders SelectedPeopleList.Controlled.Example.tsx co
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 32px;
                   }
                   &::-moz-focus-inner {
@@ -628,7 +624,6 @@ exports[`Component Examples renders SelectedPeopleList.Controlled.Example.tsx co
                         margin-right: 4px;
                         margin-top: 0;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Cancel"
                   role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Basic.Example.tsx.shot
@@ -198,7 +198,6 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 23px;
               }
               &::-moz-focus-inner {
@@ -299,7 +298,6 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
                     margin-right: 0px;
                     margin-top: 0px;
                     text-align: center;
-                    vertical-align: middle;
                   }
               data-icon-name="ChevronUpSmall"
               role="presentation"
@@ -342,7 +340,6 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 23px;
               }
               &::-moz-focus-inner {
@@ -443,7 +440,6 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
                     margin-right: 0px;
                     margin-top: 0px;
                     text-align: center;
-                    vertical-align: middle;
                   }
               data-icon-name="ChevronDownSmall"
               role="presentation"
@@ -628,7 +624,6 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 23px;
               }
               &::-moz-focus-inner {
@@ -729,7 +724,6 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
                     margin-right: 0px;
                     margin-top: 0px;
                     text-align: center;
-                    vertical-align: middle;
                   }
               data-icon-name="ChevronUpSmall"
               role="presentation"
@@ -772,7 +766,6 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 23px;
               }
               &::-moz-focus-inner {
@@ -873,7 +866,6 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
                     margin-right: 0px;
                     margin-top: 0px;
                     text-align: center;
-                    vertical-align: middle;
                   }
               data-icon-name="ChevronDownSmall"
               role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
@@ -189,7 +189,6 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 23px;
               }
               &::-moz-focus-inner {
@@ -287,7 +286,6 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
                     margin-right: 0px;
                     margin-top: 0px;
                     text-align: center;
-                    vertical-align: middle;
                   }
               data-icon-name="ChevronUpSmall"
               role="presentation"
@@ -335,7 +333,6 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 23px;
               }
               &::-moz-focus-inner {
@@ -433,7 +430,6 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
                     margin-right: 0px;
                     margin-top: 0px;
                     text-align: center;
-                    vertical-align: middle;
                   }
               data-icon-name="ChevronDownSmall"
               role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithEndPosition.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithEndPosition.Example.tsx.shot
@@ -198,7 +198,6 @@ exports[`Component Examples renders SpinButton.BasicWithEndPosition.Example.tsx 
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 23px;
               }
               &::-moz-focus-inner {
@@ -299,7 +298,6 @@ exports[`Component Examples renders SpinButton.BasicWithEndPosition.Example.tsx 
                     margin-right: 0px;
                     margin-top: 0px;
                     text-align: center;
-                    vertical-align: middle;
                   }
               data-icon-name="ChevronUpSmall"
               role="presentation"
@@ -342,7 +340,6 @@ exports[`Component Examples renders SpinButton.BasicWithEndPosition.Example.tsx 
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 23px;
               }
               &::-moz-focus-inner {
@@ -443,7 +440,6 @@ exports[`Component Examples renders SpinButton.BasicWithEndPosition.Example.tsx 
                     margin-right: 0px;
                     margin-top: 0px;
                     text-align: center;
-                    vertical-align: middle;
                   }
               data-icon-name="ChevronDownSmall"
               role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIcon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIcon.Example.tsx.shot
@@ -198,7 +198,6 @@ exports[`Component Examples renders SpinButton.BasicWithIcon.Example.tsx correct
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 23px;
               }
               &::-moz-focus-inner {
@@ -299,7 +298,6 @@ exports[`Component Examples renders SpinButton.BasicWithIcon.Example.tsx correct
                     margin-right: 0px;
                     margin-top: 0px;
                     text-align: center;
-                    vertical-align: middle;
                   }
               data-icon-name="ChevronUpSmall"
               role="presentation"
@@ -342,7 +340,6 @@ exports[`Component Examples renders SpinButton.BasicWithIcon.Example.tsx correct
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 23px;
               }
               &::-moz-focus-inner {
@@ -443,7 +440,6 @@ exports[`Component Examples renders SpinButton.BasicWithIcon.Example.tsx correct
                     margin-right: 0px;
                     margin-top: 0px;
                     text-align: center;
-                    vertical-align: middle;
                   }
               data-icon-name="ChevronDownSmall"
               role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
@@ -212,7 +212,6 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 23px;
               }
               &::-moz-focus-inner {
@@ -310,7 +309,6 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
                     margin-right: 0px;
                     margin-top: 0px;
                     text-align: center;
-                    vertical-align: middle;
                   }
               data-icon-name="ChevronUpSmall"
               role="presentation"
@@ -358,7 +356,6 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 23px;
               }
               &::-moz-focus-inner {
@@ -456,7 +453,6 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
                     margin-right: 0px;
                     margin-top: 0px;
                     text-align: center;
-                    vertical-align: middle;
                   }
               data-icon-name="ChevronDownSmall"
               role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.CustomStyled.Example.tsx.shot
@@ -170,7 +170,6 @@ exports[`Component Examples renders SpinButton.CustomStyled.Example.tsx correctl
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 23px;
               }
               &::-moz-focus-inner {
@@ -271,7 +270,6 @@ exports[`Component Examples renders SpinButton.CustomStyled.Example.tsx correctl
                     margin-right: 0px;
                     margin-top: 0px;
                     text-align: center;
-                    vertical-align: middle;
                   }
               data-icon-name="ChevronUpSmall"
               role="presentation"
@@ -314,7 +312,6 @@ exports[`Component Examples renders SpinButton.CustomStyled.Example.tsx correctl
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 23px;
               }
               &::-moz-focus-inner {
@@ -415,7 +412,6 @@ exports[`Component Examples renders SpinButton.CustomStyled.Example.tsx correctl
                     margin-right: 0px;
                     margin-top: 0px;
                     text-align: center;
-                    vertical-align: middle;
                   }
               data-icon-name="ChevronDownSmall"
               role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Stateful.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Stateful.Example.tsx.shot
@@ -176,7 +176,6 @@ exports[`Component Examples renders SpinButton.Stateful.Example.tsx correctly 1`
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 23px;
               }
               &::-moz-focus-inner {
@@ -277,7 +276,6 @@ exports[`Component Examples renders SpinButton.Stateful.Example.tsx correctly 1`
                     margin-right: 0px;
                     margin-top: 0px;
                     text-align: center;
-                    vertical-align: middle;
                   }
               data-icon-name="ChevronUpSmall"
               role="presentation"
@@ -320,7 +318,6 @@ exports[`Component Examples renders SpinButton.Stateful.Example.tsx correctly 1`
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 23px;
               }
               &::-moz-focus-inner {
@@ -421,7 +418,6 @@ exports[`Component Examples renders SpinButton.Stateful.Example.tsx correctly 1`
                     margin-right: 0px;
                     margin-top: 0px;
                     text-align: center;
-                    vertical-align: middle;
                   }
               data-icon-name="ChevronDownSmall"
               role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SwatchColorPicker.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SwatchColorPicker.Basic.Example.tsx.shot
@@ -86,7 +86,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -256,7 +255,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -426,7 +424,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -596,7 +593,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -766,7 +762,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -983,7 +978,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -1142,7 +1136,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -1301,7 +1294,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -1460,7 +1452,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -1619,7 +1610,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -1825,7 +1815,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -1984,7 +1973,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -2143,7 +2131,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -2302,7 +2289,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -2461,7 +2447,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -2677,7 +2662,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -2847,7 +2831,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -3017,7 +3000,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -3187,7 +3169,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -3361,7 +3342,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -3531,7 +3511,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -3701,7 +3680,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -3871,7 +3849,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -4045,7 +4022,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -4215,7 +4191,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -4385,7 +4360,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -4555,7 +4529,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 35px;
                   }
                   &::-moz-focus-inner {
@@ -4778,7 +4751,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -4955,7 +4927,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -5132,7 +5103,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -5309,7 +5279,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {
@@ -5486,7 +5455,6 @@ exports[`Component Examples renders SwatchColorPicker.Basic.Example.tsx correctl
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 20px;
                   }
                   &::-moz-focus-inner {

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TeachingBubble.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TeachingBubble.Basic.Example.tsx.shot
@@ -35,7 +35,6 @@ exports[`Component Examples renders TeachingBubble.Basic.Example.tsx correctly 1
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TeachingBubble.Condensed.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TeachingBubble.Condensed.Example.tsx.shot
@@ -35,7 +35,6 @@ exports[`Component Examples renders TeachingBubble.Condensed.Example.tsx correct
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TeachingBubble.Illustration.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TeachingBubble.Illustration.Example.tsx.shot
@@ -35,7 +35,6 @@ exports[`Component Examples renders TeachingBubble.Illustration.Example.tsx corr
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TeachingBubble.MultiStep.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TeachingBubble.MultiStep.Example.tsx.shot
@@ -35,7 +35,6 @@ exports[`Component Examples renders TeachingBubble.MultiStep.Example.tsx correct
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TeachingBubble.SmallHeadline.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TeachingBubble.SmallHeadline.Example.tsx.shot
@@ -35,7 +35,6 @@ exports[`Component Examples renders TeachingBubble.SmallHeadline.Example.tsx cor
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TeachingBubble.Wide.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TeachingBubble.Wide.Example.tsx.shot
@@ -35,7 +35,6 @@ exports[`Component Examples renders TeachingBubble.Wide.Example.tsx correctly 1`
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TeachingBubble.WideIllustration.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TeachingBubble.WideIllustration.Example.tsx.shot
@@ -35,7 +35,6 @@ exports[`Component Examples renders TeachingBubble.WideIllustration.Example.tsx 
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.CustomRender.Example.tsx.shot
@@ -106,7 +106,6 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 32px;
               }
               &::-moz-focus-inner {
@@ -197,7 +196,6 @@ exports[`Component Examples renders TextField.CustomRender.Example.tsx correctly
                     margin-right: 4px;
                     margin-top: 0;
                     text-align: center;
-                    vertical-align: middle;
                   }
               data-icon-name="Info"
               role="presentation"

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.AbsolutePosition.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.AbsolutePosition.Example.tsx.shot
@@ -51,7 +51,6 @@ exports[`Component Examples renders Tooltip.AbsolutePosition.Example.tsx correct
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Basic.Example.tsx.shot
@@ -44,7 +44,6 @@ exports[`Component Examples renders Tooltip.Basic.Example.tsx correctly 1`] = `
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Custom.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Custom.Example.tsx.shot
@@ -43,7 +43,6 @@ exports[`Component Examples renders Tooltip.Custom.Example.tsx correctly 1`] = `
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
         }
         &::-moz-focus-inner {
           border: 0;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Interactive.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Tooltip.Interactive.Example.tsx.shot
@@ -44,7 +44,6 @@ exports[`Component Examples renders Tooltip.Interactive.Example.tsx correctly 1`
             text-align: center;
             text-decoration: none;
             user-select: none;
-            vertical-align: top;
           }
           &::-moz-focus-inner {
             border: 0;

--- a/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/PeoplePicker/__snapshots__/PeoplePicker.test.tsx.snap
@@ -522,7 +522,6 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 24px;
                   }
                   &::-moz-focus-inner {
@@ -607,7 +606,6 @@ exports[`PeoplePicker renders correctly with preselected items 1`] = `
                         margin-top: 0;
                         speak: none;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Cancel"
                 >

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/__snapshots__/Suggestions.test.tsx.snap
@@ -70,7 +70,6 @@ exports[`Suggestions renders a list properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -207,7 +206,6 @@ exports[`Suggestions renders a list properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -341,7 +339,6 @@ exports[`Suggestions renders a list properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -475,7 +472,6 @@ exports[`Suggestions renders a list properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -609,7 +605,6 @@ exports[`Suggestions renders a list properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -743,7 +738,6 @@ exports[`Suggestions renders a list properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -877,7 +871,6 @@ exports[`Suggestions renders a list properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -1011,7 +1004,6 @@ exports[`Suggestions renders a list properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -1145,7 +1137,6 @@ exports[`Suggestions renders a list properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -1279,7 +1270,6 @@ exports[`Suggestions renders a list properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -1413,7 +1403,6 @@ exports[`Suggestions renders a list properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -1547,7 +1536,6 @@ exports[`Suggestions renders a list properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -1681,7 +1669,6 @@ exports[`Suggestions renders a list properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -1815,7 +1802,6 @@ exports[`Suggestions renders a list properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -1949,7 +1935,6 @@ exports[`Suggestions renders a list properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -2114,7 +2099,6 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -2251,7 +2235,6 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -2385,7 +2368,6 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -2519,7 +2501,6 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -2653,7 +2634,6 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -2787,7 +2767,6 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -2921,7 +2900,6 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -3055,7 +3033,6 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -3189,7 +3166,6 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -3323,7 +3299,6 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -3457,7 +3432,6 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -3591,7 +3565,6 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -3725,7 +3698,6 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -3859,7 +3831,6 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -3993,7 +3964,6 @@ exports[`Suggestions renders a list properly with CSS-in-JS styles 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -4146,7 +4116,6 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -4280,7 +4249,6 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -4414,7 +4382,6 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -4548,7 +4515,6 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -4682,7 +4648,6 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -4816,7 +4781,6 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -4950,7 +4914,6 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -5084,7 +5047,6 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -5220,7 +5182,6 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -5357,7 +5318,6 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -5491,7 +5451,6 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -5625,7 +5584,6 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -5759,7 +5717,6 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -5893,7 +5850,6 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {
@@ -6027,7 +5983,6 @@ exports[`Suggestions scrolls to selected index properly 1`] = `
                 text-align: center;
                 text-decoration: none;
                 user-select: none;
-                vertical-align: top;
                 width: 100%;
               }
               &::-moz-focus-inner {

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/__snapshots__/TagItem.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/__snapshots__/TagItem.test.tsx.snap
@@ -105,7 +105,6 @@ exports[`TagItem accepts title override 1`] = `
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
           width: 30px;
         }
         &::-moz-focus-inner {
@@ -190,7 +189,6 @@ exports[`TagItem accepts title override 1`] = `
               margin-top: 0;
               speak: none;
               text-align: center;
-              vertical-align: middle;
             }
         data-icon-name="Cancel"
       >
@@ -331,7 +329,6 @@ exports[`TagItem defaults title to item name for non string children 1`] = `
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
           width: 30px;
         }
         &::-moz-focus-inner {
@@ -416,7 +413,6 @@ exports[`TagItem defaults title to item name for non string children 1`] = `
               margin-top: 0;
               speak: none;
               text-align: center;
-              vertical-align: middle;
             }
         data-icon-name="Cancel"
       >
@@ -532,7 +528,6 @@ exports[`TagItem renders correctly 1`] = `
           text-align: center;
           text-decoration: none;
           user-select: none;
-          vertical-align: top;
           width: 30px;
         }
         &::-moz-focus-inner {
@@ -617,7 +612,6 @@ exports[`TagItem renders correctly 1`] = `
               margin-top: 0;
               speak: none;
               text-align: center;
-              vertical-align: middle;
             }
         data-icon-name="Cancel"
       >

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/__snapshots__/TagPicker.test.tsx.snap
@@ -167,7 +167,6 @@ exports[`TagPicker renders correctly 1`] = `
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 30px;
                   }
                   &::-moz-focus-inner {
@@ -252,7 +251,6 @@ exports[`TagPicker renders correctly 1`] = `
                         margin-top: 0;
                         speak: none;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Cancel"
                 >
@@ -479,7 +477,6 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
                     text-align: center;
                     text-decoration: none;
                     user-select: none;
-                    vertical-align: top;
                     width: 30px;
                   }
                   &::-moz-focus-inner {
@@ -564,7 +561,6 @@ exports[`TagPicker renders picker with selected item correctly 1`] = `
                         margin-top: 0;
                         speak: none;
                         text-align: center;
-                        vertical-align: middle;
                       }
                   data-icon-name="Cancel"
                 >


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Chromium DevTools flags these usages of `vertical-align` as "unused" when capturing a "CSS Overview" snapshot on SharePoint Online and Fabric Storybook. I tested by manually modifying the styles and did not notice a visual difference. The fewer styles, the lighter the CSSOM.

Below screenshot is a capture of a SharePoint Online page.

![image](https://user-images.githubusercontent.com/706967/75399933-8a8ada00-58b2-11ea-98e7-d9dfcdf71cc9.png)

Below screenshot is a capture of `master` Fabric Storybook.

![image](https://user-images.githubusercontent.com/706967/75401010-bb204300-58b5-11ea-8290-f324a2c4d1e7.png)

Raising this PR to see if Screener fails visual regression test across the various permutations.

#### Focus areas to test

- Button and Icon visual regression tests should pass.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12090)

cc: @patmill @antonlabunets 