### PR TITLE
Fix unnecessary render of components decorated by withResponsiveMode

### DIFF
--- a/change/office-ui-fabric-react-2020-03-11-14-21-36-keco-initializeResponsiveMode.json
+++ b/change/office-ui-fabric-react-2020-03-11-14-21-36-keco-initializeResponsiveMode.json
@@ -1,6 +1,6 @@
 {
   "type": "minor",
-  "comment": "Add initializeResponsiveMode render performance optimization",
+  "comment": "withResponsiveMode: Add initializeResponsiveMode render performance optimization",
   "packageName": "office-ui-fabric-react",
   "email": "KevinTCoughlin@users.noreply.github.com",
   "commit": "e6454e02c8a936bbdace936fb4065d2654f52a68",

--- a/change/office-ui-fabric-react-2020-03-11-14-21-36-keco-initializeResponsiveMode.json
+++ b/change/office-ui-fabric-react-2020-03-11-14-21-36-keco-initializeResponsiveMode.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "Add initializeResponsiveMode render performance optimization",
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com",
+  "commit": "e6454e02c8a936bbdace936fb4065d2654f52a68",
+  "dependentChangeType": "patch",
+  "date": "2020-03-11T21:21:36.741Z"
+}

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withResponsiveMode.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withResponsiveMode.tsx
@@ -37,6 +37,19 @@ export function setResponsiveMode(responsiveMode: ResponsiveMode | undefined): v
   _defaultMode = responsiveMode;
 }
 
+/**
+ * Initializes the responsive mode to the current window size. This can be used to avoid
+ * a re-render during first component mount since the window would otherwise not be measured
+ * until after mounting.
+ */
+export function initializeResponsiveMode(element?: HTMLElement): void {
+  if (typeof window !== 'undefined') {
+    const currentWindow = (element && getWindow(element)) || window;
+
+    getResponsiveMode(currentWindow);
+  }
+}
+
 export function withResponsiveMode<TProps extends { responsiveMode?: ResponsiveMode }, TState>(
   ComposedComponent: new (props: TProps, ...args: any[]) => React.Component<TProps, TState>
 ): any {
@@ -68,46 +81,46 @@ export function withResponsiveMode<TProps extends { responsiveMode?: ResponsiveM
     }
 
     private _onResize = () => {
-      const responsiveMode = this._getResponsiveMode();
+      const element = findDOMNode(this) as Element;
+      const currentWindow = (element && getWindow(element)) || window;
+      const responsiveMode = getResponsiveMode(currentWindow);
 
       if (responsiveMode !== this.state.responsiveMode) {
         this.setState({
-          responsiveMode: responsiveMode
+          responsiveMode
         });
       }
     };
-
-    private _getResponsiveMode(): ResponsiveMode {
-      let responsiveMode = ResponsiveMode.small;
-      const element = findDOMNode(this) as Element;
-      const win = getWindow(element);
-
-      if (typeof win !== 'undefined') {
-        try {
-          while (win.innerWidth > RESPONSIVE_MAX_CONSTRAINT[responsiveMode]) {
-            responsiveMode++;
-          }
-        } catch (e) {
-          // Return a best effort result in cases where we're in the browser but it throws on getting innerWidth.
-          responsiveMode = _defaultMode || _lastMode || ResponsiveMode.large;
-        }
-
-        // Tracking last mode just gives us a better default in future renders,
-        // which avoids starting with the wrong value if we've measured once.
-        _lastMode = responsiveMode;
-      } else {
-        if (_defaultMode !== undefined) {
-          responsiveMode = _defaultMode;
-        } else {
-          throw new Error(
-            'Content was rendered in a server environment without providing a default responsive mode. ' +
-              'Call setResponsiveMode to define what the responsive mode is.'
-          );
-        }
-      }
-
-      return responsiveMode;
-    }
   };
   return hoistStatics(ComposedComponent, resultClass);
+}
+
+function getResponsiveMode(currentWindow: Window | undefined): ResponsiveMode {
+  let responsiveMode = ResponsiveMode.small;
+
+  if (currentWindow) {
+    try {
+      while (currentWindow.innerWidth > RESPONSIVE_MAX_CONSTRAINT[responsiveMode]) {
+        responsiveMode++;
+      }
+    } catch (e) {
+      // Return a best effort result in cases where we're in the browser but it throws on getting innerWidth.
+      responsiveMode = _defaultMode || _lastMode || ResponsiveMode.large;
+    }
+
+    // Tracking last mode just gives us a better default in future renders,
+    // which avoids starting with the wrong value if we've measured once.
+    _lastMode = responsiveMode;
+  } else {
+    if (_defaultMode !== undefined) {
+      responsiveMode = _defaultMode;
+    } else {
+      throw new Error(
+        'Content was rendered in a server environment without providing a default responsive mode. ' +
+          'Call setResponsiveMode to define what the responsive mode is.'
+      );
+    }
+  }
+
+  return responsiveMode;
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

The default value of `ResponsiveMode` has presented a performance problem for SharePoint Online because it causes an unnecessary render with initial `this.state = { responsiveMode: ResponsiveMode.Large }`. 

![image](https://user-images.githubusercontent.com/706967/76382194-20901d00-6315-11ea-94a2-1eb82c76ee2e.png)

To mitigate this render, developers have written:

```tsx
setResponsiveMode(ResponsiveMode.unknown);
```

The above removes the unnecessary render pass. However, it introduces another performance problem where the React tree short-circuits on initial commit, introducing artificial delay to what _was_ a synchronous render pass.

**Example from SPO:**

![image](https://user-images.githubusercontent.com/706967/76381547-ff2e3180-6312-11ea-911c-ac1559e99130.png)

This fix exposes an `initializeResponsiveMode` function to be invoked by the host app to set the value for `responsiveMode`, thereby avoiding the unnecessary render (borrowed from #11870).

I've confirmed locally that this fix resolves _both_ performance issues mentioned above.

cc: @johnguy0 @pingj @patmill @ThomasMichon 

#### Focus areas to test

- CI should pass

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12258)