### PR TITLE
making sure that the resolve.alias do NOT skip over the fluentui packages

### DIFF
--- a/scripts/webpack/getResolveAlias.js
+++ b/scripts/webpack/getResolveAlias.js
@@ -4,26 +4,48 @@ const findRepoDeps = require('../monorepo/findRepoDeps');
 const findGitRoot = require('../monorepo/findGitRoot');
 const { readConfig } = require('../read-config');
 
+function getOutputPath(packageJson) {
+  for (const mainField of ['module', 'main']) {
+    const main = packageJson[mainField];
+    if (main && main.includes('dist/es')) {
+      return 'dist/es';
+    } else {
+      return 'lib';
+    }
+  }
+
+  return 'lib';
+}
+
 function getResolveAlias() {
   const gitRoot = findGitRoot();
   const deps = findRepoDeps();
+
   const alias = {};
-  const excludedPackages = ['@uifabric/api-docs'];
+  const excludedPackages = ['@uifabric/api-docs', '@uifabric/build'];
 
   let cwd = process.cwd();
   const packageJson = readConfig(path.join(cwd, 'package.json'));
 
   deps.forEach(depInfo => {
-    if (!depInfo.packageJson.private && !excludedPackages.includes(depInfo.packageJson.name)) {
+    if (!excludedPackages.includes(depInfo.packageJson.name)) {
       alias[`${depInfo.packageJson.name}$`] = path.join(gitRoot, depInfo.packagePath, 'src');
       alias[`${depInfo.packageJson.name}/src`] = path.join(gitRoot, depInfo.packagePath, 'src');
-      alias[`${depInfo.packageJson.name}/lib`] = path.join(gitRoot, depInfo.packagePath, 'src');
+
+      const outputPath = getOutputPath(depInfo.packageJson);
+
+      alias[`${depInfo.packageJson.name}/${outputPath}`] = path.join(gitRoot, depInfo.packagePath, 'src');
     }
   });
 
   alias[`${packageJson.name}$`] = path.join(cwd, 'src');
   alias[`${packageJson.name}/src`] = path.join(cwd, 'src');
-  alias[`${packageJson.name}/lib`] = path.join(cwd, 'src');
+
+  const outputPath = getOutputPath(packageJson);
+
+  alias[`${packageJson.name}/${outputPath}`] = path.join(cwd, 'src');
+
+  console.log(alias);
 
   return alias;
 }

--- a/scripts/webpack/getResolveAlias.js
+++ b/scripts/webpack/getResolveAlias.js
@@ -51,8 +51,6 @@ function getResolveAlias() {
 
   alias[`${packageJson.name}/${outputPath}`] = path.join(cwd, 'src');
 
-  console.log(alias);
-
   return alias;
 }
 

--- a/scripts/webpack/getResolveAlias.js
+++ b/scripts/webpack/getResolveAlias.js
@@ -22,7 +22,13 @@ function getResolveAlias() {
   const deps = findRepoDeps();
 
   const alias = {};
-  const excludedPackages = ['@uifabric/api-docs', '@uifabric/build'];
+  const excludedPackages = [
+    '@uifabric/api-docs',
+    '@uifabric/build',
+    '@uifabric/tslint-rules',
+    '@uifabric/webpack-utils',
+    '@uifabric/jest-serializer-merge-styles'
+  ];
 
   let cwd = process.cwd();
   const packageJson = readConfig(path.join(cwd, 'package.json'));


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12107 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This fixes the resolve.alias not being set properly for FUI packages. The issues that blocked us are:

1. FUI packages are currently all `"private": true`
2. the main fields of FUI packages are pointing at `dist/es` or `dist/commonjs` instead of `lib`

So we address both of these concerns with this PR - however, I believe new code should not depend on code deeply inside the packages from same monorepo. That isn't enforced currently, so we will support the deep imports for now.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12107)