### PR TITLE
Perf Test: Fix tag argument

### DIFF
--- a/azure-pipelines.perf-test.yml
+++ b/azure-pipelines.perf-test.yml
@@ -86,8 +86,11 @@ steps:
     condition: ne(variables.buildReason, 'PullRequest')
     displayName: Performance Tests (master only)
 
+  # TODO: re-enable with proper tag filtering as needed
+  # - script: |
+  #     yarn stats:save --tag=`git tag --points-at HEAD`
   - script: |
-      yarn stats:save --tag=`git tag --points-at HEAD`
+      yarn stats:save
     condition: ne(variables.buildReason, 'PullRequest')
     displayName: Save Statistics to DB (master only)
     env:


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Perf test pipeline [is failing on release builds](https://uifabric.visualstudio.com/fabricpublic/_build/results?buildId=56191&view=logs&j=12f1170f-54f2-53f3-20dd-22fc7dff55f9&t=c3091b1e-314e-512e-11db-151fdba14cd6) due to the number of tags present. I was going to fix this by filtering out the correct tags, but I'm not sure what the tag strategy will be moving forward. [This fluent release prep](https://github.com/microsoft/fluent-ui-react/commit/cc4bc8486ab73bd9581479855b23dae35cdcf412) seems to show one tag while [the prep for this one](https://github.com/OfficeDev/office-ui-fabric-react/commit/6a1c3fb6521283edb3c905846eec7c7e5410e65e) shows a bunch of tags. Not sure which is the method going forward. 

@miroslavstastny I'd like to get with you to figure out how we need to filter tags to pass to `stats:save` properly. For now, I've just disabled the tag argument in this PR.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12186)