### PR TITLE
Styling: fix sideEffects scope in package.json

### DIFF
--- a/change/@uifabric-styling-2020-03-11-11-20-28-xgao-bundle-size.json
+++ b/change/@uifabric-styling-2020-03-11-11-20-28-xgao-bundle-size.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Styling: fix sideEffects scope",
+  "packageName": "@uifabric/styling",
+  "email": "xgao@microsoft.com",
+  "commit": "68624cb99c28f7febb5166ae8160d83b01321dad",
+  "dependentChangeType": "patch",
+  "date": "2020-03-11T18:20:28.603Z"
+}

--- a/packages/styling/package.json
+++ b/packages/styling/package.json
@@ -9,7 +9,9 @@
   "license": "MIT",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
-  "sideEffects": true,
+  "sideEffects": [
+    "lib/version.js"
+  ],
   "typings": "lib/index.d.ts",
   "scripts": {
     "build": "just-scripts build",


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes
It's unclear to me why we had `sideEffects: true` for styling package. trying to scope down to reduce bundle size. let's see if any test fails 

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12268)