### PR TITLE
Add launch configuration for debugging gulp tasks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -186,6 +186,24 @@
       },
       "sourceMaps": true,
       "console": "integratedTerminal"
+    },
+    {
+      "name": "Debug gulp task",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceRoot}/node_modules/gulp/bin/gulp.js",
+      "stopOnEntry": false,
+      "runtimeArgs": ["--nolazy", "--debug"],
+      // You can change the task name and cwd locally as needed
+      "args": ["build"],
+      "cwd": "${workspaceRoot}/packages/fluentui/react",
+      "env": {
+        "NODE_ENV": "development",
+        // This is used in scripts/babel/index.js to enable sourcemaps
+        "DEBUG": "1"
+      },
+      "sourceMaps": true,
+      "console": "integratedTerminal"
     }
   ]
 }


### PR DESCRIPTION
While fluentui code still uses gulp tasks, it can be helpful to have a launch configuration for debugging them.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12211)