### PR TITLE
Don't use gulp-cache in CI for now

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - template: azure-pipelines.tools.yml
 
-      - template: azure-pipelines.cache.yml
+      # - template: azure-pipelines.cache.yml
 
       - script: |
           yarn
@@ -69,7 +69,7 @@ jobs:
       # No need for checkout since we're using build artifacts.
       - checkout: none
 
-      - template: azure-pipelines.cache.yml
+      # - template: azure-pipelines.cache.yml
 
       - template: azure-pipelines.artifacts.yml
         parameters:
@@ -102,7 +102,7 @@ jobs:
       # No need for checkout since we're using build artifacts.
       - checkout: none
 
-      - template: azure-pipelines.cache.yml
+      # - template: azure-pipelines.cache.yml
 
       - template: azure-pipelines.artifacts.yml
         parameters:
@@ -146,7 +146,7 @@ jobs:
   - job: Deploy
     dependsOn: Build
     steps:
-      - template: azure-pipelines.cache.yml
+      # - template: azure-pipelines.cache.yml
 
       - template: azure-pipelines.artifacts.yml
         parameters:
@@ -180,7 +180,7 @@ jobs:
           yarn
         displayName: yarn
 
-      - template: azure-pipelines.cache.yml
+      # - template: azure-pipelines.cache.yml
 
       - template: azure-pipelines.tools.yml
 
@@ -207,7 +207,7 @@ jobs:
       # No need for checkout since we're using build artifacts.
       - checkout: none
 
-      - template: azure-pipelines.cache.yml
+      # - template: azure-pipelines.cache.yml
 
       - template: azure-pipelines.artifacts.yml
         parameters:

--- a/scripts/gulp/tasks/docs.ts
+++ b/scripts/gulp/tasks/docs.ts
@@ -26,6 +26,11 @@ import serve, { forceClose } from '../serve';
 
 const { paths } = config;
 
+const localCache = (task: NodeJS.ReadWriteStream, options: Parameters<typeof cache>[1]) => {
+  // don't cache in CI for now
+  return process.env.TF_BUILD ? task : cache(task, options);
+};
+
 const logWatchAdd = (filePath: string) => log('Created', chalk.blue(path.basename(filePath)));
 const logWatchChange = (filePath: string) => log('Changed', chalk.magenta(path.basename(filePath)));
 const logWatchUnlink = (filePath: string) => log('Deleted', chalk.red(path.basename(filePath)));
@@ -76,7 +81,7 @@ const schemaSrc = `${paths.posix.packages('ability-attributes')}/schema.json`;
 
 task('build:docs:component-info', () =>
   src(componentsSrc, { since: lastRun('build:docs:component-info'), cwd: paths.base(), cwdbase: true })
-    .pipe(cache(gulpReactDocgen(['DOMAttributes', 'HTMLAttributes']), { name: 'componentInfo-1' }))
+    .pipe(localCache(gulpReactDocgen(['DOMAttributes', 'HTMLAttributes']), { name: 'componentInfo-1' }))
     .pipe(dest(paths.docsSrc('componentInfo'), { cwd: paths.base() }))
 );
 
@@ -103,7 +108,7 @@ task('build:docs:example-menu', () =>
 task('build:docs:example-sources', () =>
   src(examplesSrc, { since: lastRun('build:docs:example-sources'), cwd: paths.base(), cwdbase: true })
     .pipe(
-      cache(gulpExampleSource(), {
+      localCache(gulpExampleSource(), {
         name: 'exampleSources'
       })
     )
@@ -126,7 +131,7 @@ task('build:docs:images', () => src(`${paths.docsSrc()}/**/*.{png,jpg,gif}`).pip
 
 task('build:docs:toc', () =>
   src(markdownSrc, { since: lastRun('build:docs:toc') }).pipe(
-    cache(gulpDoctoc(), {
+    localCache(gulpDoctoc(), {
       name: 'md-docs'
     })
   )


### PR DESCRIPTION
gulp-cache is sometimes restoring files to the wrong place and breaking CI builds. Turn off caching in CI until we figure out what's wrong.

This will slow down builds, but at least they'll succeed!  👍 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12169)