### PR TITLE
Fix bugs related to Line chart and stacked bar chart

### DIFF
--- a/change/@uifabric-charting-2020-03-11-13-14-26-user-v-satgar-Bug_3992921.json
+++ b/change/@uifabric-charting-2020-03-11-13-14-26-user-v-satgar-Bug_3992921.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Fix issues stacked bar chart hover issue,line chart dot and line chart y axis asserted",
+  "packageName": "@uifabric/charting",
+  "email": "v-satgar@microsoft.com",
+  "commit": "988c73430e51994f3703b3953b2516f5544ec4a7",
+  "dependentChangeType": "patch",
+  "date": "2020-03-11T07:44:26.791Z"
+}

--- a/change/@uifabric-charting-2020-03-11-13-14-26-user-v-satgar-Bug_3992921.json
+++ b/change/@uifabric-charting-2020-03-11-13-14-26-user-v-satgar-Bug_3992921.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "Fix issues stacked bar chart hover issue,line chart dot and line chart y axis asserted",
+  "comment": "Fix issues stacked bar chart hover issue,line chart dot and line chart y axis disorted",
   "packageName": "@uifabric/charting",
   "email": "v-satgar@microsoft.com",
   "commit": "988c73430e51994f3703b3953b2516f5544ec4a7",

--- a/packages/charting/src/components/LineChart/LineChart.base.tsx
+++ b/packages/charting/src/components/LineChart/LineChart.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { max as d3Max, min as d3Min } from 'd3-array';
+import { max as d3Max } from 'd3-array';
 import { axisLeft as d3AxisLeft, axisBottom as d3AxisBottom } from 'd3-axis';
 import { scaleLinear as d3ScaleLinear, scaleTime as d3ScaleTime } from 'd3-scale';
 import { select as d3Select } from 'd3-selection';
@@ -291,9 +291,9 @@ export class LineChartBase extends React.Component<
     }
   }
 
