### PR TITLE
withViewport: cleaning up resize observer on unmount.

### DIFF
--- a/change/office-ui-fabric-react-2020-03-05-21-35-08-responsive-mode.json
+++ b/change/office-ui-fabric-react-2020-03-05-21-35-08-responsive-mode.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "withViewport: cleaning up resize observer.",
+  "packageName": "office-ui-fabric-react",
+  "email": "dzearing@microsoft.com",
+  "commit": "48db247b55f3e6f2809009c6a338c52b6b3e39bd",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T05:35:08.569Z"
+}

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
@@ -116,6 +116,8 @@ export function withViewport<TProps extends { viewport?: IViewport }, TState>(
       if (this._viewportResizeObserver) {
         this._viewportResizeObserver.disconnect();
       }
+
+      this._unregisterResizeObserver();
     }
 
     public render(): JSX.Element {
@@ -124,7 +126,7 @@ export function withViewport<TProps extends { viewport?: IViewport }, TState>(
 
       return (
         <div className="ms-Viewport" ref={this._root} style={{ minWidth: 1, minHeight: 1 }}>
-          <ComposedComponent ref={this._updateComposedComponentRef} viewport={newViewport} {...(this.props as any)} />
+          <ComposedComponent ref={this._updateComposedComponentRef} viewport={newViewport} {...this.props as any} />
         </div>
       );
     }

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withViewport.tsx
@@ -112,11 +112,6 @@ export function withViewport<TProps extends { viewport?: IViewport }, TState>(
 
     public componentWillUnmount(): void {
       this._events.dispose();
-
-      if (this._viewportResizeObserver) {
-        this._viewportResizeObserver.disconnect();
-      }
-
       this._unregisterResizeObserver();
     }
 
@@ -155,7 +150,7 @@ export function withViewport<TProps extends { viewport?: IViewport }, TState>(
     private _unregisterResizeObserver = () => {
       if (this._viewportResizeObserver) {
         this._viewportResizeObserver.disconnect();
-        this._viewportResizeObserver = null;
+        delete this._viewportResizeObserver;
       }
     };
 


### PR DESCRIPTION
Seems that resize observer was added but never cleaned up.

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12216)