### PR TITLE
upgrades beachball to allow for star semver ranges to be preserved

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "vrtest": "cd apps && cd vr-tests && npm run screener"
   },
   "devDependencies": {
-    "beachball": "^1.20.0",
+    "beachball": "^1.20.1",
     "lerna": "^3.15.0",
     "lint-staged": "^7.0.5",
     "cross-env": "^5.1.4",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -64,7 +64,7 @@
     "babel-jest": "^24.5.0",
     "babel-loader": "^8.0.6",
     "babel-plugin-lodash": "^3.3.4",
-    "beachball": "^1.20.0",
+    "beachball": "^1.20.1",
     "chalk": "^2.1.0",
     "circular-dependency-plugin": "^5.0.2",
     "clean-webpack-plugin": "^0.1.19",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5750,10 +5750,10 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
-beachball@^1.20.0:
-  version "1.20.0"
-  resolved "https://registry.yarnpkg.com/beachball/-/beachball-1.20.0.tgz#db9800af3ff8f7d77763e64e91f7ae523779a2b0"
-  integrity sha512-oUdqWRiVI7x+XLRhc2UYMtOX75mjzcf323t6aYNJk4dHbuUxmb/zYRrsr0phi406GDh8rOPesB12D2Tx3UvtlQ==
+beachball@^1.20.1:
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/beachball/-/beachball-1.20.1.tgz#547314e4ddb6d1d1ed520e8fe5112b3f428ed382"
+  integrity sha512-gi9XvRThmMH80EsEwFznJqrCkCS0RWqf/T54WPPIkhZe654U7JDluHyU1gLs8+9ITAJs7JPh4l5UlOYt+tD65w==
   dependencies:
     cosmiconfig "^6.0.0"
     fs-extra "^8.0.1"


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

In a current commit: https://github.com/OfficeDev/office-ui-fabric-react/commit/7d62ed026125246aacbb4a6986b2e1ac04f2fcf1#diff-247119dda2b18c29b5bc474dfc6fa51bL28

We noticed that beachball was picking an exact version of the dependency due to a missing feature in beachball to detect the * case. This has been added in a new upgrade.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12206)