### PR TITLE
Lint and prettier updates

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,17 +1,18 @@
-package.json
+# generated or imported files
 package-deps.json
-shrinkwrap.yml
 CHANGELOG.*
 fabric-icons-*
 version.ts
 dndSim.js
-packages/tslint-rules/tslint.json
-
-*.d.ts
+monaco-typescript.d.ts
 *.api.md
 *.scss.ts
 _*.scss
 
+# messes up formatting
+packages/tslint-rules/tslint.json
+
+# folders of generated files
 lib
 lib-amd
 lib-esm
@@ -20,3 +21,6 @@ dist
 node_modules
 common/changes
 common/scripts
+coverage
+etc
+change

--- a/apps/a11y-tests/tslint.json
+++ b/apps/a11y-tests/tslint.json
@@ -1,7 +1,6 @@
 {
   "extends": ["@uifabric/tslint-rules"],
   "rules": {
-    "typedef": [false],
     "jsx-no-lambda": false
   },
   "linterOptions": {

--- a/apps/fabric-website-resources/tslint.json
+++ b/apps/fabric-website-resources/tslint.json
@@ -5,7 +5,6 @@
     "jsx-ban-props": false,
     "max-line-length": [false, 140],
     "no-any": false,
-    "typedef": [false],
     "member-access": false,
     "member-ordering": false
   }

--- a/apps/fabric-website/homepage.htm
+++ b/apps/fabric-website/homepage.htm
@@ -126,9 +126,9 @@
   } else {
     var fabricVersions = [5, 6, 7];
 
-    var fabricVersion =
-      getParameterByName('fabricVer') || window.sessionStorage.getItem('fabricVer') || fabricVersions[fabricVersions.length - 1];
-    fabricVersion = Number(fabricVersion);
+    var fabricVersion = Number(
+      getParameterByName('fabricVer') || window.sessionStorage.getItem('fabricVer') || fabricVersions[fabricVersions.length - 1]
+    );
 
     if (fabricVersions.indexOf(fabricVersion) > -1) {
       window.sessionStorage.setItem('fabricVer', fabricVersion);

--- a/apps/fabric-website/index.html
+++ b/apps/fabric-website/index.html
@@ -167,10 +167,9 @@
         var fabricVersions = [5, 6, 7];
 
         // Get fabricVer from URL param, session value, or latest version in array
-        var fabricVersion =
-          getParameterByName('fabricVer') || window.sessionStorage.getItem('fabricVer') || fabricVersions[fabricVersions.length - 1];
-        // Put this on a separate line so prettier won't add a trailing comma to the argument (would break IE 11)
-        fabricVersion = Number(fabricVersion);
+        var fabricVersion = Number(
+          getParameterByName('fabricVer') || window.sessionStorage.getItem('fabricVer') || fabricVersions[fabricVersions.length - 1]
+        );
 
         // Set session value if it's in array
         if (fabricVersions.indexOf(fabricVersion) > -1) {

--- a/apps/fabric-website/tslint.json
+++ b/apps/fabric-website/tslint.json
@@ -3,8 +3,6 @@
   "rules": {
     "deprecation": false,
     "no-any": false,
-    "no-inferrable-types": false,
-    "typedef": [false],
     "max-line-length": [false],
     "jsx-alignment": false,
     "jsx-ban-props": false,

--- a/apps/theming-designer/tslint.json
+++ b/apps/theming-designer/tslint.json
@@ -3,7 +3,6 @@
   "rules": {
     "deprecation": false,
     "no-any": false,
-    "typedef": [false],
     "prefer-const": false,
     "jsx-ban-props": false
   }

--- a/apps/todo-app/tslint.json
+++ b/apps/todo-app/tslint.json
@@ -3,7 +3,6 @@
   "rules": {
     "deprecation": false,
     "no-any": false,
-    "typedef": [false],
     "prefer-const": false
   }
 }

--- a/apps/vr-tests/tslint.json
+++ b/apps/vr-tests/tslint.json
@@ -2,7 +2,6 @@
   "extends": ["@uifabric/tslint-rules"],
   "rules": {
     "no-any": false,
-    "typedef": [false],
     "jsx-no-lambda": false,
     "jsx-ban-props": false,
     "deprecation": false

--- a/change/@fluentui-examples-2020-03-05-18-19-17-lint-config.json
+++ b/change/@fluentui-examples-2020-03-05-18-19-17-lint-config.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Remove typedef rule override",
+  "packageName": "@fluentui/examples",
+  "email": "elcraig@microsoft.com",
+  "commit": "12186bf0a00e97c34af5c510007b70610876c500",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T02:18:59.039Z"
+}

--- a/change/@fluentui-react-focus-2020-03-05-18-19-17-lint-config.json
+++ b/change/@fluentui-react-focus-2020-03-05-18-19-17-lint-config.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Remove typedef rule override",
+  "packageName": "@fluentui/react-focus",
+  "email": "elcraig@microsoft.com",
+  "commit": "12186bf0a00e97c34af5c510007b70610876c500",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T02:19:12.329Z"
+}

--- a/change/@uifabric-example-app-base-2020-03-05-18-15-07-lint-config.json
+++ b/change/@uifabric-example-app-base-2020-03-05-18-15-07-lint-config.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Run prettier on .d.ts files",
+  "packageName": "@uifabric/example-app-base",
+  "email": "elcraig@microsoft.com",
+  "commit": "eb6203e8aa6f934c2a86e1f5912d8cf5a2cfb1cb",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T02:13:46.602Z"
+}

--- a/change/@uifabric-example-data-2020-03-05-18-19-17-lint-config.json
+++ b/change/@uifabric-example-data-2020-03-05-18-19-17-lint-config.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Remove typedef rule override",
+  "packageName": "@uifabric/example-data",
+  "email": "elcraig@microsoft.com",
+  "commit": "12186bf0a00e97c34af5c510007b70610876c500",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T02:18:56.263Z"
+}

