### PR TITLE
Tests: Fix spurious infinite timer issue

### DIFF
--- a/change/office-ui-fabric-react-2020-03-03-15-35-01-jg-fix-infinite-timers.json
+++ b/change/office-ui-fabric-react-2020-03-03-15-35-01-jg-fix-infinite-timers.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Add mock for Async to prevent spurious infinite timer issue.",
+  "packageName": "office-ui-fabric-react",
+  "email": "jagore@microsoft.com",
+  "commit": "5c78a6866573bcfa7096bc625c795c3205d69e89",
+  "dependentChangeType": "patch",
+  "date": "2020-03-03T23:35:01.016Z"
+}

--- a/packages/office-ui-fabric-react/__mocks__/@uifabric/utilities.ts
+++ b/packages/office-ui-fabric-react/__mocks__/@uifabric/utilities.ts
@@ -1,0 +1,33 @@
+export * from '@uifabric/utilities';
+import { Async } from '@uifabric/utilities';
+
+// Known issue with jest's runAllTimers and debounce implementations resulting in
+// "Ran 100000 timers, and there are still more! Assuming we've hit an infinite recursion and bailing out..."
+// https://github.com/facebook/jest/issues/3465
+// Mock impl inspired from issue.
+class MockAsync extends Async {
+  public debounce(callback: Function, timeout: number) {
+    let timeoutId: number | null = null;
+    const debounced = (...args: any[]) => {
+      if (timeoutId) {
+        window.clearTimeout(timeoutId);
+      }
+      // Callback functions throughout repo aren't binding properly, so we have to access
+      // Async's private _parent member and invoke callbacks the same way Async.debounce does.
+      const invokeFunction = () => callback.apply((this as any)._parent, args);
+      timeoutId = window.setTimeout(invokeFunction, timeout);
+    };
+
+    const cancel = () => {
+      if (timeoutId) {
+        window.clearTimeout(timeoutId);
+      }
+    };
+
+    (debounced as any).cancel = cancel;
+
+    return debounced as any;
+  }
+}
+
+export { MockAsync as Async };

--- a/packages/office-ui-fabric-react/__mocks__/@uifabric/utilities.ts
+++ b/packages/office-ui-fabric-react/__mocks__/@uifabric/utilities.ts
@@ -1,6 +1,8 @@
 export * from '@uifabric/utilities';
 import { Async } from '@uifabric/utilities';
 
+declare function setTimeout(cb: Function, delay: number): number;
+
 // Known issue with jest's runAllTimers and debounce implementations resulting in
 // "Ran 100000 timers, and there are still more! Assuming we've hit an infinite recursion and bailing out..."
 // https://github.com/facebook/jest/issues/3465
@@ -11,6 +13,7 @@ class MockAsync extends Async {
     const debounced = (...args: any[]) => {
       if (timeoutId) {
         clearTimeout(timeoutId);
+        timeoutId = null;
       }
       // Callback functions throughout repo aren't binding properly, so we have to access
       // Async's private _parent member and invoke callbacks the same way Async.debounce does.
@@ -21,6 +24,7 @@ class MockAsync extends Async {
     const cancel = () => {
       if (timeoutId) {
         clearTimeout(timeoutId);
+        timeoutId = null;
       }
     };
 

--- a/packages/office-ui-fabric-react/__mocks__/@uifabric/utilities.ts
+++ b/packages/office-ui-fabric-react/__mocks__/@uifabric/utilities.ts
@@ -10,17 +10,17 @@ class MockAsync extends Async {
     let timeoutId: number | null = null;
     const debounced = (...args: any[]) => {
       if (timeoutId) {
-        window.clearTimeout(timeoutId);
+        clearTimeout(timeoutId);
       }
       // Callback functions throughout repo aren't binding properly, so we have to access
       // Async's private _parent member and invoke callbacks the same way Async.debounce does.
       const invokeFunction = () => callback.apply((this as any)._parent, args);
-      timeoutId = window.setTimeout(invokeFunction, timeout);
+      timeoutId = setTimeout(invokeFunction, timeout);
     };
 
     const cancel = () => {
       if (timeoutId) {
-        window.clearTimeout(timeoutId);
+        clearTimeout(timeoutId);
       }
     };
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Fix [spurious infinite timer issue on unit tests](https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=55536&view=logs&j=92058b04-f16a-5035-546c-cae3ad5e2f5f&t=17e772b0-f0c3-53ab-7aac-ad6df80e30d7) due to [an issue with jest's `runAllTimers` and debounce implementations](https://github.com/facebook/jest/issues/3465) by adding a mock implementation for `Async.debounce`, similar to [the mock for lodash `debounce`](https://github.com/OfficeDev/office-ui-fabric-react/blob/master/packages/fluentui/react/test/__mocks__/lodash.ts).

![image](https://user-images.githubusercontent.com/26070760/75829886-383f3280-5d64-11ea-9c48-fe7f5cd88735.png)

I was able to repro the issue by forcibly calling `Async.debounce` in a unit test, like so:

```
+import { Async } from '../../Utilities';
 import { mount, ReactWrapper } from 'enzyme';
 import { renderToStaticMarkup } from 'react-dom/server';
 
@@ -412,6 +414,13 @@ describe('TextField with error message', () => {
 
     assertErrorMessage(wrapper.getDOMNode(), errorMessage);
 
+    const AsyncInstance = new Async();
+    const DebounceResultFn2 = AsyncInstance.debounce(() => {
+      console.log('debounced');
+    }, 1000);
+
+    DebounceResultFn2();
+
     wrapper.setProps({ value: '' });
     jest.runAllTimers();
```

And confirmed that this mock fixed the issue.

Search terms: Ran 100000 timers, and there are still more! Assuming we've hit an infinite recursion and bailing out...

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12174)