### PR TITLE
Make storybook fully use dev mode

### DIFF
--- a/scripts/tasks/storybookTask.js
+++ b/scripts/tasks/storybookTask.js
@@ -6,6 +6,10 @@ const storybook = require('@storybook/react/standalone');
 
 module.exports.startStorybookTask = function startStorybookTask(options) {
   options = options || {};
+  // This shouldn't be necessary but is needed due to strange logic in
+  // storybook lib/core/src/server/config/utils.js
+  process.env.NODE_ENV = 'development';
+
   return async function() {
     let { port, quiet, ci } = argv();
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12099

#### Description of changes

Storybook has some weird logic internally which was preventing it from fully using development mode even when it was told to use development mode. This PR adds a workaround.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12108)