### PR TITLE
Ensure ContextualMenu section header generates valid element ID

### DIFF
--- a/change/office-ui-fabric-react-2020-03-13-14-26-19-fixSectionHeaderId.json
+++ b/change/office-ui-fabric-react-2020-03-13-14-26-19-fixSectionHeaderId.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Ensure ContextualMenu section header generates valid element ID",
+  "packageName": "office-ui-fabric-react",
+  "email": "ermercer@microsoft.com",
+  "commit": "3435b78843d97a1361c8d07c3c9178fdcd29b4c4",
+  "dependentChangeType": "patch",
+  "date": "2020-03-13T21:26:19.837Z"
+}

--- a/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
+++ b/packages/office-ui-fabric-react/src/components/ContextualMenu/ContextualMenu.base.tsx
@@ -571,7 +571,8 @@ export class ContextualMenuBase extends BaseComponent<IContextualMenuProps, ICon
     let headerItem;
     let groupProps;
     if (sectionProps.title) {
-      const id = this._id + sectionProps.title;
+      // Since title is a user-facing string, it needs to be stripped of whitespace in order to build a valid element ID
+      const id = this._id + sectionProps.title.replace(/\s/g, '');
       const headerContextualMenuItem: IContextualMenuItem = {
         key: `section-${sectionProps.title}-title`,
         itemType: ContextualMenuItemType.Header,


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12172
- [x] Include a change request file using `$ yarn change`

#### Description of changes

When using Fabric's `ContextualMenu` component, each section header's ID is dynamically generated based on its `title` prop.

Since the `title` prop is a user-facing string, it may contain invalid characters for an element ID (such as whitespace, e.g. "Switch views"), resulting in accessibility issues for the menu items contained in the section.

Specifically, the `aria-labelledby` attribute on the parent element with `role="group"` will not point to a valid element ID, causing Narrator to not announce the section header when narrating menu items within the section.

To fix this, the `title` prop should be sanitized by removing whitespace when building the element ID in order to conform with the HTML5 spec.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12303)