### PR TITLE
fix(FocusZone): handle activeElement === null in IE11 scenarios

### DIFF
--- a/change/@fluentui-react-focus-2020-02-28-12-23-14-focus-zone-null.json
+++ b/change/@fluentui-react-focus-2020-02-28-12-23-14-focus-zone-null.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "FocusZone: When parking focus needs to be detected, IE11 returns `null` for `activeElement`, causing focus to not be restored. We now check for `null` to ensure the feature works correctly in this environment.",
+  "packageName": "@fluentui/react-focus",
+  "email": "dzearing@microsoft.com",
+  "commit": "c0146e0beb2f04b485bd1c3aea57058c6733c53a",
+  "dependentChangeType": "patch",
+  "date": "2020-02-28T20:23:14.622Z"
+}

--- a/packages/fluentui/react-bindings/src/FocusZone/CHANGELOG.md
+++ b/packages/fluentui/react-bindings/src/FocusZone/CHANGELOG.md
@@ -3,6 +3,7 @@
 This is a list of changes made to this Stardust copy of FocusZone in comparison with the original [Fabric FocusZone @ 0f567e05952c6b50c691df2fb72d100b5e525d9e](https://github.com/OfficeDev/office-ui-fabric-react/blob/0f567e05952c6b50c691df2fb72d100b5e525d9e/packages/office-ui-fabric-react/src/components/FocusZone/FocusZone.tsx).
 
 ### Fixes
+- fix(Accessibility): When parking focus needs to be detected, IE11 returns `null` for `activeElement`, causing focus to not be restored. We now check for `null` to ensure the feature works correctly in this environment.
 - fix(Accessibility): Always handle provided onKeyDown event be propagated in inner zone ([#2140](https://github.com/microsoft/fluent-ui-react/pull/2140/files))
 - With `defaultTabbableElement` prop set tab indexes are not updated accordingly ([#342](https://github.com/stardust-ui/react/pull/342))
 - Remove unused prop `componentRef` ([#397](https://github.com/stardust-ui/react/pull/397))

--- a/packages/fluentui/react-bindings/src/FocusZone/FocusZone.tsx
+++ b/packages/fluentui/react-bindings/src/FocusZone/FocusZone.tsx
@@ -167,7 +167,9 @@ export default class FocusZone extends React.Component<FocusZoneProps> implement
     if (
       doc &&
       this._lastIndexPath &&
-      (doc.activeElement === doc.body || (this.props.restoreFocusFromRoot && doc.activeElement === this._root.current))
+      (doc.activeElement === doc.body ||
+        doc.activeElement === null ||
+        (this.props.restoreFocusFromRoot && doc.activeElement === this._root.current))
     ) {
       // The element has been removed after the render, attempt to restore focus.
       const elementToFocus = getFocusableByIndexPath(this._root.current as HTMLElement, this._lastIndexPath);

--- a/packages/react-focus/src/components/FocusZone/FocusZone.tsx
+++ b/packages/react-focus/src/components/FocusZone/FocusZone.tsx
@@ -175,7 +175,7 @@ export class FocusZone extends React.Component<IFocusZoneProps> implements IFocu
     const { current: root } = this._root;
     const doc = this._getDocument();
 
-    if (doc && this._lastIndexPath && (doc.activeElement === doc.body || doc.activeElement === root)) {
+    if (doc && this._lastIndexPath && (doc.activeElement === doc.body || doc.activeElement === root || doc.activeElement === null)) {
       // The element has been removed after the render, attempt to restore focus.
       const elementToFocus = getFocusableByIndexPath(root as HTMLElement, this._lastIndexPath);
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

When we detect if we need to park focus, we check if activeElement has moved to the body. In IE11, the value is null. We need to check for this as well.

* Note: 1st PR where we can fix BOTH copies of FocusZone at the same time!

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12125)