### PR TITLE
Cleanup: Removing 'use strict' directive in ts files since modules are emitted with a 'use strict' prologue

### DIFF
--- a/change/@uifabric-utilities-2020-03-05-16-39-28-removeUseScript.json
+++ b/change/@uifabric-utilities-2020-03-05-16-39-28-removeUseScript.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Cleanup: Removing 'use strict' directive in ts files since modules are emitted with a 'use strict' prologue.",
+  "packageName": "@uifabric/utilities",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "commit": "5cb5db07119d744a8a5247b6b0780f9005604b2d",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T00:39:28.641Z"
+}

--- a/change/office-ui-fabric-react-2020-03-05-16-39-28-removeUseScript.json
+++ b/change/office-ui-fabric-react-2020-03-05-16-39-28-removeUseScript.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Cleanup: Removing 'use strict' directive in ts files since modules are emitted with a 'use strict' prologue.",
+  "packageName": "office-ui-fabric-react",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "commit": "5cb5db07119d744a8a5247b6b0780f9005604b2d",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T00:39:25.504Z"
+}

--- a/packages/office-ui-fabric-react/src/utilities/color/shades.ts
+++ b/packages/office-ui-fabric-react/src/utilities/color/shades.ts
@@ -47,7 +47,6 @@ export enum Shade {
  * @param shade - The Shade value to validate.
  */
 export function isValidShade(shade?: Shade): boolean {
-  'use strict';
   return typeof shade === 'number' && shade >= Shade.Unshaded && shade <= Shade.Shade8;
 }
 
@@ -97,7 +96,6 @@ export function isDark(color: IColor): boolean {
  * @param isInverted - Default false. Whether the given theme is inverted (reverse strongen/soften logic)
  */
 export function getShade(color: IColor, shade: Shade, isInverted: boolean = false): IColor | null {
-  'use strict';
   if (!color) {
     return null;
   }
@@ -143,7 +141,6 @@ export function getShade(color: IColor, shade: Shade, isInverted: boolean = fals
 //   to be the darkest or lightest one. If it is <50% luminance, it will always be the darkest,
 //   otherwise it will always be the lightest.
 export function getBackgroundShade(color: IColor, shade: Shade, isInverted: boolean = false): IColor | null {
-  'use strict';
   if (!color) {
     return null;
   }

--- a/packages/utilities/src/string.ts
+++ b/packages/utilities/src/string.ts
@@ -19,8 +19,6 @@ const FORMAT_REGEX = /\{\d+\}/g;
  */
 // tslint:disable-next-line:no-any
 export function format(s: string, ...values: any[]): string {
-  'use strict';
-
   let args = values;
   // Callback match function
   function replace_func(match: string): string {


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This PR removes all instances of `'use strict'` across the TypeScript files in the repo as all TypeScript files [are emitted with a `'use strict'` prologue since TypeScript 1.8](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-1-8.html#modules-are-now-emitted-with-a-use-strict-prologue).

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12213)