### PR TITLE
Chore: Moving TableCell to be functional

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 ### BREAKING CHANGES
 - Restricted prop sets in the `TreeTitle` & `TreeItem` components which are passed to styles functions @layershifter ([#12103](https://github.com/OfficeDev/office-ui-fabric-react/pull/12103))
 - Changed `indicator` prop in `MenuItem` and `Menu` to be `Box` shorthand instead of `Icon` @mnajdova ([#12145](https://github.com/OfficeDev/office-ui-fabric-react/pull/12145))
+- Restricted prop sets in the `TableCell` component which are passed to styles functions @pompomon ([#12146](https://github.com/OfficeDev/office-ui-fabric-react/pull/12146))
 
 <!--------------------------------[ v0.45.0 ]------------------------------- -->
 ## [v0.45.0](https://github.com/OfficeDev/office-ui-fabric-react/tree/fluentui_v0.45.0) (2020-02-27)

--- a/packages/fluentui/accessibility/src/behaviors/Table/tableCellBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Table/tableCellBehavior.ts
@@ -5,7 +5,7 @@ import { Accessibility } from '../../types';
  * @specification
  * Adds role='cell'.
  */
-const tableCellBehavior: Accessibility = props => ({
+const tableCellBehavior: Accessibility<TableCellBehaviorProps> = props => ({
   attributes: {
     root: {
       role: 'cell'
@@ -14,3 +14,5 @@ const tableCellBehavior: Accessibility = props => ({
 });
 
 export default tableCellBehavior;
+
+export type TableCellBehaviorProps = never;

--- a/packages/fluentui/accessibility/src/behaviors/Table/tableHeaderCellBehavior.ts
+++ b/packages/fluentui/accessibility/src/behaviors/Table/tableHeaderCellBehavior.ts
@@ -1,4 +1,5 @@
 import { Accessibility } from '../../types';
+import { TableCellBehaviorProps } from './tableCellBehavior';
 /**
  * @description
  * Behavior for a table header cell - a cell containing header information for a column.
@@ -6,7 +7,7 @@ import { Accessibility } from '../../types';
  * @specification
  * Adds role='columnheader'.
  */
-const tableHeaderCellBehavior: Accessibility = props => ({
+const tableHeaderCellBehavior: Accessibility<TableCellBehaviorProps> = props => ({
   attributes: {
     root: {
       role: 'columnheader'

--- a/packages/fluentui/accessibility/src/behaviors/index.ts
+++ b/packages/fluentui/accessibility/src/behaviors/index.ts
@@ -85,6 +85,7 @@ export { default as carouselItemBehavior } from './Carousel/carouselItemBehavior
 export { default as tableBehavior } from './Table/tableBehavior';
 export { default as tableRowBehavior } from './Table/tableRowBehavior';
 export { default as tableCellBehavior } from './Table/tableCellBehavior';
+export * from './Table/tableCellBehavior';
 export { default as tableHeaderCellBehavior } from './Table/tableHeaderCellBehavior';
 export { default as gridNestedBehavior } from './Table/gridNestedBehavior';
 export { default as gridHeaderRowBehavior } from './Table/gridHeaderRowBehavior';

--- a/packages/fluentui/react/src/components/Table/TableCell.tsx
+++ b/packages/fluentui/react/src/components/Table/TableCell.tsx
@@ -1,30 +1,29 @@
 import * as customPropTypes from '@fluentui/react-proptypes';
-import { Accessibility, tableCellBehavior } from '@fluentui/accessibility';
+import { Accessibility, tableCellBehavior, TableCellBehaviorProps } from '@fluentui/accessibility';
 import { Ref } from '@fluentui/react-component-ref';
 import * as PropTypes from 'prop-types';
 import * as React from 'react';
 import * as _ from 'lodash';
 import {
-  UIComponent,
   childrenExist,
-  RenderResultConfig,
-  UIComponentProps,
   ChildrenComponentProps,
   commonPropTypes,
   ContentComponentProps,
-  ShorthandFactory,
   createShorthandFactory,
-  applyAccessibilityKeyHandlers
+  UIComponentProps
 } from '../../utils';
+import { useTelemetry, useStyles, getElementType, getUnhandledProps, useAccessibility } from '@fluentui/react-bindings';
+// @ts-ignore
+import { ThemeContext } from 'react-fela';
 import Box, { BoxProps } from '../Box/Box';
-import { WithAsProp, ShorthandValue, withSafeTypeForAs } from '../../types';
+import { WithAsProp, ShorthandValue, withSafeTypeForAs, FluentComponentStaticProps, ProviderContextPrepared } from '../../types';
 
 export interface TableCellProps extends UIComponentProps, ChildrenComponentProps, ContentComponentProps<ShorthandValue<BoxProps>> {
   /**
    * Accessibility behavior if overridden by the user.
    * @available TableCellBehavior
    * */
-  accessibility?: Accessibility;
+  accessibility?: Accessibility<TableCellBehaviorProps>;
 
   /**
    * Truncate cell's content
@@ -32,77 +31,105 @@ export interface TableCellProps extends UIComponentProps, ChildrenComponentProps
   truncateContent?: boolean;
 }
 
+export type TableCellStylesProps = Pick<TableCellProps, 'truncateContent'>;
+
 export interface TableCellSlotClassNames {
   content: string;
 }
 
-class TableCell extends UIComponent<WithAsProp<TableCellProps>> {
-  static displayName = 'TableCell';
+const TableCell: React.FC<WithAsProp<TableCellProps>> &
+  FluentComponentStaticProps<TableCellProps> & {
+    slotClassNames: TableCellSlotClassNames;
+  } = props => {
+  const context: ProviderContextPrepared = React.useContext(ThemeContext);
+  const { setStart, setEnd } = useTelemetry(TableCell.displayName, context.telemetry);
+  setStart();
+  const cellRef = React.useRef<HTMLElement>();
 
-  static className = 'ui-table__cell';
-
-  static slotClassNames: TableCellSlotClassNames = {
-    content: `${TableCell.className}__content`
-  };
-
-  static create: ShorthandFactory<TableCellProps>;
-
-  static propTypes = {
-    ...commonPropTypes.createCommon({
-      content: false
-    }),
-    content: customPropTypes.every([
-      customPropTypes.disallow(['children']),
-      PropTypes.oneOfType([PropTypes.arrayOf(customPropTypes.nodeContent), customPropTypes.nodeContent])
-    ]),
-    truncateContent: PropTypes.bool
-  };
-
-  static defaultProps = {
-    accessibility: tableCellBehavior as Accessibility
-  };
-
-  cellRef = React.createRef<HTMLElement>();
-
-  actionHandlers = {
-    focusCell: e => {
-      e.preventDefault();
-      this.cellRef.current.focus();
+  const { children, content, truncateContent, className, design, styles, variables } = props;
+  const hasChildren = childrenExist(children);
+  const ElementType = getElementType(props);
+  const unhandledProps = getUnhandledProps(TableCell.handledProps, props);
+  const getA11yProps = useAccessibility(props.accessibility, {
+    debugName: TableCell.displayName,
+    actionHandlers: {
+      focusCell: e => {
+        e.preventDefault();
+        cellRef.current.focus();
+      },
+      performClick: e => {
+        handleClick(e);
+      }
     },
-    performClick: e => {
-      this.handleClick(e);
-    }
-  };
+    rtl: context.rtl
+  });
 
-  handleClick = (e: React.SyntheticEvent) => {
+  const { classes, styles: resolvedStyles } = useStyles<TableCellStylesProps>(TableCell.displayName, {
+    className: TableCell.className,
+    mapPropsToStyles: () => ({
+      truncateContent
+    }),
+    mapPropsToInlineStyles: () => ({
+      className,
+      design,
+      styles,
+      variables
+    }),
+    rtl: context.rtl
+  });
+
+  const handleClick = (e: React.SyntheticEvent) => {
     if (e.currentTarget === e.target) {
-      _.invoke(this.props, 'onClick', e, this.props);
+      _.invoke(props, 'onClick', e, props);
       e.preventDefault();
     }
   };
 
-  renderComponent({ accessibility, ElementType, styles, classes, unhandledProps }: RenderResultConfig<any>): React.ReactNode {
-    const { children, content } = this.props;
-    const hasChildren = childrenExist(children);
+  const tableCell = (
+    <Ref innerRef={cellRef}>
+      <ElementType
+        {...getA11yProps('root', {
+          className: classes.root,
+          onClick: handleClick,
+          ...unhandledProps
+        })}
+      >
+        {hasChildren
+          ? children
+          : Box.create(content, {
+              defaultProps: () => ({ as: 'div', styles: resolvedStyles.content })
+            })}
+      </ElementType>
+    </Ref>
+  );
+  setEnd();
+  return tableCell;
+};
 
-    return (
-      <Ref innerRef={this.cellRef}>
-        <ElementType
-          className={classes.root}
-          {...accessibility.attributes.root}
-          {...unhandledProps}
-          {...applyAccessibilityKeyHandlers(accessibility.keyHandlers.root, unhandledProps)}
-        >
-          {hasChildren
-            ? children
-            : Box.create(content, {
-                defaultProps: () => ({ as: 'div', styles: styles.content })
-              })}
-        </ElementType>
-      </Ref>
-    );
-  }
-}
+TableCell.displayName = 'TableCell';
+
+TableCell.className = 'ui-table__cell';
+
+TableCell.slotClassNames = {
+  content: `${TableCell.className}__content`
+};
+
+TableCell.propTypes = {
+  ...commonPropTypes.createCommon({
+    content: false
+  }),
+  content: customPropTypes.every([
+    customPropTypes.disallow(['children']),
+    PropTypes.oneOfType([PropTypes.arrayOf(customPropTypes.nodeContent), customPropTypes.nodeContent])
+  ]),
+  truncateContent: PropTypes.bool
+};
+
+TableCell.handledProps = Object.keys(TableCell.propTypes) as any;
+
+TableCell.defaultProps = {
+  accessibility: tableCellBehavior as Accessibility
+};
 
 TableCell.create = createShorthandFactory({ Component: TableCell, mappedProp: 'content' });
 

--- a/packages/fluentui/react/src/components/Table/TableCell.tsx
+++ b/packages/fluentui/react/src/components/Table/TableCell.tsx
@@ -128,7 +128,7 @@ TableCell.propTypes = {
 TableCell.handledProps = Object.keys(TableCell.propTypes) as any;
 
 TableCell.defaultProps = {
-  accessibility: tableCellBehavior as Accessibility
+  accessibility: tableCellBehavior
 };
 
 TableCell.create = createShorthandFactory({ Component: TableCell, mappedProp: 'content' });

--- a/packages/fluentui/react/src/components/Table/TableCell.tsx
+++ b/packages/fluentui/react/src/components/Table/TableCell.tsx
@@ -78,14 +78,14 @@ const TableCell: React.FC<WithAsProp<TableCellProps>> &
     rtl: context.rtl
   });
 
-  const handleClick = (e: React.SyntheticEvent) => {
+  const handleClick = (e: React.MouseEvent | React.KeyboardEvent) => {
     if (e.currentTarget === e.target) {
       _.invoke(props, 'onClick', e, props);
       e.preventDefault();
     }
   };
 
-  const tableCell = (
+  const element = (
     <Ref innerRef={cellRef}>
       <ElementType
         {...getA11yProps('root', {
@@ -103,7 +103,7 @@ const TableCell: React.FC<WithAsProp<TableCellProps>> &
     </Ref>
   );
   setEnd();
-  return tableCell;
+  return element;
 };
 
 TableCell.displayName = 'TableCell';

--- a/packages/fluentui/react/src/components/Table/TableCell.tsx
+++ b/packages/fluentui/react/src/components/Table/TableCell.tsx
@@ -97,7 +97,7 @@ const TableCell: React.FC<WithAsProp<TableCellProps>> &
         {hasChildren
           ? children
           : Box.create(content, {
-              defaultProps: () => ({ as: 'div', styles: resolvedStyles.content })
+              defaultProps: () => ({ styles: resolvedStyles.content })
             })}
       </ElementType>
     </Ref>

--- a/packages/fluentui/react/src/themes/teams/components/Table/tableCellStyles.ts
+++ b/packages/fluentui/react/src/themes/teams/components/Table/tableCellStyles.ts
@@ -1,13 +1,10 @@
-import { ComponentStyleFunctionParam, ICSSInJSStyle } from '@fluentui/styles';
+import { ComponentSlotStylesPrepared, ICSSInJSStyle } from '@fluentui/styles';
 import { TeamsTableVariables } from './tableVariables';
 import { TableCellStylesProps } from '../../../../components/Table/TableCell';
 import getBorderFocusStyles from '../../getBorderFocusStyles';
 
-export default {
-  root: ({
-    variables: v,
-    theme: { siteVariables }
-  }: ComponentStyleFunctionParam<TableCellStylesProps, TeamsTableVariables>): ICSSInJSStyle => {
+const tableCellStyles: ComponentSlotStylesPrepared<TableCellStylesProps, TeamsTableVariables> = {
+  root: ({ variables: v, theme: { siteVariables } }): ICSSInJSStyle => {
     const borderFocusStyles = getBorderFocusStyles({
       siteVariables
     });
@@ -28,7 +25,7 @@ export default {
       height: '100%'
     };
   },
-  content: ({ props: { truncateContent } }: ComponentStyleFunctionParam<TableCellStylesProps, TeamsTableVariables>): ICSSInJSStyle => {
+  content: ({ props: { truncateContent } }): ICSSInJSStyle => {
     return {
       alignSelf: 'center',
       ...(truncateContent && {
@@ -40,3 +37,5 @@ export default {
     };
   }
 };
+
+export default tableCellStyles;

--- a/packages/fluentui/react/src/themes/teams/components/Table/tableCellStyles.ts
+++ b/packages/fluentui/react/src/themes/teams/components/Table/tableCellStyles.ts
@@ -1,10 +1,13 @@
 import { ComponentStyleFunctionParam, ICSSInJSStyle } from '@fluentui/styles';
 import { TeamsTableVariables } from './tableVariables';
-import { TableCellProps } from '../../../../components/Table/TableCell';
+import { TableCellStylesProps } from '../../../../components/Table/TableCell';
 import getBorderFocusStyles from '../../getBorderFocusStyles';
 
 export default {
-  root: ({ variables: v, theme: { siteVariables } }: ComponentStyleFunctionParam<TableCellProps, TeamsTableVariables>): ICSSInJSStyle => {
+  root: ({
+    variables: v,
+    theme: { siteVariables }
+  }: ComponentStyleFunctionParam<TableCellStylesProps, TeamsTableVariables>): ICSSInJSStyle => {
     const borderFocusStyles = getBorderFocusStyles({
       siteVariables
     });
@@ -25,7 +28,7 @@ export default {
       height: '100%'
     };
   },
-  content: ({ props: { truncateContent } }: ComponentStyleFunctionParam<TableCellProps, TeamsTableVariables>): ICSSInJSStyle => {
+  content: ({ props: { truncateContent } }: ComponentStyleFunctionParam<TableCellStylesProps, TeamsTableVariables>): ICSSInJSStyle => {
     return {
       alignSelf: 'center',
       ...(truncateContent && {

--- a/packages/fluentui/react/src/themes/teams/components/Table/tableCellStyles.ts
+++ b/packages/fluentui/react/src/themes/teams/components/Table/tableCellStyles.ts
@@ -28,7 +28,7 @@ const tableCellStyles: ComponentSlotStylesPrepared<TableCellStylesProps, TeamsTa
   content: ({ props: { truncateContent } }): ICSSInJSStyle => {
     return {
       alignSelf: 'center',
-      ...(truncateContent && {
+      ...(p.truncateContent && {
         display: 'block',
         overflow: 'hidden',
         textOverflow: 'ellipsis',

--- a/packages/fluentui/react/src/themes/teams/components/Table/tableCellStyles.ts
+++ b/packages/fluentui/react/src/themes/teams/components/Table/tableCellStyles.ts
@@ -25,7 +25,7 @@ const tableCellStyles: ComponentSlotStylesPrepared<TableCellStylesProps, TeamsTa
       height: '100%'
     };
   },
-  content: ({ props: { truncateContent } }): ICSSInJSStyle => {
+  content: ({ props: p }): ICSSInJSStyle => {
     return {
       alignSelf: 'center',
       ...(p.truncateContent && {

--- a/packages/fluentui/react/src/themes/teams/types.ts
+++ b/packages/fluentui/react/src/themes/teams/types.ts
@@ -56,9 +56,9 @@ import { HierarchicalTreeTitleProps } from '../../components/HierarchicalTree/Hi
 import { VideoProps } from '../../components/Video/Video';
 import { TreeItemStylesProps } from '../../components/Tree/TreeItem';
 import { TreeTitleStylesProps } from '../../components/Tree/TreeTitle';
-import { TableProps } from 'src/components/Table/Table';
-import { TableRowProps } from 'src/components/Table/TableRow';
-import { TableCellStylesProps } from 'src/components/Table/TableCell';
+import { TableProps } from '../../components/Table/Table';
+import { TableRowProps } from '../../components/Table/TableRow';
+import { TableCellStylesProps } from '../../components/Table/TableCell';
 
 export type TeamsThemeStylesProps = {
   Accordion?: AccordionProps;

--- a/packages/fluentui/react/src/themes/teams/types.ts
+++ b/packages/fluentui/react/src/themes/teams/types.ts
@@ -56,6 +56,9 @@ import { HierarchicalTreeTitleProps } from '../../components/HierarchicalTree/Hi
 import { VideoProps } from '../../components/Video/Video';
 import { TreeItemStylesProps } from '../../components/Tree/TreeItem';
 import { TreeTitleStylesProps } from '../../components/Tree/TreeTitle';
+import { TableProps } from 'src/components/Table/Table';
+import { TableRowProps } from 'src/components/Table/TableRow';
+import { TableCellStylesProps } from 'src/components/Table/TableCell';
 
 export type TeamsThemeStylesProps = {
   Accordion?: AccordionProps;
@@ -114,6 +117,9 @@ export type TeamsThemeStylesProps = {
   HierarchicalTreeItem?: HierarchicalTreeItemProps;
   HierarchicalTreeTitle?: HierarchicalTreeTitleProps;
   Video?: VideoProps;
+  Table?: TableProps;
+  TableRow?: TableRowProps;
+  TableCell?: TableCellStylesProps;
 };
 
 export type TeamsContextualColors = {

--- a/packages/fluentui/react/test/specs/components/Table/TableCell-test.tsx
+++ b/packages/fluentui/react/test/specs/components/Table/TableCell-test.tsx
@@ -4,7 +4,7 @@ import { mountWithProviderAndGetComponent } from 'test/utils';
 import TableCell from 'src/components/Table/TableCell';
 
 describe('TableCell', () => {
-  isConformant(TableCell);
+  isConformant(TableCell, { constructorName: 'TableCell' });
 
   describe('accessiblity', () => {
     handlesAccessibility(TableCell, { defaultRootRole: 'cell' });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This PR converts `TableCell` component to be functional. As in all other cases it contains a breaking change with restricted props set that will be passed to styles functions.

|TableCell|
|-|
|truncateContent|

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12146)