### PR TITLE
Text: use semantic color slot as a default.

### DIFF
--- a/change/office-ui-fabric-react-2020-02-27-14-35-07-text.json
+++ b/change/office-ui-fabric-react-2020-02-27-14-35-07-text.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Text: use semantic color slot as a default",
+  "packageName": "office-ui-fabric-react",
+  "email": "aneeshak@microsoft.com",
+  "commit": "9f2a8f9d54b6eb37934f1b07243bc9bb11546837",
+  "dependentChangeType": "patch",
+  "date": "2020-02-27T22:35:07.408Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Text/Text.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Text/Text.styles.ts
@@ -15,7 +15,9 @@ export const TextStyles: ITextComponent['styles'] = (props: ITextProps, theme: I
         fontFamily: variantObject.fontFamily,
         fontSize: variantObject.fontSize,
         fontWeight: variantObject.fontWeight,
-        color: variantObject.color,
+        // bodyText semantic slot is set to neutralPrimary which is standard for foreground color
+        // if variantObject.color is undefined, it will default to the theme's color
+        color: variantObject.color || theme.semanticColors.bodyText,
         mozOsxFontSmoothing: variantObject.MozOsxFontSmoothing,
         webkitFontSmoothing: variantObject.WebkitFontSmoothing
       },

--- a/packages/office-ui-fabric-react/src/components/Text/__snapshots__/Text.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Text/__snapshots__/Text.test.tsx.snap
@@ -7,6 +7,7 @@ exports[`Text renders Text with {0} as its children correctly 1`] = `
       {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;
+        color: #323130;
         display: inline;
         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
         font-size: 14px;
@@ -26,6 +27,7 @@ exports[`Text renders default Text correctly 1`] = `
       {
         -moz-osx-font-smoothing: grayscale;
         -webkit-font-smoothing: antialiased;
+        color: #323130;
         display: inline;
         font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
         font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.BulkOperations.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.BulkOperations.Example.tsx.shot
@@ -28,6 +28,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
@@ -44,6 +45,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.LazyLoading.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.LazyLoading.Example.tsx.shot
@@ -28,6 +28,7 @@ exports[`Component Examples renders Announced.LazyLoading.Example.tsx correctly 
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.SearchResults.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.SearchResults.Example.tsx.shot
@@ -28,6 +28,7 @@ exports[`Component Examples renders Announced.SearchResults.Example.tsx correctl
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -42,6 +42,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            color: #323130;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -42,6 +42,7 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            color: #323130;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Separator.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Separator.Basic.Example.tsx.shot
@@ -49,6 +49,7 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            color: #323130;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
@@ -134,6 +135,7 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            color: #323130;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
@@ -219,6 +221,7 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            color: #323130;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
@@ -304,6 +307,7 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            color: #323130;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
@@ -410,6 +414,7 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
+              color: #323130;
               display: inline;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
@@ -515,6 +520,7 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
+              color: #323130;
               display: inline;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
@@ -620,6 +626,7 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
+              color: #323130;
               display: inline;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;
@@ -725,6 +732,7 @@ exports[`Component Examples renders Separator.Basic.Example.tsx correctly 1`] = 
             {
               -moz-osx-font-smoothing: grayscale;
               -webkit-font-smoothing: antialiased;
+              color: #323130;
               display: inline;
               font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
               font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Separator.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Separator.Icon.Example.tsx.shot
@@ -28,6 +28,7 @@ exports[`Component Examples renders Separator.Icon.Example.tsx correctly 1`] = `
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Separator.Theming.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Separator.Theming.Example.tsx.shot
@@ -28,6 +28,7 @@ exports[`Component Examples renders Separator.Theming.Example.tsx correctly 1`] 
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Block.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Block.Example.tsx.shot
@@ -8,6 +8,7 @@ Array [
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: block;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
@@ -24,6 +25,7 @@ Array [
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: block;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
@@ -40,6 +42,7 @@ Array [
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: block;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;
@@ -56,6 +59,7 @@ Array [
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: block;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Ramp.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Ramp.Example.tsx.shot
@@ -740,6 +740,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
+                                  color: #323130;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 10px;
@@ -986,6 +987,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
+                                  color: #323130;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 10px;
@@ -1232,6 +1234,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
+                                  color: #323130;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 12px;
@@ -1478,6 +1481,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
+                                  color: #323130;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 12px;
@@ -1724,6 +1728,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
+                                  color: #323130;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 14px;
@@ -1970,6 +1975,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
+                                  color: #323130;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 16px;
@@ -2216,6 +2222,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
+                                  color: #323130;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 18px;
@@ -2462,6 +2469,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
+                                  color: #323130;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 20px;
@@ -2708,6 +2716,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
+                                  color: #323130;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 28px;
@@ -2954,6 +2963,7 @@ exports[`Component Examples renders Text.Ramp.Example.tsx correctly 1`] = `
                                 {
                                   -moz-osx-font-smoothing: grayscale;
                                   -webkit-font-smoothing: antialiased;
+                                  color: #323130;
                                   display: block;
                                   font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
                                   font-size: 68px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Wrap.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Text.Wrap.Example.tsx.shot
@@ -49,6 +49,7 @@ exports[`Component Examples renders Text.Wrap.Example.tsx correctly 1`] = `
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            color: #323130;
             display: block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 18px;
@@ -65,6 +66,7 @@ exports[`Component Examples renders Text.Wrap.Example.tsx correctly 1`] = `
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            color: #323130;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;
@@ -103,6 +105,7 @@ exports[`Component Examples renders Text.Wrap.Example.tsx correctly 1`] = `
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            color: #323130;
             display: block;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 18px;
@@ -119,6 +122,7 @@ exports[`Component Examples renders Text.Wrap.Example.tsx correctly 1`] = `
           {
             -moz-osx-font-smoothing: grayscale;
             -webkit-font-smoothing: antialiased;
+            color: #323130;
             display: inline;
             font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
             font-size: 14px;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Styled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/TextField.Styled.Example.tsx.shot
@@ -28,6 +28,7 @@ exports[`Component Examples renders TextField.Styled.Example.tsx correctly 1`] =
         {
           -moz-osx-font-smoothing: grayscale;
           -webkit-font-smoothing: antialiased;
+          color: #323130;
           display: inline;
           font-family: 'Segoe UI', 'Segoe UI Web (West European)', 'Segoe UI', -apple-system, BlinkMacSystemFont, 'Roboto', 'Helvetica Neue', sans-serif;
           font-size: 14px;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12109 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The `Text` component isn't compatible with applying theme through `Customizations.applySettings` because the `color` in `Text.styles.ts` doesn't directly use Fabric's palette or semantic color slots - instead it goes through the half-baked fonts which don't have color set properly. So this is an attempt to set the default color to be a semantic slot (`bodyText` has the value of `neutralPrimary` which is appropriate and typically used for foregroundColor which is text) so that if the font color is undefined (`variantObject.color`), then it'll fall to a defined theme color. 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12113)