### PR TITLE
feat: add disabled version for Dropdown and Input

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -40,6 +40,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Add `square` prop on the `Avatar` component @mnajdova ([#12277](https://github.com/OfficeDev/office-ui-fabric-react/pull/12277))
 - Adding `raise hand`, `raise hand colored`, `raise hand disabled`, `merge calls`, `share location`, `panorama` and `spotlight` icons @TanelVari ([#12212](https://github.com/OfficeDev/office-ui-fabric-react/pull/12212))
 - Expose `contentWrapper` shorthand from `AccordionTitle` @silviuavram ([#12265](https://github.com/OfficeDev/office-ui-fabric-react/pull/12265))
+- Add `disabled` versions for `Dropdown` and `Input` @silviuavram ([#12250](https://github.com/OfficeDev/office-ui-fabric-react/pull/12250))
 
 ### Documentation
 - Adding context menu for table row to example and prototype @kolaps33 ([#12253](https://github.com/OfficeDev/office-ui-fabric-react/pull/12253))

--- a/packages/fluentui/docs/src/examples/components/Dropdown/State/DropdownExampleDisabled.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Dropdown/State/DropdownExampleDisabled.shorthand.tsx
@@ -1,0 +1,15 @@
+import { Dropdown, Flex } from '@fluentui/react';
+import * as React from 'react';
+
+const inputItems = ['Bruce Wayne', 'Natasha Romanoff', 'Steven Strange', 'Alfred Pennyworth'];
+
+const DropdownExampleDisabled = () => {
+  return (
+    <Flex column gap="gap.smaller">
+      <Dropdown disabled={true} items={inputItems} placeholder="Select your hero, if you can ..." />
+      <Dropdown disabled={true} search={true} items={inputItems} placeholder="Start typing a name, if you can ..." />
+    </Flex>
+  );
+};
+
+export default DropdownExampleDisabled;

--- a/packages/fluentui/docs/src/examples/components/Dropdown/State/DropdownExampleDisabled.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Dropdown/State/DropdownExampleDisabled.shorthand.tsx
@@ -6,8 +6,8 @@ const inputItems = ['Bruce Wayne', 'Natasha Romanoff', 'Steven Strange', 'Alfred
 const DropdownExampleDisabled = () => {
   return (
     <Flex column gap="gap.smaller">
-      <Dropdown disabled={true} items={inputItems} placeholder="Select your hero, if you can ..." />
-      <Dropdown disabled={true} search={true} items={inputItems} placeholder="Start typing a name, if you can ..." />
+      <Dropdown disabled items={inputItems} placeholder="Select your hero, if you can ..." />
+      <Dropdown disabled search items={inputItems} placeholder="Start typing a name, if you can ..." />
     </Flex>
   );
 };

--- a/packages/fluentui/docs/src/examples/components/Dropdown/State/index.tsx
+++ b/packages/fluentui/docs/src/examples/components/Dropdown/State/index.tsx
@@ -6,6 +6,11 @@ import ExampleSection from '../../../../components/ComponentDoc/ExampleSection';
 const State = () => (
   <ExampleSection title="State">
     <ComponentExample
+      title="Disabled"
+      description="A dropdown can show it is currently unable to be interacted with."
+      examplePath="components/Dropdown/State/DropdownExampleDisabled"
+    />
+    <ComponentExample
       title="Loading"
       description="A dropdown can show that it is currently loading data."
       examplePath="components/Dropdown/State/DropdownExampleLoading"

--- a/packages/fluentui/docs/src/examples/components/Input/State/InputExampleDisabled.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Input/State/InputExampleDisabled.shorthand.tsx
@@ -1,6 +1,11 @@
 import * as React from 'react';
-import { Input } from '@fluentui/react';
+import { Input, Flex } from '@fluentui/react';
 
-const InputExampleDisabled = () => <Input fluid disabled placeholder="You shall not type ..." />;
+const InputExampleDisabled = () => (
+  <Flex gap="gap.smaller">
+    <Input fluid disabled placeholder="You shall not type ..." />
+    <Input fluid disabled clearable value="Same but clearable (apparently)" />
+  </Flex>
+);
 
 export default InputExampleDisabled;

--- a/packages/fluentui/docs/src/examples/components/Input/State/InputExampleDisabled.shorthand.tsx
+++ b/packages/fluentui/docs/src/examples/components/Input/State/InputExampleDisabled.shorthand.tsx
@@ -1,0 +1,6 @@
+import * as React from 'react';
+import { Input } from '@fluentui/react';
+
+const InputExampleDisabled = () => <Input fluid disabled placeholder="You shall not type ..." />;
+
+export default InputExampleDisabled;

--- a/packages/fluentui/docs/src/examples/components/Input/State/index.tsx
+++ b/packages/fluentui/docs/src/examples/components/Input/State/index.tsx
@@ -1,0 +1,15 @@
+import * as React from 'react';
+import ComponentExample from '../../../../components/ComponentDoc/ComponentExample';
+import ExampleSection from '../../../../components/ComponentDoc/ExampleSection';
+
+const State = () => (
+  <ExampleSection title="State">
+    <ComponentExample
+      title="Disabled"
+      description="A disabled Input can show it is currently unable to be interacted with."
+      examplePath="components/Input/State/InputExampleDisabled"
+    />
+  </ExampleSection>
+);
+
+export default State;

--- a/packages/fluentui/docs/src/examples/components/Input/index.tsx
+++ b/packages/fluentui/docs/src/examples/components/Input/index.tsx
@@ -3,11 +3,13 @@ import * as React from 'react';
 import Rtl from './Rtl';
 import Types from './Types';
 import Variations from './Variations';
+import State from './State';
 
 const InputExamples = () => (
   <div>
     <Types />
     <Variations />
+    <State />
     <Rtl />
   </div>
 );

--- a/packages/fluentui/react/src/components/Button/Button.tsx
+++ b/packages/fluentui/react/src/components/Button/Button.tsx
@@ -193,10 +193,6 @@ const Button: React.FC<WithAsProp<ButtonProps>> &
   };
 
   const handleFocus = (e: React.SyntheticEvent) => {
-    if (disabled) {
-      return;
-    }
-
     _.invoke(props, 'onFocus', e, props);
   };
 

--- a/packages/fluentui/react/src/components/Button/Button.tsx
+++ b/packages/fluentui/react/src/components/Button/Button.tsx
@@ -193,6 +193,10 @@ const Button: React.FC<WithAsProp<ButtonProps>> &
   };
 
   const handleFocus = (e: React.SyntheticEvent) => {
+    if (disabled) {
+      return;
+    }
+
     _.invoke(props, 'onFocus', e, props);
   };
 

--- a/packages/fluentui/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react/src/components/Dropdown/Dropdown.tsx
@@ -479,12 +479,11 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
                         }),
                         overrideProps: (predefinedProps: BoxProps) => ({
                           onClick: e => {
-                            if (disabled) {
-                              return;
+                            if (!disabled) {
+                              getToggleButtonProps({ disabled }).onClick(e);
                             }
 
                             _.invoke(predefinedProps, 'onClick', e);
-                            getToggleButtonProps({ disabled }).onClick(e);
                           }
                         })
                       })}
@@ -559,19 +558,17 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
               _.invoke(predefinedProps, 'onFocus', e, predefinedProps);
             },
             onBlur: e => {
-              if (disabled) {
-                return;
+              if (!disabled) {
+                onBlur(e);
               }
 
-              onBlur(e);
               _.invoke(predefinedProps, 'onBlur', e, predefinedProps);
             },
             onKeyDown: e => {
-              if (disabled) {
-                return;
+              if (!disabled) {
+                onKeyDown(e);
               }
 
-              onKeyDown(e);
               _.invoke(predefinedProps, 'onKeyDown', e, predefinedProps);
             }
           })
@@ -874,41 +871,38 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
     getInputProps: (options?: GetInputPropsOptions) => any
   ) => (predefinedProps: DropdownSearchInputProps) => {
     const handleInputBlur = (e: React.SyntheticEvent, searchInputProps: DropdownSearchInputProps) => {
-      if (disabled) {
-        return;
+      if (!disabled) {
+        this.setState({ focused: false, isFromKeyboard: isFromKeyboard() });
+
+        e.nativeEvent['preventDownshiftDefault'] = true;
       }
 
-      this.setState({ focused: false, isFromKeyboard: isFromKeyboard() });
-
-      e.nativeEvent['preventDownshiftDefault'] = true;
       _.invoke(predefinedProps, 'onInputBlur', e, searchInputProps);
     };
     const { disabled } = this.props;
 
     const handleInputKeyDown = (e: React.SyntheticEvent, searchInputProps: DropdownSearchInputProps) => {
-      if (disabled) {
-        return;
-      }
-
-      switch (keyboardKey.getCode(e)) {
-        case keyboardKey.Tab:
-          this.handleTabSelection(e, highlightedIndex, selectItemAtIndex, toggleMenu);
-          break;
-        case keyboardKey.ArrowLeft:
-          if (!rtl) {
-            this.trySetLastSelectedItemAsActive();
-          }
-          break;
-        case keyboardKey.ArrowRight:
-          if (rtl) {
-            this.trySetLastSelectedItemAsActive();
-          }
-          break;
-        case keyboardKey.Backspace:
-          this.tryRemoveItemFromValue();
-          break;
-        default:
-          break;
+      if (!disabled) {
+        switch (keyboardKey.getCode(e)) {
+          case keyboardKey.Tab:
+            this.handleTabSelection(e, highlightedIndex, selectItemAtIndex, toggleMenu);
+            break;
+          case keyboardKey.ArrowLeft:
+            if (!rtl) {
+              this.trySetLastSelectedItemAsActive();
+            }
+            break;
+          case keyboardKey.ArrowRight:
+            if (rtl) {
+              this.trySetLastSelectedItemAsActive();
+            }
+            break;
+          case keyboardKey.Backspace:
+            this.tryRemoveItemFromValue();
+            break;
+          default:
+            break;
+        }
       }
 
       _.invoke(predefinedProps, 'onInputKeyDown', e, {
@@ -935,11 +929,9 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
       // same story as above for getRootProps.
       accessibilityComboboxProps,
       onFocus: (e: React.SyntheticEvent, searchInputProps: DropdownSearchInputProps) => {
-        if (disabled) {
-          return;
+        if (!disabled) {
+          this.setState({ focused: true, isFromKeyboard: isFromKeyboard() });
         }
-
-        this.setState({ focused: true, isFromKeyboard: isFromKeyboard() });
 
         _.invoke(predefinedProps, 'onFocus', e, searchInputProps);
       },

--- a/packages/fluentui/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react/src/components/Dropdown/Dropdown.tsx
@@ -551,18 +551,10 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
           }),
           overrideProps: (predefinedProps: ButtonProps) => ({
             onClick: e => {
-              if (disabled) {
-                return;
-              }
-
               onClick(e);
               _.invoke(predefinedProps, 'onClick', e, predefinedProps);
             },
             onFocus: e => {
-              if (disabled) {
-                return;
-              }
-
               onFocus(e);
               _.invoke(predefinedProps, 'onFocus', e, predefinedProps);
             },

--- a/packages/fluentui/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react/src/components/Dropdown/Dropdown.tsx
@@ -74,7 +74,7 @@ export interface DropdownProps extends UIComponentProps<DropdownProps, DropdownS
   /** The initial value (or value array if the array has multiple selection). */
   defaultValue?: ShorthandValue<DropdownItemProps> | ShorthandCollection<DropdownItemProps>;
 
-  /** A Dropdown can be disabled. */
+  /** A dropdown can show that it cannot be interacted with. */
   disabled?: boolean;
 
   /** A dropdown can fill the width of its container. */

--- a/packages/fluentui/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react/src/components/Dropdown/Dropdown.tsx
@@ -74,6 +74,9 @@ export interface DropdownProps extends UIComponentProps<DropdownProps, DropdownS
   /** The initial value (or value array if the array has multiple selection). */
   defaultValue?: ShorthandValue<DropdownItemProps> | ShorthandCollection<DropdownItemProps>;
 
+  /** A Dropdown can be disabled. */
+  disabled?: boolean;
+
   /** A dropdown can fill the width of its container. */
   fluid?: boolean;
 
@@ -264,6 +267,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
     defaultHighlightedIndex: PropTypes.number,
     defaultSearchQuery: PropTypes.string,
     defaultValue: PropTypes.oneOfType([customPropTypes.itemShorthand, customPropTypes.collectionShorthand]),
+    disabled: PropTypes.bool,
     fluid: PropTypes.bool,
     getA11ySelectionMessage: PropTypes.object,
     getA11yStatusMessage: PropTypes.func,
@@ -399,7 +403,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
   };
 
   renderComponent({ ElementType, classes, styles, variables, unhandledProps, rtl }: RenderResultConfig<DropdownProps>) {
-    const { clearable, clearIndicator, search, multiple, getA11yStatusMessage, itemToString, toggleIndicator } = this.props;
+    const { clearable, clearIndicator, disabled, search, multiple, getA11yStatusMessage, itemToString, toggleIndicator } = this.props;
     const { highlightedIndex, open, searchQuery, value } = this.state;
 
     return (
@@ -474,10 +478,12 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
                           accessibility: indicatorBehavior
                         }),
                         overrideProps: (predefinedProps: BoxProps) => ({
-                          onClick: e => {
-                            _.invoke(predefinedProps, 'onClick', e);
-                            getToggleButtonProps().onClick(e);
-                          }
+                          ...(!disabled && {
+                            onClick: e => {
+                              _.invoke(predefinedProps, 'onClick', e);
+                              getToggleButtonProps().onClick(e);
+                            }
+                          })
                         })
                       })}
                   {this.renderItemsList(
@@ -510,7 +516,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
     rtl: boolean,
     getToggleButtonProps: (options?: GetToggleButtonPropsOptions) => any
   ): JSX.Element {
-    const { triggerButton } = this.props;
+    const { triggerButton, disabled } = this.props;
     const { value } = this.state;
 
     const content = this.getSelectedItemAsString(value[0]);
@@ -534,6 +540,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
           defaultProps: () => ({
             className: Dropdown.slotClassNames.triggerButton,
             content,
+            disabled,
             id: triggerButtonId,
             fluid: true,
             styles: styles.triggerButton,
@@ -571,7 +578,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
     toggleMenu: () => void,
     variables
   ): JSX.Element {
-    const { inline, searchInput, multiple, placeholder } = this.props;
+    const { inline, searchInput, multiple, placeholder, disabled } = this.props;
     const { searchQuery, value } = this.state;
 
     const noPlaceholder = searchQuery.length > 0 || (multiple && value.length > 0);
@@ -582,7 +589,8 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
         placeholder: noPlaceholder ? '' : placeholder,
         inline,
         variables,
-        inputRef: this.inputRef
+        inputRef: this.inputRef,
+        disabled
       }),
       overrideProps: this.handleSearchInputOverrides(
         highlightedIndex,

--- a/packages/fluentui/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react/src/components/Dropdown/Dropdown.tsx
@@ -478,12 +478,15 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
                           accessibility: indicatorBehavior
                         }),
                         overrideProps: (predefinedProps: BoxProps) => ({
-                          ...(!disabled && {
-                            onClick: e => {
-                              _.invoke(predefinedProps, 'onClick', e);
-                              getToggleButtonProps().onClick(e);
+                          onClick: e => {
+                            if (disabled) {
+                              e.preventDefault();
+                              return;
                             }
-                          })
+
+                            _.invoke(predefinedProps, 'onClick', e);
+                            getToggleButtonProps({ disabled }).onClick(e);
+                          }
                         })
                       })}
                   {this.renderItemsList(
@@ -523,6 +526,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
     const triggerButtonId = triggerButton['id'] || this.defaultTriggerButtonId;
 
     const triggerButtonProps = getToggleButtonProps({
+      disabled,
       onFocus: this.handleTriggerButtonOrListFocus,
       onBlur: this.handleTriggerButtonBlur,
       onKeyDown: e => {
@@ -548,18 +552,38 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
           }),
           overrideProps: (predefinedProps: ButtonProps) => ({
             onClick: e => {
+              if (disabled) {
+                e.preventDefault();
+                return;
+              }
+
               onClick(e);
               _.invoke(predefinedProps, 'onClick', e, predefinedProps);
             },
             onFocus: e => {
+              if (disabled) {
+                e.preventDefault();
+                return;
+              }
+
               onFocus(e);
               _.invoke(predefinedProps, 'onFocus', e, predefinedProps);
             },
             onBlur: e => {
+              if (disabled) {
+                e.preventDefault();
+                return;
+              }
+
               onBlur(e);
               _.invoke(predefinedProps, 'onBlur', e, predefinedProps);
             },
             onKeyDown: e => {
+              if (disabled) {
+                e.preventDefault();
+                return;
+              }
+
               onKeyDown(e);
               _.invoke(predefinedProps, 'onKeyDown', e, predefinedProps);
             }
@@ -863,12 +887,24 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
     getInputProps: (options?: GetInputPropsOptions) => any
   ) => (predefinedProps: DropdownSearchInputProps) => {
     const handleInputBlur = (e: React.SyntheticEvent, searchInputProps: DropdownSearchInputProps) => {
+      if (disabled) {
+        e.preventDefault();
+        return;
+      }
+
       this.setState({ focused: false, isFromKeyboard: isFromKeyboard() });
+
       e.nativeEvent['preventDownshiftDefault'] = true;
       _.invoke(predefinedProps, 'onInputBlur', e, searchInputProps);
     };
+    const { disabled } = this.props;
 
     const handleInputKeyDown = (e: React.SyntheticEvent, searchInputProps: DropdownSearchInputProps) => {
+      if (disabled) {
+        e.preventDefault();
+        return;
+      }
+
       switch (keyboardKey.getCode(e)) {
         case keyboardKey.Tab:
           this.handleTabSelection(e, highlightedIndex, selectItemAtIndex, toggleMenu);
@@ -902,6 +938,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
       // user handlers were also added to our handlers previously, at the beginning of this function.
       accessibilityInputProps: {
         ...getInputProps({
+          disabled,
           onBlur: e => {
             handleInputBlur(e, predefinedProps);
           },
@@ -913,6 +950,11 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
       // same story as above for getRootProps.
       accessibilityComboboxProps,
       onFocus: (e: React.SyntheticEvent, searchInputProps: DropdownSearchInputProps) => {
+        if (disabled) {
+          e.preventDefault();
+          return;
+        }
+
         this.setState({ focused: true, isFromKeyboard: isFromKeyboard() });
 
         _.invoke(predefinedProps, 'onFocus', e, searchInputProps);

--- a/packages/fluentui/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react/src/components/Dropdown/Dropdown.tsx
@@ -480,7 +480,6 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
                         overrideProps: (predefinedProps: BoxProps) => ({
                           onClick: e => {
                             if (disabled) {
-                              e.preventDefault();
                               return;
                             }
 
@@ -553,7 +552,6 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
           overrideProps: (predefinedProps: ButtonProps) => ({
             onClick: e => {
               if (disabled) {
-                e.preventDefault();
                 return;
               }
 
@@ -562,7 +560,6 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
             },
             onFocus: e => {
               if (disabled) {
-                e.preventDefault();
                 return;
               }
 
@@ -571,7 +568,6 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
             },
             onBlur: e => {
               if (disabled) {
-                e.preventDefault();
                 return;
               }
 
@@ -580,7 +576,6 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
             },
             onKeyDown: e => {
               if (disabled) {
-                e.preventDefault();
                 return;
               }
 
@@ -888,7 +883,6 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
   ) => (predefinedProps: DropdownSearchInputProps) => {
     const handleInputBlur = (e: React.SyntheticEvent, searchInputProps: DropdownSearchInputProps) => {
       if (disabled) {
-        e.preventDefault();
         return;
       }
 
@@ -901,7 +895,6 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
 
     const handleInputKeyDown = (e: React.SyntheticEvent, searchInputProps: DropdownSearchInputProps) => {
       if (disabled) {
-        e.preventDefault();
         return;
       }
 
@@ -951,7 +944,6 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
       accessibilityComboboxProps,
       onFocus: (e: React.SyntheticEvent, searchInputProps: DropdownSearchInputProps) => {
         if (disabled) {
-          e.preventDefault();
           return;
         }
 

--- a/packages/fluentui/react/src/components/Dropdown/DropdownSearchInput.tsx
+++ b/packages/fluentui/react/src/components/Dropdown/DropdownSearchInput.tsx
@@ -20,7 +20,7 @@ export interface DropdownSearchInputProps extends UIComponentProps<DropdownSearc
   /** Accessibility props for input slot. */
   accessibilityInputProps?: any;
 
-  /** A DropdownSearchInput can be disabled. */
+  /** A dropdown search input can show that it cannot be interacted with. */
   disabled?: boolean;
 
   /** A dropdown search input can be formatted to appear inline in the context of a Dropdown. */

--- a/packages/fluentui/react/src/components/Dropdown/DropdownSearchInput.tsx
+++ b/packages/fluentui/react/src/components/Dropdown/DropdownSearchInput.tsx
@@ -20,6 +20,9 @@ export interface DropdownSearchInputProps extends UIComponentProps<DropdownSearc
   /** Accessibility props for input slot. */
   accessibilityInputProps?: any;
 
+  /** A DropdownSearchInput can be disabled. */
+  disabled?: boolean;
+
   /** A dropdown search input can be formatted to appear inline in the context of a Dropdown. */
   inline?: boolean;
 
@@ -76,6 +79,7 @@ class DropdownSearchInput extends UIComponent<WithAsProp<DropdownSearchInputProp
     }),
     accessibilityInputProps: PropTypes.object,
     accessibilityComboboxProps: PropTypes.object,
+    disabled: PropTypes.bool,
     inline: PropTypes.bool,
     inputRef: customPropTypes.ref,
     onFocus: PropTypes.func,
@@ -102,9 +106,10 @@ class DropdownSearchInput extends UIComponent<WithAsProp<DropdownSearchInputProp
   };
 
   renderComponent({ unhandledProps, styles }: RenderResultConfig<DropdownSearchInputProps>) {
-    const { accessibilityComboboxProps, accessibilityInputProps, inputRef, placeholder } = this.props;
+    const { accessibilityComboboxProps, accessibilityInputProps, inputRef, placeholder, disabled } = this.props;
     return (
       <Input
+        disabled={disabled}
         inputRef={inputRef}
         onFocus={this.handleFocus}
         onKeyUp={this.handleKeyUp}

--- a/packages/fluentui/react/src/components/Input/Input.tsx
+++ b/packages/fluentui/react/src/components/Input/Input.tsx
@@ -190,6 +190,11 @@ class Input extends AutoControlledComponent<WithAsProp<InputProps>, InputState> 
 
   handleIconOverrides = predefinedProps => ({
     onClick: (e: React.SyntheticEvent) => {
+      if (this.props.disabled) {
+        e.preventDefault();
+        return;
+      }
+
       this.handleOnClear(e);
       this.inputRef.current.focus();
       _.invoke(predefinedProps, 'onClick', e, this.props);
@@ -197,6 +202,11 @@ class Input extends AutoControlledComponent<WithAsProp<InputProps>, InputState> 
   });
 
   handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (this.props.disabled) {
+      e.preventDefault();
+      return;
+    }
+
     const value = _.get(e, 'target.value');
 
     _.invoke(this.props, 'onChange', e, { ...this.props, value });

--- a/packages/fluentui/react/src/components/Input/Input.tsx
+++ b/packages/fluentui/react/src/components/Input/Input.tsx
@@ -190,12 +190,11 @@ class Input extends AutoControlledComponent<WithAsProp<InputProps>, InputState> 
 
   handleIconOverrides = predefinedProps => ({
     onClick: (e: React.SyntheticEvent) => {
-      if (this.props.disabled) {
-        return;
+      if (!this.props.disabled) {
+        this.handleOnClear(e);
+        this.inputRef.current.focus();
       }
 
-      this.handleOnClear(e);
-      this.inputRef.current.focus();
       _.invoke(predefinedProps, 'onClick', e, this.props);
     }
   });

--- a/packages/fluentui/react/src/components/Input/Input.tsx
+++ b/packages/fluentui/react/src/components/Input/Input.tsx
@@ -36,6 +36,9 @@ export interface InputProps extends UIComponentProps, ChildrenComponentProps, Su
   /** The default value of the input. */
   defaultValue?: string | string[];
 
+  /** An Input can be disabled. */
+  disabled?: boolean;
+
   /** An input can take the width of its container. */
   fluid?: boolean;
 
@@ -95,6 +98,7 @@ class Input extends AutoControlledComponent<WithAsProp<InputProps>, InputState> 
     }),
     clearable: PropTypes.bool,
     defaultValue: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    disabled: PropTypes.bool,
     fluid: PropTypes.bool,
     icon: customPropTypes.itemShorthandWithoutJSX,
     iconPosition: PropTypes.oneOf(['start', 'end']),
@@ -136,7 +140,7 @@ class Input extends AutoControlledComponent<WithAsProp<InputProps>, InputState> 
   };
 
   renderComponent({ accessibility, ElementType, unhandledProps, styles, variables }: RenderResultConfig<InputProps>) {
-    const { className, input, inputRef, type, wrapper } = this.props;
+    const { className, input, inputRef, type, wrapper, disabled } = this.props;
     const { value = '' } = this.state;
     const [htmlInputProps, restProps] = partitionHTMLProps(unhandledProps);
 
@@ -156,6 +160,7 @@ class Input extends AutoControlledComponent<WithAsProp<InputProps>, InputState> 
                 defaultProps: () => ({
                   ...htmlInputProps,
                   as: 'input',
+                  disabled,
                   type,
                   value,
                   className: Input.slotClassNames.input,

--- a/packages/fluentui/react/src/components/Input/Input.tsx
+++ b/packages/fluentui/react/src/components/Input/Input.tsx
@@ -191,7 +191,6 @@ class Input extends AutoControlledComponent<WithAsProp<InputProps>, InputState> 
   handleIconOverrides = predefinedProps => ({
     onClick: (e: React.SyntheticEvent) => {
       if (this.props.disabled) {
-        e.preventDefault();
         return;
       }
 
@@ -203,7 +202,6 @@ class Input extends AutoControlledComponent<WithAsProp<InputProps>, InputState> 
 
   handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (this.props.disabled) {
-      e.preventDefault();
       return;
     }
 

--- a/packages/fluentui/react/src/themes/teams-dark/components/Dropdown/dropdownVariables.ts
+++ b/packages/fluentui/react/src/themes/teams-dark/components/Dropdown/dropdownVariables.ts
@@ -18,5 +18,9 @@ export default (siteVars): Partial<DropdownVariables> => ({
   selectedItemBackgroundColor: siteVars.colors.grey[650],
   selectedItemColorFocus: siteVars.colors.grey[700], // check this value
   listItemSelectedColor: siteVars.colors.white,
-  selectedItemBackgroundColorFocus: siteVars.colors.brand[200]
+  selectedItemBackgroundColorFocus: siteVars.colors.brand[200],
+  // disabled state
+  disabledBorderColorHover: 'transparent',
+  disabledTriggerColorHover: siteVars.colors.grey[250],
+  disabledBackgroundColorHover: siteVars.colors.grey[650]
 });

--- a/packages/fluentui/react/src/themes/teams-high-contrast/components/Dropdown/dropdownVariables.ts
+++ b/packages/fluentui/react/src/themes/teams-high-contrast/components/Dropdown/dropdownVariables.ts
@@ -28,5 +28,9 @@ export default (siteVars): Partial<DropdownVariables> => ({
   selectedItemColorFocus: siteVars.colors.black,
   selectedItemBackgroundColorFocus: siteVars.accessibleCyan,
   triggerButtonColorFocusActive: siteVars.colors.white,
-  triggerButtonColorHover: siteVars.colors.white
+  triggerButtonColorHover: siteVars.colors.white,
+  // disabled state
+  disabledBorderColorHover: siteVars.colors.white,
+  disabledTriggerColorHover: siteVars.colors.white,
+  disabledBackgroundColorHover: siteVars.colors.black
 });

--- a/packages/fluentui/react/src/themes/teams/components/Dropdown/dropdownStyles.ts
+++ b/packages/fluentui/react/src/themes/teams/components/Dropdown/dropdownStyles.ts
@@ -176,13 +176,12 @@ const dropdownStyles: ComponentSlotStylesPrepared<DropdownPropsAndState, Dropdow
     display: 'flex',
     justifyContent: 'center',
 
-    backgroundImage: toggleIndicatorUrl(v.color),
+    backgroundImage: toggleIndicatorUrl(p.disabled ? v.disabledColor : v.color),
     backgroundPosition: 'center',
     backgroundRepeat: 'no-repeat',
     cursor: 'pointer',
     ...(p.disabled && {
-      cursor: 'default',
-      fill: v.disabledColor
+      cursor: 'default'
     }),
     userSelect: 'none',
 

--- a/packages/fluentui/react/src/themes/teams/components/Dropdown/dropdownStyles.ts
+++ b/packages/fluentui/react/src/themes/teams/components/Dropdown/dropdownStyles.ts
@@ -181,7 +181,8 @@ const dropdownStyles: ComponentSlotStylesPrepared<DropdownPropsAndState, Dropdow
     backgroundRepeat: 'no-repeat',
     cursor: 'pointer',
     ...(p.disabled && {
-      cursor: 'default'
+      cursor: 'default',
+      fill: v.disabledColor
     }),
     userSelect: 'none',
 

--- a/packages/fluentui/react/src/themes/teams/components/Dropdown/dropdownStyles.ts
+++ b/packages/fluentui/react/src/themes/teams/components/Dropdown/dropdownStyles.ts
@@ -73,20 +73,27 @@ const dropdownStyles: ComponentSlotStylesPrepared<DropdownPropsAndState, Dropdow
     borderRadius: v.containerBorderRadius,
     ...(p.open && p.position === 'above' && { borderRadius: v.openAboveContainerBorderRadius }),
     ...(p.open && p.position === 'below' && { borderRadius: v.openBelowContainerBorderRadius }),
-    ...(!p.disabled && {
-      ':hover': {
-        backgroundColor: v.backgroundColorHover,
-        borderColor: v.borderColorHover,
+    ':hover': {
+      backgroundColor: v.backgroundColorHover,
+      borderColor: v.borderColorHover,
 
-        ...(p.open && {
-          borderColor: v.openBorderColorHover
-        }),
+      ...(p.open && {
+        borderColor: v.openBorderColorHover
+      }),
 
-        [`& .${Dropdown.slotClassNames.triggerButton}`]: {
-          color: v.triggerButtonColorHover
-        }
+      ...(p.disabled && {
+        backgroundColor: v.disabledBackgroundColorHover,
+        borderColor: v.disabledBorderColorHover
+      }),
+
+      [`& .${Dropdown.slotClassNames.triggerButton}`]: {
+        color: v.triggerButtonColorHover,
+
+        ...(p.disabled && {
+          color: v.disabledTriggerColorHover
+        })
       }
-    }),
+    },
     ...(p.focused && {
       ...(p.search && { borderBottomColor: v.borderColorFocus }),
       ...(!p.search && !p.open && p.isFromKeyboard && getBorderFocusStyles({ variables: siteVariables })[':focus-visible'])

--- a/packages/fluentui/react/src/themes/teams/components/Dropdown/dropdownStyles.ts
+++ b/packages/fluentui/react/src/themes/teams/components/Dropdown/dropdownStyles.ts
@@ -177,8 +177,9 @@ const dropdownStyles: ComponentSlotStylesPrepared<DropdownPropsAndState, Dropdow
     backgroundImage: toggleIndicatorUrl(v.color),
     backgroundPosition: 'center',
     backgroundRepeat: 'no-repeat',
-    ...(!p.disabled && {
-      cursor: 'pointer'
+    cursor: 'pointer',
+    ...(p.disabled && {
+      cursor: 'default'
     }),
     userSelect: 'none',
 

--- a/packages/fluentui/react/src/themes/teams/components/Dropdown/dropdownStyles.ts
+++ b/packages/fluentui/react/src/themes/teams/components/Dropdown/dropdownStyles.ts
@@ -169,7 +169,7 @@ const dropdownStyles: ComponentSlotStylesPrepared<DropdownPropsAndState, Dropdow
     fontWeight: 'bold'
   }),
 
-  toggleIndicator: ({ variables: v }) => ({
+  toggleIndicator: ({ props: p, variables: v }) => ({
     alignItems: 'center',
     display: 'flex',
     justifyContent: 'center',
@@ -177,7 +177,9 @@ const dropdownStyles: ComponentSlotStylesPrepared<DropdownPropsAndState, Dropdow
     backgroundImage: toggleIndicatorUrl(v.color),
     backgroundPosition: 'center',
     backgroundRepeat: 'no-repeat',
-    cursor: 'pointer',
+    ...(!p.disabled && {
+      cursor: 'pointer'
+    }),
     userSelect: 'none',
 
     margin: 0,

--- a/packages/fluentui/react/src/themes/teams/components/Dropdown/dropdownStyles.ts
+++ b/packages/fluentui/react/src/themes/teams/components/Dropdown/dropdownStyles.ts
@@ -73,18 +73,20 @@ const dropdownStyles: ComponentSlotStylesPrepared<DropdownPropsAndState, Dropdow
     borderRadius: v.containerBorderRadius,
     ...(p.open && p.position === 'above' && { borderRadius: v.openAboveContainerBorderRadius }),
     ...(p.open && p.position === 'below' && { borderRadius: v.openBelowContainerBorderRadius }),
-    ':hover': {
-      backgroundColor: v.backgroundColorHover,
-      borderColor: v.borderColorHover,
+    ...(!p.disabled && {
+      ':hover': {
+        backgroundColor: v.backgroundColorHover,
+        borderColor: v.borderColorHover,
 
-      ...(p.open && {
-        borderColor: v.openBorderColorHover
-      }),
+        ...(p.open && {
+          borderColor: v.openBorderColorHover
+        }),
 
-      [`& .${Dropdown.slotClassNames.triggerButton}`]: {
-        color: v.triggerButtonColorHover
+        [`& .${Dropdown.slotClassNames.triggerButton}`]: {
+          color: v.triggerButtonColorHover
+        }
       }
-    },
+    }),
     ...(p.focused && {
       ...(p.search && { borderBottomColor: v.borderColorFocus }),
       ...(!p.search && !p.open && p.isFromKeyboard && getBorderFocusStyles({ variables: siteVariables })[':focus-visible'])

--- a/packages/fluentui/react/src/themes/teams/components/Dropdown/dropdownVariables.ts
+++ b/packages/fluentui/react/src/themes/teams/components/Dropdown/dropdownVariables.ts
@@ -48,6 +48,9 @@ export interface DropdownVariables {
   triggerButtonColorHover: string;
   width: string;
   overlayZIndex: number;
+  disabledBorderColorHover: string;
+  disabledTriggerColorHover: string;
+  disabledBackgroundColorHover: string;
 }
 
 const [cornerRadius, _12px_asRem] = [3, 12].map(v => pxToRem(v));
@@ -97,6 +100,10 @@ export default (siteVars): DropdownVariables => ({
   triggerButtonColorHover: siteVars.bodyColor,
   width: pxToRem(356),
   overlayZIndex: siteVars.zIndexes.overlay,
+  // disabled state
+  disabledBorderColorHover: 'transparent',
+  disabledTriggerColorHover: siteVars.bodyColor,
+  disabledBackgroundColorHover: siteVars.colors.grey[100],
 
   // these should only apply when there is content in the image/media slot:
   listItemHeaderFontSize: siteVars.fontSizes.medium,

--- a/packages/fluentui/react/src/themes/teams/components/Dropdown/dropdownVariables.ts
+++ b/packages/fluentui/react/src/themes/teams/components/Dropdown/dropdownVariables.ts
@@ -9,6 +9,7 @@ export interface DropdownVariables {
   borderColorHover: string;
   borderWidth: string;
   containerBorderRadius: string;
+  disabledColor: string;
   openAboveContainerBorderRadius: string;
   openBelowContainerBorderRadius: string;
   searchBorderBottomWidth: string;
@@ -60,6 +61,7 @@ export default (siteVars): DropdownVariables => ({
   borderColorHover: undefined,
   borderWidth: '0px',
   containerBorderRadius: `${cornerRadius}`,
+  disabledColor: siteVars.colors.grey[250],
   openAboveContainerBorderRadius: `0 0 ${cornerRadius} ${cornerRadius}`,
   openBelowContainerBorderRadius: `${cornerRadius} ${cornerRadius} 0 0`,
   searchBorderBottomWidth: pxToRem(2),

--- a/packages/fluentui/react/src/themes/teams/components/Input/inputStyles.ts
+++ b/packages/fluentui/react/src/themes/teams/components/Input/inputStyles.ts
@@ -64,6 +64,9 @@ const inputStyles: ComponentSlotStylesPrepared<InputProps & InputState, InputVar
     color: v.iconColor,
     outline: 0,
     position: v.iconPosition as PositionProperty,
+    ...(p.disabled && {
+      color: v.colorDisabled
+    }),
 
     ...(p.iconPosition === 'start' && {
       left: v.iconLeft
@@ -74,7 +77,7 @@ const inputStyles: ComponentSlotStylesPrepared<InputProps & InputState, InputVar
 
     ...(p.clearable &&
       p.hasValue && {
-        backgroundImage: clearIndicatorUrl(v.iconColor),
+        backgroundImage: clearIndicatorUrl(p.disabled ? v.colorDisabled : v.iconColor),
         backgroundPosition: 'center',
         backgroundRepeat: 'no-repeat',
         height: '100%',

--- a/packages/fluentui/react/src/themes/teams/components/Input/inputStyles.ts
+++ b/packages/fluentui/react/src/themes/teams/components/Input/inputStyles.ts
@@ -42,6 +42,15 @@ const inputStyles: ComponentSlotStylesPrepared<InputProps & InputState, InputVar
       opacity: 1 // undo Firefox default opacity
     },
 
+    // Overrides for "disabled" inputs
+    ...(p.disabled && {
+      color: v.colorDisabled,
+      boxShadow: 'none',
+      '::placeholder': {
+        color: v.colorDisabled
+      }
+    }),
+
     ':focus': {
       borderColor: v.inputFocusBorderColor
     },

--- a/packages/fluentui/react/src/themes/teams/components/Input/inputStyles.ts
+++ b/packages/fluentui/react/src/themes/teams/components/Input/inputStyles.ts
@@ -37,19 +37,19 @@ const inputStyles: ComponentSlotStylesPrepared<InputProps & InputState, InputVar
     ...(p.fluid && { width: '100%' }),
     ...(p.inline && { float: 'left' }),
 
-    '::placeholder': {
-      color: v.placeholderColor,
-      opacity: 1 // undo Firefox default opacity
-    },
-
     // Overrides for "disabled" inputs
     ...(p.disabled && {
       color: v.colorDisabled,
-      boxShadow: 'none',
-      '::placeholder': {
-        color: v.colorDisabled
-      }
+      boxShadow: 'none'
     }),
+
+    '::placeholder': {
+      color: v.placeholderColor,
+      opacity: 1, // undo Firefox default opacity
+      ...(p.disabled && {
+        color: v.colorDisabled
+      })
+    },
 
     ':focus': {
       borderColor: v.inputFocusBorderColor

--- a/packages/fluentui/react/src/themes/teams/components/Input/inputVariables.ts
+++ b/packages/fluentui/react/src/themes/teams/components/Input/inputVariables.ts
@@ -6,6 +6,7 @@ export interface InputVariables {
   borderColor: string;
   borderRadius: string;
   borderWidth: string;
+  colorDisabled: string;
   fontColor: string;
   fontSize: string;
   iconColor: string;
@@ -21,6 +22,7 @@ export interface InputVariables {
 }
 
 export default (siteVars): InputVariables => ({
+  colorDisabled: siteVars.colorScheme.brand.foregroundDisabled,
   iconPosition: 'absolute',
   iconRight: pxToRem(10),
   iconLeft: pxToRem(6),

--- a/packages/fluentui/react/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/fluentui/react/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -1304,6 +1304,8 @@ describe('Dropdown', () => {
         disabled: true
       });
 
+      expect(triggerButtonNode).toHaveAttribute('disabled');
+
       clickOnTriggerButton();
 
       expect(getItemNodes()).toHaveLength(0);
@@ -1322,6 +1324,8 @@ describe('Dropdown', () => {
         disabled: true,
         search: true
       });
+
+      expect(searchInputNode).toHaveAttribute('disabled');
 
       keyDownOnSearchInput('ArrowDown');
 

--- a/packages/fluentui/react/test/specs/components/Dropdown/Dropdown-test.tsx
+++ b/packages/fluentui/react/test/specs/components/Dropdown/Dropdown-test.tsx
@@ -696,14 +696,14 @@ describe('Dropdown', () => {
     });
 
     it('is replaced when another item is selected', () => {
-      const defaultSelectedIndex = 0;
+      const defaultValue = items[0];
       const itemSelectedIndex = 2;
       const { triggerButtonNode, clickOnItemAtIndex } = renderDropdown({
         defaultOpen: true,
-        defaultValue: items[defaultSelectedIndex]
+        defaultValue
       });
 
-      expect(triggerButtonNode).toHaveTextContent(items[defaultSelectedIndex]);
+      expect(triggerButtonNode).toHaveTextContent(defaultValue);
 
       clickOnItemAtIndex(itemSelectedIndex);
 
@@ -721,7 +721,7 @@ describe('Dropdown', () => {
       expect(getSelectedItemNodeAtIndex(1)).toHaveTextContent(items[1]);
     });
 
-    it('emoves last item on backspace when query is emtpy', () => {
+    it('removes last item on backspace when query is emtpy', () => {
       const { getSelectedItemNodes, getSelectedItemNodeAtIndex, keyDownOnSearchInput } = renderDropdown({
         multiple: true,
         search: true,
@@ -734,7 +734,7 @@ describe('Dropdown', () => {
       expect(getSelectedItemNodeAtIndex(0)).toHaveTextContent(items[0]);
     });
 
-    it('does not rempve last item on backspace when query is not empty', () => {
+    it('does not remove last item on backspace when query is not empty', () => {
       const { getSelectedItemNodes, keyDownOnSearchInput, searchInputNode } = renderDropdown({
         multiple: true,
         search: true,
@@ -763,7 +763,7 @@ describe('Dropdown', () => {
       expect(getSelectedItemNodeAtIndex(0)).toHaveTextContent(items[0]);
     });
 
-    it('does not rempve last item on backspace when selection range is 0, (y>0)', () => {
+    it('does not remove last item on backspace when selection range is 0, (y>0)', () => {
       const { getSelectedItemNodes, keyDownOnSearchInput, searchInputNode } = renderDropdown({
         multiple: true,
         search: true,
@@ -894,6 +894,7 @@ describe('Dropdown', () => {
       });
 
       wrapper.setProps({ searchQuery: newSearchQueryProp });
+
       expect(searchInputNode).toHaveValue(newSearchQueryProp);
     });
 
@@ -1294,6 +1295,59 @@ describe('Dropdown', () => {
       renderDropdown({ renderSelectedItem, multiple: true, value });
 
       expect(renderSelectedItem).toBeCalledTimes(value.length);
+    });
+  });
+
+  describe('disabled', () => {
+    it('allows no action on the trigger button', () => {
+      const { clickOnTriggerButton, focusTriggerButton, getItemNodes, triggerButtonNode, keyDownOnTriggerButton } = renderDropdown({
+        disabled: true
+      });
+
+      clickOnTriggerButton();
+
+      expect(getItemNodes()).toHaveLength(0);
+
+      focusTriggerButton();
+
+      expect(triggerButtonNode).not.toHaveFocus();
+
+      keyDownOnTriggerButton('ArrowDown');
+
+      expect(getItemNodes()).toHaveLength(0);
+    });
+
+    it('allows no action on the search input', () => {
+      const { keyDownOnSearchInput, clickOnSearchInput, focusSearchInput, getItemNodes, searchInputNode } = renderDropdown({
+        disabled: true,
+        search: true
+      });
+
+      keyDownOnSearchInput('ArrowDown');
+
+      expect(getItemNodes()).toHaveLength(0);
+
+      focusSearchInput();
+
+      expect(searchInputNode).not.toHaveFocus();
+
+      clickOnSearchInput();
+
+      expect(searchInputNode).not.toHaveFocus();
+    });
+
+    it('allows no action on the toggle indicator', () => {
+      const { clickOnToggleIndicator, toggleIndicatorNode, getItemNodes } = renderDropdown({
+        disabled: true
+      });
+
+      clickOnToggleIndicator();
+
+      expect(getItemNodes()).toHaveLength(0);
+
+      toggleIndicatorNode.focus();
+
+      expect(toggleIndicatorNode).not.toHaveFocus();
     });
   });
 });

--- a/packages/fluentui/react/test/specs/components/Dropdown/test-utils.tsx
+++ b/packages/fluentui/react/test/specs/components/Dropdown/test-utils.tsx
@@ -20,9 +20,9 @@ const renderDropdown = (props: DropdownProps = {}) => {
 
   return {
     wrapper,
-    triggerButtonNode: triggerButtonWrapper.length ? triggerButtonWrapper.getDOMNode() : null,
-    toggleIndicatorNode: toggleIndicatorWrapper.length ? toggleIndicatorWrapper.getDOMNode() : null,
-    itemsListNode: itemsListWrapper.getDOMNode(),
+    triggerButtonNode: triggerButtonWrapper.length ? triggerButtonWrapper.getDOMNode<HTMLElement>() : null,
+    toggleIndicatorNode: toggleIndicatorWrapper.length ? toggleIndicatorWrapper.getDOMNode<HTMLElement>() : null,
+    itemsListNode: itemsListWrapper.getDOMNode<HTMLElement>(),
     searchInputNode: searchInputWrapper.length ? searchInputWrapper.getDOMNode<HTMLInputElement>() : null,
     getA11yMessageContainerNode: () => findIntrinsicElement(wrapper, '[role="status"]').getDOMNode(),
     getItemNodes: () => getItemsWrapper().map(nodeWrapper => nodeWrapper.getDOMNode()),

--- a/packages/fluentui/react/test/specs/components/Input/Input-test.tsx
+++ b/packages/fluentui/react/test/specs/components/Input/Input-test.tsx
@@ -128,4 +128,23 @@ describe('Input', () => {
       expect(inputComp.find('Icon[name=""]').length).toEqual(0); // the 'x' icon disappears
     });
   });
+
+  it('disabled prop makes the input un-actionable', () => {
+    const inputComp = mount(<Input disabled />);
+    const domNode = getInputDomNode(inputComp);
+
+    expect(domNode).toHaveAttribute('disabled');
+
+    setUserInputValue(inputComp, testValue); // user types into the input
+
+    expect(domNode.value).toEqual(''); // but nothing happens
+
+    domNode.focus();
+
+    expect(domNode).not.toHaveFocus();
+
+    domNode.click();
+
+    expect(domNode).not.toHaveFocus();
+  });
 });


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #12316 
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Provides `disabled` behavior for `Dropdown` and also for `Input` (because we are using `Input` for `DropdownSearchInput`).

- only executes event handlers from `predefinedProps` if `disabled` is true.
- add `disabled` prop on native `input` and `button`.
- add `disabled` to Downshift so it does not give us handlers anymore.

Added examples in docsite for both components and also unit tests.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12250)