### PR TITLE
chore(build): Do not release fluent0 in CI

### DIFF
--- a/azure-pipelines.release-fluentui.yml
+++ b/azure-pipelines.release-fluentui.yml
@@ -42,15 +42,15 @@ steps:
       storage: fluentsite
       ContainerName: '$web'
       BlobPrefix: ''
-
-  - script: |
-      yarn test
-    displayName: yarn test
-
-  - script: |
-      yarn lint
-    displayName: yarn lint
-
-  - script: |
-      yarn release:fluentui:$(bumpType)
-    displayName: yarn release:fluentui:$(bumpType)
+# No NPM release in CI for now
+#  - script: |
+#      yarn test
+#    displayName: yarn test
+#
+#  - script: |
+#      yarn lint
+#    displayName: yarn lint
+#
+#  - script: |
+#      yarn release:fluentui:$(bumpType)
+#    displayName: yarn release:fluentui:$(bumpType)

--- a/scripts/tasks/fluentui-publish.js
+++ b/scripts/tasks/fluentui-publish.js
@@ -38,16 +38,16 @@ function setLernaPackages(root, packages) {
   }
 }
 
-function gitTagAndPush(root) {
+function gitTag(root) {
   const lernaJsonFile = path.join(root, 'lerna.json');
   const lernaJson = fs.readJSONSync(lernaJsonFile);
   const version = lernaJson.version;
   const tag = `fluentui_v${version}`;
   spawnSync('git', ['tag', '-a', '-f', tag, '-m', tag], { cwd: root });
 
-  if (argv().push) {
-    spawnSync('git', ['push', '--no-verify', '--follow-tags', '--verbose', 'origin', `HEAD:master`], { cwd: root });
-  }
+  logger.info(
+    `Release commit successfully tagged. To push the changes, run 'git push --no-verify --follow-tags --verbose origin HEAD:master'`
+  );
 }
 
 module.exports.fluentuiPrepublish = function() {
@@ -63,7 +63,7 @@ module.exports.fluentuiPostpublish = function() {
   spawnSync('git', ['add', 'packages/fluentui', 'lerna.json'], { cwd: root });
   spawnSync('git', ['commit', '-m', 'bumping @fluentui packages'], { cwd: root });
 
-  gitTagAndPush(root);
+  gitTag(root);
 };
 
 module.exports.fluentuiLernaPublish = function(bumpType) {
@@ -76,7 +76,6 @@ module.exports.fluentuiLernaPublish = function(bumpType) {
       '--no-git-reset',
       '--no-push',
       '--no-git-tag-version',
-      '--yes',
       '--registry',
       argv().registry,
       bumpType
@@ -84,10 +83,14 @@ module.exports.fluentuiLernaPublish = function(bumpType) {
 
     logger.info(`Running this command: npx ${lernaPublishArgs.join(' ')}`);
 
-    spawnSync('npx', lernaPublishArgs, {
+    const result = spawnSync('npx', lernaPublishArgs, {
       cwd: root,
       shell: true,
       stdio: 'inherit'
     });
+
+    if (result.status) {
+      throw new Error(result.error || `lerna publish failed with status ${result.status}`);
+    }
   };
 };


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Fluent0 release in CI is currently broken. As discussed offline with @kenotron, commenting out the CI part.
For now we will stick to manual releases and migrate fluent0 releases to beachball.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12138)