### PR TITLE
fix(Button): children styles differ than shorthand

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -31,6 +31,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - Fix passing down `variables` in `ToolbarMenuItem` @layershifter ([#12204](https://github.com/OfficeDev/office-ui-fabric-react/pull/12204))
 - Fix `ToolbarMenuItem` shouldn't focus menu trigger element after 'onClick' was executed on menu item @kolaps33 ([#12266](https://github.com/OfficeDev/office-ui-fabric-react/pull/12266))
 - `Carousel` accessibility fixes @kolaps33 ([#12050](https://github.com/OfficeDev/office-ui-fabric-react/pull/12050))
+- Fix different styles between children and shorthand API in `Button` component @mnajdova ([#12292](https://github.com/OfficeDev/office-ui-fabric-react/pull/12292))
 
 ### Features
 - Export `broadcast-view-fullscreen` and `broadcast-view-left` as SVG icons @davidfoulkejr ([#12126](https://github.com/OfficeDev/office-ui-fabric-react/pull/12126))

--- a/packages/fluentui/docs/src/examples/components/Button/States/ButtonExampleDisabled.tsx
+++ b/packages/fluentui/docs/src/examples/components/Button/States/ButtonExampleDisabled.tsx
@@ -1,30 +1,30 @@
 import * as React from 'react';
-import { Button, Flex, Icon, Text } from '@fluentui/react';
+import { Button, Flex, Icon } from '@fluentui/react';
 
 const ButtonExampleDisabled = () => (
   <Flex column gap="gap.smaller">
     <Flex gap="gap.smaller">
       <Button disabled>Default</Button>
       <Button disabled primary>
-        Primary
+        <Button.Content>Primary</Button.Content>
       </Button>
       <Button disabled inverted>
-        <Text content="Inverted Button" />
+        <Button.Content content="Inverted Button" />
       </Button>
       <Button disabled icon iconPosition="before" primary>
         <Icon name="emoji" xSpacing="after" />
-        <Text content="Click me" />
+        <Button.Content content="Click me" />
       </Button>
       <Button disabled circular title="Translation">
         <Icon name="translation" xSpacing="none" />
       </Button>
       <Button disabled text>
         <Icon name="call-video" xSpacing="before" />
-        <Text content="Disabled text button" />
+        <Button.Content content="Disabled text button" />
       </Button>
     </Flex>
     <Button disabled fluid>
-      Fluid
+      <Button.Content>Fluid</Button.Content>
     </Button>
   </Flex>
 );

--- a/packages/fluentui/docs/src/examples/components/Button/Types/ButtonExample.tsx
+++ b/packages/fluentui/docs/src/examples/components/Button/Types/ButtonExample.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import { Button } from '@fluentui/react';
 
-const ButtonExample = () => <Button>Click here</Button>;
+const ButtonExample = () => (
+  <Button>
+    <Button.Content>Click here</Button.Content>
+  </Button>
+);
 
 export default ButtonExample;

--- a/packages/fluentui/docs/src/examples/components/Button/Types/ButtonExampleEmphasis.tsx
+++ b/packages/fluentui/docs/src/examples/components/Button/Types/ButtonExampleEmphasis.tsx
@@ -3,8 +3,12 @@ import { Button, Flex } from '@fluentui/react';
 
 const ButtonExampleEmphasis = () => (
   <Flex gap="gap.smaller">
-    <Button primary>Primary</Button>
-    <Button secondary>Secondary</Button>
+    <Button primary>
+      <Button.Content>Primary</Button.Content>
+    </Button>
+    <Button secondary>
+      <Button.Content>Secondary</Button.Content>
+    </Button>
   </Flex>
 );
 

--- a/packages/fluentui/docs/src/examples/components/Button/Types/ButtonExampleText.tsx
+++ b/packages/fluentui/docs/src/examples/components/Button/Types/ButtonExampleText.tsx
@@ -1,16 +1,16 @@
 import * as React from 'react';
-import { Button, Text, Icon } from '@fluentui/react';
+import { Button, Icon } from '@fluentui/react';
 
 const ButtonExampleText = () => (
   <div>
     <Button text>
-      <Text content="A text button" />
+      <Button.Content content="A text button" />
     </Button>
     <br />
     <br />
     <Button text>
       <Icon name="call-video" />
-      <Text content="A text button with an icon" />
+      <Button.Content content="A text button with an icon" />
     </Button>
     <br />
     <br />
@@ -21,13 +21,13 @@ const ButtonExampleText = () => (
     <br />
     <Button text disabled>
       <Icon name="call-video" />
-      <Text content="A disabled text button with an icon" />
+      <Button.Content content="A disabled text button with an icon" />
     </Button>
     <br />
     <br />
     <Button text primary>
       <Icon name="call-video" />
-      <Text content="A primary text button with an icon" />
+      <Button.Content content="A primary text button with an icon" />
     </Button>
   </div>
 );

--- a/packages/fluentui/docs/src/examples/components/Button/Usage/ButtonExampleContentAndIcon.tsx
+++ b/packages/fluentui/docs/src/examples/components/Button/Usage/ButtonExampleContentAndIcon.tsx
@@ -1,19 +1,19 @@
 import * as React from 'react';
-import { Button, Icon, Text, Flex } from '@fluentui/react';
+import { Button, Icon, Flex } from '@fluentui/react';
 
 const ButtonExampleContentAndIcon = () => (
   <Flex gap="gap.large">
     <Button icon primary>
       <Icon name="call-video" xSpacing="after" />
-      <Text content="Join call" />
+      <Button.Content content="Join call" />
     </Button>
     <Button icon>
-      <Text content="Join call" />
+      <Button.Content content="Join call" />
       <Icon name="call-video" xSpacing="before" />
     </Button>
     <Button icon text>
       <Icon name="call-video" xSpacing="after" />
-      <Text content="Join call" />
+      <Button.Content content="Join call" />
     </Button>
   </Flex>
 );

--- a/packages/fluentui/docs/src/examples/components/Button/Usage/ButtonExampleOverflow.tsx
+++ b/packages/fluentui/docs/src/examples/components/Button/Usage/ButtonExampleOverflow.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import { Button } from '@fluentui/react';
 
-const ButtonExampleOverflow = () => <Button>See how this very long text shows up in the button</Button>;
+const ButtonExampleOverflow = () => (
+  <Button>
+    <Button.Content>See how this very long text shows up in the button</Button.Content>
+  </Button>
+);
 
 export default ButtonExampleOverflow;

--- a/packages/fluentui/docs/src/examples/components/Button/Variations/ButtonExampleCircular.tsx
+++ b/packages/fluentui/docs/src/examples/components/Button/Variations/ButtonExampleCircular.tsx
@@ -3,7 +3,9 @@ import { Button, Flex, Icon } from '@fluentui/react';
 
 const ButtonExampleCircular = () => (
   <Flex gap="gap.smaller">
-    <Button circular>C</Button>
+    <Button circular>
+      <Button.Content>C</Button.Content>
+    </Button>
     <Button circular icon title="Emoji">
       <Icon name="emoji" xSpacing="none" />
     </Button>

--- a/packages/fluentui/docs/src/examples/components/Button/Variations/ButtonExampleFluid.tsx
+++ b/packages/fluentui/docs/src/examples/components/Button/Variations/ButtonExampleFluid.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import { Button } from '@fluentui/react';
 
-const ButtonExampleFluid = () => <Button fluid>Fits to Container</Button>;
+const ButtonExampleFluid = () => (
+  <Button fluid>
+    <Button.Content>Fits to Container</Button.Content>
+  </Button>
+);
 
 export default ButtonExampleFluid;

--- a/packages/fluentui/react/src/components/Button/Button.tsx
+++ b/packages/fluentui/react/src/components/Button/Button.tsx
@@ -15,7 +15,6 @@ import {
   SizeValue
 } from '../../utils';
 import Icon, { IconProps } from '../Icon/Icon';
-import Box, { BoxProps } from '../Box/Box';
 import Loader, { LoaderProps } from '../Loader/Loader';
 import {
   ComponentEventHandler,
@@ -26,11 +25,12 @@ import {
   ProviderContextPrepared
 } from '../../types';
 import ButtonGroup from './ButtonGroup';
+import ButtonContent, { ButtonContentProps } from './ButtonContent';
 import { getElementType, getUnhandledProps, useAccessibility, useStyles, useTelemetry } from '@fluentui/react-bindings';
 // @ts-ignore
 import { ThemeContext } from 'react-fela';
 
-export interface ButtonProps extends UIComponentProps, ContentComponentProps<ShorthandValue<BoxProps>>, ChildrenComponentProps {
+export interface ButtonProps extends UIComponentProps, ContentComponentProps<ShorthandValue<ButtonContentProps>>, ChildrenComponentProps {
   /** Accessibility behavior if overridden by the user. */
   accessibility?: Accessibility;
 
@@ -88,7 +88,8 @@ export interface ButtonProps extends UIComponentProps, ContentComponentProps<Sho
   size?: SizeValue;
 }
 
-const Button: React.FC<WithAsProp<ButtonProps>> & FluentComponentStaticProps<ButtonProps> & { Group: typeof ButtonGroup } = props => {
+const Button: React.FC<WithAsProp<ButtonProps>> &
+  FluentComponentStaticProps<ButtonProps> & { Group: typeof ButtonGroup; Content: typeof ButtonContent } = props => {
   const context: ProviderContextPrepared = React.useContext(ThemeContext);
   const { setStart, setEnd } = useTelemetry(Button.displayName, context.telemetry);
   setStart();
@@ -212,8 +213,8 @@ const Button: React.FC<WithAsProp<ButtonProps>> & FluentComponentStaticProps<But
         <>
           {loading && renderLoader()}
           {iconPosition !== 'after' && renderIcon()}
-          {Box.create(content, {
-            defaultProps: () => getA11Props('content', { as: 'span', styles: resolvedStyles.content })
+          {ButtonContent.create(content, {
+            defaultProps: () => getA11Props('content', { as: 'span', size, styles: resolvedStyles.content })
           })}
           {iconPosition === 'after' && renderIcon()}
         </>
@@ -258,6 +259,7 @@ Button.propTypes = {
 Button.handledProps = Object.keys(Button.propTypes) as any;
 
 Button.Group = ButtonGroup;
+Button.Content = ButtonContent;
 
 Button.create = createShorthandFactory({ Component: Button, mappedProp: 'content' });
 

--- a/packages/fluentui/react/src/components/Button/ButtonContent.tsx
+++ b/packages/fluentui/react/src/components/Button/ButtonContent.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+import { useStyles, useTelemetry, getElementType, getUnhandledProps } from '@fluentui/react-bindings';
+import * as customPropTypes from '@fluentui/react-proptypes';
+// @ts-ignore
+import { ThemeContext } from 'react-fela';
+
+import { childrenExist, commonPropTypes, createShorthandFactory, rtlTextContainer } from '../../utils';
+import { FluentComponentStaticProps, ProviderContextPrepared, WithAsProp, withSafeTypeForAs } from '../../types';
+import { BoxProps } from '../Box/Box';
+import { ButtonProps } from './Button';
+
+export interface ButtonContentProps extends BoxProps {
+  size?: ButtonProps['size'];
+}
+
+export type ButtonContentStylesProps = Pick<ButtonContentProps, 'size'>;
+
+const ButtonContent: React.FC<WithAsProp<ButtonContentProps>> & FluentComponentStaticProps<ButtonContentProps> = props => {
+  const context: ProviderContextPrepared = React.useContext(ThemeContext);
+  const { setStart, setEnd } = useTelemetry(ButtonContent.displayName, context.telemetry);
+  setStart();
+
+  const { size, content, children, className, styles, variables, design } = props;
+
+  const { classes } = useStyles<ButtonContentStylesProps>(ButtonContent.displayName, {
+    className,
+    mapPropsToStyles: () => ({ size }),
+    mapPropsToInlineStyles: () => ({
+      className,
+      styles,
+      variables,
+      design
+    }),
+    rtl: context.rtl
+  });
+
+  const ElementType = getElementType(props);
+  const unhandledProps = getUnhandledProps(ButtonContent.handledProps, props);
+
+  const result = (
+    <ElementType {...rtlTextContainer.getAttributes({ forElements: [children, content] })} className={classes.root} {...unhandledProps}>
+      {childrenExist(children) ? children : content}
+    </ElementType>
+  );
+
+  setEnd();
+
+  return result;
+};
+
+ButtonContent.displayName = 'ButtonContent';
+ButtonContent.className = 'ui-button__content';
+
+ButtonContent.propTypes = {
+  ...commonPropTypes.createCommon(),
+  size: customPropTypes.size
+};
+
+ButtonContent.handledProps = Object.keys(ButtonContent.propTypes) as any;
+
+ButtonContent.create = createShorthandFactory({
+  Component: ButtonContent,
+  mappedProp: 'content'
+});
+
+/**
+ * A ButtonContent allows a user to have a dedicated component that can be targeted from the theme.
+ */
+export default withSafeTypeForAs<typeof ButtonContent, ButtonContentProps>(ButtonContent);

--- a/packages/fluentui/react/src/index.ts
+++ b/packages/fluentui/react/src/index.ts
@@ -38,6 +38,8 @@ export * from './components/Button/Button';
 export { default as Button } from './components/Button/Button';
 export * from './components/Button/ButtonGroup';
 export { default as ButtonGroup } from './components/Button/ButtonGroup';
+export * from './components/Button/ButtonContent';
+export { default as ButtonContent } from './components/Button/ButtonContent';
 
 export * from './components/Chat/Chat';
 export { default as Chat } from './components/Chat/Chat';

--- a/packages/fluentui/react/src/themes/teams/componentStyles.ts
+++ b/packages/fluentui/react/src/themes/teams/componentStyles.ts
@@ -10,6 +10,7 @@ export { default as Avatar } from './components/Avatar/avatarStyles';
 
 export { default as Button } from './components/Button/buttonStyles';
 export { default as ButtonGroup } from './components/Button/buttonGroupStyles';
+export { default as ButtonContent } from './components/Button/buttonContentStyles';
 
 export { default as Chat } from './components/Chat/chatStyles';
 export { default as ChatItem } from './components/Chat/chatItemStyles';

--- a/packages/fluentui/react/src/themes/teams/componentVariables.ts
+++ b/packages/fluentui/react/src/themes/teams/componentVariables.ts
@@ -9,6 +9,7 @@ export { default as Avatar } from './components/Avatar/avatarVariables';
 
 export { default as Button } from './components/Button/buttonVariables';
 export { default as ButtonGroup } from './components/Button/buttonVariables';
+export { default as ButtonContent } from './components/Button/buttonContentVariables';
 
 export { default as Chat } from './components/Chat/chatVariables';
 export { default as ChatItem } from './components/Chat/chatItemVariables';

--- a/packages/fluentui/react/src/themes/teams/components/Button/buttonContentStyles.ts
+++ b/packages/fluentui/react/src/themes/teams/components/Button/buttonContentStyles.ts
@@ -1,0 +1,21 @@
+import { ComponentSlotStylesPrepared } from '@fluentui/styles';
+import { ButtonVariables } from './buttonVariables';
+import { ButtonContentStylesProps } from '../../../../components/Button/ButtonContent';
+
+const buttonContentStyles: ComponentSlotStylesPrepared<ButtonContentStylesProps, ButtonVariables> = {
+  root: ({ props: p, variables: v }) => ({
+    overflow: 'hidden',
+    textOverflow: 'ellipsis',
+    whiteSpace: 'nowrap',
+    fontSize: v.contentFontSize,
+    fontWeight: v.contentFontWeight,
+    lineHeight: v.contentLineHeight,
+
+    ...(p.size === 'small' && {
+      fontSize: v.sizeSmallContentFontSize,
+      lineHeight: v.sizeSmallContentLineHeight
+    })
+  })
+};
+
+export default buttonContentStyles;

--- a/packages/fluentui/react/src/themes/teams/components/Button/buttonContentVariables.ts
+++ b/packages/fluentui/react/src/themes/teams/components/Button/buttonContentVariables.ts
@@ -1,0 +1,2 @@
+import buttonVariables from './buttonVariables';
+export default buttonVariables;

--- a/packages/fluentui/react/src/themes/teams/components/Button/buttonContentVariables.ts
+++ b/packages/fluentui/react/src/themes/teams/components/Button/buttonContentVariables.ts
@@ -1,2 +1,3 @@
 import buttonVariables from './buttonVariables';
+
 export default buttonVariables;

--- a/packages/fluentui/react/src/themes/teams/components/Button/buttonStyles.ts
+++ b/packages/fluentui/react/src/themes/teams/components/Button/buttonStyles.ts
@@ -227,21 +227,6 @@ const buttonStyles: ComponentSlotStylesPrepared<ButtonStylesProps, ButtonVariabl
     };
   },
 
-  // modifies the text of the button
-  content: ({ props: p, variables: v }): ICSSInJSStyle => ({
-    overflow: 'hidden',
-    textOverflow: 'ellipsis',
-    whiteSpace: 'nowrap',
-    fontSize: v.contentFontSize,
-    fontWeight: v.contentFontWeight,
-    lineHeight: v.contentLineHeight,
-
-    ...(p.size === 'small' && {
-      fontSize: v.sizeSmallContentFontSize,
-      lineHeight: v.sizeSmallContentLineHeight
-    })
-  }),
-
   icon: ({ props: p }) => ({
     // when loading, hide the icon
     ...(p.loading && {

--- a/packages/fluentui/react/src/themes/teams/types.ts
+++ b/packages/fluentui/react/src/themes/teams/types.ts
@@ -9,6 +9,7 @@ import { AttachmentProps } from '../../components/Attachment/Attachment';
 import { AvatarStylesProps } from '../../components/Avatar/Avatar';
 import { ButtonGroupProps } from '../../components/Button/ButtonGroup';
 import { ButtonStylesProps } from './components/Button/buttonStyles';
+import { ButtonContentStylesProps } from '../../components/Button/ButtonContent';
 import { ChatItemStylesProps } from '../../components/Chat/ChatItem';
 import { ChatMessageStylesProps } from '../../components/Chat/ChatMessage';
 import { ChatStylesProps } from '../../components/Chat/Chat';
@@ -73,6 +74,7 @@ export type TeamsThemeStylesProps = {
   Attachment?: AttachmentProps;
   Avatar?: AvatarStylesProps;
   Button?: ButtonStylesProps;
+  ButtonContent?: ButtonContentStylesProps;
   ButtonGroup?: ButtonGroupProps;
   Chat?: ChatStylesProps;
   ChatItem?: ChatItemStylesProps;


### PR DESCRIPTION
This PR fixes https://github.com/microsoft/fluent-ui-react/issues/1589 - children styles differ than shorthand. For fixing the issue, I've created ButtonContent component, that contains all styles that were previosly in the buttonStyle's content slot, and used this component in the children examples that we had.