--- a/change/@uifabric-experiments-2020-03-05-18-19-17-lint-config.json
+++ b/change/@uifabric-experiments-2020-03-05-18-19-17-lint-config.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Remove typedef rule override",
+  "packageName": "@uifabric/experiments",
+  "email": "elcraig@microsoft.com",
+  "commit": "12186bf0a00e97c34af5c510007b70610876c500",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T02:19:03.056Z"
+}

--- a/change/@uifabric-fabric-website-2020-03-05-18-15-07-lint-config.json
+++ b/change/@uifabric-fabric-website-2020-03-05-18-15-07-lint-config.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Remove trailing comma prevention hack",
+  "packageName": "@uifabric/fabric-website",
+  "email": "elcraig@microsoft.com",
+  "commit": "eb6203e8aa6f934c2a86e1f5912d8cf5a2cfb1cb",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T02:13:21.052Z"
+}

--- a/change/@uifabric-fabric-website-resources-2020-03-05-18-19-17-lint-config.json
+++ b/change/@uifabric-fabric-website-resources-2020-03-05-18-19-17-lint-config.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Remove typedef rule override",
+  "packageName": "@uifabric/fabric-website-resources",
+  "email": "elcraig@microsoft.com",
+  "commit": "12186bf0a00e97c34af5c510007b70610876c500",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T02:18:42.404Z"
+}

--- a/change/@uifabric-foundation-2020-03-05-18-19-17-lint-config.json
+++ b/change/@uifabric-foundation-2020-03-05-18-19-17-lint-config.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Remove typedef rule override",
+  "packageName": "@uifabric/foundation",
+  "email": "elcraig@microsoft.com",
+  "commit": "12186bf0a00e97c34af5c510007b70610876c500",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T02:19:05.669Z"
+}

--- a/change/@uifabric-migration-2020-03-05-18-19-17-lint-config.json
+++ b/change/@uifabric-migration-2020-03-05-18-19-17-lint-config.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Remove typedef rule override",
+  "packageName": "@uifabric/migration",
+  "email": "elcraig@microsoft.com",
+  "commit": "12186bf0a00e97c34af5c510007b70610876c500",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T02:19:07.418Z"
+}

--- a/change/@uifabric-react-cards-2020-03-05-18-19-17-lint-config.json
+++ b/change/@uifabric-react-cards-2020-03-05-18-19-17-lint-config.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Remove typedef rule override",
+  "packageName": "@uifabric/react-cards",
+  "email": "elcraig@microsoft.com",
+  "commit": "12186bf0a00e97c34af5c510007b70610876c500",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T02:19:10.718Z"
+}

