### PR TITLE
restore onRenderIcon prop for ContextualMenuSplitButton

### DIFF
--- a/change/office-ui-fabric-react-2020-03-06-03-40-23-fix-split-button-bug.json
+++ b/change/office-ui-fabric-react-2020-03-06-03-40-23-fix-split-button-bug.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "restore onRenderIcon prop for ContextualMenuSplitButton",
+  "packageName": "office-ui-fabric-react",
+  "email": "kinhln@microsoft.com",
+  "commit": "a0e64f183eb1f65310e7e635145a71ce3238ddd8",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T11:40:23.862Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
@@ -125,6 +125,7 @@ export class ContextualMenuSplitButton extends ContextualMenuItemWrapper {
       checked: item.checked,
       iconProps: item.iconProps,
       onRenderIcon: item.onRenderIcon,
+      data: item.data,
       'data-is-focusable': false
     };
 

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenuItemWrapper/ContextualMenuSplitButton.tsx
@@ -117,12 +117,14 @@ export class ContextualMenuSplitButton extends ContextualMenuItemWrapper {
       // tslint:disable:deprecation
       name: item.name,
       text: item.text || item.name,
+      secondaryText: item.secondaryText,
       // tslint:enable:deprecation
       className: classNames.splitPrimary,
       canCheck: item.canCheck,
       isChecked: item.isChecked,
       checked: item.checked,
       iconProps: item.iconProps,
+      onRenderIcon: item.onRenderIcon,
       'data-is-focusable': false
     };
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12196 
- [x] Include a change request file using `$ yarn change`

#### Description of changes

In the render() function of ContextualMenuSplitButton, it transfers many of its props to an intermediate object. However, it misses 3 props, `data`, `secondaryText` and `onRenderIcon`. 

In this change, I'm adding those 3 props.

#### Focus areas to test

Using the `ContextualMenu` component that has a split button, then attempt to assign one of these above 3 props. 


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12222)