### PR TITLE
Suggestions: Deprecating unused searchErrorText prop.

### DIFF
--- a/change/office-ui-fabric-react-2020-03-04-10-39-03-deprecateSearchErrorText.json
+++ b/change/office-ui-fabric-react-2020-03-04-10-39-03-deprecateSearchErrorText.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Suggestions: Deprecating unused searchErrorText prop.",
+  "packageName": "office-ui-fabric-react",
+  "email": "Humberto.Morimoto@microsoft.com",
+  "commit": "940dd1bbce3b97868d9895345089997b9b5b5c7b",
+  "dependentChangeType": "patch",
+  "date": "2020-03-04T18:39:03.568Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -7338,6 +7338,7 @@ export interface ISuggestionsProps<T> extends React.Props<any> {
     resultsFooter?: (props: ISuggestionsProps<T>) => JSX.Element;
     resultsFooterFull?: (props: ISuggestionsProps<T>) => JSX.Element;
     resultsMaximumNumber?: number;
+    // @deprecated
     searchErrorText?: string;
     searchForMoreText?: string;
     searchingText?: string;

--- a/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.types.ts
+++ b/packages/office-ui-fabric-react/src/components/pickers/Suggestions/Suggestions.types.ts
@@ -113,6 +113,8 @@ export interface ISuggestionsProps<T> extends React.Props<any> {
 
   /**
    * The text that should appear if there is a search error.
+   *
+   * @deprecated Use noResultsFoundText instead.
    */
   searchErrorText?: string;
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12037
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR marks an unused prop in `Suggestions` as deprecated so that we can mark it for removal later.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12190)