### PR TITLE
Website: fix links to controls with sub-pages

### DIFF
--- a/apps/fabric-website/src/pages/Overviews/ControlsPage/ControlsPage.tsx
+++ b/apps/fabric-website/src/pages/Overviews/ControlsPage/ControlsPage.tsx
@@ -36,6 +36,8 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
             content: (
               <ul className={PageStyles.uListFlex}>
                 {category.pages.map(page => {
+                  // If a page has sub-pages, it's considered a category and doesn't have its own URL.
+                  // Get the URL from the first sub-page instead.
                   const url = page.url || (page.pages && page.pages[0] && page.pages[0].url);
                   return url ? (
                     <li key={url} className={css(PageStyles.uThird)}>

--- a/apps/fabric-website/src/pages/Overviews/ControlsPage/ControlsPage.tsx
+++ b/apps/fabric-website/src/pages/Overviews/ControlsPage/ControlsPage.tsx
@@ -35,11 +35,14 @@ function _otherSections(platform: Platforms): IPageSectionProps<Platforms>[] {
             sectionName: category.title,
             content: (
               <ul className={PageStyles.uListFlex}>
-                {category.pages.map(page => (
-                  <li key={page.url} className={css(PageStyles.uThird)}>
-                    <Link href={page.url}>{page.title}</Link>
-                  </li>
-                ))}
+                {category.pages.map(page => {
+                  const url = page.url || (page.pages && page.pages[0] && page.pages[0].url);
+                  return url ? (
+                    <li key={url} className={css(PageStyles.uThird)}>
+                      <Link href={url}>{page.title}</Link>
+                    </li>
+                  ) : null;
+                })}
               </ul>
             )
           }

--- a/change/@uifabric-fabric-website-2020-02-26-16-25-49-detailslist-link.json
+++ b/change/@uifabric-fabric-website-2020-02-26-16-25-49-detailslist-link.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Controls page: fix links to controls with sub-pages",
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com",
+  "commit": "be9de1a5cef64a5c98aa3ca666bfe61219c4b54c",
+  "dependentChangeType": "patch",
+  "date": "2020-02-27T00:25:49.359Z"
+}


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12031
- [x] Include a change request file using `$ yarn change`

#### Description of changes

On the main controls page of the website, links to controls such as DetailsList and Announced which have sub-pages were not working. This PR fixes the generation of links in that case.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12091)