### PR TITLE
Link: Make focus work even when Link has block children

### DIFF
--- a/change/office-ui-fabric-react-2020-02-28-16-59-49-linkFocus.json
+++ b/change/office-ui-fabric-react-2020-02-28-16-59-49-linkFocus.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Link: Make focus work even when Link has block children.",
+  "packageName": "office-ui-fabric-react",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "commit": "95336258136489ea0b76f932e36285438f2a3faf",
+  "dependentChangeType": "patch",
+  "date": "2020-02-29T00:59:49.720Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
+++ b/packages/office-ui-fabric-react/src/components/Link/Link.styles.ts
@@ -32,9 +32,10 @@ export const getStyles = (props: ILinkStyleProps): ILinkStyles => {
           '.ms-Fabric--isFocusVisible &:focus': {
             // Can't use getFocusStyle because it doesn't support wrapping links
             // https://github.com/OfficeDev/office-ui-fabric-react/issues/4883#issuecomment-406743543
-            // A box-shadow allows the focus rect to wrap links that span multiple lines
+            // Using box-shadow and outline allows the focus rect to wrap links that span multiple lines
             // and helps the focus rect avoid getting clipped.
             boxShadow: `0 0 0 1px ${focusBorderColor} inset`,
+            outline: `1px auto ${focusBorderColor}`,
             selectors: {
               [HighContrastSelector]: {
                 outline: '1px solid WindowText'

--- a/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
+++ b/packages/office-ui-fabric-react/src/components/Link/__snapshots__/Link.test.tsx.snap
@@ -16,6 +16,7 @@ exports[`Link renders Link correctly 1`] = `
       }
       .ms-Fabric--isFocusVisible &:focus {
         box-shadow: 0 0 0 1px #605e5c inset;
+        outline: 1px auto #605e5c;
       }
       @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid WindowText;
@@ -80,6 +81,7 @@ exports[`Link renders Link with "as=div" a div element 1`] = `
       }
       .ms-Fabric--isFocusVisible &:focus {
         box-shadow: 0 0 0 1px #605e5c inset;
+        outline: 1px auto #605e5c;
       }
       @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid WindowText;
@@ -131,6 +133,7 @@ exports[`Link renders Link with a custom class name 1`] = `
       }
       .ms-Fabric--isFocusVisible &:focus {
         box-shadow: 0 0 0 1px #605e5c inset;
+        outline: 1px auto #605e5c;
       }
       @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid WindowText;
@@ -194,6 +197,7 @@ exports[`Link renders Link with no href as a button 1`] = `
       }
       .ms-Fabric--isFocusVisible &:focus {
         box-shadow: 0 0 0 1px #605e5c inset;
+        outline: 1px auto #605e5c;
       }
       @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid WindowText;
@@ -248,6 +252,7 @@ exports[`Link renders disabled Link correctly 1`] = `
       }
       .ms-Fabric--isFocusVisible &:focus {
         box-shadow: 0 0 0 1px #605e5c inset;
+        outline: 1px auto #605e5c;
       }
       @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid WindowText;
@@ -303,6 +308,7 @@ exports[`Link renders disabled Link with no href as a button correctly 1`] = `
       }
       .ms-Fabric--isFocusVisible &:focus {
         box-shadow: 0 0 0 1px #605e5c inset;
+        outline: 1px auto #605e5c;
       }
       @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid WindowText;
@@ -366,6 +372,7 @@ exports[`Link supports non button/anchor html attributes when "as=" is used 1`] 
       }
       .ms-Fabric--isFocusVisible &:focus {
         box-shadow: 0 0 0 1px #605e5c inset;
+        outline: 1px auto #605e5c;
       }
       @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
         outline: 1px solid WindowText;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Basic.Example.tsx.shot
