### PR TITLE
Make screener for FUI even faster by not depending on a build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -146,9 +146,6 @@ jobs:
   - job: Deploy
     dependsOn: Build
     steps:
-      # No need for checkout since we're using build artifacts.
-      - checkout: none
-
       - template: azure-pipelines.cache.yml
 
       - template: azure-pipelines.artifacts.yml
@@ -178,17 +175,12 @@ jobs:
         condition: always()
 
   - job: ScreenerFluent
-    dependsOn: Build
     steps:
-      # No need for checkout since we're using build artifacts.
-      - checkout: none
+      - script: |
+          yarn
+        displayName: yarn
 
       - template: azure-pipelines.cache.yml
-
-      - template: azure-pipelines.artifacts.yml
-        parameters:
-          artifact: Build-PR-$(Build.BuildNumber)
-          buildId: $(Build.BuildId)
 
       - template: azure-pipelines.tools.yml
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This will make the Screener FUI job start earlier and rely on its own webpack and build:docs step to generate the bundles. This should cut the build times from 27minutes to 20minutes:

![image](https://user-images.githubusercontent.com/34725/75591468-addd9280-5a34-11ea-8234-f5e1d5c2be06.png)


#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12128)