### PR TITLE
DetailsList: updated drag drop example to be more intuitive, allow dragging to the last row

### DIFF
--- a/change/office-ui-fabric-react-2020-02-28-15-48-39-xgao-drag-drop-dl.json
+++ b/change/office-ui-fabric-react-2020-02-28-15-48-39-xgao-drag-drop-dl.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "DetailsList Example: change drag drop behavior to be more intuitive, allow dragging to the last row",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "7061c70910e6d5078c7405c839fccb4c05e2e9b1",
+  "dependentChangeType": "patch",
+  "date": "2020-02-28T23:48:39.855Z"
+}

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.DragDrop.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.DragDrop.Example.tsx
@@ -192,16 +192,12 @@ export class DetailsListDragDropExample extends React.Component<{}, IDetailsList
       ? (this._selection.getSelection() as IExampleItem[])
       : [this._draggedItem!];
 
+    const insertIndex = this.state.items.indexOf(item);
     const items = this.state.items.filter(itm => draggedItems.indexOf(itm) === -1);
-    let insertIndex = items.indexOf(item);
-
-    // if dragging/dropping on itself, index will be 0.
-    if (insertIndex === -1) {
-      insertIndex = 0;
-    }
 
     items.splice(insertIndex, 0, ...draggedItems);
+    console.log({ insertIndex, draggedItems, items });
 
-    this.setState({ items: items });
+    this.setState({ items });
   }
 }

--- a/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.DragDrop.Example.tsx
+++ b/packages/office-ui-fabric-react/src/components/DetailsList/examples/DetailsList.DragDrop.Example.tsx
@@ -196,7 +196,6 @@ export class DetailsListDragDropExample extends React.Component<{}, IDetailsList
     const items = this.state.items.filter(itm => draggedItems.indexOf(itm) === -1);
 
     items.splice(insertIndex, 0, ...draggedItems);
-    console.log({ insertIndex, draggedItems, items });
 
     this.setState({ items });
   }


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #11675
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Updated the Drag and Drop DetailsList example:
1. Put the dragged row onto the row it got dropped onto (this is a more intuitive experience)
2. By doing 1, we also enable dragging any row the the last row (it's currently impossible to do so)
3. Removed an odd logic: dragging and dropping onto a same row put the row as first row

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12130)