### PR TITLE
Pass contextual menu default item renderer to onRenderMenuList

### DIFF
--- a/change/office-ui-fabric-react-2020-03-05-14-11-07-ContextualMenuDefaultItemRenderer.json
+++ b/change/office-ui-fabric-react-2020-03-05-14-11-07-ContextualMenuDefaultItemRenderer.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Pass default ContextualMenuItem renderer to onRenderMenuList",
+  "packageName": "office-ui-fabric-react",
+  "email": "owcampbe@microsoft.com",
+  "commit": "8e158df51b7a51595af7c16822966eee148b3359",
+  "dependentChangeType": "patch",
+  "date": "2020-03-05T22:11:07.095Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -2960,6 +2960,20 @@ export interface IContextualMenuItemProps extends React.HTMLAttributes<IContextu
 }
 
 // @public (undocumented)
+export interface IContextualMenuItemRenderProps extends IContextualMenuItem {
+    // (undocumented)
+    focusableElementIndex: number;
+    // (undocumented)
+    hasCheckmarks: boolean;
+    // (undocumented)
+    hasIcons: boolean;
+    // (undocumented)
+    index: number;
+    // (undocumented)
+    totalItemCount: number;
+}
+
+// @public (undocumented)
 export interface IContextualMenuItemStyleProps {
     checked: boolean;
     className?: string;
@@ -2997,7 +3011,7 @@ export interface IContextualMenuItemStyles extends IButtonStyles {
 // @public (undocumented)
 export interface IContextualMenuListProps {
     // (undocumented)
-    defaultMenuItemRenderer: (item: IInternalContextualMenuItem) => React.ReactNode;
+    defaultMenuItemRenderer: (item: IContextualMenuItemRenderProps) => React.ReactNode;
     // (undocumented)
     hasCheckmarks: boolean;
     // (undocumented)
@@ -5104,20 +5118,6 @@ export interface IImageStyles {
 export interface IInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
     'aria-label'?: string;
     defaultVisibleValue?: string;
-}
-
-// @public (undocumented)
-export interface IInternalContextualMenuItem extends IContextualMenuItem {
-    // (undocumented)
-    focusableElementIndex: number;
-    // (undocumented)
-    hasCheckmarks: boolean;
-    // (undocumented)
-    hasIcons: boolean;
-    // (undocumented)
-    index: number;
-    // (undocumented)
-    totalItemCount: number;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -2997,7 +2997,7 @@ export interface IContextualMenuItemStyles extends IButtonStyles {
 // @public (undocumented)
 export interface IContextualMenuListProps {
     // (undocumented)
-    defaultMenuItemRenderer: (item: IContextualMenuItem, index: number, focusableElementIndex: number, totalItemCount: number, hasCheckmarks: boolean, hasIcons: boolean) => React.ReactNode;
+    defaultMenuItemRenderer: (item: IInternalContextualMenuItem) => React.ReactNode;
     // (undocumented)
     hasCheckmarks: boolean;
     // (undocumented)
@@ -5104,6 +5104,20 @@ export interface IImageStyles {
 export interface IInputProps extends React.InputHTMLAttributes<HTMLInputElement> {
     'aria-label'?: string;
     defaultVisibleValue?: string;
+}
+
+// @public (undocumented)
+export interface IInternalContextualMenuItem extends IContextualMenuItem {
+    // (undocumented)
+    focusableElementIndex: number;
+    // (undocumented)
+    hasCheckmarks: boolean;
+    // (undocumented)
+    hasIcons: boolean;
+    // (undocumented)
+    index: number;
+    // (undocumented)
+    totalItemCount: number;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -2997,6 +2997,8 @@ export interface IContextualMenuItemStyles extends IButtonStyles {
 // @public (undocumented)
 export interface IContextualMenuListProps {
     // (undocumented)
+    defaultMenuItemRenderer: (item: IContextualMenuItem, index: number, focusableElementIndex: number, totalItemCount: number, hasCheckmarks: boolean, hasIcons: boolean) => React.ReactNode;
+    // (undocumented)
     hasCheckmarks: boolean;
     // (undocumented)
     hasIcons: boolean;

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -352,7 +352,10 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
                     items,
                     totalItemCount,
                     hasCheckmarks,
-                    hasIcons
+                    hasIcons,
+                    defaultMenuItemRenderer: (items, index, focusableElementIndex, totalItemCount, hasCheckmarks, hasIcons) => {
+                      return this._renderMenuItem(items, index, focusableElementIndex, totalItemCount, hasCheckmarks, hasIcons);
+                    }
                   },
                   this._onRenderMenuList
                 )}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -5,7 +5,8 @@ import {
   ContextualMenuItemType,
   IContextualMenuListProps,
   IContextualMenuStyleProps,
-  IContextualMenuStyles
+  IContextualMenuStyles,
+  IInternalContextualMenuItem
 } from './ContextualMenu.types';
 import { DirectionalHint } from '../../common/DirectionalHint';
 import { FocusZone, FocusZoneDirection, IFocusZoneProps, FocusZoneTabbableElements } from '../../FocusZone';
@@ -353,9 +354,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
                     totalItemCount,
                     hasCheckmarks,
                     hasIcons,
-                    defaultMenuItemRenderer: (_items, _index, _focusableElementIndex, _totalItemCount, _hasCheckmarks, _hasIcons) => {
-                      return this._renderMenuItem(_items, _index, _focusableElementIndex, _totalItemCount, _hasCheckmarks, _hasIcons);
-                    }
+                    defaultMenuItemRenderer: this._renderMenuItem
                   },
                   this._onRenderMenuList
                 )}
@@ -442,14 +441,14 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
     return (
       <ul className={this._classNames.list} onKeyDown={this._onKeyDown} onKeyUp={this._onKeyUp} role="menu">
         {menuListProps.items.map((item, index) => {
-          const menuItem = this._renderMenuItem(
-            item,
+          const menuItem = this._renderMenuItem({
+            ...item,
             index,
-            indexCorrection,
-            menuListProps.totalItemCount,
-            menuListProps.hasCheckmarks,
-            menuListProps.hasIcons
-          );
+            focusableElementIndex: indexCorrection,
+            totalItemCount: menuListProps.totalItemCount,
+            hasCheckmarks: menuListProps.hasCheckmarks,
+            hasIcons: menuListProps.hasIcons
+          });
           if (item.itemType !== ContextualMenuItemType.Divider && item.itemType !== ContextualMenuItemType.Header) {
             const indexIncrease = item.customOnRenderListLength ? item.customOnRenderListLength : 1;
             indexCorrection += indexIncrease;
@@ -460,18 +459,11 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
     );
   };
 
-  private _renderMenuItem(
-    item: IContextualMenuItem,
-    index: number,
-    focusableElementIndex: number,
-    totalItemCount: number,
-    hasCheckmarks: boolean,
-    hasIcons: boolean
-  ): React.ReactNode {
+  private _renderMenuItem = (item: IInternalContextualMenuItem): React.ReactNode => {
     const renderedItems: React.ReactNode[] = [];
     const iconProps = item.iconProps || { iconName: 'None' };
     // tslint:disable-next-line:deprecation
-    const { getItemClassNames, itemProps } = item;
+    const { getItemClassNames, itemProps, index, focusableElementIndex, totalItemCount, hasCheckmarks, hasIcons } = item;
     const styles = itemProps ? itemProps.styles : undefined;
 
     // We only send a dividerClassName when the item to be rendered is a divider. For all other cases, the default divider style is used.
@@ -556,7 +548,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
     }
 
     return renderedItems;
-  }
+  };
 
   private _renderSectionItem(
     sectionItem: IContextualMenuItem,
@@ -596,7 +588,14 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
               {sectionProps.topDivider && this._renderSeparator(index, menuClassNames, true, true)}
               {headerItem && this._renderListItem(headerItem, sectionItem.key || index, menuClassNames, sectionItem.title)}
               {sectionProps.items.map((contextualMenuItem, itemsIndex) =>
-                this._renderMenuItem(contextualMenuItem, itemsIndex, itemsIndex, sectionProps.items.length, hasCheckmarks, hasIcons)
+                this._renderMenuItem({
+                  ...contextualMenuItem,
+                  index: itemsIndex,
+                  focusableElementIndex: itemsIndex,
+                  totalItemCount: sectionProps.items.length,
+                  hasCheckmarks,
+                  hasIcons
+                })
               )}
               {sectionProps.bottomDivider && this._renderSeparator(index, menuClassNames, false, true)}
             </ul>

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -6,7 +6,7 @@ import {
   IContextualMenuListProps,
   IContextualMenuStyleProps,
   IContextualMenuStyles,
-  IInternalContextualMenuItem
+  IContextualMenuItemRenderProps
 } from './ContextualMenu.types';
 import { DirectionalHint } from '../../common/DirectionalHint';
 import { FocusZone, FocusZoneDirection, IFocusZoneProps, FocusZoneTabbableElements } from '../../FocusZone';
@@ -459,7 +459,7 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
     );
   };
 
-  private _renderMenuItem = (item: IInternalContextualMenuItem): React.ReactNode => {
+  private _renderMenuItem = (item: IContextualMenuItemRenderProps): React.ReactNode => {
     const renderedItems: React.ReactNode[] = [];
     const iconProps = item.iconProps || { iconName: 'None' };
     // tslint:disable-next-line:deprecation

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -353,8 +353,8 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
                     totalItemCount,
                     hasCheckmarks,
                     hasIcons,
-                    defaultMenuItemRenderer: (items, index, focusableElementIndex, totalItemCount, hasCheckmarks, hasIcons) => {
-                      return this._renderMenuItem(items, index, focusableElementIndex, totalItemCount, hasCheckmarks, hasIcons);
+                    defaultMenuItemRenderer: (_items, _index, _focusableElementIndex, _totalItemCount, _hasCheckmarks, _hasIcons) => {
+                      return this._renderMenuItem(_items, _index, _focusableElementIndex, _totalItemCount, _hasCheckmarks, _hasIcons);
                     }
                   },
                   this._onRenderMenuList

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -272,6 +272,14 @@ export interface IContextualMenuListProps {
   totalItemCount: number;
   hasCheckmarks: boolean;
   hasIcons: boolean;
+  defaultMenuItemRenderer: (
+    item: IContextualMenuItem,
+    index: number,
+    focusableElementIndex: number,
+    totalItemCount: number,
+    hasCheckmarks: boolean,
+    hasIcons: boolean
+  ) => React.ReactNode;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -267,7 +267,7 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
 /**
  * {@docCategory ContextualMenu}
  */
-export interface IInternalContextualMenuItem extends IContextualMenuItem {
+export interface IContextualMenuItemRenderProps extends IContextualMenuItem {
   index: number;
   focusableElementIndex: number;
   totalItemCount: number;
@@ -283,7 +283,7 @@ export interface IContextualMenuListProps {
   totalItemCount: number;
   hasCheckmarks: boolean;
   hasIcons: boolean;
-  defaultMenuItemRenderer: (item: IInternalContextualMenuItem) => React.ReactNode;
+  defaultMenuItemRenderer: (item: IContextualMenuItemRenderProps) => React.ReactNode;
 }
 
 /**

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.types.ts
@@ -267,19 +267,23 @@ export interface IContextualMenuProps extends IBaseProps<IContextualMenu>, IWith
 /**
  * {@docCategory ContextualMenu}
  */
+export interface IInternalContextualMenuItem extends IContextualMenuItem {
+  index: number;
+  focusableElementIndex: number;
+  totalItemCount: number;
+  hasCheckmarks: boolean;
+  hasIcons: boolean;
+}
+
+/**
+ * {@docCategory ContextualMenu}
+ */
 export interface IContextualMenuListProps {
   items: IContextualMenuItem[];
   totalItemCount: number;
   hasCheckmarks: boolean;
   hasIcons: boolean;
-  defaultMenuItemRenderer: (
-    item: IContextualMenuItem,
-    index: number,
-    focusableElementIndex: number,
-    totalItemCount: number,
-    hasCheckmarks: boolean,
-    hasIcons: boolean
-  ) => React.ReactNode;
+  defaultMenuItemRenderer: (item: IInternalContextualMenuItem) => React.ReactNode;
 }
 
 /**


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

When overriding the ContextualMenu's default onRenderMenuList, you lose access to the default ContextualMenuItem renderer.

This change adds a defaultMenuItemRenderer field to IContextualMenuListProps, allowing consumers to override onRenderMenuList and still use the default ContextualMenuItem renderer.

The motivation for this change was to add virtualization support to ContextualMenu by using a <List> component in onRenderMenuList while still using the default item renderer.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12209)