### PR TITLE
Make scrub script clear jest and gulp cache

### DIFF
--- a/scripts/scrub.js
+++ b/scripts/scrub.js
@@ -111,6 +111,10 @@ async function run() {
     }
   }
 
+  // do this first so it can use locally-installed jest (if available) before deleting it
+  console.log('\nClearing Jest cache...');
+  await spawn('npx', ['jest', '--clearCache']);
+
   const failedPaths = [];
 
   console.log("\nDeleting symlinks from packages' node_modules and rush temp files...");

--- a/scripts/scrub.js
+++ b/scripts/scrub.js
@@ -111,9 +111,17 @@ async function run() {
     }
   }
 
-  // do this first so it can use locally-installed jest (if available) before deleting it
+  // do these before deleting node_nodules
   console.log('\nClearing Jest cache...');
   await spawn('npx', ['jest', '--clearCache']);
+  try {
+    console.log('\nAttempting to clear gulp-cache...');
+    const cache = require('gulp-cache');
+    cache.clearAll();
+    console.log('...success!');
+  } catch (err) {
+    console.log('Clearing gulp-cache failed, likely due it not being installed.');
+  }
 
   const failedPaths = [];
 


### PR DESCRIPTION
Jest has a separate transpilation cache stored in the OS temp directory, and sometimes this cache can cause really strange test errors. So I updated the scrub script to include clearing the jest cache.

Also attempt to clear `gulp-cache`'s cache (which is in the temp directory too).

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12154)