--- a/change/@uifabric-tslint-rules-2020-03-05-18-15-07-lint-config.json
+++ b/change/@uifabric-tslint-rules-2020-03-05-18-15-07-lint-config.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Add dep on tslint-config-prettier and remove redundant rules; disable typedef rule",
+  "packageName": "@uifabric/tslint-rules",
+  "email": "elcraig@microsoft.com",
+  "commit": "eb6203e8aa6f934c2a86e1f5912d8cf5a2cfb1cb",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T02:15:07.477Z"
+}

--- a/change/@uifabric-tsx-editor-2020-03-05-18-19-17-lint-config.json
+++ b/change/@uifabric-tsx-editor-2020-03-05-18-19-17-lint-config.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Remove typedef rule override",
+  "packageName": "@uifabric/tsx-editor",
+  "email": "elcraig@microsoft.com",
+  "commit": "12186bf0a00e97c34af5c510007b70610876c500",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T02:19:13.933Z"
+}

--- a/change/@uifabric-utilities-2020-03-05-18-19-17-lint-config.json
+++ b/change/@uifabric-utilities-2020-03-05-18-19-17-lint-config.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Remove typedef rule override",
+  "packageName": "@uifabric/utilities",
+  "email": "elcraig@microsoft.com",
+  "commit": "12186bf0a00e97c34af5c510007b70610876c500",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T02:19:15.748Z"
+}

--- a/change/@uifabric-webpack-utils-2020-03-05-18-19-17-lint-config.json
+++ b/change/@uifabric-webpack-utils-2020-03-05-18-19-17-lint-config.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Remove typedef rule override",
+  "packageName": "@uifabric/webpack-utils",
+  "email": "elcraig@microsoft.com",
+  "commit": "12186bf0a00e97c34af5c510007b70610876c500",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T02:19:17.443Z"
+}

--- a/change/office-ui-fabric-react-2020-03-05-18-19-17-lint-config.json
+++ b/change/office-ui-fabric-react-2020-03-05-18-19-17-lint-config.json
@@ -1,0 +1,9 @@
+{
+  "type": "none",
+  "comment": "Remove typedef rule override",
+  "packageName": "office-ui-fabric-react",
+  "email": "elcraig@microsoft.com",
+  "commit": "12186bf0a00e97c34af5c510007b70610876c500",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T02:19:09.040Z"
+}

--- a/packages/example-app-base/src/utilities/parser/BaseParser.ts
+++ b/packages/example-app-base/src/utilities/parser/BaseParser.ts
@@ -2,8 +2,6 @@
  * Base for a parser - does not actually do any parsing.
  */
 export class BaseParser {
-  // Disabled bc of tslint conflict https://github.com/palantir/tslint/issues/711
-  // tslint:disable:no-inferrable-types
   private _currLocation: number = 0;
   private _str: string;
   private _strLength: number;

--- a/packages/example-app-base/tslint.json
+++ b/packages/example-app-base/tslint.json
@@ -2,7 +2,6 @@
   "extends": ["@uifabric/tslint-rules"],
   "rules": {
     "deprecation": false,
-    "typedef": false,
     "jsx-ban-props": false
   }
 }

--- a/packages/example-app-base/typings/markdown-to-jsx/index.d.ts
+++ b/packages/example-app-base/typings/markdown-to-jsx/index.d.ts
@@ -7,7 +7,7 @@ declare module 'markdown-to-jsx' {
       [key: string]: {
         component: string | React.ComponentClass<any> | React.FunctionComponent<any>;
         props?: any;
-      }
+      };
     };
   }
 
@@ -16,5 +16,5 @@ declare module 'markdown-to-jsx' {
     children?: string | React.ComponentClass<any> | React.FunctionComponent<any>;
   }
 
-  export default class Markdown extends React.Component<IMarkdownProps> { }
+  export default class Markdown extends React.Component<IMarkdownProps> {}
 }

--- a/packages/example-data/tslint.json
+++ b/packages/example-data/tslint.json
@@ -1,6 +1,3 @@
 {
-  "extends": ["@uifabric/tslint-rules"],
-  "rules": {
-    "typedef": false
-  }
+  "extends": ["@uifabric/tslint-rules"]
 }

--- a/packages/examples/tslint.json
+++ b/packages/examples/tslint.json
@@ -2,7 +2,6 @@
   "extends": ["@uifabric/tslint-rules"],
   "rules": {
     "deprecation": true,
-    "no-any": false,
-    "typedef": [false]
+    "no-any": false
   }
 }