@@ -97,6 +97,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;
@@ -177,6 +178,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;
@@ -325,6 +327,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;
@@ -482,6 +485,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;
@@ -551,6 +555,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;
@@ -620,6 +625,7 @@ exports[`Component Examples renders ActivityItem.Basic.Example.tsx correctly 1`]
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/ActivityItem.Persona.Example.tsx.shot
@@ -173,6 +173,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;
@@ -478,6 +479,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;
@@ -547,6 +549,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;
@@ -616,6 +619,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;
@@ -975,6 +979,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;
@@ -1044,6 +1049,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;
@@ -1463,6 +1469,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;
@@ -1532,6 +1539,7 @@ exports[`Component Examples renders ActivityItem.Persona.Example.tsx correctly 1
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.BulkOperations.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Announced.BulkOperations.Example.tsx.shot
@@ -1651,6 +1651,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                     }
                                     .ms-Fabric--isFocusVisible &:focus {
                                       box-shadow: 0 0 0 1px #605e5c inset;
+                                      outline: 1px auto #605e5c;
                                     }
                                     @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                                       outline: 1px solid WindowText;
@@ -2294,6 +2295,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                     }
                                     .ms-Fabric--isFocusVisible &:focus {
                                       box-shadow: 0 0 0 1px #605e5c inset;
+                                      outline: 1px auto #605e5c;
                                     }
                                     @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                                       outline: 1px solid WindowText;
@@ -2937,6 +2939,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                     }
                                     .ms-Fabric--isFocusVisible &:focus {
                                       box-shadow: 0 0 0 1px #605e5c inset;
+                                      outline: 1px auto #605e5c;
                                     }
                                     @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                                       outline: 1px solid WindowText;
@@ -3580,6 +3583,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                     }
                                     .ms-Fabric--isFocusVisible &:focus {
                                       box-shadow: 0 0 0 1px #605e5c inset;
+                                      outline: 1px auto #605e5c;
                                     }
                                     @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                                       outline: 1px solid WindowText;
@@ -4223,6 +4227,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                     }
                                     .ms-Fabric--isFocusVisible &:focus {
                                       box-shadow: 0 0 0 1px #605e5c inset;
+                                      outline: 1px auto #605e5c;
                                     }
                                     @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                                       outline: 1px solid WindowText;
@@ -4866,6 +4871,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                     }
                                     .ms-Fabric--isFocusVisible &:focus {
                                       box-shadow: 0 0 0 1px #605e5c inset;
+                                      outline: 1px auto #605e5c;
                                     }
                                     @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                                       outline: 1px solid WindowText;
@@ -5509,6 +5515,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                     }
                                     .ms-Fabric--isFocusVisible &:focus {
                                       box-shadow: 0 0 0 1px #605e5c inset;
+                                      outline: 1px auto #605e5c;
                                     }
                                     @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                                       outline: 1px solid WindowText;
@@ -6152,6 +6159,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                     }
                                     .ms-Fabric--isFocusVisible &:focus {
                                       box-shadow: 0 0 0 1px #605e5c inset;
+                                      outline: 1px auto #605e5c;
                                     }
                                     @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                                       outline: 1px solid WindowText;
@@ -6795,6 +6803,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                     }
                                     .ms-Fabric--isFocusVisible &:focus {
                                       box-shadow: 0 0 0 1px #605e5c inset;
+                                      outline: 1px auto #605e5c;
                                     }
                                     @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                                       outline: 1px solid WindowText;
@@ -7438,6 +7447,7 @@ exports[`Component Examples renders Announced.BulkOperations.Example.tsx correct
                                     }
                                     .ms-Fabric--isFocusVisible &:focus {
                                       box-shadow: 0 0 0 1px #605e5c inset;
+                                      outline: 1px auto #605e5c;
                                     }
                                     @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                                       outline: 1px solid WindowText;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Icon.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Icon.Example.tsx.shot
@@ -347,6 +347,7 @@ exports[`Component Examples renders Button.Icon.Example.tsx correctly 1`] = `
           }
           .ms-Fabric--isFocusVisible &:focus {
             box-shadow: 0 0 0 1px #605e5c inset;
+            outline: 1px auto #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
             outline: 1px solid WindowText;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Other.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Checkbox.Other.Example.tsx.shot
@@ -615,6 +615,7 @@ exports[`Component Examples renders Checkbox.Other.Example.tsx correctly 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.CustomGroupHeaders.Example.tsx.shot
@@ -799,6 +799,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                   }
                                   .ms-Fabric--isFocusVisible &:focus {
                                     box-shadow: 0 0 0 1px #605e5c inset;
+                                    outline: 1px auto #605e5c;
                                   }
                                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                                     outline: 1px solid WindowText;
