### PR TITLE
Dialog: fix isOpen deprecated prop no longer being honored

### DIFF
--- a/change/office-ui-fabric-react-2020-02-27-11-49-35-xgao-dialog-isOpen.json
+++ b/change/office-ui-fabric-react-2020-02-27-11-49-35-xgao-dialog-isOpen.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Dialog: fix isOpen deprecated prop no longer being hornored",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "5c496fd32a93cceed4b5e0fe4fbc3bc88a48cefd",
+  "dependentChangeType": "patch",
+  "date": "2020-02-27T19:49:35.063Z"
+}

--- a/change/office-ui-fabric-react-2020-02-27-11-49-35-xgao-dialog-isOpen.json
+++ b/change/office-ui-fabric-react-2020-02-27-11-49-35-xgao-dialog-isOpen.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Dialog: fix isOpen deprecated prop no longer being hornored",
+  "comment": "Dialog: fix isOpen deprecated prop no longer being honored",
   "packageName": "office-ui-fabric-react",
   "email": "xgao@microsoft.com",
   "commit": "5c496fd32a93cceed4b5e0fe4fbc3bc88a48cefd",

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.base.tsx
@@ -162,7 +162,7 @@ export class DialogBase extends React.Component<IDialogProps, {}> {
         {...mergedModalProps}
         isDarkOverlay={mergedModalProps.isDarkOverlay}
         isBlocking={mergedModalProps.isBlocking}
-        isOpen={hidden !== undefined ? !hidden : isOpen}
+        isOpen={isOpen !== undefined ? isOpen : !hidden}
         className={classNames.root}
         containerClassName={classNames.main}
         onDismiss={onDismiss ? onDismiss : mergedModalProps.onDismiss}

--- a/packages/office-ui-fabric-react/src/components/Dialog/Dialog.test.tsx
+++ b/packages/office-ui-fabric-react/src/components/Dialog/Dialog.test.tsx
@@ -71,6 +71,31 @@ describe('Dialog', () => {
     wrapper.unmount();
   });
 
+  it('deprecated isOpen controls open state of the dialog', () => {
+    setWarningCallback(() => {
+      /* suppress deprecation warning as error */
+    });
+
+    jest.useFakeTimers();
+    let dismissedCalled = false;
+
+    const handleDismissed = () => {
+      dismissedCalled = true;
+    };
+    const wrapper = mount(<DialogBase isOpen={true} modalProps={{ onDismissed: handleDismissed }} />);
+
+    expect(document.querySelector('[role="dialog"]')).not.toBeNull();
+    wrapper.setProps({ isOpen: false });
+    wrapper.update();
+
+    jest.runAllTimers();
+    expect(document.querySelector('[role="dialog"]')).toBeNull();
+    expect(dismissedCalled).toEqual(true);
+    wrapper.unmount();
+
+    setWarningCallback();
+  });
+
   it('Properly attaches auto-generated aria attributes IDs', () => {
     const wrapper = mount(
       <DialogBase


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
`hidden` has a default value as `true`, so it's never `undefined` when it's not passed. therefore `isOpen` is not being honored. Added test to cover this deprecated prop since a lot people might still relaying on it.

Regression from [this change](https://github.com/OfficeDev/office-ui-fabric-react/commit/4460bc39dcc5d6f4c7221aa84bed2311aa65ffe0#diff-0160f0383f77d549acdba1fa24f20e2e)

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12106)