### PR TITLE
fix(performance): increase iterations for potential perf regressions

### DIFF
--- a/packages/fluentui/docs/src/examples/components/Dropdown/Performance/DropdownManyItems.perf.tsx
+++ b/packages/fluentui/docs/src/examples/components/Dropdown/Performance/DropdownManyItems.perf.tsx
@@ -10,6 +10,7 @@ const inputItems = _.times(300, (i: number) => ({
 
 const DropdownManyItemsPerf = () => <Dropdown defaultOpen items={inputItems} placeholder="Select your hero" />;
 
+DropdownManyItemsPerf.iterations = 5000;
 DropdownManyItemsPerf.filename = 'DropdownManyItems.perf.tsx';
 
 export default DropdownManyItemsPerf;

--- a/packages/fluentui/docs/src/examples/components/Dropdown/Performance/DropdownManyItems.perf.tsx
+++ b/packages/fluentui/docs/src/examples/components/Dropdown/Performance/DropdownManyItems.perf.tsx
@@ -10,7 +10,7 @@ const inputItems = _.times(300, (i: number) => ({
 
 const DropdownManyItemsPerf = () => <Dropdown defaultOpen items={inputItems} placeholder="Select your hero" />;
 
-DropdownManyItemsPerf.iterations = 1000;
+DropdownManyItemsPerf.iterations = 5;
 DropdownManyItemsPerf.filename = 'DropdownManyItems.perf.tsx';
 
 export default DropdownManyItemsPerf;

--- a/packages/fluentui/docs/src/examples/components/Dropdown/Performance/DropdownManyItems.perf.tsx
+++ b/packages/fluentui/docs/src/examples/components/Dropdown/Performance/DropdownManyItems.perf.tsx
@@ -10,7 +10,7 @@ const inputItems = _.times(300, (i: number) => ({
 
 const DropdownManyItemsPerf = () => <Dropdown defaultOpen items={inputItems} placeholder="Select your hero" />;
 
-DropdownManyItemsPerf.iterations = 5000;
+DropdownManyItemsPerf.iterations = 3000;
 DropdownManyItemsPerf.filename = 'DropdownManyItems.perf.tsx';
 
 export default DropdownManyItemsPerf;

--- a/packages/fluentui/docs/src/examples/components/Dropdown/Performance/DropdownManyItems.perf.tsx
+++ b/packages/fluentui/docs/src/examples/components/Dropdown/Performance/DropdownManyItems.perf.tsx
@@ -10,7 +10,7 @@ const inputItems = _.times(300, (i: number) => ({
 
 const DropdownManyItemsPerf = () => <Dropdown defaultOpen items={inputItems} placeholder="Select your hero" />;
 
-DropdownManyItemsPerf.iterations = 3000;
+DropdownManyItemsPerf.iterations = 2000;
 DropdownManyItemsPerf.filename = 'DropdownManyItems.perf.tsx';
 
 export default DropdownManyItemsPerf;

--- a/packages/fluentui/docs/src/examples/components/Dropdown/Performance/DropdownManyItems.perf.tsx
+++ b/packages/fluentui/docs/src/examples/components/Dropdown/Performance/DropdownManyItems.perf.tsx
@@ -10,7 +10,7 @@ const inputItems = _.times(300, (i: number) => ({
 
 const DropdownManyItemsPerf = () => <Dropdown defaultOpen items={inputItems} placeholder="Select your hero" />;
 
-DropdownManyItemsPerf.iterations = 2000;
+DropdownManyItemsPerf.iterations = 1000;
 DropdownManyItemsPerf.filename = 'DropdownManyItems.perf.tsx';
 
 export default DropdownManyItemsPerf;

--- a/packages/fluentui/docs/src/examples/components/List/Performance/ListWith60ListItems.perf.tsx
+++ b/packages/fluentui/docs/src/examples/components/List/Performance/ListWith60ListItems.perf.tsx
@@ -29,7 +29,7 @@ const items = _.times(60, i => ({
 
 const ListWith60ListItems = () => <List items={items} />;
 
-ListWith60ListItems.iterations = 1;
+ListWith60ListItems.iterations = 10;
 ListWith60ListItems.filename = 'ListWith60ListItems.perf.tsx';
 
 export default ListWith60ListItems;

--- a/packages/fluentui/docs/src/examples/components/Status/Performance/StatusMinimal.perf.tsx
+++ b/packages/fluentui/docs/src/examples/components/Status/Performance/StatusMinimal.perf.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 
 const StatusMinimalPerf = () => <Status />;
 
-StatusMinimalPerf.iterations = 5000;
+StatusMinimalPerf.iterations = 10000;
 StatusMinimalPerf.filename = 'StatusMinimal.perf.tsx';
 
 export default StatusMinimalPerf;

--- a/packages/fluentui/perf-test/stories/Button.perf.tsx
+++ b/packages/fluentui/perf-test/stories/Button.perf.tsx
@@ -3,7 +3,7 @@ import { DefaultButton as ButtonFabric } from 'office-ui-fabric-react';
 import { Button as ButtonFluent } from '@fluentui/react';
 
 export default {
-  iterations: 1000
+  iterations: 5000
 };
 
 export const Fabric = () => <ButtonFabric />;


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

The PRs in [this list](https://github.com/OfficeDev/office-ui-fabric-react/pulls?q=is%3Apr+is%3Aopen+%22potential+regressions%22) have potential regressions that are false - only failing because they didn't run for enough iterations. Went through each of the scenarios that were supposedly regressing and if they were already hitting 1000 ticks, I ignored them but if they weren't I increased the iteration count.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12300)