### PR TITLE
Remove usages of BaseComponent and initializeFocusRects

### DIFF
--- a/apps/fabric-website-resources/src/components/pages/ColorsPage.tsx
+++ b/apps/fabric-website-resources/src/components/pages/ColorsPage.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import './ColorsPage.global.scss';
 
+import { Async } from 'office-ui-fabric-react/lib/Utilities';
 import { loadTheme } from 'office-ui-fabric-react/lib/Styling';
 import { CodepenComponent } from '@uifabric/example-app-base';
 import { IColor } from 'office-ui-fabric-react/lib/utilities/color/interfaces';
@@ -43,9 +44,12 @@ const codepenSamples =
 
 export class ColorsPage extends React.Component<{}, IColorsPageState> {
   private _semanticSlotColorChangeTimeout: number;
+  private _async: Async;
 
   constructor(props: {}) {
     super(props);
+
+    this._async = new Async(this);
 
     const themeRules = themeRulesStandardCreator();
     ThemeGenerator.insureSlots(themeRules, isDark(themeRules[BaseSlots[BaseSlots.backgroundColor]].color!));
@@ -70,6 +74,8 @@ export class ColorsPage extends React.Component<{}, IColorsPageState> {
 
     // and apply the default theme to overwrite any existing custom theme
     loadTheme({});
+
+    this._async.dispose();
   }
 
   public render(): JSX.Element {

--- a/apps/fabric-website-resources/src/components/pages/ColorsPage.tsx
+++ b/apps/fabric-website-resources/src/components/pages/ColorsPage.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import './ColorsPage.global.scss';
-import { BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
 
 import { loadTheme } from 'office-ui-fabric-react/lib/Styling';
 import { CodepenComponent } from '@uifabric/example-app-base';
@@ -42,7 +41,7 @@ const codepenSamples =
   '</div>);\n  }\n}\n' +
   "ReactDOM.render(<Content />,document.getElementById('content'));";
 
-export class ColorsPage extends BaseComponent<{}, IColorsPageState> {
+export class ColorsPage extends React.Component<{}, IColorsPageState> {
   private _semanticSlotColorChangeTimeout: number;
 
   constructor(props: {}) {

--- a/apps/theming-designer/src/components/ThemingDesigner.tsx
+++ b/apps/theming-designer/src/components/ThemingDesigner.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { AccessibilityChecker } from './AccessibilityChecker';
-import { BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
 import { BaseSlots, IThemeRules, FabricSlots, ThemeGenerator, themeRulesStandardCreator } from 'office-ui-fabric-react/lib/ThemeGenerator';
 import { createTheme, ITheme } from 'office-ui-fabric-react/lib/Styling';
 import { ThemeSlots } from './ThemeSlots';

--- a/apps/theming-designer/src/components/ThemingDesigner.tsx
+++ b/apps/theming-designer/src/components/ThemingDesigner.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { AccessibilityChecker } from './AccessibilityChecker';
 import { BaseSlots, IThemeRules, FabricSlots, ThemeGenerator, themeRulesStandardCreator } from 'office-ui-fabric-react/lib/ThemeGenerator';
+import { Async } from 'office-ui-fabric-react/lib/Utilities';
 import { createTheme, ITheme } from 'office-ui-fabric-react/lib/Styling';
 import { ThemeSlots } from './ThemeSlots';
 import { getColorFromString, IColor } from 'office-ui-fabric-react/lib/Color';
@@ -70,11 +71,18 @@ const Main = (props: IStackProps) => (
 export class ThemingDesigner extends React.Component<{}, IThemingDesignerState> {
   private _colorChangeTimeout: number;
   private _fabricPaletteColorChangeTimeout: number;
+  private _async: Async;
 
   constructor(props: {}) {
     super(props);
 
+    this._async = new Async(this);
+
     this.state = this._buildInitialState();
+  }
+
+  public componentWillUnmount(): void {
+    this._async.dispose();
   }
 
   public render() {

--- a/apps/theming-designer/src/components/ThemingDesigner.tsx
+++ b/apps/theming-designer/src/components/ThemingDesigner.tsx
@@ -68,7 +68,7 @@ const Main = (props: IStackProps) => (
   />
 );
 
-export class ThemingDesigner extends BaseComponent<{}, IThemingDesignerState> {
+export class ThemingDesigner extends React.Component<{}, IThemingDesignerState> {
   private _colorChangeTimeout: number;
   private _fabricPaletteColorChangeTimeout: number;
 

--- a/apps/todo-app/src/components/TodoForm.tsx
+++ b/apps/todo-app/src/components/TodoForm.tsx
@@ -41,7 +41,7 @@ export interface ITodoFormState {
  * TextField: https://fabricreact.azurewebsites.net/fabric-react/master/#/examples/textfield
  * Button: https://fabricreact.azurewebsites.net/fabric-react/master/#/examples/button
  */
-export default class TodoForm extends BaseComponent<ITodoFormProps, ITodoFormState> {
+export default class TodoForm extends React.Component<ITodoFormProps, ITodoFormState> {
   private _textField = React.createRef<ITextField>();
 
   constructor(props: ITodoFormProps) {

--- a/apps/todo-app/src/components/TodoForm.tsx
+++ b/apps/todo-app/src/components/TodoForm.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, IBaseProps } from 'office-ui-fabric-react/lib/Utilities';
+import { IBaseProps, initializeComponentRef } from 'office-ui-fabric-react/lib/Utilities';
 import { PrimaryButton } from 'office-ui-fabric-react/lib/Button';
 import { TextField, ITextField } from 'office-ui-fabric-react/lib/TextField';
 import * as stylesImport from './Todo.scss';
@@ -47,6 +47,7 @@ export default class TodoForm extends React.Component<ITodoFormProps, ITodoFormS
   constructor(props: ITodoFormProps) {
     super(props);
 
+    initializeComponentRef(this);
     this.state = {
       inputValue: '',
       errorMessage: ''

--- a/change/@uifabric-date-time-2020-03-16-10-34-15-xgao-deprecate-base-comp.json
+++ b/change/@uifabric-date-time-2020-03-16-10-34-15-xgao-deprecate-base-comp.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "remove all usages of BaseComponent and initializeFocusRects",
+  "packageName": "@uifabric/date-time",
+  "email": "xgao@microsoft.com",
+  "commit": "cb3fa154d4cfc66bc9f31942c3657581d1d814ad",
+  "dependentChangeType": "patch",
+  "date": "2020-03-16T17:33:47.955Z"
+}

--- a/change/@uifabric-experiments-2020-03-16-10-34-15-xgao-deprecate-base-comp.json
+++ b/change/@uifabric-experiments-2020-03-16-10-34-15-xgao-deprecate-base-comp.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "remove all usages of BaseComponent and initializeFocusRects",
+  "packageName": "@uifabric/experiments",
+  "email": "xgao@microsoft.com",
+  "commit": "cb3fa154d4cfc66bc9f31942c3657581d1d814ad",
+  "dependentChangeType": "patch",
+  "date": "2020-03-16T17:33:50.344Z"
+}

--- a/change/@uifabric-fabric-website-resources-2020-03-16-10-34-15-xgao-deprecate-base-comp.json
+++ b/change/@uifabric-fabric-website-resources-2020-03-16-10-34-15-xgao-deprecate-base-comp.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "remove all usages of BaseComponent and initializeFocusRects",
+  "packageName": "@uifabric/fabric-website-resources",
+  "email": "xgao@microsoft.com",
+  "commit": "cb3fa154d4cfc66bc9f31942c3657581d1d814ad",
+  "dependentChangeType": "patch",
+  "date": "2020-03-16T17:33:42.630Z"
+}

--- a/change/@uifabric-utilities-2020-03-16-10-34-15-xgao-deprecate-base-comp.json
+++ b/change/@uifabric-utilities-2020-03-16-10-34-15-xgao-deprecate-base-comp.json
@@ -1,0 +1,9 @@
+{
+  "type": "minor",
+  "comment": "deprecate BaseComonent, remove all usages of BaseComponent and initializeFocusRects",
+  "packageName": "@uifabric/utilities",
+  "email": "xgao@microsoft.com",
+  "commit": "cb3fa154d4cfc66bc9f31942c3657581d1d814ad",
+  "dependentChangeType": "patch",
+  "date": "2020-03-16T17:34:15.326Z"
+}

--- a/packages/date-time/etc/date-time.api.md
+++ b/packages/date-time/etc/date-time.api.md
@@ -4,7 +4,6 @@
 
 ```ts
 
-import { BaseComponent } from '@uifabric/utilities';
 import { DateRangeType } from 'office-ui-fabric-react/lib/utilities/dateValues/DateValues';
 import { DayOfWeek } from 'office-ui-fabric-react/lib/utilities/dateValues/DateValues';
 import { FirstWeekOfYear } from 'office-ui-fabric-react/lib/utilities/dateValues/DateValues';
@@ -36,10 +35,12 @@ export const Calendar: React.FunctionComponent<ICalendarProps>;
 export const DatePicker: React.FunctionComponent<IDatePickerProps>;
 
 // @public (undocumented)
-export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerState> implements IDatePicker {
+export class DatePickerBase extends React.Component<IDatePickerProps, IDatePickerState> implements IDatePicker {
     constructor(props: IDatePickerProps);
     // (undocumented)
     componentDidUpdate(prevProps: IDatePickerProps, prevState: IDatePickerState): void;
+    // (undocumented)
+    componentWillUnmount(): void;
     // (undocumented)
     static defaultProps: IDatePickerProps;
     // (undocumented)
@@ -92,7 +93,7 @@ export interface ICalendarDayGridStyles {
 
 // Warning: (ae-forgotten-export) The symbol "ICalendarDay" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "ICalendarDayGridProps" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface ICalendarDayProps extends IBaseProps_2<ICalendarDay>, ICalendarDayGridProps {
     allFocusable?: boolean;
@@ -133,7 +134,7 @@ export interface ICalendarIconStrings {
 }
 
 // Warning: (ae-forgotten-export) The symbol "ICalendarMonth" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface ICalendarMonthProps extends IBaseProps_2<ICalendarMonth> {
     allFocusable?: boolean;
@@ -368,7 +369,7 @@ export interface IWeeklyDayPickerStrings extends ICalendarStrings {
 }
 
 // Warning: (ae-forgotten-export) The symbol "ICalendarDayGridStyleProps" needs to be exported by the entry point index.d.ts
-// 
+//
 // @public (undocumented)
 export interface IWeeklyDayPickerStyleProps extends ICalendarDayGridStyleProps {
     className?: string;

--- a/packages/date-time/src/components/Calendar/Calendar.base.tsx
+++ b/packages/date-time/src/components/Calendar/Calendar.base.tsx
@@ -13,7 +13,7 @@ import { CalendarDay } from './CalendarDay/CalendarDay';
 import { CalendarMonth } from './CalendarMonth/CalendarMonth';
 import { ICalendarDay } from './CalendarDay/CalendarDay.types';
 import { ICalendarMonth } from './CalendarMonth/CalendarMonth.types';
-import { css, BaseComponent, KeyCodes, classNamesFunction, focusAsync, format } from '@uifabric/utilities';
+import { css, KeyCodes, classNamesFunction, focusAsync, format, initializeComponentRef, FocusRects } from '@uifabric/utilities';
 import { IProcessedStyleSet } from '@uifabric/styling';
 import { DayPickerStrings } from './defaults';
 import { addMonths, addYears } from 'office-ui-fabric-react/lib/utilities/dateMath/DateMath';
@@ -62,7 +62,7 @@ export interface ICalendarState {
   isDayPickerVisible?: boolean;
 }
 
-export class CalendarBase extends BaseComponent<ICalendarProps, ICalendarState> implements ICalendar {
+export class CalendarBase extends React.Component<ICalendarProps, ICalendarState> implements ICalendar {
   public static defaultProps: ICalendarProps = {
     onSelectDate: undefined,
     onDismiss: undefined,
@@ -94,6 +94,8 @@ export class CalendarBase extends BaseComponent<ICalendarProps, ICalendarState> 
 
   constructor(props: ICalendarProps) {
     super(props);
+
+    initializeComponentRef(this);
     const currentDate = props.value && !isNaN(props.value.getTime()) ? props.value : props.today || new Date();
 
     this.state = {
@@ -240,6 +242,7 @@ export class CalendarBase extends BaseComponent<ICalendarProps, ICalendarState> 
         ) : (
           this._renderGoToTodayButton(classes)
         )}
+        <FocusRects />
       </div>
     );
   }

--- a/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarDay/CalendarDay.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, KeyCodes, css, getId, classNamesFunction } from '@uifabric/utilities';
+import { KeyCodes, css, getId, classNamesFunction, initializeComponentRef } from '@uifabric/utilities';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { addMonths, compareDatePart, getMonthStart, getMonthEnd } from 'office-ui-fabric-react/lib/utilities/dateMath/DateMath';
 import { ICalendarDayProps, ICalendarDayStyleProps, ICalendarDayStyles } from './CalendarDay.types';
@@ -14,7 +14,7 @@ export interface ICalendarDayState {
   animateBackwards?: boolean;
 }
 
-export class CalendarDayBase extends BaseComponent<ICalendarDayProps, ICalendarDayState> {
+export class CalendarDayBase extends React.Component<ICalendarDayProps, ICalendarDayState> {
   private _dayGrid = React.createRef<ICalendarDayGrid>();
 
   public static getDerivedStateFromProps(
@@ -52,6 +52,8 @@ export class CalendarDayBase extends BaseComponent<ICalendarDayProps, ICalendarD
 
   public constructor(props: ICalendarDayProps) {
     super(props);
+
+    initializeComponentRef(this);
 
     this._onSelectNextMonth = this._onSelectNextMonth.bind(this);
     this._onSelectPrevMonth = this._onSelectPrevMonth.bind(this);

--- a/packages/date-time/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
@@ -13,7 +13,7 @@ import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { ICalendarMonthProps, ICalendarMonthStyles, ICalendarMonthStyleProps } from './CalendarMonth.types';
 import { getStyles } from './CalendarMonth.styles';
 import { defaultIconStrings, defaultDateTimeFormatterCallbacks } from '../Calendar.base';
-import { BaseComponent, css, getRTL, classNamesFunction, KeyCodes, format, initializeComponentRef } from '@uifabric/utilities';
+import { css, getRTL, classNamesFunction, KeyCodes, format, initializeComponentRef } from '@uifabric/utilities';
 import { ICalendarYear, ICalendarYearRange } from '../CalendarYear/CalendarYear.types';
 import { CalendarYear } from '../CalendarYear/CalendarYear';
 

--- a/packages/date-time/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarMonth/CalendarMonth.base.tsx
@@ -13,7 +13,7 @@ import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { ICalendarMonthProps, ICalendarMonthStyles, ICalendarMonthStyleProps } from './CalendarMonth.types';
 import { getStyles } from './CalendarMonth.styles';
 import { defaultIconStrings, defaultDateTimeFormatterCallbacks } from '../Calendar.base';
-import { BaseComponent, css, getRTL, classNamesFunction, KeyCodes, format } from '@uifabric/utilities';
+import { BaseComponent, css, getRTL, classNamesFunction, KeyCodes, format, initializeComponentRef } from '@uifabric/utilities';
 import { ICalendarYear, ICalendarYearRange } from '../CalendarYear/CalendarYear.types';
 import { CalendarYear } from '../CalendarYear/CalendarYear';
 
@@ -27,7 +27,7 @@ export interface ICalendarMonthState {
   previousNavigatedDate?: Date;
 }
 
-export class CalendarMonthBase extends BaseComponent<ICalendarMonthProps, ICalendarMonthState> {
+export class CalendarMonthBase extends React.Component<ICalendarMonthProps, ICalendarMonthState> {
   public static defaultProps: Partial<ICalendarMonthProps> = {
     styles: getStyles,
     strings: undefined,
@@ -67,6 +67,8 @@ export class CalendarMonthBase extends BaseComponent<ICalendarMonthProps, ICalen
 
   constructor(props: ICalendarMonthProps) {
     super(props);
+
+    initializeComponentRef(this);
 
     this.state = {
       isYearPickerVisible: false,

--- a/packages/date-time/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
@@ -9,15 +9,7 @@ import {
   ICalendarYearStyleProps,
   ICalendarYearStyles
 } from './CalendarYear.types';
-import {
-  BaseComponent,
-  KeyCodes,
-  getRTL,
-  classNamesFunction,
-  css,
-  format,
-  initializeComponentRef
-} from 'office-ui-fabric-react/lib/Utilities';
+import { KeyCodes, getRTL, classNamesFunction, css, format, initializeComponentRef } from 'office-ui-fabric-react/lib/Utilities';
 import { FocusZone } from 'office-ui-fabric-react/lib/FocusZone';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { ICalendarIconStrings } from '../Calendar.types';

--- a/packages/date-time/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
+++ b/packages/date-time/src/components/Calendar/CalendarYear/CalendarYear.base.tsx
@@ -9,7 +9,15 @@ import {
   ICalendarYearStyleProps,
   ICalendarYearStyles
 } from './CalendarYear.types';
-import { BaseComponent, KeyCodes, getRTL, classNamesFunction, css, format } from 'office-ui-fabric-react/lib/Utilities';
+import {
+  BaseComponent,
+  KeyCodes,
+  getRTL,
+  classNamesFunction,
+  css,
+  format,
+  initializeComponentRef
+} from 'office-ui-fabric-react/lib/Utilities';
 import { FocusZone } from 'office-ui-fabric-react/lib/FocusZone';
 import { Icon } from 'office-ui-fabric-react/lib/Icon';
 import { ICalendarIconStrings } from '../Calendar.types';
@@ -396,7 +404,13 @@ class CalendarYearTitle extends React.Component<ICalendarYearHeaderProps, {}> {
   };
 }
 
-class CalendarYearHeader extends BaseComponent<ICalendarYearHeaderProps, {}> {
+class CalendarYearHeader extends React.Component<ICalendarYearHeaderProps, {}> {
+  constructor(props: ICalendarYearHeaderProps) {
+    super(props);
+
+    initializeComponentRef(this);
+  }
+
   public render(): JSX.Element {
     const { styles, theme, className, animateBackwards, animationDirection } = this.props;
 
@@ -428,7 +442,7 @@ class CalendarYearHeader extends BaseComponent<ICalendarYearHeaderProps, {}> {
   };
 }
 
-export class CalendarYearBase extends BaseComponent<ICalendarYearProps, ICalendarYearState> implements ICalendarYear {
+export class CalendarYearBase extends React.Component<ICalendarYearProps, ICalendarYearState> implements ICalendarYear {
   private _gridRef: CalendarYearGrid;
 
   public static getDerivedStateFromProps(
@@ -465,6 +479,9 @@ export class CalendarYearBase extends BaseComponent<ICalendarYearProps, ICalenda
 
   constructor(props: ICalendarYearProps) {
     super(props);
+
+    initializeComponentRef(this);
+
     this.state = CalendarYearBase._getState(props);
   }
 

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import {
-  BaseComponent,
   KeyCodes,
   css,
   getId,

--- a/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
+++ b/packages/date-time/src/components/CalendarDayGrid/CalendarDayGrid.base.tsx
@@ -9,7 +9,8 @@ import {
   format,
   classNamesFunction,
   find,
-  findIndex
+  findIndex,
+  initializeComponentRef
 } from '@uifabric/utilities';
 import { FocusZone } from 'office-ui-fabric-react/lib/FocusZone';
 import {
@@ -57,13 +58,15 @@ export interface ICalendarDayGridState {
   animateBackwards?: boolean;
 }
 
-export class CalendarDayGridBase extends BaseComponent<ICalendarDayGridProps, ICalendarDayGridState> {
+export class CalendarDayGridBase extends React.Component<ICalendarDayGridProps, ICalendarDayGridState> {
   private navigatedDay: HTMLElement | null;
   private days: { [key: string]: HTMLElement | null } = {};
   private classNames: IProcessedStyleSet<ICalendarDayGridStyles>;
 
   public constructor(props: ICalendarDayGridProps) {
     super(props);
+
+    initializeComponentRef(this);
 
     this.state = {
       activeDescendantId: getId(),

--- a/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
@@ -1,6 +1,15 @@
 import * as React from 'react';
 import { IDatePicker, IDatePickerProps, IDatePickerStrings, IDatePickerStyleProps, IDatePickerStyles } from './DatePicker.types';
-import { BaseComponent, KeyCodes, classNamesFunction, getId, getNativeProps, divProperties, css } from '@uifabric/utilities';
+import {
+  KeyCodes,
+  classNamesFunction,
+  getId,
+  getNativeProps,
+  divProperties,
+  css,
+  initializeComponentRef,
+  Async
+} from '@uifabric/utilities';
 import { Calendar, ICalendar, DayOfWeek } from '../../Calendar';
 import { FirstWeekOfYear } from 'office-ui-fabric-react/lib/utilities/dateValues/DateValues';
 import { Callout } from 'office-ui-fabric-react/lib/Callout';
@@ -34,7 +43,7 @@ const DEFAULT_STRINGS: IDatePickerStrings = {
   weekNumberFormatString: 'Week number {0}'
 };
 
-export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerState> implements IDatePicker {
+export class DatePickerBase extends React.Component<IDatePickerProps, IDatePickerState> implements IDatePicker {
   public static defaultProps: IDatePickerProps = {
     allowTextInput: false,
     formatDate: (date: Date) => {
@@ -77,8 +86,13 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
   private _preventFocusOpeningPicker: boolean;
   private _id: string;
 
+  private _async: Async;
+
   constructor(props: IDatePickerProps) {
     super(props);
+
+    initializeComponentRef(this);
+
     this.state = this._getDefaultState();
 
     this._id = props.id || getId('DatePicker');
@@ -139,6 +153,10 @@ export class DatePickerBase extends BaseComponent<IDatePickerProps, IDatePickerS
         this.props.onAfterMenuDismiss();
       }
     }
+  }
+
+  public componentWillUnmount(): void {
+    this._async.dispose();
   }
 
   public render(): JSX.Element {

--- a/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
+++ b/packages/date-time/src/components/DatePicker/DatePicker.base.tsx
@@ -91,6 +91,7 @@ export class DatePickerBase extends React.Component<IDatePickerProps, IDatePicke
   constructor(props: IDatePickerProps) {
     super(props);
 
+    this._async = new Async(this);
     initializeComponentRef(this);
 
     this.state = this._getDefaultState();

--- a/packages/date-time/src/components/WeeklyDayPicker/WeeklyDayPicker.base.tsx
+++ b/packages/date-time/src/components/WeeklyDayPicker/WeeklyDayPicker.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, classNamesFunction, css, KeyCodes, getRTL, initializeComponentRef } from '@uifabric/utilities';
+import { classNamesFunction, css, KeyCodes, getRTL, initializeComponentRef } from '@uifabric/utilities';
 import { IProcessedStyleSet } from '@uifabric/styling';
 import { IWeeklyDayPickerProps, IWeeklyDayPickerStyleProps, IWeeklyDayPickerStyles } from './WeeklyDayPicker.types';
 import {

--- a/packages/date-time/src/components/WeeklyDayPicker/WeeklyDayPicker.base.tsx
+++ b/packages/date-time/src/components/WeeklyDayPicker/WeeklyDayPicker.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, classNamesFunction, css, KeyCodes, getRTL } from '@uifabric/utilities';
+import { BaseComponent, classNamesFunction, css, KeyCodes, getRTL, initializeComponentRef } from '@uifabric/utilities';
 import { IProcessedStyleSet } from '@uifabric/styling';
 import { IWeeklyDayPickerProps, IWeeklyDayPickerStyleProps, IWeeklyDayPickerStyles } from './WeeklyDayPicker.types';
 import {
@@ -63,7 +63,7 @@ export interface IWeeklyDayPickerState {
   animationDirection: AnimationDirection;
 }
 
-export class WeeklyDayPickerBase extends BaseComponent<IWeeklyDayPickerProps, IWeeklyDayPickerState> {
+export class WeeklyDayPickerBase extends React.Component<IWeeklyDayPickerProps, IWeeklyDayPickerState> {
   public static defaultProps: IWeeklyDayPickerProps = {
     onSelectDate: undefined,
     initialDate: undefined,
@@ -108,6 +108,9 @@ export class WeeklyDayPickerBase extends BaseComponent<IWeeklyDayPickerProps, IW
 
   public constructor(props: IWeeklyDayPickerProps) {
     super(props);
+
+    initializeComponentRef(this);
+
     const currentDate = props.initialDate && !isNaN(props.initialDate.getTime()) ? props.initialDate : props.today || new Date();
 
     this.state = {

--- a/packages/experiments/src/components/BAFAccordion/Accordion.tsx
+++ b/packages/experiments/src/components/BAFAccordion/Accordion.tsx
@@ -3,7 +3,7 @@
  */
 
 import { DefaultButton } from 'office-ui-fabric-react/lib/Button';
-import { BaseComponent, css, composeRenderFunction } from 'office-ui-fabric-react/lib/Utilities';
+import { initializeComponentRef, css, composeRenderFunction } from 'office-ui-fabric-react/lib/Utilities';
 import * as React from 'react';
 import './Accordion.scss';
 import { IAccordion, IAccordionProps } from './Accordion.types';
@@ -13,9 +13,11 @@ export interface IAccordionState {
   isContentVisible?: boolean | undefined;
 }
 
-export class Accordion extends BaseComponent<IAccordionProps, IAccordionState> implements IAccordion {
+export class Accordion extends React.Component<IAccordionProps, IAccordionState> implements IAccordion {
   constructor(props: IAccordionProps) {
     super(props);
+
+    initializeComponentRef(this);
 
     this.state = {
       isContentVisible: false

--- a/packages/experiments/src/components/FloatingSuggestions/FloatingSuggestions.tsx
+++ b/packages/experiments/src/components/FloatingSuggestions/FloatingSuggestions.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as styles from './FloatingSuggestions.scss';
-import { initializeComponentRef, css, KeyCodes } from 'office-ui-fabric-react/lib/Utilities';
+import { Async, initializeComponentRef, css, KeyCodes } from 'office-ui-fabric-react/lib/Utilities';
 import { Callout, DirectionalHint } from 'office-ui-fabric-react/lib/Callout';
 import { IFloatingSuggestions, IFloatingSuggestionsProps, IFloatingSuggestionsInnerSuggestionProps } from './FloatingSuggestions.types';
 import { ISuggestionModel } from 'office-ui-fabric-react/lib/Pickers';
@@ -20,10 +20,12 @@ export class FloatingSuggestions<TItem> extends React.Component<IFloatingSuggest
   private suggestionsControl: React.RefObject<SuggestionsControl<TItem>> = React.createRef();
   private currentPromise: PromiseLike<TItem[]>;
   private isComponentMounted: boolean = false;
+  private _async: Async;
 
   constructor(basePickerProps: IFloatingSuggestionsProps<TItem>) {
     super(basePickerProps);
 
+    this._async = new Async(this);
     initializeComponentRef(this);
 
     this.suggestionStore = basePickerProps.suggestionsStore;
@@ -113,6 +115,7 @@ export class FloatingSuggestions<TItem> extends React.Component<IFloatingSuggest
   public componentWillUnmount(): void {
     this._unbindFromInputElement();
     this.isComponentMounted = false;
+    this._async.dispose();
   }
 
   // tslint:disable-next-line function-name

--- a/packages/experiments/src/components/FloatingSuggestions/FloatingSuggestions.tsx
+++ b/packages/experiments/src/components/FloatingSuggestions/FloatingSuggestions.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import * as styles from './FloatingSuggestions.scss';
-import { BaseComponent, css, KeyCodes } from 'office-ui-fabric-react/lib/Utilities';
+import { initializeComponentRef, css, KeyCodes } from 'office-ui-fabric-react/lib/Utilities';
 import { Callout, DirectionalHint } from 'office-ui-fabric-react/lib/Callout';
 import { IFloatingSuggestions, IFloatingSuggestionsProps, IFloatingSuggestionsInnerSuggestionProps } from './FloatingSuggestions.types';
 import { ISuggestionModel } from 'office-ui-fabric-react/lib/Pickers';
@@ -13,7 +13,7 @@ export interface IFloatingSuggestionsState {
   didBind: boolean;
 }
 
-export class FloatingSuggestions<TItem> extends BaseComponent<IFloatingSuggestionsProps<TItem>, IFloatingSuggestionsState>
+export class FloatingSuggestions<TItem> extends React.Component<IFloatingSuggestionsProps<TItem>, IFloatingSuggestionsState>
   implements IFloatingSuggestions<TItem> {
   private root = React.createRef<HTMLDivElement>();
   private suggestionStore: SuggestionsStore<TItem>;
@@ -23,6 +23,8 @@ export class FloatingSuggestions<TItem> extends BaseComponent<IFloatingSuggestio
 
   constructor(basePickerProps: IFloatingSuggestionsProps<TItem>) {
     super(basePickerProps);
+
+    initializeComponentRef(this);
 
     this.suggestionStore = basePickerProps.suggestionsStore;
     this.state = {

--- a/packages/experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsControl.tsx
+++ b/packages/experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsControl.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, css, KeyCodes } from 'office-ui-fabric-react/lib/Utilities';
+import { css, KeyCodes, initializeComponentRef } from 'office-ui-fabric-react/lib/Utilities';
 import { ISuggestionModel } from 'office-ui-fabric-react/lib/Pickers';
 import { ISuggestionsHeaderFooterItemProps, ISuggestionsControlProps, ISuggestionsHeaderFooterProps } from './Suggestions.types';
 import { SuggestionsCore } from './SuggestionsCore';
@@ -20,7 +20,13 @@ export interface ISuggestionsControlState<T> {
   suggestions: ISuggestionModel<T>[];
 }
 
-export class SuggestionsHeaderFooterItem extends BaseComponent<ISuggestionsHeaderFooterItemProps, {}> {
+export class SuggestionsHeaderFooterItem extends React.Component<ISuggestionsHeaderFooterItemProps, {}> {
+  constructor(props: ISuggestionsHeaderFooterItemProps) {
+    super(props);
+
+    initializeComponentRef(this);
+  }
+
   public render(): JSX.Element {
     const { renderItem, onExecute, isSelected, id, className } = this.props;
     return onExecute ? (
@@ -44,12 +50,14 @@ export class SuggestionsHeaderFooterItem extends BaseComponent<ISuggestionsHeade
 /**
  * Class when used with SuggestionsStore, renders a suggestions control with customizable headers and footers
  */
-export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProps<T>, ISuggestionsControlState<T>> {
-  private _selectedElement: HTMLDivElement;
-  private _suggestions: SuggestionsCore<T>;
+export class SuggestionsControl<T> extends React.Component<ISuggestionsControlProps<T>, ISuggestionsControlState<T>> {
+  private _selectedElement = React.createRef<HTMLDivElement>();
+  private _suggestions = React.createRef<SuggestionsCore<T>>();
 
   constructor(suggestionsProps: ISuggestionsControlProps<T>) {
     super(suggestionsProps);
+
+    initializeComponentRef(this);
 
     this.state = {
       selectedHeaderIndex: -1,
@@ -59,12 +67,10 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
   }
 
   public componentDidMount(): void {
-    super.componentDidMount();
     this._resetSelectedItem();
   }
 
   public componentDidUpdate(prevProps: ISuggestionsControlProps<T>, prevState: ISuggestionsControlState<T>): void {
-    super.componentDidUpdate(prevProps, prevState);
     this.scrollSelected();
   }
 
@@ -78,7 +84,7 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
   }
 
   public componentWillUnmount(): void {
-    this._suggestions.deselectAllSuggestions();
+    this._suggestions.current?.deselectAllSuggestions();
   }
 
   public render(): JSX.Element {
@@ -93,20 +99,20 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
     );
   }
 
-  public get currentSuggestion(): ISuggestionModel<T> {
-    return this._suggestions && this._suggestions.getCurrentItem();
+  public get currentSuggestion(): ISuggestionModel<T> | undefined {
+    return this._suggestions.current?.getCurrentItem();
   }
 
   public get currentSuggestionIndex(): number {
-    return this._suggestions ? this._suggestions.currentIndex : -1;
+    return this._suggestions.current ? this._suggestions.current.currentIndex : -1;
   }
 
   public get selectedElement(): HTMLDivElement | undefined {
-    return this._selectedElement ? this._selectedElement : this._suggestions.selectedElement;
+    return this._suggestions.current?.selectedElement;
   }
 
   public hasSuggestionSelected(): boolean {
-    return this._suggestions && this._suggestions.hasSuggestionSelected();
+    return this._suggestions.current?.hasSuggestionSelected() || false;
   }
 
   public hasSelection(): boolean {
@@ -123,7 +129,7 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
       if (selectedHeaderItem.onExecute) {
         selectedHeaderItem.onExecute();
       }
-    } else if (this._suggestions.hasSuggestionSelected()) {
+    } else if (this._suggestions.current?.hasSuggestionSelected()) {
       this.props.onCurrentlySelectedSuggestionChosen();
     } else if (footerItemsProps && selectedFooterIndex !== -1 && selectedFooterIndex < footerItemsProps.length) {
       const selectedFooterItem = footerItemsProps[selectedFooterIndex];
@@ -134,7 +140,7 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
   }
 
   public removeSuggestion(index?: number): void {
-    this._suggestions.removeSuggestion(index ? index : this._suggestions.currentIndex);
+    this._suggestions.current?.removeSuggestion(index ? index : this._suggestions.current?.currentIndex);
   }
 
   /**
@@ -145,12 +151,12 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
     const { selectedHeaderIndex, selectedFooterIndex } = this.state;
     let isKeyDownHandled = false;
     if (keyCode === KeyCodes.down) {
-      if (selectedHeaderIndex === -1 && !this._suggestions.hasSuggestionSelected() && selectedFooterIndex === -1) {
+      if (selectedHeaderIndex === -1 && !this._suggestions.current?.hasSuggestionSelected() && selectedFooterIndex === -1) {
         this._selectFirstItem();
       } else if (selectedHeaderIndex !== -1) {
         this._selectNextItem(SuggestionItemType.header);
         isKeyDownHandled = true;
-      } else if (this._suggestions.hasSuggestionSelected()) {
+      } else if (this._suggestions.current?.hasSuggestionSelected()) {
         this._selectNextItem(SuggestionItemType.suggestion);
         isKeyDownHandled = true;
       } else if (selectedFooterIndex !== -1) {
@@ -158,12 +164,12 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
         isKeyDownHandled = true;
       }
     } else if (keyCode === KeyCodes.up) {
-      if (selectedHeaderIndex === -1 && !this._suggestions.hasSuggestionSelected() && selectedFooterIndex === -1) {
+      if (selectedHeaderIndex === -1 && !this._suggestions.current?.hasSuggestionSelected() && selectedFooterIndex === -1) {
         this._selectLastItem();
       } else if (selectedHeaderIndex !== -1) {
         this._selectPreviousItem(SuggestionItemType.header);
         isKeyDownHandled = true;
-      } else if (this._suggestions.hasSuggestionSelected()) {
+      } else if (this._suggestions.current?.hasSuggestionSelected()) {
         this._selectPreviousItem(SuggestionItemType.suggestion);
         isKeyDownHandled = true;
       } else if (selectedFooterIndex !== -1) {
@@ -182,8 +188,8 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
 
   // TODO get the element to scroll into view properly regardless of direction.
   public scrollSelected(): void {
-    if (this._selectedElement) {
-      this._selectedElement.scrollIntoView(false);
+    if (this._selectedElement.current) {
+      this._selectedElement.current.scrollIntoView(false);
     }
   }
 
@@ -202,8 +208,7 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
           const isSelected = selectedHeaderIndex !== -1 && selectedHeaderIndex === index;
           return headerItemProps.shouldShow() ? (
             <div
-              // tslint:disable-next-line:deprecation
-              ref={this._resolveRef(isSelected ? '_selectedElement' : '')}
+              ref={isSelected ? this._selectedElement : undefined}
               id={'sug-header' + index}
               key={'sug-header' + index}
               role="listitem"
@@ -237,8 +242,7 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
           const isSelected = selectedFooterIndex !== -1 && selectedFooterIndex === index;
           return footerItemProps.shouldShow() ? (
             <div
-              // tslint:disable-next-line:deprecation
-              ref={this._resolveRef(isSelected ? '_selectedElement' : '')}
+              ref={isSelected ? this._selectedElement : undefined}
               id={'sug-footer' + index}
               key={'sug-footer' + index}
               role="listitem"
@@ -260,7 +264,7 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
 
   private _renderSuggestions(): JSX.Element {
     // tslint:disable-next-line:deprecation
-    return <SuggestionsCore<T> ref={this._resolveRef('_suggestions')} {...this.props} suggestions={this.state.suggestions} />;
+    return <SuggestionsCore<T> ref={this._suggestions} {...this.props} suggestions={this.state.suggestions} />;
   }
 
   /**
@@ -321,7 +325,7 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
    */
   private _resetSelectedItem(): void {
     this.setState({ selectedHeaderIndex: -1, selectedFooterIndex: -1 });
-    this._suggestions.deselectAllSuggestions();
+    this._suggestions.current?.deselectAllSuggestions();
 
     // Select the first item if the shouldSelectFirstItem prop is not set or it is set and it returns true
     if (this.props.shouldSelectFirstItem === undefined || this.props.shouldSelectFirstItem()) {
@@ -368,7 +372,7 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
   private _selectNextItemOfItemType(itemType: SuggestionItemType, currentIndex: number = -1): boolean {
     if (itemType === SuggestionItemType.suggestion) {
       if (this.state.suggestions.length > currentIndex + 1) {
-        this._suggestions.setSelectedSuggestion(currentIndex + 1);
+        this._suggestions.current?.setSelectedSuggestion(currentIndex + 1);
         this.setState({ selectedHeaderIndex: -1, selectedFooterIndex: -1 });
         return true;
       }
@@ -382,7 +386,7 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
           if (item.onExecute && item.shouldShow()) {
             this.setState({ selectedHeaderIndex: isHeader ? i : -1 });
             this.setState({ selectedFooterIndex: isHeader ? -1 : i });
-            this._suggestions.deselectAllSuggestions();
+            this._suggestions.current?.deselectAllSuggestions();
             return true;
           }
         }
@@ -402,7 +406,7 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
     if (itemType === SuggestionItemType.suggestion) {
       const index = currentIndex !== undefined ? currentIndex : this.state.suggestions.length;
       if (index > 0) {
-        this._suggestions.setSelectedSuggestion(index - 1);
+        this._suggestions.current?.setSelectedSuggestion(index - 1);
         this.setState({ selectedHeaderIndex: -1, selectedFooterIndex: -1 });
         return true;
       }
@@ -417,7 +421,7 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
             if (item.onExecute && item.shouldShow()) {
               this.setState({ selectedHeaderIndex: isHeader ? i : -1 });
               this.setState({ selectedFooterIndex: isHeader ? -1 : i });
-              this._suggestions.deselectAllSuggestions();
+              this._suggestions.current?.deselectAllSuggestions();
               return true;
             }
           }
@@ -433,7 +437,7 @@ export class SuggestionsControl<T> extends BaseComponent<ISuggestionsControlProp
       case SuggestionItemType.header:
         return this.state.selectedHeaderIndex;
       case SuggestionItemType.suggestion:
-        return this._suggestions.currentIndex;
+        return this._suggestions.current!.currentIndex;
       case SuggestionItemType.footer:
         return this.state.selectedFooterIndex;
     }

--- a/packages/experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsCore.tsx
+++ b/packages/experiments/src/components/FloatingSuggestions/Suggestions/SuggestionsCore.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, css } from 'office-ui-fabric-react/lib/Utilities';
+import { css, initializeComponentRef } from 'office-ui-fabric-react/lib/Utilities';
 import { ISuggestionModel } from 'office-ui-fabric-react/lib/Pickers';
 import { SuggestionsItem } from './SuggestionsItem';
 import { ISuggestionsCoreProps } from './Suggestions.types';
@@ -22,13 +22,15 @@ function hasKey<T>(i: T): i is T & { key: string | number } {
 /**
  * Class when used with SuggestionsStore, renders a basic suggestions control
  */
-export class SuggestionsCore<T> extends BaseComponent<ISuggestionsCoreProps<T>, {}> {
+export class SuggestionsCore<T> extends React.Component<ISuggestionsCoreProps<T>, {}> {
   public currentIndex: number;
   public currentSuggestion: ISuggestionModel<T> | undefined;
-  protected _selectedElement: HTMLDivElement;
+  protected _selectedElement = React.createRef<HTMLDivElement>();
 
   constructor(suggestionsProps: ISuggestionsCoreProps<T>) {
     super(suggestionsProps);
+
+    initializeComponentRef(this);
     this.currentIndex = -1;
   }
 
@@ -77,7 +79,7 @@ export class SuggestionsCore<T> extends BaseComponent<ISuggestionsCoreProps<T>, 
   }
 
   public get selectedElement(): HTMLDivElement | undefined {
-    return this._selectedElement;
+    return this._selectedElement.current || undefined;
   }
 
   public getCurrentItem(): ISuggestionModel<T> {
@@ -151,8 +153,7 @@ export class SuggestionsCore<T> extends BaseComponent<ISuggestionsCoreProps<T>, 
       >
         {suggestions.map((suggestion: ISuggestionModel<T>, index: number) => (
           <div
-            // tslint:disable-next-line:deprecation
-            ref={this._resolveRef(suggestion.selected || index === this.currentIndex ? '_selectedElement' : '')}
+            ref={suggestion.selected || index === this.currentIndex ? this._selectedElement : undefined}
             key={hasKey(suggestion.item) ? suggestion.item.key : index}
             id={'sug-' + index}
             role="listitem"
@@ -176,8 +177,8 @@ export class SuggestionsCore<T> extends BaseComponent<ISuggestionsCoreProps<T>, 
 
   // TODO get the element to scroll into view properly regardless of direction.
   public scrollSelected(): void {
-    if (this._selectedElement && this._selectedElement.scrollIntoView !== undefined) {
-      this._selectedElement.scrollIntoView(false);
+    if (this._selectedElement.current?.scrollIntoView !== undefined) {
+      this._selectedElement.current.scrollIntoView(false);
     }
   }
 

--- a/packages/experiments/src/components/Pagination/Pagination.base.tsx
+++ b/packages/experiments/src/components/Pagination/Pagination.base.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { IconButton } from 'office-ui-fabric-react/lib/Button';
-import { BaseComponent, classNamesFunction } from '../../Utilities';
+import { initializeComponentRef, classNamesFunction } from '../../Utilities';
 import { PageNumber } from './PageNumber';
 import { IPaginationProps, IPaginationString, IPaginationStyleProps, IPaginationStyles } from './Pagination.types';
 import { ComboBox, IComboBoxOption, IComboBox } from 'office-ui-fabric-react/lib/ComboBox';
@@ -14,7 +14,7 @@ const DEFAULT_STRINGS: IPaginationString = {
   divider: '-'
 };
 
-export class PaginationBase extends BaseComponent<IPaginationProps> {
+export class PaginationBase extends React.Component<IPaginationProps> {
   public static defaultProps: Partial<IPaginationProps> = {
     selectedPageIndex: 0,
     format: 'comboBox',
@@ -30,6 +30,8 @@ export class PaginationBase extends BaseComponent<IPaginationProps> {
 
   constructor(props: IPaginationProps) {
     super(props);
+
+    initializeComponentRef(this);
   }
 
   public render(): JSX.Element {

--- a/packages/experiments/src/components/Sidebar/Sidebar.tsx
+++ b/packages/experiments/src/components/Sidebar/Sidebar.tsx
@@ -7,7 +7,7 @@ import { IButtonStyles } from 'office-ui-fabric-react/lib/Button';
 import { DirectionalHint } from 'office-ui-fabric-react/lib/common/DirectionalHint';
 import { ScrollablePane } from 'office-ui-fabric-react/lib/ScrollablePane';
 import { concatStyleSets, ITheme } from 'office-ui-fabric-react/lib/Styling';
-import { BaseComponent, KeyCodes } from 'office-ui-fabric-react/lib/Utilities';
+import { KeyCodes, initializeComponentRef, FocusRects } from 'office-ui-fabric-react/lib/Utilities';
 import * as React from 'react';
 import { Accordion } from '../BAFAccordion/Accordion';
 import { getSidebarClassNames, ISidebarClassNames } from './Sidebar.classNames';
@@ -21,7 +21,7 @@ export interface ISidebarState {
   isCollapsed: boolean;
 }
 
-export class Sidebar extends BaseComponent<ISidebarProps, ISidebarState> implements ISidebar {
+export class Sidebar extends React.Component<ISidebarProps, ISidebarState> implements ISidebar {
   private _theme: ITheme;
   private _classNames: ISidebarClassNames;
   private _colors: SidebarColors;
@@ -30,6 +30,7 @@ export class Sidebar extends BaseComponent<ISidebarProps, ISidebarState> impleme
   constructor(props: ISidebarProps) {
     super(props);
 
+    initializeComponentRef(this);
     this.state = {
       isCollapsed: false
     };
@@ -90,6 +91,7 @@ export class Sidebar extends BaseComponent<ISidebarProps, ISidebarState> impleme
             {footerItems.map((item: ISidebarItemProps) => this._renderItemInSidebar(item))}
           </FocusZone>
         )}
+        <FocusRects />
       </div>
     );
   }

--- a/packages/experiments/src/components/Sidebar/SidebarButton.tsx
+++ b/packages/experiments/src/components/Sidebar/SidebarButton.tsx
@@ -3,14 +3,11 @@
  */
 
 import { DefaultButton, IButtonProps } from 'office-ui-fabric-react/lib/Button';
-import { BaseComponent } from 'office-ui-fabric-react/lib/Utilities';
 import * as React from 'react';
 import { getSidebarButtonStyles } from './SidebarButton.styles';
 
-export class SidebarButton extends BaseComponent<IButtonProps, {}> {
-  public render(): JSX.Element {
-    const { styles, theme } = this.props;
+export const SidebarButton: React.FunctionComponent<IButtonProps> = props => {
+  const { styles, theme } = props;
 
-    return <DefaultButton {...this.props} styles={getSidebarButtonStyles(theme!, styles)} />;
-  }
-}
+  return <DefaultButton {...props} styles={getSidebarButtonStyles(theme!, styles)} />;
+};

--- a/packages/experiments/src/components/Slider/Slider.base.tsx
+++ b/packages/experiments/src/components/Slider/Slider.base.tsx
@@ -1,19 +1,22 @@
 import * as React from 'react';
-import { BaseComponent, KeyCodes, css, getId, getRTL, getRTLSafeKeyCode } from '../../Utilities';
+import { initializeComponentRef, KeyCodes, css, getId, getRTL, getRTLSafeKeyCode, warnMutuallyExclusive } from '../../Utilities';
 import { ISliderProps, ISlider, ISliderStyleProps, ISliderStyles, ISliderMarks } from './Slider.types';
 import { classNamesFunction, getNativeProps, divProperties } from '../../Utilities';
 import { Label } from 'office-ui-fabric-react/lib/Label';
 import { TooltipHost } from 'office-ui-fabric-react/lib/Tooltip';
 import { DirectionalHint } from 'office-ui-fabric-react/lib/common/DirectionalHint';
+import { Async, EventGroup, FocusRects } from '@uifabric/utilities';
 export interface ISliderState {
   value?: number;
   renderedValue?: number;
 }
 
 const getClassNames = classNamesFunction<ISliderStyleProps, ISliderStyles>();
+const COMPONENT_NAME = 'Slider';
+
 export const ONKEYDOWN_TIMEOUT_DURATION = 1000;
-// tslint:disable:jsx-ban-props
-export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implements ISlider {
+
+export class SliderBase extends React.Component<ISliderProps, ISliderState> implements ISlider {
   public static defaultProps: ISliderProps = {
     step: 1,
     min: 0,
@@ -32,10 +35,16 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
   private _hostId: string = getId('tooltipHost');
   private _buttonId: string = getId('targetButton');
 
+  private _async: Async;
+  private _events: EventGroup;
+
   constructor(props: ISliderProps) {
     super(props);
 
-    this._warnMutuallyExclusive({
+    this._async = new Async(this);
+    this._events = new EventGroup(this);
+    initializeComponentRef(this);
+    warnMutuallyExclusive(COMPONENT_NAME, props, {
       value: 'defaultValue'
     });
 
@@ -47,6 +56,11 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
       value: value,
       renderedValue: undefined
     };
+  }
+
+  public componentWillUnmount(): void {
+    this._async.dispose();
+    this._events.dispose();
   }
 
   public render(): React.ReactElement<{}> {
@@ -182,6 +196,7 @@ export class SliderBase extends BaseComponent<ISliderProps, ISliderState> implem
           </div>
         </div>
         <div />
+        <FocusRects />
       </div>
     ) as React.ReactElement<{}>;
   }

--- a/packages/experiments/src/components/Slider/Slider.base.tsx
+++ b/packages/experiments/src/components/Slider/Slider.base.tsx
@@ -16,6 +16,7 @@ const COMPONENT_NAME = 'Slider';
 
 export const ONKEYDOWN_TIMEOUT_DURATION = 1000;
 
+// tslint:disable:jsx-ban-props
 export class SliderBase extends React.Component<ISliderProps, ISliderState> implements ISlider {
   public static defaultProps: ISliderProps = {
     step: 1,

--- a/packages/experiments/src/components/Tile/ShimmerTile/ShimmerTile.base.tsx
+++ b/packages/experiments/src/components/Tile/ShimmerTile/ShimmerTile.base.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { BaseComponent, classNamesFunction } from '../../../Utilities';
+import { initializeComponentRef, classNamesFunction } from '../../../Utilities';
 import { IShimmerTileProps, IShimmerTileStyleProps, IShimmerTileStyles } from './ShimmerTile.types';
 import { TileSize } from '../Tile.types';
 import { TileLayoutSizes } from '../Tile';
@@ -50,11 +50,13 @@ const PLACEHOLDER_SIZES: {
 
 const getClassNames = classNamesFunction<IShimmerTileStyleProps, IShimmerTileStyles>();
 
-export class ShimmerTileBase extends BaseComponent<IShimmerTileProps, {}> {
+export class ShimmerTileBase extends React.Component<IShimmerTileProps, {}> {
   private _classNames: { [key in keyof IShimmerTileStyles]: string };
 
   constructor(props: IShimmerTileProps) {
     super(props);
+
+    initializeComponentRef(this);
   }
 
   public render(): JSX.Element {

--- a/packages/experiments/src/components/VirtualizedList/VirtualizedList.tsx
+++ b/packages/experiments/src/components/VirtualizedList/VirtualizedList.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { IVirtualizedListProps } from './VirtualizedList.types';
 import { IScrollContainerContext, ScrollContainerContextTypes } from '../../utilities/scrolling/ScrollContainer';
 import { IObjectWithKey } from 'office-ui-fabric-react/lib/Selection';
-import { BaseComponent, getParent, css } from 'office-ui-fabric-react/lib/Utilities';
+import { BaseComponent, getParent, css, initializeComponentRef, EventGroup } from 'office-ui-fabric-react/lib/Utilities';
 
 interface IRange {
   /** Start of range */
@@ -22,7 +22,7 @@ export interface IVirtualizedListState {
   items: React.ReactNode[];
 }
 
-export class VirtualizedList<TItem extends IObjectWithKey> extends BaseComponent<IVirtualizedListProps<TItem>, IVirtualizedListState> {
+export class VirtualizedList<TItem extends IObjectWithKey> extends React.Component<IVirtualizedListProps<TItem>, IVirtualizedListState> {
   public static contextTypes: typeof ScrollContainerContextTypes = ScrollContainerContextTypes;
   public context: IScrollContainerContext;
 
@@ -32,8 +32,13 @@ export class VirtualizedList<TItem extends IObjectWithKey> extends BaseComponent
 
   private _focusedIndex: number;
 
+  private _events: EventGroup;
+
   constructor(props: IVirtualizedListProps<TItem>, context: IScrollContainerContext) {
     super(props, context);
+
+    this._events = new EventGroup(this);
+    initializeComponentRef(this);
 
     this._focusedIndex = -1;
 
@@ -61,6 +66,10 @@ export class VirtualizedList<TItem extends IObjectWithKey> extends BaseComponent
 
   public componentDidUpdate(): void {
     this._updateObservedElements();
+  }
+
+  public componentWillUnmount(): void {
+    this._events.dispose();
   }
 
   // tslint:disable-next-line function-name

--- a/packages/experiments/src/components/VirtualizedList/VirtualizedList.tsx
+++ b/packages/experiments/src/components/VirtualizedList/VirtualizedList.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { IVirtualizedListProps } from './VirtualizedList.types';
 import { IScrollContainerContext, ScrollContainerContextTypes } from '../../utilities/scrolling/ScrollContainer';
 import { IObjectWithKey } from 'office-ui-fabric-react/lib/Selection';
-import { BaseComponent, getParent, css, initializeComponentRef, EventGroup } from 'office-ui-fabric-react/lib/Utilities';
+import { getParent, css, initializeComponentRef, EventGroup } from 'office-ui-fabric-react/lib/Utilities';
 
 interface IRange {
   /** Start of range */

--- a/packages/experiments/src/utilities/scrolling/ScrollContainer.tsx
+++ b/packages/experiments/src/utilities/scrolling/ScrollContainer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { IScrollContainerProps } from './ScrollContainer.types';
-import { BaseComponent, css } from 'office-ui-fabric-react/lib/Utilities';
+import { BaseComponent, css, Async, initializeComponentRef } from 'office-ui-fabric-react/lib/Utilities';
 
 import * as ScrollContainerStyles from './ScrollContainer.scss';
 
@@ -25,7 +25,7 @@ export const ScrollContainerContextTypes = {
   scrollContainer: PropTypes.object.isRequired
 };
 
-export class ScrollContainer extends BaseComponent<IScrollContainerProps> implements IScrollContainer {
+export class ScrollContainer extends React.Component<IScrollContainerProps> implements IScrollContainer {
   public static childContextTypes: typeof ScrollContainerContextTypes = ScrollContainerContextTypes;
 
   private _observer: IntersectionObserver;
@@ -34,6 +34,15 @@ export class ScrollContainer extends BaseComponent<IScrollContainerProps> implem
 
   private _callbacks: IVisibleCallback[] = [];
   private _pendingElements: Element[] = [];
+
+  private _async: Async;
+
+  constructor(props: IScrollContainerProps) {
+    super(props);
+
+    this._async = new Async(this);
+    initializeComponentRef(this);
+  }
 
   public getChildContext(): IScrollContainerContext {
     return {
@@ -73,6 +82,8 @@ export class ScrollContainer extends BaseComponent<IScrollContainerProps> implem
     if (this._observer) {
       this._observer.disconnect();
     }
+
+    this._async.dispose();
   }
 
   private _resolveRoot = (element: HTMLDivElement): void => {

--- a/packages/experiments/src/utilities/scrolling/ScrollContainer.tsx
+++ b/packages/experiments/src/utilities/scrolling/ScrollContainer.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import * as PropTypes from 'prop-types';
 import { IScrollContainerProps } from './ScrollContainer.types';
-import { BaseComponent, css, Async, initializeComponentRef } from 'office-ui-fabric-react/lib/Utilities';
+import { css, Async, initializeComponentRef } from 'office-ui-fabric-react/lib/Utilities';
 
 import * as ScrollContainerStyles from './ScrollContainer.scss';
 

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -80,7 +80,7 @@ export class AutoScroll {
     dispose(): void;
     }
 
-// @public
+// @public @deprecated
 export class BaseComponent<TProps extends IBaseProps = {}, TState = {}> extends React.Component<TProps, TState> {
     constructor(props: TProps, context?: any);
     protected readonly _async: Async;

--- a/packages/utilities/etc/utilities.api.md
+++ b/packages/utilities/etc/utilities.api.md
@@ -581,6 +581,9 @@ export const imgProperties: string[];
 // @public
 export function initializeComponentRef<TProps extends IBaseProps, TState>(obj: React.Component<TProps, TState>): void;
 
+// @public @deprecated
+export function initializeFocusRects(window?: Window): void;
+
 // @public
 export const inputProperties: string[];
 

--- a/packages/utilities/src/BaseComponent.test.tsx
+++ b/packages/utilities/src/BaseComponent.test.tsx
@@ -7,6 +7,7 @@ import { BaseComponent } from './BaseComponent';
 
 describe('BaseComponent', () => {
   it('can resolve refs', () => {
+    // tslint:disable-next-line:deprecation
     class Foo extends BaseComponent<{}, {}> {
       public root: HTMLElement;
 

--- a/packages/utilities/src/BaseComponent.ts
+++ b/packages/utilities/src/BaseComponent.ts
@@ -15,6 +15,8 @@ import { IBaseProps } from './BaseComponent.types';
  *
  * @public
  * {@docCategory BaseComponent}
+ *
+ * @deprecated Do not use. We are moving away from class component.
  */
 export class BaseComponent<TProps extends IBaseProps = {}, TState = {}> extends React.Component<TProps, TState> {
   /**
@@ -51,6 +53,7 @@ export class BaseComponent<TProps extends IBaseProps = {}, TState = {}> extends 
     // tslint:disable-next-line:deprecation
     initializeFocusRects();
 
+    // tslint:disable-next-line:deprecation
     _makeAllSafe(this, BaseComponent.prototype, [
       'componentDidMount',
       'shouldComponentUpdate',
@@ -230,12 +233,14 @@ export class BaseComponent<TProps extends IBaseProps = {}, TState = {}> extends 
  * ensures that the BaseComponent's methods are called before the subclass's. This ensures that
  * componentWillUnmount in the base is called and that things in the _disposables array are disposed.
  */
+// tslint:disable-next-line:deprecation
 function _makeAllSafe(obj: BaseComponent<{}, {}>, prototype: Object, methodNames: string[]): void {
   for (let i = 0, len = methodNames.length; i < len; i++) {
     _makeSafe(obj, prototype, methodNames[i]);
   }
 }
 
+// tslint:disable-next-line:deprecation
 function _makeSafe(obj: BaseComponent<{}, {}>, prototype: Object, methodName: string): void {
   // tslint:disable:no-any
   let classMethod = (obj as any)[methodName];

--- a/packages/utilities/src/BaseComponent.ts
+++ b/packages/utilities/src/BaseComponent.ts
@@ -6,7 +6,6 @@ import { ISettingsMap } from './warn/warn';
 import { warnConditionallyRequiredProps } from './warn/warnConditionallyRequiredProps';
 import { warnMutuallyExclusive } from './warn/warnMutuallyExclusive';
 import { warnDeprecations } from './warn/warnDeprecations';
-import { initializeFocusRects } from './initializeFocusRects';
 import { IRefObject } from './createRef';
 import { IBaseProps } from './BaseComponent.types';
 
@@ -48,10 +47,6 @@ export class BaseComponent<TProps extends IBaseProps = {}, TState = {}> extends 
   // tslint:disable-next-line:no-any
   constructor(props: TProps, context?: any) {
     super(props, context);
-
-    // Ensure basic assumptions about the environment.
-    // tslint:disable-next-line:deprecation
-    initializeFocusRects();
 
     // tslint:disable-next-line:deprecation
     _makeAllSafe(this, BaseComponent.prototype, [

--- a/packages/utilities/src/index.ts
+++ b/packages/utilities/src/index.ts
@@ -41,6 +41,7 @@ export * from './getId';
 export * from './hoist';
 export * from './hoistStatics';
 export * from './initializeComponentRef';
+export * from './initializeFocusRects';
 export * from './useFocusRects';
 export * from './initials';
 export * from './keyboard';

--- a/packages/utilities/src/setFocusVisibility.test.tsx
+++ b/packages/utilities/src/setFocusVisibility.test.tsx
@@ -1,14 +1,22 @@
-import { initializeFocusRects } from './initializeFocusRects';
+import * as React from 'react';
+import { FocusRects } from './useFocusRects';
 import { IsFocusHiddenClassName, IsFocusVisibleClassName, setFocusVisibility } from './setFocusVisibility';
 import * as getWindow from './dom/getWindow';
+import { mount, ReactWrapper } from 'enzyme';
 
 describe('setFocusVisibility', () => {
+  let wrapper: ReactWrapper;
   let classNames: string[] = [];
 
   // tslint:disable-next-line:no-any
   const mockWindow: { [key: string]: any } = {
     addEventListener: (name: string, callback: Function) => {
       mockWindow[name] = callback;
+    },
+    removeEventListener: (name: string, callback: Function) => {
+      if (mockWindow[name] === callback) {
+        mockWindow[name] = undefined;
+      }
     },
     document: {
       body: {
@@ -39,9 +47,11 @@ describe('setFocusVisibility', () => {
   beforeEach(() => {
     spyOn(getWindow, 'getWindow').and.returnValue(mockWindow);
     classNames = [];
-    // tslint:disable-next-line:deprecation
-    initializeFocusRects(mockWindow as Window);
+
+    wrapper = mount(<FocusRects />);
   });
+
+  afterEach(() => wrapper.unmount());
 
   it('hints to show focus', () => {
     setFocusVisibility(true);


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [x] Include a change request file using `$ yarn change`

#### Description of changes
- Deprecate `BaseComponent`
- Remove usage of `BaseComponent` everywhere (related PR: #12295)
- Remove usage of `initializeFocusRects` everywhere (related PR: #12244)
- Bring back (deprecated) `initializeFocusRects` to index.js to avoid breaking users

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12320)