### PR TITLE
fix(Tree): use context to supply generated props to items

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -21,6 +21,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ### Fixes
 - Fix exports for themes to make them treeshakable @layershifter ([#12224](https://github.com/OfficeDev/office-ui-fabric-react/pull/12224))
+- Fix referentially unstable props in `TreeItem` @silviuavram ([#12182](https://github.com/OfficeDev/office-ui-fabric-react/pull/12182))
 
 <!--------------------------------[ v0.46.0 ]------------------------------- -->
 ## [v0.46.0](https://github.com/OfficeDev/office-ui-fabric-react/tree/fluentui_v0.46.0) (2020-03-05)

--- a/packages/fluentui/docs/src/prototypes/VirtualizedTree/VirtualizedTree.tsx
+++ b/packages/fluentui/docs/src/prototypes/VirtualizedTree/VirtualizedTree.tsx
@@ -18,13 +18,11 @@ function TreeVirtualizer(props: TreeVirtualizerProps) {
     const { renderedItems } = props;
     const { parent } = treeItemProps;
 
-    renderedItems[index].props.onFocusParent(e, treeItemProps);
-
     if (!parent) {
       return;
     }
 
-    const indexOfParent = renderedItems.findIndex((renderedItem: React.ReactElement) => renderedItem.props['id'] === parent['id']);
+    const indexOfParent = renderedItems.findIndex((renderedItem: React.ReactElement) => renderedItem.props['id'] === parent);
 
     // If parent already visible, then it should be focused by Tree.
     if (renderedItems[indexOfParent].props['contentRef'].current) {

--- a/packages/fluentui/docs/src/prototypes/VirtualizedTree/VirtualizedTree.tsx
+++ b/packages/fluentui/docs/src/prototypes/VirtualizedTree/VirtualizedTree.tsx
@@ -4,7 +4,7 @@ import { CellMeasurer, CellMeasurerCache, List as ReactVirtualizedList } from 'r
 import getItems from './itemsGenerator';
 
 interface TreeVirtualizerProps {
-  renderedItems: (React.ReactElement & { ref: React.RefObject<HTMLLIElement> })[];
+  renderedItems: React.ReactElement[];
 }
 
 function TreeVirtualizer(props: TreeVirtualizerProps) {
@@ -23,8 +23,9 @@ function TreeVirtualizer(props: TreeVirtualizerProps) {
     }
 
     const indexOfParent = renderedItems.findIndex((renderedItem: React.ReactElement) => renderedItem.props['id'] === parent);
+
     // If parent already visible, then it should be focused by Tree.
-    if (renderedItems[indexOfParent].ref.current) {
+    if (renderedItems[indexOfParent].props['contentRef'].current) {
       return;
     }
 
@@ -58,7 +59,7 @@ function TreeVirtualizer(props: TreeVirtualizerProps) {
       scrollToIndex={scrollToIndex}
       onRowsRendered={() => {
         if (scrollToIndex !== undefined) {
-          props.renderedItems[scrollToIndex].ref.current.focus();
+          props.renderedItems[scrollToIndex].props.contentRef.current.focus();
           // Once scrolling is complete we remove the index to avoid scrolling to the same
           // item at every render.
           setScrollToIndex(undefined);

--- a/packages/fluentui/docs/src/prototypes/VirtualizedTree/VirtualizedTree.tsx
+++ b/packages/fluentui/docs/src/prototypes/VirtualizedTree/VirtualizedTree.tsx
@@ -4,7 +4,7 @@ import { CellMeasurer, CellMeasurerCache, List as ReactVirtualizedList } from 'r
 import getItems from './itemsGenerator';
 
 interface TreeVirtualizerProps {
-  renderedItems: React.ReactElement[];
+  renderedItems: (React.ReactElement & { ref: React.RefObject<HTMLLIElement> })[];
 }
 
 function TreeVirtualizer(props: TreeVirtualizerProps) {
@@ -23,9 +23,8 @@ function TreeVirtualizer(props: TreeVirtualizerProps) {
     }
 
     const indexOfParent = renderedItems.findIndex((renderedItem: React.ReactElement) => renderedItem.props['id'] === parent);
-
     // If parent already visible, then it should be focused by Tree.
-    if (renderedItems[indexOfParent].props['contentRef'].current) {
+    if (renderedItems[indexOfParent].ref.current) {
       return;
     }
 
@@ -59,7 +58,7 @@ function TreeVirtualizer(props: TreeVirtualizerProps) {
       scrollToIndex={scrollToIndex}
       onRowsRendered={() => {
         if (scrollToIndex !== undefined) {
-          props.renderedItems[scrollToIndex].props.contentRef.current.focus();
+          props.renderedItems[scrollToIndex].ref.current.focus();
           // Once scrolling is complete we remove the index to avoid scrolling to the same
           // item at every render.
           setScrollToIndex(undefined);

--- a/packages/fluentui/react/src/components/Tree/Tree.tsx
+++ b/packages/fluentui/react/src/components/Tree/Tree.tsx
@@ -197,14 +197,6 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
     }
   });
 
-  setActiveItemIds = (e: React.SyntheticEvent, activeItemIds: string[]) => {
-    _.invoke(this.props, 'onActiveItemIdsChange', e, { ...this.props, activeItemIds });
-
-    this.setState({
-      activeItemIds
-    });
-  };
-
   onFocusFirstChild = (itemId: string) => {
     const currentElement = this.itemsRef.get(itemId);
 
@@ -220,6 +212,7 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
 
     elementToBeFocused.focus();
   };
+
   onSiblingsExpand = (e: React.SyntheticEvent, treeItemProps: TreeItemProps) => {
     if (this.props.exclusive) {
       return;
@@ -240,6 +233,7 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
 
     this.setActiveItemIds(e, activeItemIds);
   };
+
   onFocusParent = (parent: string) => {
     const parentRef = this.itemsRef.get(parent);
 
@@ -293,6 +287,14 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
 
     return renderItems(items);
   }
+
+  setActiveItemIds = (e: React.SyntheticEvent, activeItemIds: string[]) => {
+    _.invoke(this.props, 'onActiveItemIdsChange', e, { ...this.props, activeItemIds });
+
+    this.setState({
+      activeItemIds
+    });
+  };
 
   renderComponent({ ElementType, classes, accessibility, unhandledProps }) {
     const { children, renderedItems } = this.props;

--- a/packages/fluentui/react/src/components/Tree/Tree.tsx
+++ b/packages/fluentui/react/src/components/Tree/Tree.tsx
@@ -72,7 +72,7 @@ export interface TreeProps extends UIComponentProps, ChildrenComponentProps {
    * @param renderedItem - The array of rendered items.
    * @returns The render prop result.
    */
-  renderedItems?: (renderedItems: React.ReactElement[]) => React.ReactNode;
+  renderedItems?: (renderedItems: (React.ReactElement & { ref: React.RefObject<HTMLLIElement> })[]) => React.ReactNode;
 }
 
 export interface TreeItemForRenderProps {
@@ -258,7 +258,7 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
     onTitleClick: this.onTitleClick
   };
 
-  renderContent(accessibility: ReactAccessibilityBehavior): React.ReactElement[] {
+  renderContent(accessibility: ReactAccessibilityBehavior): any {
     const { items, renderItemTitle } = this.props;
 
     if (!items) return null;
@@ -273,7 +273,7 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
           this.itemsRef.set(itemId, React.createRef<HTMLElement>());
         }
 
-        const renderedItem = TreeItem.create(item, {
+        const renderedItem = (TreeItem as any).create(item, {
           defaultProps: () => ({
             accessibility: accessibility.childBehaviors ? accessibility.childBehaviors.item : undefined,
             className: Tree.slotClassNames.item,
@@ -283,7 +283,7 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
             parent,
             level,
             index: index + 1, // Used for aria-posinset and it's 1-based.
-            contentRef: this.itemsRef.get(itemId),
+            ref: this.itemsRef.get(itemId),
             treeSize: items.length
           })
         });

--- a/packages/fluentui/react/src/components/Tree/Tree.tsx
+++ b/packages/fluentui/react/src/components/Tree/Tree.tsx
@@ -72,7 +72,7 @@ export interface TreeProps extends UIComponentProps, ChildrenComponentProps {
    * @param renderedItem - The array of rendered items.
    * @returns The render prop result.
    */
-  renderedItems?: (renderedItems: (React.ReactElement & { ref: React.RefObject<HTMLLIElement> })[]) => React.ReactNode;
+  renderedItems?: (renderedItems: React.ReactElement[]) => React.ReactNode;
 }
 
 export interface TreeItemForRenderProps {
@@ -258,7 +258,7 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
     onTitleClick: this.onTitleClick
   };
 
-  renderContent(accessibility: ReactAccessibilityBehavior): any {
+  renderContent(accessibility: ReactAccessibilityBehavior): React.ReactElement[] {
     const { items, renderItemTitle } = this.props;
 
     if (!items) return null;
@@ -273,7 +273,7 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
           this.itemsRef.set(itemId, React.createRef<HTMLElement>());
         }
 
-        const renderedItem = (TreeItem as any).create(item, {
+        const renderedItem = TreeItem.create(item, {
           defaultProps: () => ({
             accessibility: accessibility.childBehaviors ? accessibility.childBehaviors.item : undefined,
             className: Tree.slotClassNames.item,
@@ -283,7 +283,7 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
             parent,
             level,
             index: index + 1, // Used for aria-posinset and it's 1-based.
-            ref: this.itemsRef.get(itemId),
+            contentRef: this.itemsRef.get(itemId),
             treeSize: items.length
           })
         });

--- a/packages/fluentui/react/src/components/Tree/Tree.tsx
+++ b/packages/fluentui/react/src/components/Tree/Tree.tsx
@@ -230,7 +230,7 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
   });
 
   setActiveItemIds = (e: React.SyntheticEvent, activeItemIds: string[]) => {
-    _.invoke(this.props, 'onActiveItemIds', e, { ...this.props, activeItemIds });
+    _.invoke(this.props, 'onActiveItemIdsChange', e, { ...this.props, activeItemIds });
 
     this.setState({
       activeItemIds

--- a/packages/fluentui/react/src/components/Tree/Tree.tsx
+++ b/packages/fluentui/react/src/components/Tree/Tree.tsx
@@ -197,6 +197,16 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
     }
   });
 
+  onFocusParent = (parent: string) => {
+    const parentRef = this.itemsRef.get(parent);
+
+    if (!parentRef || !parentRef.current) {
+      return;
+    }
+
+    parentRef.current.focus();
+  };
+
   onFocusFirstChild = (itemId: string) => {
     const currentElement = this.itemsRef.get(itemId);
 
@@ -232,16 +242,6 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
     }
 
     this.setActiveItemIds(e, activeItemIds);
-  };
-
-  onFocusParent = (parent: string) => {
-    const parentRef = this.itemsRef.get(parent);
-
-    if (!parentRef || !parentRef.current) {
-      return;
-    }
-
-    parentRef.current.focus();
   };
 
   contextValue: TreeItemRenderContextValue = {

--- a/packages/fluentui/react/src/components/Tree/Tree.tsx
+++ b/packages/fluentui/react/src/components/Tree/Tree.tsx
@@ -244,6 +244,14 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
     this.setActiveItemIds(e, activeItemIds);
   };
 
+  setActiveItemIds = (e: React.SyntheticEvent, activeItemIds: string[]) => {
+    _.invoke(this.props, 'onActiveItemIdsChange', e, { ...this.props, activeItemIds });
+
+    this.setState({
+      activeItemIds
+    });
+  };
+
   contextValue: TreeItemRenderContextValue = {
     onFocusParent: this.onFocusParent,
     onSiblingsExpand: this.onSiblingsExpand,
@@ -287,14 +295,6 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
 
     return renderItems(items);
   }
-
-  setActiveItemIds = (e: React.SyntheticEvent, activeItemIds: string[]) => {
-    _.invoke(this.props, 'onActiveItemIdsChange', e, { ...this.props, activeItemIds });
-
-    this.setState({
-      activeItemIds
-    });
-  };
 
   renderComponent({ ElementType, classes, accessibility, unhandledProps }) {
     const { children, renderedItems } = this.props;

--- a/packages/fluentui/react/src/components/Tree/Tree.tsx
+++ b/packages/fluentui/react/src/components/Tree/Tree.tsx
@@ -27,7 +27,7 @@ import {
   ShorthandValue,
   ComponentEventHandler
 } from '../../types';
-import { hasSubtree, removeItemAtIndex, getSiblings, TreeItemContext, TreeItemRenderContextValue } from './utils';
+import { hasSubtree, removeItemAtIndex, getSiblings, TreeContext, TreeRenderContextValue } from './utils';
 
 export interface TreeSlotClassNames {
   item: string;
@@ -251,7 +251,7 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
     });
   };
 
-  contextValue: TreeItemRenderContextValue = {
+  contextValue: TreeRenderContextValue = {
     onFocusParent: this.onFocusParent,
     onSiblingsExpand: this.onSiblingsExpand,
     onFocusFirstChild: this.onFocusFirstChild,
@@ -299,7 +299,7 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
     const { children, renderedItems } = this.props;
 
     return (
-      <TreeItemContext.Provider value={this.contextValue}>
+      <TreeContext.Provider value={this.contextValue}>
         <Ref innerRef={this.treeRef}>
           <ElementType
             className={classes.root}
@@ -315,7 +315,7 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
               : this.renderContent(accessibility)}
           </ElementType>
         </Ref>
-      </TreeItemContext.Provider>
+      </TreeContext.Provider>
     );
   }
 

--- a/packages/fluentui/react/src/components/Tree/Tree.tsx
+++ b/packages/fluentui/react/src/components/Tree/Tree.tsx
@@ -27,7 +27,7 @@ import {
   ShorthandValue,
   ComponentEventHandler
 } from '../../types';
-import { hasSubtree, removeItemAtIndex, TreeItemContext, TreeItemRenderContextValue } from './utils';
+import { hasSubtree, removeItemAtIndex, getSiblings, TreeItemContext, TreeItemRenderContextValue } from './utils';
 
 export interface TreeSlotClassNames {
   item: string;
@@ -177,8 +177,9 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
     }
 
     let { activeItemIds } = this.state;
-    const { id, siblings } = treeItemProps;
-    const { exclusive } = this.props;
+    const { id } = treeItemProps;
+    const { exclusive, items } = this.props;
+    const siblings = getSiblings(items, id);
 
     const activeItemIdIndex = activeItemIds.indexOf(id);
 
@@ -220,12 +221,14 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
   };
 
   onSiblingsExpand = (e: React.SyntheticEvent, treeItemProps: TreeItemProps) => {
-    if (this.props.exclusive) {
+    const { exclusive, items } = this.props;
+    if (exclusive) {
       return;
     }
 
-    const { id: itemId, siblings } = treeItemProps;
+    const { id } = treeItemProps;
     const { activeItemIds } = this.state;
+    const siblings = getSiblings(items, id);
 
     siblings.forEach(sibling => {
       if (hasSubtree(sibling) && !this.isActiveItem(sibling['id'])) {
@@ -233,8 +236,8 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
       }
     });
 
-    if (hasSubtree(treeItemProps) && !this.isActiveItem(itemId)) {
-      activeItemIds.push(itemId);
+    if (hasSubtree(treeItemProps) && !this.isActiveItem(id)) {
+      activeItemIds.push(id);
     }
 
     this.setActiveItemIds(e, activeItemIds);
@@ -280,8 +283,8 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
             parent,
             level,
             index: index + 1, // Used for aria-posinset and it's 1-based.
-            siblings: items.filter(currentItem => currentItem !== item),
-            contentRef: this.itemsRef.get(itemId)
+            contentRef: this.itemsRef.get(itemId),
+            treeSize: items.length
           })
         });
 

--- a/packages/fluentui/react/src/components/Tree/Tree.tsx
+++ b/packages/fluentui/react/src/components/Tree/Tree.tsx
@@ -226,47 +226,6 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
       this.setActiveItemIds(e, activeItemIds);
 
       _.invoke(predefinedProps, 'onTitleClick', e, treeItemProps);
-    },
-    onFocusFirstChild: (e: React.SyntheticEvent, treeItemProps: TreeItemProps) => {
-      const { id } = treeItemProps;
-
-      const { itemsForRender } = this.state;
-      const currentElement = itemsForRender[id].elementRef;
-
-      if (!currentElement || !currentElement.current) {
-        return;
-      }
-
-      const elementToBeFocused = getNextElement(this.treeRef.current, currentElement.current);
-
-      if (!elementToBeFocused) {
-        return;
-      }
-
-      elementToBeFocused.focus();
-      _.invoke(predefinedProps, 'onFocusFirstChild', e, treeItemProps);
-    },
-    onSiblingsExpand: (e: React.SyntheticEvent, treeItemProps: TreeItemProps) => {
-      if (this.props.exclusive) {
-        return;
-      }
-
-      const { id, siblings } = treeItemProps;
-      const { activeItemIds } = this.state;
-
-      siblings.forEach(sibling => {
-        if (hasSubtree(sibling) && !this.isActiveItem(sibling['id'])) {
-          activeItemIds.push(sibling['id']);
-        }
-      });
-
-      if (hasSubtree(treeItemProps) && !this.isActiveItem(id)) {
-        activeItemIds.push(id);
-      }
-
-      this.setActiveItemIds(e, activeItemIds);
-
-      _.invoke(predefinedProps, 'onSiblingsExpand', e, treeItemProps);
     }
   });
 
@@ -278,6 +237,43 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
     });
   };
 
+  onFocusFirstChild = (itemId: string) => {
+    const { itemsForRender } = this.state;
+    const currentElement = itemsForRender[itemId].elementRef;
+
+    if (!currentElement || !currentElement.current) {
+      return;
+    }
+
+    const elementToBeFocused = getNextElement(this.treeRef.current, currentElement.current);
+
+    if (!elementToBeFocused) {
+      return;
+    }
+
+    elementToBeFocused.focus();
+  };
+  onSiblingsExpand = (e: React.SyntheticEvent, treeItemProps: TreeItemProps) => {
+    if (this.props.exclusive) {
+      return;
+    }
+
+    const { id: itemId } = treeItemProps;
+    const { activeItemIds, itemsForRender } = this.state;
+    const siblings = itemsForRender[itemId].siblings;
+
+    siblings.forEach(sibling => {
+      if (hasSubtree(sibling) && !this.isActiveItem(sibling['id'])) {
+        activeItemIds.push(sibling['id']);
+      }
+    });
+
+    if (hasSubtree(treeItemProps) && !this.isActiveItem(itemId)) {
+      activeItemIds.push(itemId);
+    }
+
+    this.setActiveItemIds(e, activeItemIds);
+  };
   onFocusParent = (itemId: string) => {
     const { parentRef } = this.state.itemsForRender[itemId];
 
@@ -289,7 +285,9 @@ class Tree extends AutoControlledComponent<WithAsProp<TreeProps>, TreeState> {
   };
 
   contextValue: TreeItemRenderContextValue = {
-    onFocusParent: this.onFocusParent
+    onFocusParent: this.onFocusParent,
+    onSiblingsExpand: this.onSiblingsExpand,
+    onFocusFirstChild: this.onFocusFirstChild
   };
 
   renderContent(accessibility: ReactAccessibilityBehavior): React.ReactElement[] {

--- a/packages/fluentui/react/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react/src/components/Tree/TreeItem.tsx
@@ -115,7 +115,7 @@ const TreeItem: React.FC<WithAsProp<TreeItemProps>> &
   const hasSubtreeItem = hasSubtree(props);
   // size of the tree without children.
   const treeSize = siblings ? siblings.length + 1 : 1;
-  const { onFocusParent, onSiblingsExpand, onFocusFirstChild } = React.useContext(TreeItemContext);
+  const { onFocusParent, onSiblingsExpand, onFocusFirstChild, onTitleClick } = React.useContext(TreeItemContext);
 
   const getA11Props = useAccessibility(accessibility, {
     actionHandlers: {
@@ -129,8 +129,7 @@ const TreeItem: React.FC<WithAsProp<TreeItemProps>> &
         e.preventDefault();
         e.stopPropagation();
 
-        _.invoke(props, 'onFocusParent', e, props);
-        onFocusParent(props.parent);
+        handleFocusParent(e);
       },
       collapse: e => {
         e.preventDefault();
@@ -148,15 +147,13 @@ const TreeItem: React.FC<WithAsProp<TreeItemProps>> &
         e.preventDefault();
         e.stopPropagation();
 
-        _.invoke(props, 'onFocusFirstChild', e, props);
-        onFocusFirstChild(props.id);
+        handleFocusFirstChild(e);
       },
       expandSiblings: e => {
         e.preventDefault();
         e.stopPropagation();
 
-        _.invoke(props, 'onSiblingsExpand', e, props);
-        onSiblingsExpand(e, props);
+        handleSiblingsExpand(e);
       }
     },
     debugName: TreeItem.className,
@@ -179,7 +176,20 @@ const TreeItem: React.FC<WithAsProp<TreeItemProps>> &
   });
 
   const handleTitleClick = e => {
+    onTitleClick(e, props);
     _.invoke(props, 'onTitleClick', e, props);
+  };
+  const handleFocusFirstChild = e => {
+    _.invoke(props, 'onFocusFirstChild', e, props);
+    onFocusFirstChild(props.id);
+  };
+  const handleFocusParent = e => {
+    _.invoke(props, 'onFocusParent', e, props);
+    onFocusParent(props.parent);
+  };
+  const handleSiblingsExpand = e => {
+    _.invoke(props, 'onSiblingsExpand', e, props);
+    onSiblingsExpand(e, props);
   };
   const handleTitleOverrides = (predefinedProps: TreeTitleProps) => ({
     onClick: (e, titleProps) => {

--- a/packages/fluentui/react/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react/src/components/Tree/TreeItem.tsx
@@ -16,7 +16,16 @@ import {
   ChildrenComponentProps,
   rtlTextContainer
 } from '../../utils';
-import { ComponentEventHandler, ShorthandRenderFunction, ShorthandValue, ShorthandCollection, ProviderContextPrepared } from '../../types';
+import {
+  ComponentEventHandler,
+  WithAsProp,
+  ShorthandRenderFunction,
+  ShorthandValue,
+  withSafeTypeForAs,
+  ShorthandCollection,
+  FluentComponentStaticProps,
+  ProviderContextPrepared
+} from '../../types';
 import TreeTitle, { TreeTitleProps } from './TreeTitle';
 import { hasSubtree, TreeContext } from './utils';
 
@@ -81,16 +90,27 @@ export interface TreeItemProps extends UIComponentProps, ChildrenComponentProps 
 
 export type TreeItemStylesProps = Required<Pick<TreeItemProps, 'level'>>;
 
-const TreeItem: React.FC<TreeItemProps> & {
-  slotClassNames: TreeItemSlotClassNames;
-  className: string;
-  handledProps: (keyof TreeItemProps)[];
-} = (props, ref) => {
+const TreeItem: React.FC<WithAsProp<TreeItemProps>> &
+  FluentComponentStaticProps<TreeItemProps> & { slotClassNames: TreeItemSlotClassNames } = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
   const { setStart, setEnd } = useTelemetry(TreeItem.displayName, context.telemetry);
   setStart();
 
-  const { accessibility, children, className, design, title, renderItemTitle, expanded, level, index, styles, variables, treeSize } = props;
+  const {
+    accessibility,
+    children,
+    className,
+    contentRef,
+    design,
+    title,
+    renderItemTitle,
+    expanded,
+    level,
+    index,
+    styles,
+    variables,
+    treeSize
+  } = props;
 
   const hasSubtreeItem = hasSubtree(props);
   const { onFocusParent, onSiblingsExpand, onFocusFirstChild, onTitleClick } = React.useContext(TreeContext);
@@ -205,7 +225,8 @@ const TreeItem: React.FC<TreeItemProps> & {
           })}
     </ElementType>
   );
-  const elementWithRef = <Ref innerRef={ref}>{element}</Ref>;
+
+  const elementWithRef = contentRef ? <Ref innerRef={contentRef}>{element}</Ref> : element;
   setEnd();
 
   return elementWithRef;
@@ -243,10 +264,8 @@ TreeItem.defaultProps = {
 };
 TreeItem.handledProps = Object.keys(TreeItem.propTypes) as any;
 
-const TreeItemWithRef = React.forwardRef<HTMLLIElement, TreeItemProps>(TreeItem);
-
-(TreeItemWithRef as any).create = createShorthandFactory({
-  Component: TreeItemWithRef,
+TreeItem.create = createShorthandFactory({
+  Component: TreeItem,
   mappedProp: 'title'
 });
 
@@ -256,4 +275,4 @@ const TreeItemWithRef = React.forwardRef<HTMLLIElement, TreeItemProps>(TreeItem)
  * @accessibility
  * Implements [ARIA TreeView](https://www.w3.org/TR/wai-aria-practices-1.1/#TreeView) design pattern.
  */
-export default TreeItemWithRef;
+export default withSafeTypeForAs<typeof TreeItem, TreeItemProps, 'li'>(TreeItem);

--- a/packages/fluentui/react/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react/src/components/Tree/TreeItem.tsx
@@ -49,8 +49,17 @@ export interface TreeItemProps extends UIComponentProps, ChildrenComponentProps 
   /** Level of the tree/subtree that contains this item. */
   level?: number;
 
+  /** Called when the item's first child is about to be focused. */
+  onFocusFirstChild?: ComponentEventHandler<TreeItemProps>;
+
+  /** Called when the item's parent is about to be focused. */
+  onFocusParent?: ComponentEventHandler<TreeItemProps>;
+
   /** Called when a tree title is clicked. */
   onTitleClick?: ComponentEventHandler<TreeItemProps>;
+
+  /** Called when the item's siblings are about to be expanded. */
+  onSiblingsExpand?: ComponentEventHandler<TreeItemProps>;
 
   /** Whether or not the item is in the expanded state. Only makes sense if item has children items. */
   expanded?: boolean;
@@ -102,6 +111,7 @@ const TreeItem: React.FC<WithAsProp<TreeItemProps>> &
         e.preventDefault();
         e.stopPropagation();
 
+        _.invoke(props, 'onFocusParent', e, props);
         onFocusParent(props.id);
       },
       collapse: e => {
@@ -120,12 +130,14 @@ const TreeItem: React.FC<WithAsProp<TreeItemProps>> &
         e.preventDefault();
         e.stopPropagation();
 
+        _.invoke(props, 'onFocusFirstChild', e, props);
         onFocusFirstChild(props.id);
       },
       expandSiblings: e => {
         e.preventDefault();
         e.stopPropagation();
 
+        _.invoke(props, 'onSiblingsExpand', e, props);
         onSiblingsExpand(e, props);
       }
     },
@@ -207,7 +219,10 @@ TreeItem.propTypes = {
   index: PropTypes.number,
   items: customPropTypes.collectionShorthand,
   level: PropTypes.number,
+  onFocusFirstChild: PropTypes.func,
+  onFocusParent: PropTypes.func,
   onTitleClick: PropTypes.func,
+  onSiblingsExpand: PropTypes.func,
   expanded: PropTypes.bool,
   parent: customPropTypes.itemShorthand,
   renderItemTitle: PropTypes.func,

--- a/packages/fluentui/react/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react/src/components/Tree/TreeItem.tsx
@@ -52,12 +52,6 @@ export interface TreeItemProps extends UIComponentProps, ChildrenComponentProps 
   /** Called when a tree title is clicked. */
   onTitleClick?: ComponentEventHandler<TreeItemProps>;
 
-  /** Called when the item's first child is about to be focused. */
-  onFocusFirstChild?: ComponentEventHandler<TreeItemProps>;
-
-  /** Called when the item's siblings are about to be expanded. */
-  onSiblingsExpand?: ComponentEventHandler<TreeItemProps>;
-
   /** Whether or not the item is in the expanded state. Only makes sense if item has children items. */
   expanded?: boolean;
 
@@ -94,7 +88,7 @@ const TreeItem: React.FC<WithAsProp<TreeItemProps>> &
   const hasSubtreeItem = hasSubtree(props);
   // size of the tree without children.
   const treeSize = siblings ? siblings.length + 1 : 1;
-  const { onFocusParent } = React.useContext(TreeItemContext);
+  const { onFocusParent, onSiblingsExpand, onFocusFirstChild } = React.useContext(TreeItemContext);
 
   const getA11Props = useAccessibility(accessibility, {
     actionHandlers: {
@@ -126,13 +120,13 @@ const TreeItem: React.FC<WithAsProp<TreeItemProps>> &
         e.preventDefault();
         e.stopPropagation();
 
-        _.invoke(props, 'onFocusFirstChild', e, props);
+        onFocusFirstChild(props.id);
       },
       expandSiblings: e => {
         e.preventDefault();
         e.stopPropagation();
 
-        _.invoke(props, 'onSiblingsExpand', e, props);
+        onSiblingsExpand(e, props);
       }
     },
     debugName: TreeItem.className,
@@ -214,8 +208,6 @@ TreeItem.propTypes = {
   items: customPropTypes.collectionShorthand,
   level: PropTypes.number,
   onTitleClick: PropTypes.func,
-  onFocusFirstChild: PropTypes.func,
-  onSiblingsExpand: PropTypes.func,
   expanded: PropTypes.bool,
   parent: customPropTypes.itemShorthand,
   renderItemTitle: PropTypes.func,

--- a/packages/fluentui/react/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react/src/components/Tree/TreeItem.tsx
@@ -16,16 +16,7 @@ import {
   ChildrenComponentProps,
   rtlTextContainer
 } from '../../utils';
-import {
-  ComponentEventHandler,
-  WithAsProp,
-  ShorthandRenderFunction,
-  ShorthandValue,
-  withSafeTypeForAs,
-  ShorthandCollection,
-  FluentComponentStaticProps,
-  ProviderContextPrepared
-} from '../../types';
+import { ComponentEventHandler, ShorthandRenderFunction, ShorthandValue, ShorthandCollection, ProviderContextPrepared } from '../../types';
 import TreeTitle, { TreeTitleProps } from './TreeTitle';
 import { hasSubtree, TreeContext } from './utils';
 
@@ -90,27 +81,16 @@ export interface TreeItemProps extends UIComponentProps, ChildrenComponentProps 
 
 export type TreeItemStylesProps = Required<Pick<TreeItemProps, 'level'>>;
 
-const TreeItem: React.FC<WithAsProp<TreeItemProps>> &
-  FluentComponentStaticProps<TreeItemProps> & { slotClassNames: TreeItemSlotClassNames } = props => {
+const TreeItem: React.FC<TreeItemProps> & {
+  slotClassNames: TreeItemSlotClassNames;
+  className: string;
+  handledProps: (keyof TreeItemProps)[];
+} = (props, ref) => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
   const { setStart, setEnd } = useTelemetry(TreeItem.displayName, context.telemetry);
   setStart();
 
-  const {
-    accessibility,
-    children,
-    className,
-    contentRef,
-    design,
-    title,
-    renderItemTitle,
-    expanded,
-    level,
-    index,
-    styles,
-    variables,
-    treeSize
-  } = props;
+  const { accessibility, children, className, design, title, renderItemTitle, expanded, level, index, styles, variables, treeSize } = props;
 
   const hasSubtreeItem = hasSubtree(props);
   const { onFocusParent, onSiblingsExpand, onFocusFirstChild, onTitleClick } = React.useContext(TreeContext);
@@ -225,8 +205,7 @@ const TreeItem: React.FC<WithAsProp<TreeItemProps>> &
           })}
     </ElementType>
   );
-
-  const elementWithRef = contentRef ? <Ref innerRef={contentRef}>{element}</Ref> : element;
+  const elementWithRef = <Ref innerRef={ref}>{element}</Ref>;
   setEnd();
 
   return elementWithRef;
@@ -264,8 +243,10 @@ TreeItem.defaultProps = {
 };
 TreeItem.handledProps = Object.keys(TreeItem.propTypes) as any;
 
-TreeItem.create = createShorthandFactory({
-  Component: TreeItem,
+const TreeItemWithRef = React.forwardRef<HTMLLIElement, TreeItemProps>(TreeItem);
+
+(TreeItemWithRef as any).create = createShorthandFactory({
+  Component: TreeItemWithRef,
   mappedProp: 'title'
 });
 
@@ -275,4 +256,4 @@ TreeItem.create = createShorthandFactory({
  * @accessibility
  * Implements [ARIA TreeView](https://www.w3.org/TR/wai-aria-practices-1.1/#TreeView) design pattern.
  */
-export default withSafeTypeForAs<typeof TreeItem, TreeItemProps, 'li'>(TreeItem);
+export default TreeItemWithRef;

--- a/packages/fluentui/react/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react/src/components/Tree/TreeItem.tsx
@@ -71,9 +71,6 @@ export interface TreeItemProps extends UIComponentProps, ChildrenComponentProps 
   /** The id of the parent tree item, if any. */
   parent?: string;
 
-  /** Array with the ids of the tree item's siblings, if any. */
-  siblings?: ShorthandCollection<TreeItemProps>;
-
   /**
    * A custom render iterator for rendering each tree title.
    * The default component, props, and children are available for each tree title.
@@ -83,6 +80,9 @@ export interface TreeItemProps extends UIComponentProps, ChildrenComponentProps 
    * @param children - The computed children for this slot.
    */
   renderItemTitle?: ShorthandRenderFunction<TreeTitleProps>;
+
+  /** Size of the tree/subtree that contains this item. */
+  treeSize?: number;
 
   /** Properties for TreeTitle. */
   title?: ShorthandValue<TreeTitleProps>;
@@ -107,14 +107,12 @@ const TreeItem: React.FC<WithAsProp<TreeItemProps>> &
     expanded,
     level,
     index,
-    siblings,
     styles,
-    variables
+    variables,
+    treeSize
   } = props;
 
   const hasSubtreeItem = hasSubtree(props);
-  // size of the tree without children.
-  const treeSize = siblings ? siblings.length + 1 : 1;
   const { onFocusParent, onSiblingsExpand, onFocusFirstChild, onTitleClick } = React.useContext(TreeItemContext);
 
   const getA11Props = useAccessibility(accessibility, {
@@ -258,7 +256,7 @@ TreeItem.propTypes = {
   expanded: PropTypes.bool,
   parent: PropTypes.string,
   renderItemTitle: PropTypes.func,
-  siblings: customPropTypes.collectionShorthand,
+  treeSize: PropTypes.number,
   title: customPropTypes.itemShorthand
 };
 TreeItem.defaultProps = {

--- a/packages/fluentui/react/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react/src/components/Tree/TreeItem.tsx
@@ -27,7 +27,7 @@ import {
   ProviderContextPrepared
 } from '../../types';
 import TreeTitle, { TreeTitleProps } from './TreeTitle';
-import { hasSubtree, TreeItemContext } from './utils';
+import { hasSubtree, TreeContext } from './utils';
 
 export interface TreeItemSlotClassNames {
   title: string;
@@ -113,7 +113,7 @@ const TreeItem: React.FC<WithAsProp<TreeItemProps>> &
   } = props;
 
   const hasSubtreeItem = hasSubtree(props);
-  const { onFocusParent, onSiblingsExpand, onFocusFirstChild, onTitleClick } = React.useContext(TreeItemContext);
+  const { onFocusParent, onSiblingsExpand, onFocusFirstChild, onTitleClick } = React.useContext(TreeContext);
 
   const getA11Props = useAccessibility(accessibility, {
     actionHandlers: {

--- a/packages/fluentui/react/src/components/Tree/TreeItem.tsx
+++ b/packages/fluentui/react/src/components/Tree/TreeItem.tsx
@@ -6,6 +6,7 @@ import * as PropTypes from 'prop-types';
 import * as React from 'react';
 // @ts-ignore
 import { ThemeContext } from 'react-fela';
+import { Ref } from '@fluentui/react-component-ref';
 
 import {
   childrenExist,
@@ -37,6 +38,9 @@ export interface TreeItemProps extends UIComponentProps, ChildrenComponentProps 
   /** Accessibility behavior if overridden by the user. */
   accessibility?: Accessibility<TreeItemBehaviorProps>;
 
+  /** Ref for the item DOM element. */
+  contentRef?: React.Ref<HTMLElement>;
+
   /** Id needed to identify this item inside the Tree. */
   id: string;
 
@@ -65,7 +69,7 @@ export interface TreeItemProps extends UIComponentProps, ChildrenComponentProps 
   expanded?: boolean;
 
   /** The id of the parent tree item, if any. */
-  parent?: ShorthandValue<TreeItemProps>;
+  parent?: string;
 
   /** Array with the ids of the tree item's siblings, if any. */
   siblings?: ShorthandCollection<TreeItemProps>;
@@ -92,7 +96,21 @@ const TreeItem: React.FC<WithAsProp<TreeItemProps>> &
   const { setStart, setEnd } = useTelemetry(TreeItem.displayName, context.telemetry);
   setStart();
 
-  const { accessibility, children, className, design, title, renderItemTitle, expanded, level, index, siblings, styles, variables } = props;
+  const {
+    accessibility,
+    children,
+    className,
+    contentRef,
+    design,
+    title,
+    renderItemTitle,
+    expanded,
+    level,
+    index,
+    siblings,
+    styles,
+    variables
+  } = props;
 
   const hasSubtreeItem = hasSubtree(props);
   // size of the tree without children.
@@ -112,7 +130,7 @@ const TreeItem: React.FC<WithAsProp<TreeItemProps>> &
         e.stopPropagation();
 
         _.invoke(props, 'onFocusParent', e, props);
-        onFocusParent(props.id);
+        onFocusParent(props.parent);
       },
       collapse: e => {
         e.preventDefault();
@@ -173,9 +191,7 @@ const TreeItem: React.FC<WithAsProp<TreeItemProps>> &
   const ElementType = getElementType(props);
   const unhandledProps = getUnhandledProps(TreeItem.handledProps, props);
 
-  setEnd();
-
-  return (
+  const element = (
     <ElementType
       {...getA11Props('root', {
         className: classes.root,
@@ -201,6 +217,11 @@ const TreeItem: React.FC<WithAsProp<TreeItemProps>> &
           })}
     </ElementType>
   );
+
+  const elementWithRef = contentRef ? <Ref innerRef={contentRef}>{element}</Ref> : element;
+  setEnd();
+
+  return elementWithRef;
 };
 
 TreeItem.className = 'ui-tree__item';
@@ -215,6 +236,7 @@ TreeItem.propTypes = {
   ...commonPropTypes.createCommon({
     content: false
   }),
+  contentRef: customPropTypes.ref,
   id: PropTypes.string.isRequired,
   index: PropTypes.number,
   items: customPropTypes.collectionShorthand,
@@ -224,7 +246,7 @@ TreeItem.propTypes = {
   onTitleClick: PropTypes.func,
   onSiblingsExpand: PropTypes.func,
   expanded: PropTypes.bool,
-  parent: customPropTypes.itemShorthand,
+  parent: PropTypes.string,
   renderItemTitle: PropTypes.func,
   siblings: customPropTypes.collectionShorthand,
   title: customPropTypes.itemShorthand

--- a/packages/fluentui/react/src/components/Tree/utils/index.ts
+++ b/packages/fluentui/react/src/components/Tree/utils/index.ts
@@ -11,6 +11,36 @@ export const removeItemAtIndex = (items: any[], itemIndex: number): any[] => {
   return [...items.slice(0, itemIndex), ...items.slice(itemIndex + 1)];
 };
 
+/**
+ * Looks for the item inside the nested items array and returns its siblings.
+ * @param {any[]} items The nested items array.
+ * @param {string} itemId The id of the item to return the children of.
+ * @returns {any[]} The item siblings
+ */
+export const getSiblings = (items: any[], itemId: string): any[] => {
+  function getSiblingsFn(items: any[]) {
+    const itemIndex = items.findIndex(item => item.id === itemId);
+
+    if (itemIndex > -1) {
+      return removeItemAtIndex(items, itemIndex);
+    }
+
+    for (const item of items) {
+      if (item.items) {
+        const result = getSiblingsFn(item.items);
+
+        if (result) {
+          return result;
+        }
+      }
+    }
+
+    return null;
+  }
+
+  return getSiblingsFn(items);
+};
+
 export interface TreeItemRenderContextValue {
   onFocusFirstChild: (itemId: string) => void;
   onFocusParent: (itemId: string) => void;

--- a/packages/fluentui/react/src/components/Tree/utils/index.ts
+++ b/packages/fluentui/react/src/components/Tree/utils/index.ts
@@ -45,7 +45,7 @@ export interface TreeRenderContextValue {
   onFocusFirstChild: (itemId: string) => void;
   onFocusParent: (itemId: string) => void;
   onSiblingsExpand: (e: React.SyntheticEvent, itemProps: TreeItemProps) => void;
-  onTitleClick: (e: React.SyntheticEvent, treeItemProps: TreeItemProps) => void;
+  onTitleClick: (e: React.SyntheticEvent, itemProps: TreeItemProps) => void;
 }
 
 export const TreeContext = React.createContext<TreeRenderContextValue>(null);

--- a/packages/fluentui/react/src/components/Tree/utils/index.ts
+++ b/packages/fluentui/react/src/components/Tree/utils/index.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash';
+import * as React from 'react';
 import { TreeItemProps } from '../TreeItem';
 import { ShorthandValue } from '../../../types';
 
@@ -9,3 +10,9 @@ export const hasSubtree = (item: TreeItemProps | ShorthandValue<TreeItemProps>):
 export const removeItemAtIndex = (items: any[], itemIndex: number): any[] => {
   return [...items.slice(0, itemIndex), ...items.slice(itemIndex + 1)];
 };
+
+export interface TreeItemRenderContextValue {
+  onFocusParent: (itemId: string) => void;
+}
+
+export const TreeItemContext = React.createContext<TreeItemRenderContextValue>(null);

--- a/packages/fluentui/react/src/components/Tree/utils/index.ts
+++ b/packages/fluentui/react/src/components/Tree/utils/index.ts
@@ -41,11 +41,11 @@ export const getSiblings = (items: any[], itemId: string): any[] => {
   return getSiblingsFn(items);
 };
 
-export interface TreeItemRenderContextValue {
+export interface TreeRenderContextValue {
   onFocusFirstChild: (itemId: string) => void;
   onFocusParent: (itemId: string) => void;
   onSiblingsExpand: (e: React.SyntheticEvent, itemProps: TreeItemProps) => void;
   onTitleClick: (e: React.SyntheticEvent, treeItemProps: TreeItemProps) => void;
 }
 
-export const TreeItemContext = React.createContext<TreeItemRenderContextValue>(null);
+export const TreeContext = React.createContext<TreeRenderContextValue>(null);

--- a/packages/fluentui/react/src/components/Tree/utils/index.ts
+++ b/packages/fluentui/react/src/components/Tree/utils/index.ts
@@ -12,7 +12,9 @@ export const removeItemAtIndex = (items: any[], itemIndex: number): any[] => {
 };
 
 export interface TreeItemRenderContextValue {
+  onFocusFirstChild: (itemId: string) => void;
   onFocusParent: (itemId: string) => void;
+  onSiblingsExpand: (e: React.SyntheticEvent, itemProps: TreeItemProps) => void;
 }
 
 export const TreeItemContext = React.createContext<TreeItemRenderContextValue>(null);

--- a/packages/fluentui/react/src/components/Tree/utils/index.ts
+++ b/packages/fluentui/react/src/components/Tree/utils/index.ts
@@ -15,6 +15,7 @@ export interface TreeItemRenderContextValue {
   onFocusFirstChild: (itemId: string) => void;
   onFocusParent: (itemId: string) => void;
   onSiblingsExpand: (e: React.SyntheticEvent, itemProps: TreeItemProps) => void;
+  onTitleClick: (e: React.SyntheticEvent, treeItemProps: TreeItemProps) => void;
 }
 
 export const TreeItemContext = React.createContext<TreeItemRenderContextValue>(null);

--- a/packages/fluentui/react/src/components/Tree/utils/index.ts
+++ b/packages/fluentui/react/src/components/Tree/utils/index.ts
@@ -48,4 +48,9 @@ export interface TreeRenderContextValue {
   onTitleClick: (e: React.SyntheticEvent, itemProps: TreeItemProps) => void;
 }
 
-export const TreeContext = React.createContext<TreeRenderContextValue>(null);
+export const TreeContext = React.createContext<TreeRenderContextValue>({
+  onFocusFirstChild: _.noop,
+  onFocusParent: _.noop,
+  onSiblingsExpand: _.noop,
+  onTitleClick: _.noop
+});

--- a/packages/fluentui/react/src/utils/factories.ts
+++ b/packages/fluentui/react/src/utils/factories.ts
@@ -112,7 +112,7 @@ export function createShorthandFactory<TInstance extends React.Component, P>(con
 }): ShorthandFactory<P>;
 export function createShorthandFactory<P>({ Component, mappedProp, mappedArrayProp, allowsJSX }) {
   if (typeof Component !== 'function' && typeof Component !== 'string') {
-    // throw new Error('createShorthandFactory() Component must be a string or function.');
+    throw new Error('createShorthandFactory() Component must be a string or function.');
   }
 
   return (val, options: CreateShorthandOptions<P>) =>
@@ -146,7 +146,7 @@ function createShorthandFromValue<P>({
   options?: CreateShorthandOptions<P>;
 }) {
   if (typeof Component !== 'function' && typeof Component !== 'string') {
-    // throw new Error('createShorthand() Component must be a string or function.');
+    throw new Error('createShorthand() Component must be a string or function.');
   }
   // short circuit noop values
   const valIsNoop = _.isNil(value) || typeof value === 'boolean';

--- a/packages/fluentui/react/src/utils/factories.ts
+++ b/packages/fluentui/react/src/utils/factories.ts
@@ -112,7 +112,7 @@ export function createShorthandFactory<TInstance extends React.Component, P>(con
 }): ShorthandFactory<P>;
 export function createShorthandFactory<P>({ Component, mappedProp, mappedArrayProp, allowsJSX }) {
   if (typeof Component !== 'function' && typeof Component !== 'string') {
-    throw new Error('createShorthandFactory() Component must be a string or function.');
+    // throw new Error('createShorthandFactory() Component must be a string or function.');
   }
 
   return (val, options: CreateShorthandOptions<P>) =>
@@ -146,7 +146,7 @@ function createShorthandFromValue<P>({
   options?: CreateShorthandOptions<P>;
 }) {
   if (typeof Component !== 'function' && typeof Component !== 'string') {
-    throw new Error('createShorthand() Component must be a string or function.');
+    // throw new Error('createShorthand() Component must be a string or function.');
   }
   // short circuit noop values
   const valIsNoop = _.isNil(value) || typeof value === 'boolean';


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

- Passing onFocusParent, onTitleClick, onFocusFirstChild and onSiblingsExpand through context from Tree to TreeItem. Removed them from overrideProps.
- Creating contentRef only once.
- Removing itemsForRender and generating the props relevant for accessibility directly in `renderItems`.
- Removed siblings prop and compute it only when needed.

Fixes https://github.com/microsoft/fluent-ui-react/issues/2295.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12182)