### PR TITLE
chore(Menu): refactor styles in High Contrast theme

### DIFF
--- a/packages/fluentui/react/src/themes/teams-high-contrast/components/Menu/menuItemStyles.ts
+++ b/packages/fluentui/react/src/themes/teams-high-contrast/components/Menu/menuItemStyles.ts
@@ -18,18 +18,18 @@ const menuItemStyles: ComponentSlotStylesPrepared<MenuItemPropsAndState, MenuVar
       ':hover': {
         color: v.colorActive,
 
-        ...(underlined && {
-          color: v.color
-        }),
-
         ...((iconOnly || vertical) && {
           color: v.colorActive,
           background: v.backgroundColorFocus
         }),
 
         ...(!active && {
-          ...(primary && !underlined && { color: v.colorActive }),
+          ...(primary && { color: v.colorActive }),
           background: v.backgroundColorFocus
+        }),
+
+        ...(underlined && {
+          color: v.color
         })
       },
 

--- a/packages/fluentui/react/src/themes/teams-high-contrast/components/Menu/menuItemStyles.ts
+++ b/packages/fluentui/react/src/themes/teams-high-contrast/components/Menu/menuItemStyles.ts
@@ -19,12 +19,10 @@ const menuItemStyles: ComponentSlotStylesPrepared<MenuItemPropsAndState, MenuVar
         color: v.colorActive,
 
         ...((iconOnly || vertical) && {
-          color: v.colorActive,
           background: v.backgroundColorFocus
         }),
 
         ...(!active && {
-          ...(primary && { color: v.colorActive }),
           background: v.backgroundColorFocus
         }),
 