--- a/packages/experiments/tslint.json
+++ b/packages/experiments/tslint.json
@@ -1,7 +1,6 @@
 {
   "extends": ["@uifabric/tslint-rules"],
   "rules": {
-    "no-any": false,
-    "typedef": [false]
+    "no-any": false
   }
 }

--- a/packages/fluentui/docs/src/global.d.ts
+++ b/packages/fluentui/docs/src/global.d.ts
@@ -3,25 +3,25 @@
 /* eslint-disable spaced-comment */
 /// <reference types="react" />
 
-declare const __DEV__: boolean
-declare const __PATH_SEP__: string
-declare const __BASENAME__: string
+declare const __DEV__: boolean;
+declare const __PATH_SEP__: string;
+declare const __BASENAME__: string;
 
 declare module '*.json' {
-  const value: any
-  export default value
+  const value: any;
+  export default value;
 }
 
 declare module '*.mdx' {
   export const meta: {
-    title: string
-  }
-  const value: React.ComponentType
+    title: string;
+  };
+  const value: React.ComponentType;
 
-  export default value
+  export default value;
 }
 
 declare interface Window {
-  resetExternalLayout?: () => void
-  switchTheme?: (themeName: string) => void
+  resetExternalLayout?: () => void;
+  switchTheme?: (themeName: string) => void;
 }

--- a/packages/foundation/tslint.json
+++ b/packages/foundation/tslint.json
@@ -1,7 +1,6 @@
 {
   "extends": ["@uifabric/tslint-rules"],
   "rules": {
-    "no-any": false,
-    "typedef": [false]
+    "no-any": false
   }
 }

--- a/packages/migration/tslint.json
+++ b/packages/migration/tslint.json
@@ -1,6 +1,3 @@
 {
-  "extends": ["@uifabric/tslint-rules"],
-  "rules": {
-    "typedef": false
-  }
+  "extends": ["@uifabric/tslint-rules"]
 }

--- a/packages/office-ui-fabric-react/tslint.json
+++ b/packages/office-ui-fabric-react/tslint.json
@@ -3,7 +3,6 @@
   "rules": {
     "jsx-ban-props": false,
     "no-any": false,
-    "typedef": [false],
     "import-blacklist": [true, { "../../Styling": ["FontSizes"] }]
   }
 }

--- a/packages/react-cards/tslint.json
+++ b/packages/react-cards/tslint.json
@@ -2,7 +2,6 @@
   "extends": ["@uifabric/tslint-rules"],
   "rules": {
     "deprecation": true,
-    "no-any": false,
-    "typedef": [false]
+    "no-any": false
   }
 }

--- a/packages/react-focus/tslint.json
+++ b/packages/react-focus/tslint.json
@@ -1,6 +1,3 @@
 {
-  "extends": ["@uifabric/tslint-rules"],
-  "rules": {
-    "typedef": [true, "call-signature", "parameter", "property-declaration", "member-variable-declaration"]
-  }
+  "extends": ["@uifabric/tslint-rules"]
 }

--- a/packages/tslint-rules/package.json
+++ b/packages/tslint-rules/package.json
@@ -9,7 +9,8 @@
   },
   "license": "MIT",
   "dependencies": {
-    "tslint-react": "^3.2.0"
+    "tslint-react": "^3.2.0",
+    "tslint-config-prettier": "^1.18.0"
   },
   "peerDependencies": {
     "tslint": "*"

--- a/packages/tslint-rules/tslint.json
+++ b/packages/tslint-rules/tslint.json
@@ -44,13 +44,7 @@
     ],
     "no-arg": true,
     "radix": true,
-    "typedef": [
-      true,
-      "call-signature",
-      "parameter",
-      "arrow-parameter",
-      "property-declaration"
-    ],
+    "typedef": [false],
     "prefer-const": true,
     "no-inferrable-types": false,
     "no-null-keyword": false,

