### PR TITLE
Keco/6.0/with responsive mode

### DIFF
--- a/change/office-ui-fabric-react-2020-03-11-16-55-29-keco-6.0-withResponsiveMode.json
+++ b/change/office-ui-fabric-react-2020-03-11-16-55-29-keco-6.0-withResponsiveMode.json
@@ -1,0 +1,8 @@
+{
+  "type": "minor",
+  "comment": "withResponsiveMode: Add initializeResponsiveMode perf optimization to avoid unnecessary render",
+  "packageName": "office-ui-fabric-react",
+  "email": "KevinTCoughlin@users.noreply.github.com",
+  "commit": "e3c270fdb5a20549d0868c82df9d442c998f71db",
+  "date": "2020-03-11T23:55:29.258Z"
+}

--- a/packages/office-ui-fabric-react/src/utilities/decorators/withResponsiveMode.tsx
+++ b/packages/office-ui-fabric-react/src/utilities/decorators/withResponsiveMode.tsx
@@ -37,6 +37,19 @@ export function setResponsiveMode(responsiveMode: ResponsiveMode | undefined): v
   _defaultMode = responsiveMode;
 }
 
+/**
+ * Initializes the responsive mode to the current window size. This can be used to avoid
+ * a re-render during first component mount since the window would otherwise not be measured
+ * until after mounting.
+ */
+export function initializeResponsiveMode(element?: HTMLElement): void {
+  if (typeof window !== 'undefined') {
+    const currentWindow = (element && getWindow(element)) || window;
+
+    getResponsiveMode(currentWindow);
+  }
+}
+
 export function withResponsiveMode<TProps extends { responsiveMode?: ResponsiveMode }, TState>(
   ComposedComponent: new (props: TProps, ...args: any[]) => React.Component<TProps, TState>
 ): any {
@@ -68,46 +81,46 @@ export function withResponsiveMode<TProps extends { responsiveMode?: ResponsiveM
     }
 
     private _onResize = () => {
-      const responsiveMode = this._getResponsiveMode();
+      const element = findDOMNode(this) as Element;
+      const currentWindow = (element && getWindow(element)) || window;
+      const responsiveMode = getResponsiveMode(currentWindow);
 
       if (responsiveMode !== this.state.responsiveMode) {
         this.setState({
-          responsiveMode: responsiveMode
+          responsiveMode
         });
       }
     };
-
-    private _getResponsiveMode(): ResponsiveMode {
-      let responsiveMode = ResponsiveMode.small;
-      const element = findDOMNode(this) as Element;
-      const win = getWindow(element);
-
-      if (typeof win !== 'undefined') {
-        try {
-          while (win.innerWidth > RESPONSIVE_MAX_CONSTRAINT[responsiveMode]) {
-            responsiveMode++;
-          }
-        } catch (e) {
-          // Return a best effort result in cases where we're in the browser but it throws on getting innerWidth.
-          responsiveMode = _defaultMode || _lastMode || ResponsiveMode.large;
-        }
-
-        // Tracking last mode just gives us a better default in future renders,
-        // which avoids starting with the wrong value if we've measured once.
-        _lastMode = responsiveMode;
-      } else {
-        if (_defaultMode !== undefined) {
-          responsiveMode = _defaultMode;
-        } else {
-          throw new Error(
-            'Content was rendered in a server environment without providing a default responsive mode. ' +
-              'Call setResponsiveMode to define what the responsive mode is.'
-          );
-        }
-      }
-
-      return responsiveMode;
-    }
   };
   return hoistStatics(ComposedComponent, resultClass);
+}
+
+function getResponsiveMode(currentWindow: Window | undefined): ResponsiveMode {
+  let responsiveMode = ResponsiveMode.small;
+
+  if (currentWindow) {
+    try {
+      while (currentWindow.innerWidth > RESPONSIVE_MAX_CONSTRAINT[responsiveMode]) {
+        responsiveMode++;
+      }
+    } catch (e) {
+      // Return a best effort result in cases where we're in the browser but it throws on getting innerWidth.
+      responsiveMode = _defaultMode || _lastMode || ResponsiveMode.large;
+    }
+
+    // Tracking last mode just gives us a better default in future renders,
+    // which avoids starting with the wrong value if we've measured once.
+    _lastMode = responsiveMode;
+  } else {
+    if (_defaultMode !== undefined) {
+      responsiveMode = _defaultMode;
+    } else {
+      throw new Error(
+        'Content was rendered in a server environment without providing a default responsive mode. ' +
+          'Call setResponsiveMode to define what the responsive mode is.'
+      );
+    }
+  }
+
+  return responsiveMode;
 }


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes

Cherry-pick of #12258 to help reduce unnecessary renders due to `withResponsiveMode` default state for Partners using Fabric `6.0`.

#### Focus areas to test

- CI should pass


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12275)