### PR TITLE
chore: downgrade `inline-style-prefixer` to 5.1.0

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -11741,9 +11741,9 @@ inline-style-parser@0.1.1:
   integrity sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q==
 
 inline-style-prefixer@^5.1.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-5.1.1.tgz#43074a2c6f2cdb7cb2e8116b23fd04c635188501"
-  integrity sha512-l2zxmdGF/QZNfR3b1hnPr0pkTZUSYYOCCO9zz/AAtaw/LNi1PpjzwumMIz+WKmVhqnWpDdaoqan7yOZM9u2ELQ==
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/inline-style-prefixer/-/inline-style-prefixer-5.1.0.tgz#cb63195f9456dcda25cf59743e45c4d9815b0811"
+  integrity sha512-giteQHPMrApQOSjNSjteO5ZGSGMRf9gas14fRy2lg2buSc1nRnj6o6xuNds5cMTKrkncyrTu3gJn/yflFMVdmg==
   dependencies:
     css-in-js-utils "^2.0.0"
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12162
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

During migration to this repo we accidentally bumped to `inline-style-prefixer@5.1.1` which contains a buggy support for prefixing `span` in CSS grids, https://github.com/robinweser/inline-style-prefixer/blob/master/CHANGELOG.md#511.

We used previously `5.1.0`:
https://github.com/microsoft/fluent-ui-react/blob/c38d3b7926cbc10fc82eb83b63d62a7c4aad9891/yarn.lock#L12588

Until we will have check `5.1.2` I think the best is to downgrade this dependency.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12163)