### PR TITLE
Fix CI environment variable checks

### DIFF
--- a/scripts/config/jest/jestSetup.fluent-ui-react.js
+++ b/scripts/config/jest/jestSetup.fluent-ui-react.js
@@ -13,7 +13,7 @@ enzyme.configure({
   disableLifecycleMethods: true
 });
 
-if (process.env.CI) {
+if (process.env.TF_BUILD) {
   jest.spyOn(console, 'log');
   jest.spyOn(console, 'info');
   jest.spyOn(console, 'warn');

--- a/scripts/gulp/tasks/perf.ts
+++ b/scripts/gulp/tasks/perf.ts
@@ -118,7 +118,7 @@ task('perf:run', async () => {
   const times = (argv.times as string) || DEFAULT_RUN_TIMES;
   const filter = argv.filter;
 
-  const bar = process.env.CI ? { tick: _.noop } : new ProgressBar(':bar :current/:total', { total: times });
+  const bar = process.env.TF_BUILD ? { tick: _.noop } : new ProgressBar(':bar :current/:total', { total: times });
 
   let browser;
 

--- a/scripts/gulp/tasks/stats.ts
+++ b/scripts/gulp/tasks/stats.ts
@@ -189,15 +189,13 @@ task('stats:save', async () => {
 
   const mergedPerfStats = mergePerfStats(perfStats, flamegrillStats);
 
-  const prUrl =
-    process.env.CIRCLE_PULL_REQUEST ||
-    `${process.env.SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI}/pull/${process.env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER}`;
+  const prUrl = `${process.env.SYSTEM_PULLREQUEST_SOURCEREPOSITORYURI}/pull/${process.env.SYSTEM_PULLREQUEST_PULLREQUESTNUMBER}`;
 
   const statsPayload = {
-    sha: process.env.BUILD_SOURCEVERSION || process.env.CIRCLE_SHA1,
-    branch: process.env.BUILD_SOURCEBRANCHNAME || process.env.CIRCLE_BRANCH,
+    sha: process.env.BUILD_SOURCEVERSION,
+    branch: process.env.BUILD_SOURCEBRANCHNAME,
     pr: prUrl, // optional
-    build: process.env.BUILD_BUILDID || process.env.CIRCLE_BUILD_NUM,
+    build: process.env.BUILD_BUILDID,
     ...commandLineArgs, // allow command line overwrites
     bundleSize: bundleStats,
     performance: mergedPerfStats,

--- a/scripts/gulp/tasks/test-unit.ts
+++ b/scripts/gulp/tasks/test-unit.ts
@@ -20,7 +20,7 @@ const jestConfigFromArgv: Partial<JestPluginConfig> = {
   testFilePattern: argv.testFilePattern as string
 };
 
-if (process.env.CI) {
+if (process.env.TF_BUILD) {
   jestConfigFromArgv.maxWorkers = 2;
 }
 

--- a/scripts/jest/setupTests.js
+++ b/scripts/jest/setupTests.js
@@ -13,7 +13,7 @@ enzyme.configure({
   disableLifecycleMethods: true
 });
 
-if (process.env.CI) {
+if (process.env.TF_BUILD) {
   jest.spyOn(console, 'log');
   jest.spyOn(console, 'info');
   jest.spyOn(console, 'warn');

--- a/scripts/puppeteer/puppeteer.config.ts
+++ b/scripts/puppeteer/puppeteer.config.ts
@@ -3,7 +3,7 @@ import { LaunchOptions } from 'puppeteer';
 /** Common set of args to be passed to Chromium. */
 const chromiumArgs: LaunchOptions['args'] = [
   // Workaround for newPage hang in CircleCI: https://github.com/GoogleChrome/puppeteer/issues/1409#issuecomment-453845568
-  process.env.CI && '--single-process'
+  process.env.TF_BUILD && '--single-process'
 ].filter(Boolean);
 
 export const safeLaunchOptions = (launchOptions?: LaunchOptions) => {

--- a/scripts/webpack/webpack.config.ts
+++ b/scripts/webpack/webpack.config.ts
@@ -103,7 +103,7 @@ const webpackConfig: webpack.Configuration = {
       contextRegExp: /moment$/
     }),
     __DEV__ &&
-      !process.env.CI &&
+      !process.env.TF_BUILD &&
       new webpack.ProgressPlugin({
         entries: true,
         modules: true,


### PR DESCRIPTION
Switch checks for CircleCI environment variables (such as `process.env.CI`) to the corresponding ADO variables. Among other things, this helps reduce the amount of log output which is not helpful in CI, such as from ProgressPlugin.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12093)