--- a/packages/tslint-rules/tslint.json
+++ b/packages/tslint-rules/tslint.json
@@ -1,6 +1,7 @@
 {
   "extends": [
-    "tslint-react"
+    "tslint-react",
+    "tslint-config-prettier"
   ],
   "linterOptions": {
     "exclude": [
@@ -20,18 +21,13 @@
         "function-regex": "^[_]?[a-z][\\w\\d]+$"
       }
     ],
-    "jsx-curly-spacing": {
-      "when": "always"
-    },
     "jsx-no-bind": true,
     "jsx-boolean-value": [
       "never"
     ],
-    "jsx-equals-spacing": "never",
     "jsx-key": true,
     "jsx-no-lambda": true,
     "jsx-self-close": true,
-    "jsx-wrap-multiline": false,
     "jsx-no-multiline-js": false,
     "jsx-no-string-ref": true,
     "jsx-ban-props": [
@@ -46,13 +42,6 @@
     "triple-equals": [
       true
     ],
-    "max-line-length": [
-      true,
-      {
-        "limit": 140,
-        "ignore-pattern": "require\\(|https?:\\/\\/"
-      }
-    ],
     "no-arg": true,
     "radix": true,
     "typedef": [
@@ -63,21 +52,9 @@
       "property-declaration"
     ],
     "prefer-const": true,
-    "quotemark": [
-      true,
-      "single",
-      "jsx-double",
-      "avoid-escape"
-    ],
     "no-inferrable-types": false,
     "no-null-keyword": false,
     "export-name": false,
-    "trailing-comma": [
-      false
-    ],
-    "whitespace": [
-      false
-    ],
     "no-switch-case-fall-through": false,
     "variable-name": [
       true,
@@ -92,13 +69,7 @@
       "check-space"
     ],
     "curly": true,
-    "eofline": false,
     "forin": true,
-    "indent": [
-      true,
-      "spaces",
-      2
-    ],
     "interface-name": [
       true,
       "always-prefix"
@@ -130,7 +101,6 @@
     "missing-optional-annotation": true,
     "no-any": true,
     "no-bitwise": true,
-    "no-consecutive-blank-lines": true,
     "no-console": [
       true,
       "debug",
@@ -150,35 +120,11 @@
     "no-internal-module": true,
     "no-shadowed-variable": true,
     "no-string-literal": true,
-    "no-trailing-whitespace": true,
-    "no-unnecessary-semicolons": true,
     "no-unused-expression": false,
     "no-unused-variable": false, // defer to typescript's no unused local instead
     "no-with-statement": false,
     "no-var-keyword": true,
     "object-literal-sort-keys": false,
-    "one-line": [
-      true,
-      "check-open-brace",
-      "check-catch",
-      "check-else",
-      "check-whitespace"
-    ],
-    "semicolon": [
-      true,
-      "always",
-      "ignore-bound-class-methods"
-    ],
-    "typedef-whitespace": [
-      true,
-      {
-        "call-signature": "nospace",
-        "index-signature": "nospace",
-        "parameter": "nospace",
-        "property-declaration": "nospace",
-        "variable-declaration": "nospace"
-      }
-    ],
     "use-named-parameter": true,
     "ban": [
       true,

--- a/packages/tsx-editor/tslint.json
+++ b/packages/tsx-editor/tslint.json
@@ -1,4 +1,6 @@
 {
   "extends": ["@uifabric/tslint-rules"],
-  "rules": { "typedef": false, "jsx-ban-props": false }
+  "rules": {
+    "jsx-ban-props": false
+  }
 }

--- a/packages/utilities/src/EventGroup.ts
+++ b/packages/utilities/src/EventGroup.ts
@@ -58,7 +58,6 @@ export interface IDeclaredEventsByName {
  * {@docCategory EventGroup}
  */
 export class EventGroup {
-  // tslint:disable-next-line:no-inferrable-types
   private static _uniqueId: number = 0;
   // tslint:disable-next-line:no-any
   private _parent: any;

--- a/packages/webpack-utils/tslint.json
+++ b/packages/webpack-utils/tslint.json
@@ -3,7 +3,6 @@
   "rules": {
     "deprecation": false,
     "no-function-expression": false,
-    "no-any": false,
-    "no-inferrable-types": false
+    "no-any": false
   }
 }

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,6 +1,6 @@
 // https://prettier.io/docs/en/configuration.html
 module.exports = {
-  printWidth: 140,
+  printWidth: 140, // 120
   tabWidth: 2,
   singleQuote: true,
   // trailingComma: 'all',

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -3,6 +3,7 @@ module.exports = {
   printWidth: 140,
   tabWidth: 2,
   singleQuote: true,
+  // trailingComma: 'all',
   overrides: [
     {
       files: 'apps/vr-tests/**/*',
@@ -12,5 +13,12 @@ module.exports = {
         printWidth: 100
       }
     }
+    // {
+    //   // These files may be run as-is in IE 11 and must not have ES5-incompatible trailing commas
+    //   files: ['*.html', '*.htm'],
+    //   options: {
+    //     trailingComma: 'es5',
+    //   },
+    // },
   ]
 };

--- a/scripts/tslint.fluentui.json
+++ b/scripts/tslint.fluentui.json
@@ -1,30 +1,10 @@
 {
   "extends": ["tslint-config-airbnb", "tslint-config-prettier"],
   "rules": {
-    "arrow-parens": false,
-    "align": [false],
     "import-name": [false],
     "function-name": false,
-    "max-line-length": [false],
     "no-increment-decrement": false,
-    "object-curly-spacing": [false],
     "object-shorthand-properties-first": [false],
-    "quotemark": [false],
-    "ter-arrow-parens": [false],
-    "ter-computed-property-spacing": [false],
-    "ter-indent": [false],
-    "trailing-comma": [
-      false,
-      {
-        "multiline": {
-          "objects": "always",
-          "arrays": "always",
-          "functions": "always",
-          "typeLiterals": "ignore"
-        },
-        "esSpecCompliant": true
-      }
-    ],
     "variable-name": false
   }
 }

--- a/scripts/updateReleaseNotes/index.d.ts
+++ b/scripts/updateReleaseNotes/index.d.ts
@@ -7,7 +7,7 @@ interface IChangelog {
 
 /** Represents an entry in a CHANGELOG.json's `entries` array */
 interface IChangelogEntry {
-  comments: { major: IChangelogComment[]; minor: IChangelogComment[]; patch: IChangelogComment[]; };
+  comments: { major: IChangelogComment[]; minor: IChangelogComment[]; patch: IChangelogComment[] };
   /** Package name */
   name?: string;
   /** Entry date */
@@ -26,7 +26,6 @@ interface IChangelogComment {
   /** Commit SHA */
   commit?: string;
 }
-
 
 interface ICommit {
   /** Commit SHA */

--- a/typings/custom-global/index.d.ts
+++ b/typings/custom-global/index.d.ts
@@ -66,6 +66,6 @@ declare var process: {
      * For `mode` see: https://webpack.js.org/configuration/mode/#usage
      * For DefinePlugin see: https://webpack.js.org/plugins/define-plugin/#root
      */
-    NODE_ENV: "development" | "production"
+    NODE_ENV: 'development' | 'production';
   };
 };

--- a/typings/screener-runner/index.d.ts
+++ b/typings/screener-runner/index.d.ts
@@ -6,98 +6,95 @@ declare module 'screener-runner' {
   // TODO: move these out of global and import where appropriate
   global {
     export type ScreenerRunnerKeys = {
-      alt: string
-      control: string
-      enter: string
-      escape: string
-      return: string
-      shift: string
-      tab: string
-      leftArrow: string
-      upArrow: string
-      rightArrow: string
-      downArrow: string
-    }
+      alt: string;
+      control: string;
+      enter: string;
+      escape: string;
+      return: string;
+      shift: string;
+      tab: string;
+      leftArrow: string;
+      upArrow: string;
+      rightArrow: string;
+      downArrow: string;
+    };
 
     export interface ScreenerStepBuilder {
       /** This executes custom JS code against the client browser the test is running in. */
-      executeScript(code: string): ScreenerStepBuilder
+      executeScript(code: string): ScreenerStepBuilder;
 
       /** This will click on the first element matching the provided css selector. */
-      click(selector: string): ScreenerStepBuilder
+      click(selector: string): ScreenerStepBuilder;
 
       /** This will capture a visual snapshot. */
-      snapshot(name: string, options?: any): ScreenerStepBuilder
+      snapshot(name: string, options?: any): ScreenerStepBuilder;
 
       /** this will move the mouse over the first element matching the provided css selector. */
-      hover(selector: string): ScreenerStepBuilder
+      hover(selector: string): ScreenerStepBuilder;
 
       /** This will press and hold the mouse button over the first element matching the provided css selector. */
-      mouseDown(selector: string): ScreenerStepBuilder
+      mouseDown(selector: string): ScreenerStepBuilder;
 
       /** This will release the mouse button. selector is optional. */
-      mouseUp(selector: string): ScreenerStepBuilder
+      mouseUp(selector: string): ScreenerStepBuilder;
 
       /** This will set cursor focus on the first element matching the provided css selector. */
-      focus(selector: string): ScreenerStepBuilder
+      focus(selector: string): ScreenerStepBuilder;
 
       /** This will set the value of the input field matching the provided css selector. */
-      setValue(selector: string, value: string, options?: any): ScreenerStepBuilder
+      setValue(selector: string, value: string, options?: any): ScreenerStepBuilder;
 
       /** This will send the provided keys to the first element matching the provided css selector. */
-      keys(selector: string, key: string): ScreenerStepBuilder
+      keys(selector: string, key: string): ScreenerStepBuilder;
 
       /** This will pause execution for the specified number of ms. */
-      wait(ms: number): ScreenerStepBuilder
+      wait(ms: number): ScreenerStepBuilder;
 
       /** This will override the global cssAnimations option for the current UI state. Set to true to enable CSS Animations, and set to false to disable. */
-      cssAnimations(isEnabled: boolean): ScreenerStepBuilder
+      cssAnimations(isEnabled: boolean): ScreenerStepBuilder;
 
       /** This will set the current UI state to right-to-left direction. */
-      rtl(): ScreenerStepBuilder
+      rtl(): ScreenerStepBuilder;
 
       /** This will set the current UI state to left-to-right direction. */
-      ltr(): ScreenerStepBuilder
+      ltr(): ScreenerStepBuilder;
 
       /** This will return the steps to be run. */
-      end(): any[]
+      end(): any[];
 
       /** This will reset the layout. */
-      resetExternalLayout(): ScreenerStepBuilder
+      resetExternalLayout(): ScreenerStepBuilder;
 
-      url(url: string): ScreenerStepBuilder
+      url(url: string): ScreenerStepBuilder;
 
       /** This will switch the theme. Not actually part of screener-runner. */
-      switchTheme(themeName: ScreenerThemeName): ScreenerStepBuilder
+      switchTheme(themeName: ScreenerThemeName): ScreenerStepBuilder;
     }
 
     // These ones are not actually part of screener-runner
 
     /** Keys of `themes` object exported from `@fluentui/react/src/index`. */
-    export type ScreenerThemeName = 'teams' | 'teamsDark' | 'teamsHighContrast'
+    export type ScreenerThemeName = 'teams' | 'teamsDark' | 'teamsHighContrast';
 
-    export type ScreenerStep = (
-      steps: ScreenerStepBuilder,
-      keys: ScreenerRunnerKeys,
-    ) => ScreenerStepBuilder
-    export type ScreenerSteps = ScreenerStep[]
+    export type ScreenerStep = (steps: ScreenerStepBuilder, keys: ScreenerRunnerKeys) => ScreenerStepBuilder;
+    export type ScreenerSteps = ScreenerStep[];
 
     export type ScreenerTestsConfig = {
-      steps?: ScreenerStep[]
-      themes?: ScreenerThemeName[]
-    }
+      steps?: ScreenerStep[];
+      themes?: ScreenerThemeName[];
+    };
   }
 }
 
 declare module 'screener-runner/src/steps' {
   const Steps: {
-    new (): ScreenerStepBuilder
-  }
+    new (): ScreenerStepBuilder;
+  };
 
-  export default Steps
+  export default Steps;
 }
 
 declare module 'screener-runner/src/keys' {
-  const keys: ScreenerRunnerKeys
-  export default keys
+  const keys: ScreenerRunnerKeys;
+  export default keys;
 }


### PR DESCRIPTION
#### Pull request checklist

- [x] Include a change request file using `$ yarn change`

#### Description of changes

Make `@uifabric/tslint-rules` extend `tslint-config-prettier` to prevent tslint/prettier conflicts, and remove rules which are redundant with [rules provided by that preset](https://unpkg.com/tslint-config-prettier@1.18.0/lib/index.json). (Same with fluentui tslint config, which already extended `tslint-config-prettier`.)

Remove `typedef` rule from `@uifabric/tslint-rules`--we turn it off in almost all packages, so clearly we don't want it. And remove all the overrides of that rule (as well as `no-inferrable-types`, which we already turn off by default).

Also some prettier-related changes before the giant PR to add trailing commas and change line length:
- Add a preview of the new settings (including override which prevents problematic non-ES5 trailing commas in JS within HTML files)
- Revert a hack I'd previously added to two HTML files to prevent a problematic trailing comma
- Un-ignore most .d.ts files, and format them
- Ignore change files (humans don't look at them and they're quickly deleted, so formatting doesn't matter)
- Other minor ignore path updates

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12214)