### PR TITLE
Shallow compare performance optimization

### DIFF
--- a/change/@uifabric-utilities-2020-02-29-12-36-47-shallow-compare-optimization.json
+++ b/change/@uifabric-utilities-2020-02-29-12-36-47-shallow-compare-optimization.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Skips unnecessary equality check in shallowCompare to increase performance",
+  "packageName": "@uifabric/utilities",
+  "email": "chce@netcompany.com",
+  "commit": "e590df08d02260882e225af34674b61285d66261",
+  "dependentChangeType": "patch",
+  "date": "2020-02-29T11:36:47.081Z"
+}

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -1133,7 +1133,7 @@ export function setVirtualParent(child: HTMLElement, parent: HTMLElement): void;
 export function setWarningCallback(warningCallback?: (message: string) => void): void;
 
 // @public
-export function shallowCompare<TA, TB>(a: TA, b: TB): boolean;
+export function shallowCompare<TA extends any, TB extends any>(a: TA, b: TB): boolean;
 
 // @public
 export function shouldWrapFocus(element: HTMLElement, noWrapDataAttribute: 'data-no-vertical-wrap' | 'data-no-horizontal-wrap'): boolean;

--- a/packages/utilities/src/object.ts
+++ b/packages/utilities/src/object.ts
@@ -3,8 +3,13 @@ import { getId, resetIds } from './getId';
 
 export { getId, resetIds };
 
+/**
+ * Compares a to b and b to a.
+ *
+ * @public
+ */
 // tslint:disable-next-line:no-any
-function checkProperties(a: any, b: any): boolean {
+export function shallowCompare<TA extends any, TB extends any>(a: TA, b: TB): boolean {
   for (let propName in a) {
     if (a.hasOwnProperty(propName)) {
       if (!b.hasOwnProperty(propName) || b[propName] !== a[propName]) {
@@ -12,17 +17,14 @@ function checkProperties(a: any, b: any): boolean {
       }
     }
   }
-
+  for (let propName in b) {
+    if (b.hasOwnProperty(propName)) {
+      if (!a.hasOwnProperty(propName)) {
+        return false;
+      }
+    }
+  }
   return true;
-}
-
-/**
- * Compares a to b and b to a.
- *
- * @public
- */
-export function shallowCompare<TA, TB>(a: TA, b: TB): boolean {
-  return checkProperties(a, b) && checkProperties(b, a);
 }
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12030 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

I've removed the last equality check in shallowCompare. Either the objects will have all the same properties, in which case it will be fine to only check on the run through of object A, or they will have differing properties, in which case it will be caught in either of the two run-throughs of the properties.
#### Focus areas to test
DetailsList's useReducedRowRenderer, and other components that use this function for object comparison


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12133)