### PR TITLE
fixes the docgen plugin to inject base and cwd for caching purposes

### DIFF
--- a/azure-pipelines.cache.yml
+++ b/azure-pipelines.cache.yml
@@ -2,9 +2,9 @@
 steps:
   - task: Cache@2
     inputs:
-      key: 'gulp-cache | "$(Agent.OS)"'
+      key: 'gulp-cache-v001 | "$(Agent.OS)"'
       restoreKeys: |
-        gulp-cache | "$(Agent.OS)"
-        gulp-cache
+        gulp-cache-v001 | "$(Agent.OS)"
+        gulp-cache-v001
       path: /tmp/gulp-cache
     displayName: Cache gulp-cache

--- a/scripts/gulp/plugins/gulp-react-docgen.ts
+++ b/scripts/gulp/plugins/gulp-react-docgen.ts
@@ -5,6 +5,10 @@ import Vinyl from 'vinyl';
 
 import { getComponentInfo } from './util';
 
+import config from '../../config';
+
+const { paths } = config;
+
 const pluginName = 'gulp-react-docgen';
 
 export default (ignoredInterfaces: string[] = []) =>
@@ -23,7 +27,10 @@ export default (ignoredInterfaces: string[] = []) =>
       const infoFilename = file.basename.replace(/\.tsx$/, '.info.json');
       const contents = getComponentInfo(file.path, ignoredInterfaces);
 
+      // Forcing the base & cwd to be paths.base() to make sure this is cached & restored at the right location
       const infoFile = new Vinyl({
+        base: paths.base(),
+        cwd: paths.base(),
         path: `./${infoFilename}`,
         contents: Buffer.from(JSON.stringify(contents, null, 2))
       });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

@layershifter pointed out that we're not currently using the fixed cwd / base stuff in the docgen plugin. This will address the fact that some of the gulp-cache files are randomly injected with incorrect base

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12170)