### PR TITLE
Adding proper border color for Menu

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -16,6 +16,7 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Updating `Menu` border in Teams dark theme to the correct color @notandrew ([#12000](https://github.com/OfficeDev/office-ui-fabric-react/pull/12103))
 
 ### BREAKING CHANGES
 - Restricted prop sets in the `TreeTitle` & `TreeItem` components which are passed to styles functions @layershifter ([#12103](https://github.com/OfficeDev/office-ui-fabric-react/pull/12103))

--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -16,7 +16,8 @@
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- Updating `Menu` border in Teams dark theme to the correct color @notandrew ([#12000](https://github.com/OfficeDev/office-ui-fabric-react/pull/12103))
+### Fixes
+- Updating `Menu` border in Teams dark theme to the correct color @notandrew ([#12171](https://github.com/OfficeDev/office-ui-fabric-react/pull/12171))
 
 ### BREAKING CHANGES
 - Restricted prop sets in the `TreeTitle` & `TreeItem` components which are passed to styles functions @layershifter ([#12103](https://github.com/OfficeDev/office-ui-fabric-react/pull/12103))

--- a/packages/fluentui/react/src/themes/teams-dark/components/Menu/menuVariables.ts
+++ b/packages/fluentui/react/src/themes/teams-dark/components/Menu/menuVariables.ts
@@ -25,6 +25,7 @@ export default (siteVars: any): Partial<MenuVariables> => ({
 
   color: siteVars.colors.grey[250],
   colorActive: siteVars.colors.white,
+  borderColor: siteVars.colorScheme.default.border2,
 
   primaryBorderColor: siteVars.colors.grey[600],
   pointingIndicatorBackgroundColor: siteVars.colors.brand[400],


### PR DESCRIPTION
Adding the correct color border to Menu:

before:
![image](https://user-images.githubusercontent.com/6237759/75828353-7aff0b80-5d60-11ea-9b45-df93e6b0c9a0.png)

after:
![image](https://user-images.githubusercontent.com/6237759/75828361-82beb000-5d60-11ea-897e-dfc0b28bb91f.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12171)