@@ -865,6 +866,7 @@ exports[`Component Examples renders DetailsList.CustomGroupHeaders.Example.tsx c
                                   }
                                   .ms-Fabric--isFocusVisible &:focus {
                                     box-shadow: 0 0 0 1px #605e5c inset;
+                                    outline: 1px auto #605e5c;
                                   }
                                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                                     outline: 1px solid WindowText;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DetailsList.NavigatingFocus.Example.tsx.shot
@@ -1097,6 +1097,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 }
                                 .ms-Fabric--isFocusVisible &:focus {
                                   box-shadow: 0 0 0 1px #605e5c inset;
+                                  outline: 1px auto #605e5c;
                                 }
                                 @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                                   outline: 1px solid WindowText;
@@ -1624,6 +1625,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 }
                                 .ms-Fabric--isFocusVisible &:focus {
                                   box-shadow: 0 0 0 1px #605e5c inset;
+                                  outline: 1px auto #605e5c;
                                 }
                                 @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                                   outline: 1px solid WindowText;
@@ -2151,6 +2153,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 }
                                 .ms-Fabric--isFocusVisible &:focus {
                                   box-shadow: 0 0 0 1px #605e5c inset;
+                                  outline: 1px auto #605e5c;
                                 }
                                 @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                                   outline: 1px solid WindowText;
@@ -2678,6 +2681,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 }
                                 .ms-Fabric--isFocusVisible &:focus {
                                   box-shadow: 0 0 0 1px #605e5c inset;
+                                  outline: 1px auto #605e5c;
                                 }
                                 @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                                   outline: 1px solid WindowText;
@@ -3205,6 +3209,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 }
                                 .ms-Fabric--isFocusVisible &:focus {
                                   box-shadow: 0 0 0 1px #605e5c inset;
+                                  outline: 1px auto #605e5c;
                                 }
                                 @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                                   outline: 1px solid WindowText;
@@ -3732,6 +3737,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 }
                                 .ms-Fabric--isFocusVisible &:focus {
                                   box-shadow: 0 0 0 1px #605e5c inset;
+                                  outline: 1px auto #605e5c;
                                 }
                                 @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                                   outline: 1px solid WindowText;
@@ -4259,6 +4265,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 }
                                 .ms-Fabric--isFocusVisible &:focus {
                                   box-shadow: 0 0 0 1px #605e5c inset;
+                                  outline: 1px auto #605e5c;
                                 }
                                 @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                                   outline: 1px solid WindowText;
@@ -4786,6 +4793,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 }
                                 .ms-Fabric--isFocusVisible &:focus {
                                   box-shadow: 0 0 0 1px #605e5c inset;
+                                  outline: 1px auto #605e5c;
                                 }
                                 @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                                   outline: 1px solid WindowText;
@@ -5313,6 +5321,7 @@ exports[`Component Examples renders DetailsList.NavigatingFocus.Example.tsx corr
                                 }
                                 .ms-Fabric--isFocusVisible &:focus {
                                   box-shadow: 0 0 0 1px #605e5c inset;
+                                  outline: 1px auto #605e5c;
                                 }
                                 @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                                   outline: 1px solid WindowText;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Compact.Example.tsx.shot
@@ -558,6 +558,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                   }
                   .ms-Fabric--isFocusVisible &:focus {
                     box-shadow: 0 0 0 1px #605e5c inset;
+                    outline: 1px auto #605e5c;
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                     outline: none;
@@ -666,6 +667,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                   }
                   .ms-Fabric--isFocusVisible &:focus {
                     box-shadow: 0 0 0 1px #605e5c inset;
+                    outline: 1px auto #605e5c;
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                     outline: none;
@@ -774,6 +776,7 @@ exports[`Component Examples renders DocumentCard.Compact.Example.tsx correctly 1
                   }
                   .ms-Fabric--isFocusVisible &:focus {
                     box-shadow: 0 0 0 1px #605e5c inset;
+                    outline: 1px auto #605e5c;
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                     outline: none;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/DocumentCard.Complete.Example.tsx.shot
@@ -158,6 +158,7 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
                 }
                 .ms-Fabric--isFocusVisible &:focus {
                   box-shadow: 0 0 0 1px #605e5c inset;
+                  outline: 1px auto #605e5c;
                 }
                 @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                   outline: none;
@@ -266,6 +267,7 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
                 }
                 .ms-Fabric--isFocusVisible &:focus {
                   box-shadow: 0 0 0 1px #605e5c inset;
+                  outline: 1px auto #605e5c;
                 }
                 @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                   outline: none;
@@ -374,6 +376,7 @@ exports[`Component Examples renders DocumentCard.Complete.Example.tsx correctly 
                 }
                 .ms-Fabric--isFocusVisible &:focus {
                   box-shadow: 0 0 0 1px #605e5c inset;
+                  outline: 1px auto #605e5c;
                 }
                 @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                   outline: none;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Click.Example.tsx.shot
@@ -398,6 +398,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Click.Example.tsx correctl
           }
           .ms-Fabric--isFocusVisible &:focus {
             box-shadow: 0 0 0 1px #605e5c inset;
+            outline: 1px auto #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
             outline: 1px solid WindowText;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.Example.tsx.shot
@@ -582,6 +582,7 @@ exports[`Component Examples renders FocusTrapZone.Box.Example.tsx correctly 1`] 
             }
             .ms-Fabric--isFocusVisible &:focus {
               box-shadow: 0 0 0 1px #605e5c inset;
+              outline: 1px auto #605e5c;
             }
             @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
               outline: 1px solid WindowText;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusTrapZone.Box.FocusOnCustomElement.Example.tsx.shot