-  private _prepareDatapoints(minVal: number, maxVal: number, splitInto: number, includeZero: boolean): number[] {
+  private _prepareDatapoints(maxVal: number, splitInto: number): number[] {
     const val = Math.ceil(maxVal / splitInto);
-    const dataPointsArray: number[] = minVal > 100 ? [100, val] : includeZero ? [0, val] : [val];
+    const dataPointsArray: number[] = [0, val];
     while (dataPointsArray[dataPointsArray.length - 1] < maxVal) {
       dataPointsArray.push(dataPointsArray[dataPointsArray.length - 1] + val);
     }
@@ -337,10 +337,7 @@ export class LineChartBase extends React.Component<
     const yMax = d3Max(this._points, (point: ILineChartPoints) => {
       return d3Max(point.data, (item: ILineChartDataPoint) => item.y);
     })!;
-    const yMin = d3Min(this._points, (point: ILineChartPoints) => {
-      return d3Min(point.data, (item: ILineChartDataPoint) => item.y);
-    })!;
-    const domainValues = this._prepareDatapoints(yMin, yMax, 4, true);
+    const domainValues = this._prepareDatapoints(yMax, 4);
     const yAxisScale = d3ScaleLinear()
       .domain([0, domainValues[domainValues.length - 1]])
       .range([this.state.containerHeight - this.margins.bottom, this.margins.top]);
@@ -362,6 +359,12 @@ export class LineChartBase extends React.Component<
     for (let i = 0; i < this._points.length; i++) {
       const legendVal: string = this._points[i].legend;
       const lineColor: string = this._points[i].color;
+      if (this._points[i].data.length === 1) {
+        const keyVal = this._uniqLineText + i;
+        const x1 = this._points[i].data[0].x;
+        const y1 = this._points[i].data[0].y;
+        lines.push(<circle id={keyVal} key={keyVal} r={3.5} cx={this._xAxisScale(x1)} cy={this._yAxisScale(y1)} fill={lineColor} />);
+      }
       for (let j = 1; j < this._points[i].data.length; j++) {
         const keyVal = this._uniqLineText + i + '_' + j;
         const x1 = this._points[i].data[j - 1].x;

--- a/packages/charting/src/components/LineChart/examples/LineChart.Basic.Example.tsx
+++ b/packages/charting/src/components/LineChart/examples/LineChart.Basic.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IChartProps, ILineChartProps, LineChart } from '../../../LineChart';
+import { IChartProps, ILineChartProps, LineChart } from '@uifabric/charting';
 import { DefaultPalette } from 'office-ui-fabric-react/lib/Styling';
 import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
 

--- a/packages/charting/src/components/LineChart/examples/LineChart.Basic.Example.tsx
+++ b/packages/charting/src/components/LineChart/examples/LineChart.Basic.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IChartProps, ILineChartPoints, ILineChartProps, LineChart } from '../../../LineChart';
+import { IChartProps, ILineChartProps, LineChart } from '../../../LineChart';
 import { DefaultPalette } from 'office-ui-fabric-react/lib/Styling';
 import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
 

--- a/packages/charting/src/components/LineChart/examples/LineChart.Basic.Example.tsx
+++ b/packages/charting/src/components/LineChart/examples/LineChart.Basic.Example.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { IChartProps, ILineChartPoints, ILineChartProps, LineChart } from '@uifabric/charting';
+import { IChartProps, ILineChartPoints, ILineChartProps, LineChart } from '../../../LineChart';
 import { DefaultPalette } from 'office-ui-fabric-react/lib/Styling';
 import { mergeStyles } from 'office-ui-fabric-react/lib/Styling';
 
@@ -18,28 +18,78 @@ export class LineChartBasicExample extends React.Component<{}, {}> {
   }
 
   private _basicExample(): JSX.Element {
-    const points: ILineChartPoints[] = [
-      {
-        data: [
-          { x: 0, y: 10 },
-          { x: 5, y: 18 },
-          { x: 10, y: 24 },
-          { x: 15, y: 25 },
-          { x: 20, y: 15 },
-          { x: 25, y: 30 },
-          { x: 30, y: 18 },
-          { x: 35, y: 32 },
-          { x: 40, y: 29 },
-          { x: 45, y: 43 },
-          { x: 50, y: 46 }
-        ],
-        legend: 'First',
-        color: DefaultPalette.blue
-      }
-    ];
     const data: IChartProps = {
       chartTitle: 'Line Chart',
-      lineChartData: points
+      lineChartData: [
+        {
+          legend: 'From_Legacy_to_O365',
+          data: [
+            {
+              x: new Date('2020-03-03T00:00:00.000Z'),
+              y: 297
+            },
+            {
+              x: new Date('2020-03-04T00:00:00.000Z'),
+              y: 284
+            },
+            {
+              x: new Date('2020-03-05T00:00:00.000Z'),
+              y: 282
+            },
+            {
+              x: new Date('2020-03-06T00:00:00.000Z'),
+              y: 294
+            },
+            {
+              x: new Date('2020-03-07T00:00:00.000Z'),
+              y: 294
+            },
+            {
+              x: new Date('2020-03-08T00:00:00.000Z'),
+              y: 300
+            },
+            {
+              x: new Date('2020-03-09T00:00:00.000Z'),
+              y: 298
+            }
+          ],
+          color: DefaultPalette.blue
+        },
+        {
+          legend: 'All',
+          data: [
+            {
+              x: new Date('2020-03-03T00:00:00.000Z'),
+              y: 297
+            },
+            {
+              x: new Date('2020-03-04T00:00:00.000Z'),
+              y: 284
+            },
+            {
+              x: new Date('2020-03-05T00:00:00.000Z'),
+              y: 282
+            },
+            {
+              x: new Date('2020-03-06T00:00:00.000Z'),
+              y: 294
+            },
+            {
+              x: new Date('2020-03-07T00:00:00.000Z'),
+              y: 294
+            },
+            {
+              x: new Date('2020-03-08T00:00:00.000Z'),
+              y: 300
+            },
+            {
+              x: new Date('2020-03-09T00:00:00.000Z'),
+              y: 298
+            }
+          ],
+          color: DefaultPalette.green
+        }
+      ]
     };
     const rootStyle: IRootStyles = { width: '700px', height: '300px' };
     return (

--- a/packages/charting/src/components/LineChart/examples/LineChart.Multiple.Example.tsx
+++ b/packages/charting/src/components/LineChart/examples/LineChart.Multiple.Example.tsx
@@ -26,55 +26,19 @@ export class LineChartMultipleExample extends React.Component<{}, {}> {
   private _styledExample(): JSX.Element {
     const points: ILineChartPoints[] = [
       {
-        data: [
-          { x: new Date('2018/01/01'), y: 10 },
-          { x: new Date('2018/01/15'), y: 18 },
-          { x: new Date('2018/01/28'), y: 24 },
-          { x: new Date('2018/02/01'), y: 25 },
-          { x: new Date('2018/03/01'), y: 15 },
-          { x: new Date('2018/03/15'), y: 30 },
-          { x: new Date('2018/03/28'), y: 18 },
-          { x: new Date('2018/04/04'), y: 32 },
-          { x: new Date('2018/04/15'), y: 29 },
-          { x: new Date('2018/05/05'), y: 43 },
-          { x: new Date('2018/06/01'), y: 45 }
-        ],
+        data: [{ x: new Date('2018/01/01'), y: 10 }],
         legend: 'First',
         color: DefaultPalette.blue,
         onLegendClick: this._onLegendClickHandler
       },
       {
-        data: [
-          { x: new Date('2018/01/01'), y: 10 },
-          { x: new Date('2018/01/07'), y: 18 },
-          { x: new Date('2018/01/15'), y: 24 },
-          { x: new Date('2018/02/01'), y: 25 },
-          { x: new Date('2018/03/10'), y: 15 },
-          { x: new Date('2018/03/15'), y: 30 },
-          { x: new Date('2018/03/20'), y: 18 },
-          { x: new Date('2018/04/10'), y: 32 },
-          { x: new Date('2018/04/20'), y: 29 },
-          { x: new Date('2018/05/16'), y: 43 },
-          { x: new Date('2018/06/01'), y: 45 }
-        ],
+        data: [{ x: new Date('2018/03/15'), y: 30 }],
         legend: 'Second',
         color: DefaultPalette.green,
         onLegendClick: this._onLegendClickHandler
       },
       {
-        data: [
-          { x: new Date('2018/01/06'), y: 10 },
-          { x: new Date('2018/01/18'), y: 18 },
-          { x: new Date('2018/01/25'), y: 24 },
-          { x: new Date('2018/02/10'), y: 25 },
-          { x: new Date('2018/03/03'), y: 15 },
-          { x: new Date('2018/03/07'), y: 30 },
-          { x: new Date('2018/03/15'), y: 18 },
-          { x: new Date('2018/04/10'), y: 32 },
-          { x: new Date('2018/04/17'), y: 29 },
-          { x: new Date('2018/05/10'), y: 43 },
-          { x: new Date('2018/06/01'), y: 45 }
-        ],
+        data: [{ x: new Date('2018/06/01'), y: 45 }],
         legend: 'Third',
         color: DefaultPalette.red,
         onLegendClick: this._onLegendClickHandler

--- a/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/MultiStackedBarChart.base.tsx
@@ -84,7 +84,7 @@ export class MultiStackedBarChartBase extends React.Component<IMultiStackedBarCh
         {!hideLegend && <div className={this._classNames.legendContainer}>{legends}</div>}
         {isCalloutVisible ? (
           <Callout
-            gapSpace={5}
+            gapSpace={10}
             isBeakVisible={false}
             target={this.state.refSelected}
             setInitialFocus={true}

--- a/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
+++ b/packages/charting/src/components/StackedBarChart/StackedBarChart.base.tsx
@@ -135,7 +135,7 @@ export class StackedBarChartBase extends React.Component<IStackedBarChartProps, 
               <g>{bars[0]}</g>
               {isCalloutVisible ? (
                 <Callout
-                  gapSpace={5}
+                  gapSpace={10}
                   isBeakVisible={false}
                   target={this.state.refSelected}
                   setInitialFocus={true}


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #12260, #12261 
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
Fix the following bugs

1. - Line chart should show a dot when there is only one element
2. - Callout is flickering for the stacked bar chart
3. - Line chart y-axis lines are getting disorted

#### Focus areas to test
Line chart and stacked bar chart 

#### Screenshots 
1.
![image](https://user-images.githubusercontent.com/13463251/76394253-2defea80-639b-11ea-8d1d-b04a84d22a40.png)
2.
![image](https://user-images.githubusercontent.com/13463251/76394405-76a7a380-639b-11ea-91d5-1e3f1b577d20.png)
3.
![image](https://user-images.githubusercontent.com/13463251/76394446-8aeba080-639b-11ea-9a16-973f36a5e84b.png)




###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12259)