### PR TITLE
SpinButton: fix content overlapping with border under certain resolutions

### DIFF
--- a/change/office-ui-fabric-react-2020-02-28-10-48-43-xgao-fix-spinbutton-style.json
+++ b/change/office-ui-fabric-react-2020-02-28-10-48-43-xgao-fix-spinbutton-style.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "SpinButton: fix SpinButton content overlapping with border under certain resolutions",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "59292ee86d5ac772ff48205efa1d37e53a336720",
+  "dependentChangeType": "patch",
+  "date": "2020-02-28T18:48:43.430Z"
+}

--- a/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/SpinButton.styles.ts
@@ -1,4 +1,4 @@
-import { IRawStyle, ITheme, concatStyleSets, HighContrastSelector, IconFontSizes } from '../../Styling';
+import { IRawStyle, ITheme, concatStyleSets, HighContrastSelector, IconFontSizes, getInputFocusStyle } from '../../Styling';
 import { IButtonStyles } from '../../Button';
 import { ISpinButtonStyles } from './SpinButton.types';
 import { memoizeFunction } from '../../Utilities';
@@ -18,11 +18,13 @@ const _getDisabledStyles = memoizeFunction(
 
     return {
       backgroundColor: SpinButtonBackgroundColorDisabled,
-      borderColor: SpinButtonBackgroundColorDisabled,
       pointerEvents: 'none',
       cursor: 'default',
       color: SpinButtonTextColorDisabled,
       selectors: {
+        ':after': {
+          borderColor: SpinButtonBackgroundColorDisabled
+        },
         [HighContrastSelector]: {
           color: 'GrayText'
         }
@@ -181,38 +183,42 @@ export const getStyles = memoizeFunction(
         boxSizing: 'border-box',
         height: DEFAULT_HEIGHT,
         minWidth: DEFAULT_MIN_WIDTH,
-        border: `1px solid ${SpinButtonRootBorderColor}`,
-        borderRadius: effects.roundedCorner2
+        selectors: {
+          // setting border using pseudo-element here in order to prevent:
+          // input and chevron buttons to overlap border under certain resolutions
+          ':after': {
+            pointerEvents: 'none',
+            content: "''",
+            position: 'absolute',
+            left: 0,
+            top: 0,
+            bottom: 0,
+            right: 0,
+            borderWidth: '1px',
+            borderStyle: 'solid',
+            borderColor: SpinButtonRootBorderColor,
+            borderRadius: effects.roundedCorner2
+          }
+        }
       },
       spinButtonWrapperTopBottom: {
         width: '100%'
       },
       spinButtonWrapperHovered: {
-        borderColor: SpinButtonRootBorderColorHovered,
         selectors: {
-          [HighContrastSelector]: {
-            borderColor: 'Highlight'
-          }
-        }
-      },
-      spinButtonWrapperFocused: {
-        selectors: {
-          [HighContrastSelector]: {
-            borderColor: 'Highlight'
-          },
           ':after': {
-            pointerEvents: 'none',
-            content: "''",
-            position: 'absolute',
-            left: -1,
-            top: -1,
-            bottom: -1,
-            right: -1,
-            border: `2px solid ${SpinButtonRootBorderColorFocused}`,
-            borderRadius: effects.roundedCorner2
+            borderColor: SpinButtonRootBorderColorHovered
+          },
+          [HighContrastSelector]: {
+            selectors: {
+              ':after': {
+                borderColor: 'Highlight'
+              }
+            }
           }
         }
       },
+      spinButtonWrapperFocused: getInputFocusStyle(SpinButtonRootBorderColorFocused, effects.roundedCorner2),
       spinButtonWrapperDisabled: _getDisabledStyles(theme),
       input: {
         boxSizing: 'border-box',
@@ -224,7 +230,7 @@ export const getStyles = memoizeFunction(
         color: SpinButtonInputTextColor,
         backgroundColor: SpinButtonRootBackgroundColor,
         height: '100%',
-        padding: '0 8px',
+        padding: '0 8px 0 9px',
         outline: 0,
         display: 'block',
         minWidth: DEFAULT_MIN_WIDTH - ARROW_BUTTON_WIDTH - 2,

--- a/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/__snapshots__/SpinButton.test.tsx.snap
@@ -58,18 +58,29 @@ exports[`SpinButton renders SpinButton correctly 1`] = `
     className=
 
         {
-          border-radius: 2px;
-          border: 1px solid #605e5c;
           box-sizing: border-box;
           display: flex;
           height: 32px;
           min-width: 86px;
           position: relative;
         }
-        &:hover {
+        &:after {
+          border-color: #605e5c;
+          border-radius: 2px;
+          border-style: solid;
+          border-width: 1px;
+          bottom: 0px;
+          content: '';
+          left: 0px;
+          pointer-events: none;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+        }
+        &:hover:after {
           border-color: #323130;
         }
-        @media screen and (-ms-high-contrast: active){&:hover {
+        @media screen and (-ms-high-contrast: active){&:hover:after {
           border-color: Highlight;
         }
   >
@@ -102,7 +113,7 @@ exports[`SpinButton renders SpinButton correctly 1`] = `
             outline: 0px;
             overflow: hidden;
             padding-bottom: 0;
-            padding-left: 8px;
+            padding-left: 9px;
             padding-right: 8px;
             padding-top: 0;
             text-overflow: ellipsis;
@@ -489,18 +500,29 @@ exports[`SpinButton renders SpinButton correctly with values that the user passe
     className=
 
         {
-          border-radius: 2px;
-          border: 1px solid #605e5c;
           box-sizing: border-box;
           display: flex;
           height: 32px;
           min-width: 86px;
           position: relative;
         }
-        &:hover {
+        &:after {
+          border-color: #605e5c;
+          border-radius: 2px;
+          border-style: solid;
+          border-width: 1px;
+          bottom: 0px;
+          content: '';
+          left: 0px;
+          pointer-events: none;
+          position: absolute;
+          right: 0px;
+          top: 0px;
+        }
+        &:hover:after {
           border-color: #323130;
         }
-        @media screen and (-ms-high-contrast: active){&:hover {
+        @media screen and (-ms-high-contrast: active){&:hover:after {
           border-color: Highlight;
         }
     data-test="test"
@@ -535,7 +557,7 @@ exports[`SpinButton renders SpinButton correctly with values that the user passe
             outline: 0px;
             overflow: hidden;
             padding-bottom: 0;
-            padding-left: 8px;
+            padding-left: 9px;
             padding-right: 8px;
             padding-top: 0;
             text-overflow: ellipsis;

--- a/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.Basic.Example.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { SpinButton } from 'office-ui-fabric-react/lib/SpinButton';
-import { Stack } from '../../Stack';
+import { Stack } from 'office-ui-fabric-react/lib/Stack';
 
 export class SpinButtonBasicExample extends React.Component<any, any> {
   public render(): JSX.Element {

--- a/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.Basic.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/SpinButton/examples/SpinButton.Basic.Example.tsx
@@ -1,10 +1,11 @@
 import * as React from 'react';
 import { SpinButton } from 'office-ui-fabric-react/lib/SpinButton';
+import { Stack } from '../../Stack';
 
 export class SpinButtonBasicExample extends React.Component<any, any> {
   public render(): JSX.Element {
     return (
-      <div style={{ width: '400px' }}>
+      <Stack tokens={{ childrenGap: 10 }} styles={{ root: { width: 400 } }}>
         <SpinButton
           defaultValue="0"
           label={'Basic SpinButton:'}
@@ -29,7 +30,7 @@ export class SpinButtonBasicExample extends React.Component<any, any> {
           incrementButtonAriaLabel={'Increase value by 0.1'}
           decrementButtonAriaLabel={'Decrease value by 0.1'}
         />
-      </div>
+      </Stack>
     );
   }
 }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -631,18 +631,29 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
               className=
 
                   {
-                    border-radius: 2px;
-                    border: 1px solid #605e5c;
                     box-sizing: border-box;
                     display: flex;
                     height: 32px;
                     min-width: 86px;
                     position: relative;
                   }
-                  &:hover {
+                  &:after {
+                    border-color: #605e5c;
+                    border-radius: 2px;
+                    border-style: solid;
+                    border-width: 1px;
+                    bottom: 0px;
+                    content: '';
+                    left: 0px;
+                    pointer-events: none;
+                    position: absolute;
+                    right: 0px;
+                    top: 0px;
+                  }
+                  &:hover:after {
                     border-color: #323130;
                   }
-                  @media screen and (-ms-high-contrast: active){&:hover {
+                  @media screen and (-ms-high-contrast: active){&:hover:after {
                     border-color: Highlight;
                   }
               data-ktp-target="ktp-a-3"
@@ -677,7 +688,7 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                       outline: 0px;
                       overflow: hidden;
                       padding-bottom: 0;
-                      padding-left: 8px;
+                      padding-left: 9px;
                       padding-right: 8px;
                       padding-top: 0;
                       text-overflow: ellipsis;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Basic.Example.tsx.shot
@@ -2,11 +2,25 @@
 
 exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] = `
 <div
-  style={
-    Object {
-      "width": "400px",
-    }
-  }
+  className=
+      ms-Stack
+      {
+        box-sizing: border-box;
+        display: flex;
+        flex-direction: column;
+        flex-wrap: nowrap;
+        height: auto;
+        width: 400px;
+      }
+      & > * {
+        text-overflow: ellipsis;
+      }
+      & > *:not(:first-child) {
+        margin-top: 10px;
+      }
+      & > *:not(.ms-StackItem) {
+        flex-shrink: 1;
+      }
 >
   <div
     className=
@@ -87,18 +101,29 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
       className=
 
           {
-            border-radius: 2px;
-            border: 1px solid #605e5c;
             box-sizing: border-box;
             display: flex;
             height: 32px;
             min-width: 86px;
             position: relative;
           }
-          &:hover {
+          &:after {
+            border-color: #605e5c;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+          &:hover:after {
             border-color: #323130;
           }
-          @media screen and (-ms-high-contrast: active){&:hover {
+          @media screen and (-ms-high-contrast: active){&:hover:after {
             border-color: Highlight;
           }
     >
@@ -131,7 +156,7 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
               outline: 0px;
               overflow: hidden;
               padding-bottom: 0;
-              padding-left: 8px;
+              padding-left: 9px;
               padding-right: 8px;
               padding-top: 0;
               text-overflow: ellipsis;
@@ -517,18 +542,29 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
       className=
 
           {
-            border-radius: 2px;
-            border: 1px solid #605e5c;
             box-sizing: border-box;
             display: flex;
             height: 32px;
             min-width: 86px;
             position: relative;
           }
-          &:hover {
+          &:after {
+            border-color: #605e5c;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+          &:hover:after {
             border-color: #323130;
           }
-          @media screen and (-ms-high-contrast: active){&:hover {
+          @media screen and (-ms-high-contrast: active){&:hover:after {
             border-color: Highlight;
           }
     >
@@ -561,7 +597,7 @@ exports[`Component Examples renders SpinButton.Basic.Example.tsx correctly 1`] =
               outline: 0px;
               overflow: hidden;
               padding-bottom: 0;
-              padding-left: 8px;
+              padding-left: 9px;
               padding-right: 8px;
               padding-top: 0;
               text-overflow: ellipsis;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicDisabled.Example.tsx.shot
@@ -69,9 +69,6 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
 
           {
             background-color: #f3f2f1;
-            border-color: #f3f2f1;
-            border-radius: 2px;
-            border: 1px solid #605e5c;
             box-sizing: border-box;
             color: #a19f9d;
             cursor: default;
@@ -80,6 +77,19 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
             min-width: 86px;
             pointer-events: none;
             position: relative;
+          }
+          &:after {
+            border-color: #f3f2f1;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
           }
           @media screen and (-ms-high-contrast: active){& {
             color: GrayText;
@@ -96,7 +106,6 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
             ms-spinButton-input
             {
               background-color: #f3f2f1;
-              border-color: #f3f2f1;
               border-radius: 2px 0 0 2px;
               border-style: none;
               box-shadow: none;
@@ -115,13 +124,16 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
               outline: 0px;
               overflow: hidden;
               padding-bottom: 0;
-              padding-left: 8px;
+              padding-left: 9px;
               padding-right: 8px;
               padding-top: 0;
               pointer-events: none;
               text-overflow: ellipsis;
               user-select: text;
               white-space: nowrap;
+            }
+            &:after {
+              border-color: #f3f2f1;
             }
             @media screen and (-ms-high-contrast: active){& {
               color: GrayText;
@@ -144,12 +156,14 @@ exports[`Component Examples renders SpinButton.BasicDisabled.Example.tsx correct
 
             {
               background-color: #f3f2f1;
-              border-color: #f3f2f1;
               color: #a19f9d;
               cursor: default;
               display: block;
               height: 100%;
               pointer-events: none;
+            }
+            &:after {
+              border-color: #f3f2f1;
             }
             @media screen and (-ms-high-contrast: active){& {
               color: GrayText;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithEndPosition.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithEndPosition.Example.tsx.shot
@@ -87,18 +87,29 @@ exports[`Component Examples renders SpinButton.BasicWithEndPosition.Example.tsx 
       className=
 
           {
-            border-radius: 2px;
-            border: 1px solid #605e5c;
             box-sizing: border-box;
             display: flex;
             height: 32px;
             min-width: 86px;
             position: relative;
           }
-          &:hover {
+          &:after {
+            border-color: #605e5c;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+          &:hover:after {
             border-color: #323130;
           }
-          @media screen and (-ms-high-contrast: active){&:hover {
+          @media screen and (-ms-high-contrast: active){&:hover:after {
             border-color: Highlight;
           }
     >
@@ -131,7 +142,7 @@ exports[`Component Examples renders SpinButton.BasicWithEndPosition.Example.tsx 
               outline: 0px;
               overflow: hidden;
               padding-bottom: 0;
-              padding-left: 8px;
+              padding-left: 9px;
               padding-right: 8px;
               padding-top: 0;
               text-overflow: ellipsis;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIcon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIcon.Example.tsx.shot
@@ -87,18 +87,29 @@ exports[`Component Examples renders SpinButton.BasicWithIcon.Example.tsx correct
       className=
 
           {
-            border-radius: 2px;
-            border: 1px solid #605e5c;
             box-sizing: border-box;
             display: flex;
             height: 32px;
             min-width: 86px;
             position: relative;
           }
-          &:hover {
+          &:after {
+            border-color: #605e5c;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+          &:hover:after {
             border-color: #323130;
           }
-          @media screen and (-ms-high-contrast: active){&:hover {
+          @media screen and (-ms-high-contrast: active){&:hover:after {
             border-color: Highlight;
           }
     >
@@ -131,7 +142,7 @@ exports[`Component Examples renders SpinButton.BasicWithIcon.Example.tsx correct
               outline: 0px;
               overflow: hidden;
               padding-bottom: 0;
-              padding-left: 8px;
+              padding-left: 9px;
               padding-right: 8px;
               padding-top: 0;
               text-overflow: ellipsis;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.BasicWithIconDisabled.Example.tsx.shot
@@ -92,9 +92,6 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
 
           {
             background-color: #f3f2f1;
-            border-color: #f3f2f1;
-            border-radius: 2px;
-            border: 1px solid #605e5c;
             box-sizing: border-box;
             color: #a19f9d;
             cursor: default;
@@ -103,6 +100,19 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
             min-width: 86px;
             pointer-events: none;
             position: relative;
+          }
+          &:after {
+            border-color: #f3f2f1;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
           }
           @media screen and (-ms-high-contrast: active){& {
             color: GrayText;
@@ -119,7 +129,6 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
             ms-spinButton-input
             {
               background-color: #f3f2f1;
-              border-color: #f3f2f1;
               border-radius: 2px 0 0 2px;
               border-style: none;
               box-shadow: none;
@@ -138,13 +147,16 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
               outline: 0px;
               overflow: hidden;
               padding-bottom: 0;
-              padding-left: 8px;
+              padding-left: 9px;
               padding-right: 8px;
               padding-top: 0;
               pointer-events: none;
               text-overflow: ellipsis;
               user-select: text;
               white-space: nowrap;
+            }
+            &:after {
+              border-color: #f3f2f1;
             }
             @media screen and (-ms-high-contrast: active){& {
               color: GrayText;
@@ -167,12 +179,14 @@ exports[`Component Examples renders SpinButton.BasicWithIconDisabled.Example.tsx
 
             {
               background-color: #f3f2f1;
-              border-color: #f3f2f1;
               color: #a19f9d;
               cursor: default;
               display: block;
               height: 100%;
               pointer-events: none;
+            }
+            &:after {
+              border-color: #f3f2f1;
             }
             @media screen and (-ms-high-contrast: active){& {
               color: GrayText;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.CustomStyled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.CustomStyled.Example.tsx.shot
@@ -59,18 +59,29 @@ exports[`Component Examples renders SpinButton.CustomStyled.Example.tsx correctl
       className=
 
           {
-            border-radius: 2px;
-            border: 1px solid #605e5c;
             box-sizing: border-box;
             display: flex;
             height: 32px;
             min-width: 86px;
             position: relative;
           }
-          &:hover {
+          &:after {
+            border-color: #605e5c;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+          &:hover:after {
             border-color: #323130;
           }
-          @media screen and (-ms-high-contrast: active){&:hover {
+          @media screen and (-ms-high-contrast: active){&:hover:after {
             border-color: Highlight;
           }
     >
@@ -103,7 +114,7 @@ exports[`Component Examples renders SpinButton.CustomStyled.Example.tsx correctl
               outline: 0px;
               overflow: hidden;
               padding-bottom: 0;
-              padding-left: 8px;
+              padding-left: 9px;
               padding-right: 8px;
               padding-top: 0;
               text-overflow: ellipsis;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Stateful.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/SpinButton.Stateful.Example.tsx.shot
@@ -65,18 +65,29 @@ exports[`Component Examples renders SpinButton.Stateful.Example.tsx correctly 1`
       className=
 
           {
-            border-radius: 2px;
-            border: 1px solid #605e5c;
             box-sizing: border-box;
             display: flex;
             height: 32px;
             min-width: 86px;
             position: relative;
           }
-          &:hover {
+          &:after {
+            border-color: #605e5c;
+            border-radius: 2px;
+            border-style: solid;
+            border-width: 1px;
+            bottom: 0px;
+            content: '';
+            left: 0px;
+            pointer-events: none;
+            position: absolute;
+            right: 0px;
+            top: 0px;
+          }
+          &:hover:after {
             border-color: #323130;
           }
-          @media screen and (-ms-high-contrast: active){&:hover {
+          @media screen and (-ms-high-contrast: active){&:hover:after {
             border-color: Highlight;
           }
     >
@@ -109,7 +120,7 @@ exports[`Component Examples renders SpinButton.Stateful.Example.tsx correctly 1`
               outline: 0px;
               overflow: hidden;
               padding-bottom: 0;
-              padding-left: 8px;
+              padding-left: 9px;
               padding-right: 8px;
               padding-top: 0;
               text-overflow: ellipsis;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12023
- [x] Include a change request file using `$ yarn change`

#### Description of changes
The content (input & chevron buttons) would overlap with the border and causing visual defects like:
![image](https://user-images.githubusercontent.com/1207059/75578096-1c602780-5a18-11ea-91e5-f2366471565d.png)
![image](https://user-images.githubusercontent.com/1207059/75578143-30a42480-5a18-11ea-96a2-62f827c8c96c.png)

The fix I made is to set the border using `:after` content, similar to what we did for ComboBox in #11638. A drawback of this fix is for current users who uses `styles` prop to change the border would need to change to set `:after` content border instead. But I still think we should have this fixed since it's affecting Edge/Chrome browsers under popular resolution such as 1920x1080.

Here is after the fix: 
![image](https://user-images.githubusercontent.com/1207059/75578454-b9bb5b80-5a18-11ea-9360-915a3c7c666a.png)

#### Focus areas to test
- Different screen resolutions
- High contrast mode


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12124)