@@ -583,6 +583,7 @@ exports[`Component Examples renders FocusTrapZone.Box.FocusOnCustomElement.Examp
             }
             .ms-Fabric--isFocusVisible &:focus {
               box-shadow: 0 0 0 1px #605e5c inset;
+              outline: 1px auto #605e5c;
             }
             @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
               outline: 1px solid WindowText;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.List.Example.tsx.shot
@@ -231,6 +231,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;
@@ -883,6 +884,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;
@@ -1535,6 +1537,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;
@@ -2187,6 +2190,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;
@@ -2839,6 +2843,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;
@@ -3491,6 +3496,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;
@@ -4143,6 +4149,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;
@@ -4795,6 +4802,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;
@@ -5447,6 +5455,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;
@@ -6099,6 +6108,7 @@ exports[`Component Examples renders FocusZone.List.Example.tsx correctly 1`] = `
               }
               .ms-Fabric--isFocusVisible &:focus {
                 box-shadow: 0 0 0 1px #605e5c inset;
+                outline: 1px auto #605e5c;
               }
               @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                 outline: 1px solid WindowText;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Basic.Example.tsx.shot
@@ -1177,6 +1177,7 @@ exports[`Component Examples renders Keytips.Basic.Example.tsx correctly 1`] = `
                   }
                   .ms-Fabric--isFocusVisible &:focus {
                     box-shadow: 0 0 0 1px #605e5c inset;
+                    outline: 1px auto #605e5c;
                   }
                   @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
                     outline: 1px solid WindowText;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Link.Basic.Example.tsx.shot
@@ -19,6 +19,7 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
           }
           .ms-Fabric--isFocusVisible &:focus {
             box-shadow: 0 0 0 1px #605e5c inset;
+            outline: 1px auto #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
             outline: 1px solid WindowText;
@@ -80,6 +81,7 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
           }
           .ms-Fabric--isFocusVisible &:focus {
             box-shadow: 0 0 0 1px #605e5c inset;
+            outline: 1px auto #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
             outline: 1px solid WindowText;
@@ -133,6 +135,7 @@ exports[`Component Examples renders Link.Basic.Example.tsx correctly 1`] = `
           }
           .ms-Fabric--isFocusVisible &:focus {
             box-shadow: 0 0 0 1px #605e5c inset;
+            outline: 1px auto #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
             outline: 1px solid WindowText;

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Basic.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/OverflowSet.Basic.Example.tsx.shot
@@ -62,6 +62,7 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           }
           .ms-Fabric--isFocusVisible &:focus {
             box-shadow: 0 0 0 1px #605e5c inset;
+            outline: 1px auto #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
             outline: 1px solid WindowText;
@@ -138,6 +139,7 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           }
           .ms-Fabric--isFocusVisible &:focus {
             box-shadow: 0 0 0 1px #605e5c inset;
+            outline: 1px auto #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
             outline: 1px solid WindowText;
@@ -214,6 +216,7 @@ exports[`Component Examples renders OverflowSet.Basic.Example.tsx correctly 1`] 
           }
           .ms-Fabric--isFocusVisible &:focus {
             box-shadow: 0 0 0 1px #605e5c inset;
+            outline: 1px auto #605e5c;
           }
           @media screen and (-ms-high-contrast: active){.ms-Fabric--isFocusVisible &:focus {
             outline: 1px solid WindowText;


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12033
- [x] Include a change request file using `$ yarn change`

#### Description of changes

`Links` with block elements as their `children` were not getting focus styling correctly. This was happening due to focus styling being just applied via `boxShadow`. This PR fixes that issue by applying focus styling via both `boxShadow` and `outline`.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12131)