### PR TITLE
MarqueeSelection: clearing html references on unmount.

### DIFF
--- a/change/office-ui-fabric-react-2020-03-03-08-43-50-marquee.json
+++ b/change/office-ui-fabric-react-2020-03-03-08-43-50-marquee.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "MarqueeSelection: deleting html element references on unmount.",
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com",
+  "commit": "1ced31c315a5109d7576d7744ce7b6b16cf9f82a",
+  "dependentChangeType": "patch",
+  "date": "2020-03-03T16:43:50.555Z"
+}

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
@@ -76,6 +76,8 @@ export class MarqueeSelectionBase extends BaseComponent<IMarqueeSelectionProps, 
     if (this._autoScroll) {
       this._autoScroll.dispose();
     }
+    delete this._scrollableParent;
+    delete this._scrollableSurface;
   }
 
   public render(): JSX.Element {


### PR DESCRIPTION
In case this is a possible leak for child window scenarios, clearing html element references on unmount.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12165)