### PR TITLE
fix: make export treeshakable in Fluent v0

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -17,6 +17,9 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ## [Unreleased]
 
+### Fixes
+- Fix exports for themes to make them treeshakable @layershifter ([#12224](https://github.com/OfficeDev/office-ui-fabric-react/pull/12224))
+
 <!--------------------------------[ v0.46.0 ]------------------------------- -->
 ## [v0.46.0](https://github.com/OfficeDev/office-ui-fabric-react/tree/fluentui_v0.46.0) (2020-03-05)
 [Compare changes](https://github.com/OfficeDev/office-ui-fabric-react/compare/fluentuizero_v0.45.0..fluentuizero_v0.46.0)

--- a/packages/fluentui/react/src/index.ts
+++ b/packages/fluentui/react/src/index.ts
@@ -1,10 +1,9 @@
+import * as themes from './themes';
+
 //
 // Theme
 //
-// work around api-extractor limitation
-import { fontAwesome, teams, teamsDark, teamsHighContrast } from './themes';
-
-export const themes = { fontAwesome, teams, teamsDark, teamsHighContrast };
+export { themes };
 export * from './themes/types';
 export * from './themes/colorUtils';
 


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes https://github.com/microsoft/fluent-ui-react/issues/2324
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This change was introduced in https://github.com/microsoft/fluent-ui-react/pull/2121 and breaks treeshaking for themes, i.e. all themes will be loaded always.

![image](https://user-images.githubusercontent.com/14183168/76092772-438e9a00-5fc0-11ea-8eab-76267a7e05df.png)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12224)