### PR TITLE
Export GroupedListSection

### DIFF
--- a/change/office-ui-fabric-react-2020-03-06-11-38-13-Public-GroupedListSection.json
+++ b/change/office-ui-fabric-react-2020-03-06-11-38-13-Public-GroupedListSection.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Export GroupedListSection",
+  "packageName": "office-ui-fabric-react",
+  "email": "owcampbe@microsoft.com",
+  "commit": "31cb2dc96b17298470b88d1a879dac9b65128b54",
+  "dependentChangeType": "patch",
+  "date": "2020-03-06T19:38:13.897Z"
+}

--- a/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
+++ b/packages/office-ui-fabric-react/etc/office-ui-fabric-react.api.md
@@ -18,6 +18,7 @@ import { IFontStyles } from '@uifabric/styling';
 import { IHTMLSlot } from '@uifabric/foundation';
 import { IObjectWithKey } from '@uifabric/utilities';
 import { IPoint } from '@uifabric/utilities';
+import { IProcessedStyleSet } from '@uifabric/styling';
 import { IRawStyle } from '@uifabric/styling';
 import { IRectangle } from '@uifabric/utilities';
 import { IRefObject } from '@uifabric/utilities';
@@ -1349,6 +1350,23 @@ export class GroupedListBase extends React.Component<IGroupedListProps, IGrouped
     toggleCollapseAll(allCollapsed: boolean): void;
     // (undocumented)
     UNSAFE_componentWillReceiveProps(newProps: IGroupedListProps): void;
+    }
+
+// @public (undocumented)
+export class GroupedListSection extends React.Component<IGroupedListSectionProps, IGroupedListSectionState> {
+    constructor(props: IGroupedListSectionProps);
+    // (undocumented)
+    componentDidMount(): void;
+    // (undocumented)
+    componentDidUpdate(previousProps: IGroupedListSectionProps): void;
+    // (undocumented)
+    componentWillUnmount(): void;
+    // (undocumented)
+    forceListUpdate(): void;
+    // (undocumented)
+    forceUpdate(): void;
+    // (undocumented)
+    render(): JSX.Element;
     }
 
 // @public (undocumented)
@@ -4783,6 +4801,46 @@ export interface IGroupedListProps extends React.ClassAttributes<GroupedListBase
     theme?: ITheme;
     usePageCache?: boolean;
     viewport?: IViewport;
+}
+
+// @public (undocumented)
+export interface IGroupedListSectionProps extends React.ClassAttributes<GroupedListSection> {
+    compact?: boolean;
+    componentRef?: () => void;
+    dragDropEvents?: IDragDropEvents;
+    dragDropHelper?: IDragDropHelper;
+    eventsToRegister?: {
+        eventName: string;
+        callback: (context: IDragDropContext, event?: any) => void;
+    }[];
+    footerProps?: IGroupFooterProps;
+    getGroupItemLimit?: (group: IGroup) => number;
+    group?: IGroup;
+    groupedListClassNames?: IProcessedStyleSet<IGroupedListStyles>;
+    groupIndex?: number;
+    groupNestingDepth?: number;
+    groupProps?: IGroupRenderProps;
+    groups?: IGroup[];
+    headerProps?: IGroupHeaderProps;
+    items: any[];
+    listProps?: IListProps;
+    onRenderCell: (nestingDepth?: number, item?: any, index?: number) => React.ReactNode;
+    onRenderGroupFooter?: IRenderFunction<IGroupFooterProps>;
+    onRenderGroupHeader?: IRenderFunction<IGroupHeaderProps>;
+    onRenderGroupShowAll?: IRenderFunction<IGroupShowAllProps>;
+    onShouldVirtualize?: (props: IListProps) => boolean;
+    selection?: ISelection;
+    selectionMode?: SelectionMode;
+    showAllProps?: IGroupShowAllProps;
+    viewport?: IViewport;
+}
+
+// @public (undocumented)
+export interface IGroupedListSectionState {
+    // (undocumented)
+    isDropping?: boolean;
+    // (undocumented)
+    isSelected?: boolean;
 }
 
 // @public (undocumented)

--- a/packages/office-ui-fabric-react/src/components/GroupedList/index.ts
+++ b/packages/office-ui-fabric-react/src/components/GroupedList/index.ts
@@ -9,3 +9,4 @@ export * from './GroupShowAll';
 export { IGroupShowAllStyleProps, IGroupShowAllStyles } from './GroupShowAll.types';
 export { GroupSpacer } from './GroupSpacer';
 export * from './GroupSpacer.types';
+export * from './GroupedListSection';


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

This change exports the GroupedListSection control used internally in GroupedList.

I need a version of GroupedList that supports non-contiguous groups i.e. given an array of groups, which each contain an array of items. In order to implement this control, I'd prefer to be able to reuse the GroupedListSection used in GroupedList. This way, my control can be a fairly thin wrapper over a List of GroupedListSections.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12227)