### PR TITLE
TagPicker: key can be string or number in ITag interface.

### DIFF
--- a/change/office-ui-fabric-react-2020-03-02-13-03-02-itag.json
+++ b/change/office-ui-fabric-react-2020-03-02-13-03-02-itag.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "ITag: key can be number, in addition to string.",
+  "packageName": "office-ui-fabric-react",
+  "email": "aneeshak@microsoft.com",
+  "commit": "93886728575eb30677efac4e593c71f30eaed14e",
+  "dependentChangeType": "patch",
+  "date": "2020-03-02T21:03:02.307Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -7440,7 +7440,7 @@ export interface ISwatchColorPickerStyles {
 
 // @public
 export interface ITag {
-    key: string;
+    key: string | number;
     name: string;
 }
 

--- a/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagPicker.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/TagPicker/TagPicker.types.ts
@@ -14,7 +14,7 @@ export interface ITag {
   name: string;
 
   /** Unique key for the item. */
-  key: string;
+  key: string | number;
 }
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12118 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

`ITag` interface's `key` extended to allow type `number`.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12152)