### PR TITLE
[Cherry-pick to 6.0] MarqueeSelection: deleting html element references on unmount.

### DIFF
--- a/change/office-ui-fabric-react-2020-03-05-14-57-28-6.0.json
+++ b/change/office-ui-fabric-react-2020-03-05-14-57-28-6.0.json
@@ -1,0 +1,8 @@
+{
+  "type": "patch",
+  "comment": "MarqueeSelection: deleting html element references on unmount.",
+  "packageName": "office-ui-fabric-react",
+  "email": "xgao@microsoft.com",
+  "commit": "c895cd96849c18694135f5c7ee708fa6492a3e54",
+  "date": "2020-03-05T22:57:28.418Z"
+}

--- a/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/MarqueeSelection/MarqueeSelection.base.tsx
@@ -75,6 +75,8 @@ export class MarqueeSelectionBase extends BaseComponent<IMarqueeSelectionProps, 
     if (this._autoScroll) {
       this._autoScroll.dispose();
     }
+    delete this._scrollableParent;
+    delete this._scrollableSurface;
   }
 
   public render(): JSX.Element {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
Cherry pick fix: https://github.com/OfficeDev/office-ui-fabric-react/pull/12165/files

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12210)