### PR TITLE
Fix the legacy items wrapper styles.

### DIFF
--- a/change/office-ui-fabric-react-2020-03-05-12-41-55-fix-legacy-picker-styles.json
+++ b/change/office-ui-fabric-react-2020-03-05-12-41-55-fix-legacy-picker-styles.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Fix the legacy items wrapper styles.",
+  "packageName": "office-ui-fabric-react",
+  "email": "lijunle@gmail.com",
+  "commit": "2e985195c35027e9e6aa31e788168ec191d96903",
+  "dependentChangeType": "patch",
+  "date": "2020-03-05T20:41:55.509Z"
+}

--- a/packages/office-ui-fabric-react/src/components/pickers/BasePicker.scss
+++ b/packages/office-ui-fabric-react/src/components/pickers/BasePicker.scss
@@ -41,6 +41,7 @@
 .pickerItems {
   display: flex;
   flex-wrap: wrap;
+  max-width: 100%;
 }
 
 .screenReaderOnly {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The CSS-in-JS styles and legacy styles for base picker is not compatible. There is a small differences and it will cause the picker item exceed the picker area.

![image](https://user-images.githubusercontent.com/1296500/76023890-f5559a00-5ede-11ea-9239-d4344788385c.png)

#### Focus areas to test

Base picker, people picker.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12207)