--- a/packages/fluentui/react/src/themes/teams-high-contrast/components/Menu/menuItemStyles.ts
+++ b/packages/fluentui/react/src/themes/teams-high-contrast/components/Menu/menuItemStyles.ts
@@ -77,7 +77,6 @@ const menuItemStyles: ComponentSlotStylesPrepared<MenuItemPropsAndState, MenuVar
         }),
 
       ...(disabled && {
-        cursor: 'default',
         ':hover': {
           // reset all existing hover styles
         }

--- a/packages/fluentui/react/src/themes/teams-high-contrast/components/Menu/menuItemStyles.ts
+++ b/packages/fluentui/react/src/themes/teams-high-contrast/components/Menu/menuItemStyles.ts
@@ -18,17 +18,8 @@ const menuItemStyles: ComponentSlotStylesPrepared<MenuItemPropsAndState, MenuVar
       ':hover': {
         color: v.colorActive,
 
-        ...((iconOnly || vertical) && {
-          background: v.backgroundColorFocus
-        }),
-
-        ...(!active && {
-          background: v.backgroundColorFocus
-        }),
-
-        ...(underlined && {
-          color: v.color
-        })
+        ...(underlined && { color: v.color }),
+        ...(!underlined && { background: v.backgroundColorFocus })
       },
 
       ...(active && {

--- a/packages/fluentui/react/src/themes/teams-high-contrast/components/Menu/menuItemStyles.ts
+++ b/packages/fluentui/react/src/themes/teams-high-contrast/components/Menu/menuItemStyles.ts
@@ -17,6 +17,16 @@ const menuItemStyles: ComponentSlotStylesPrepared<MenuItemPropsAndState, MenuVar
 
       ':hover': {
         color: v.colorActive,
+
+        ...(underlined && {
+          color: v.color
+        }),
+
+        ...((iconOnly || vertical) && {
+          color: v.colorActive,
+          background: v.backgroundColorFocus
+        }),
+
         ...(!active && {
           ...(primary && !underlined && { color: v.colorActive }),
           background: v.backgroundColorFocus
@@ -34,19 +44,6 @@ const menuItemStyles: ComponentSlotStylesPrepared<MenuItemPropsAndState, MenuVar
         color: v.colorActive,
 
         ...(!underlined && { background: v.backgroundColorFocus })
-      }),
-
-      ...((iconOnly || vertical) && {
-        ':hover': {
-          color: v.colorActive,
-          background: v.backgroundColorFocus
-        }
-      }),
-
-      ...(underlined && {
-        ':hover': {
-          color: v.color
-        }
       }),
 
       ...(pointing &&

--- a/packages/fluentui/react/src/themes/teams-high-contrast/components/Menu/menuItemStyles.ts
+++ b/packages/fluentui/react/src/themes/teams-high-contrast/components/Menu/menuItemStyles.ts
@@ -23,21 +23,17 @@ const menuItemStyles: ComponentSlotStylesPrepared<MenuItemPropsAndState, MenuVar
         })
       },
 
-      ...(active &&
-        !underlined && {
-          background: v.backgroundColorActive,
-          color: v.colorActive
-        }),
+      ...(active && {
+        color: v.colorActive,
+
+        ...(underlined && { color: v.color }),
+        ...(!underlined && { background: v.backgroundColorActive })
+      }),
 
       ...((iconOnly || vertical) && {
         ...(isFromKeyboard && {
           color: v.colorActive,
           background: v.backgroundColorFocus
-        }),
-
-        ...(active && {
-          color: v.colorActive,
-          background: v.backgroundColorActive
         }),
 
         ':hover': {
@@ -47,9 +43,6 @@ const menuItemStyles: ComponentSlotStylesPrepared<MenuItemPropsAndState, MenuVar
       }),
 
       ...(underlined && {
-        ...(active && {
-          color: v.color
-        }),
         ':hover': {
           color: v.color
         },

--- a/packages/fluentui/react/src/themes/teams-high-contrast/components/Menu/menuItemStyles.ts
+++ b/packages/fluentui/react/src/themes/teams-high-contrast/components/Menu/menuItemStyles.ts
@@ -11,49 +11,38 @@ const menuItemStyles: ComponentSlotStylesPrepared<MenuItemPropsAndState, MenuVar
     const { iconOnly, isFromKeyboard, vertical, active, underlined, primary, pointing, disabled } = p;
 
     return {
+      [`&>.${MenuItem.className}>.${MenuItem.slotClassNames.indicator}`]: {
+        backgroundImage: submenuIndicatorUrl(v.colorActive, p.vertical)
+      },
+
       ':hover': {
         color: v.colorActive,
         ...(!active && {
           ...(primary && !underlined && { color: v.colorActive }),
           background: v.backgroundColorFocus
-        }),
-        [`&>.${MenuItem.className}>.${MenuItem.slotClassNames.indicator}`]: {
-          backgroundImage: submenuIndicatorUrl(v.colorActive, p.vertical)
-        }
+        })
       },
 
       ...(active &&
         !underlined && {
           background: v.backgroundColorActive,
-          color: v.colorActive,
-          [`&>.${MenuItem.className}>.${MenuItem.slotClassNames.indicator}`]: {
-            backgroundImage: submenuIndicatorUrl(v.colorActive, p.vertical)
-          }
+          color: v.colorActive
         }),
 
       ...((iconOnly || vertical) && {
         ...(isFromKeyboard && {
           color: v.colorActive,
-          background: v.backgroundColorFocus,
-          [`&>.${MenuItem.className}>.${MenuItem.slotClassNames.indicator}`]: {
-            backgroundImage: submenuIndicatorUrl(v.colorActive, p.vertical)
-          }
+          background: v.backgroundColorFocus
         }),
 
         ...(active && {
           color: v.colorActive,
-          background: v.backgroundColorActive,
-          [`&>.${MenuItem.className}>.${MenuItem.slotClassNames.indicator}`]: {
-            backgroundImage: submenuIndicatorUrl(v.colorActive, p.vertical)
-          }
+          background: v.backgroundColorActive
         }),
 
         ':hover': {
           color: v.colorActive,
-          background: v.backgroundColorFocus,
-          [`&>.${MenuItem.className}>.${MenuItem.slotClassNames.indicator}`]: {
-            backgroundImage: submenuIndicatorUrl(v.colorActive, p.vertical)
-          }
+          background: v.backgroundColorFocus
         }
       }),
 

--- a/packages/fluentui/react/src/themes/teams-high-contrast/components/Menu/menuItemStyles.ts
+++ b/packages/fluentui/react/src/themes/teams-high-contrast/components/Menu/menuItemStyles.ts
@@ -8,8 +8,6 @@ type MenuItemPropsAndState = MenuItemProps & MenuItemState;
 
 const menuItemStyles: ComponentSlotStylesPrepared<MenuItemPropsAndState, MenuVariables> = {
   wrapper: ({ props: p, variables: v }): ICSSInJSStyle => {
-    const { iconOnly, isFromKeyboard, vertical, active, underlined, primary, pointing, disabled } = p;
-
     return {
       [`&>.${MenuItem.className}>.${MenuItem.slotClassNames.indicator}`]: {
         backgroundImage: submenuIndicatorUrl(v.colorActive, p.vertical)
@@ -18,31 +16,31 @@ const menuItemStyles: ComponentSlotStylesPrepared<MenuItemPropsAndState, MenuVar
       ':hover': {
         color: v.colorActive,
 
-        ...(underlined && { color: v.color }),
-        ...(!underlined && { background: v.backgroundColorFocus })
+        ...(p.underlined && { color: v.color }),
+        ...(!p.underlined && { background: v.backgroundColorFocus })
       },
 
-      ...(active && {
+      ...(p.active && {
         color: v.colorActive,
 
-        ...(underlined && { color: v.color }),
-        ...(!underlined && { background: v.backgroundColorActive })
+        ...(p.underlined && { color: v.color }),
+        ...(!p.underlined && { background: v.backgroundColorActive })
       }),
 
-      ...(isFromKeyboard && {
+      ...(p.isFromKeyboard && {
         color: v.colorActive,
 
-        ...(!underlined && { background: v.backgroundColorFocus })
+        ...(!p.underlined && { background: v.backgroundColorFocus })
       }),
 
-      ...(pointing &&
-        vertical && {
+      ...(p.pointing &&
+        p.vertical && {
           '::before': {
             display: 'none'
           }
         }),
 
-      ...(disabled && {
+      ...(p.disabled && {
         ':hover': {
           // reset all existing hover styles
         }

--- a/packages/fluentui/react/src/themes/teams-high-contrast/components/Menu/menuItemStyles.ts
+++ b/packages/fluentui/react/src/themes/teams-high-contrast/components/Menu/menuItemStyles.ts
@@ -30,12 +30,13 @@ const menuItemStyles: ComponentSlotStylesPrepared<MenuItemPropsAndState, MenuVar
         ...(!underlined && { background: v.backgroundColorActive })
       }),
 
-      ...((iconOnly || vertical) && {
-        ...(isFromKeyboard && {
-          color: v.colorActive,
-          background: v.backgroundColorFocus
-        }),
+      ...(isFromKeyboard && {
+        color: v.colorActive,
 
+        ...(!underlined && { background: v.backgroundColorFocus })
+      }),
+
+      ...((iconOnly || vertical) && {
         ':hover': {
           color: v.colorActive,
           background: v.backgroundColorFocus
@@ -45,10 +46,7 @@ const menuItemStyles: ComponentSlotStylesPrepared<MenuItemPropsAndState, MenuVar
       ...(underlined && {
         ':hover': {
           color: v.color
-        },
-        ...(isFromKeyboard && {
-          color: v.colorActive
-        })
+        }
       }),
 
       ...(pointing &&

--- a/packages/fluentui/react/src/themes/teams/components/Menu/menuItemStyles.ts
+++ b/packages/fluentui/react/src/themes/teams/components/Menu/menuItemStyles.ts
@@ -259,6 +259,7 @@ const menuItemStyles: ComponentSlotStylesPrepared<MenuItemPropsAndState, MenuVar
 
       ...(disabled && {
         color: v.colorDisabled || colors.foregroundDisabled,
+        cursor: 'default',
         ':hover': {
           // empty - overwrite all existing hover styles
         }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

This PR simplifies styles for `MenuItem` in Teams High Contrast theme without regressions. All changes are done on per-commit basis for easier review.



###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12251)