### PR TITLE
Adding onClick callback to divider in SplitButtons that stops propagation so that clicking on the divider does not trigger action

### DIFF
--- a/change/office-ui-fabric-react-2020-03-16-15-37-59-splitButtonDivider.json
+++ b/change/office-ui-fabric-react-2020-03-16-15-37-59-splitButtonDivider.json
@@ -1,0 +1,9 @@
+{
+  "type": "patch",
+  "comment": "Adding onClick callback to divider in SplitButtons that stops propagation so that clicking on the divider does not trigger action.",
+  "packageName": "office-ui-fabric-react",
+  "email": "humbertomakotomorimoto@gmail.com",
+  "commit": "64d2c080fcb69ec5e89acbeace6a1f5c77fa0580",
+  "dependentChangeType": "patch",
+  "date": "2020-03-16T22:37:59.137Z"
+}

--- a/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
+++ b/packages/office-ui-fabric-react/src/components/Button/BaseButton.tsx
@@ -656,7 +656,10 @@ export class BaseButton extends React.Component<IBaseButtonProps, IBaseButtonSta
 
   private _onRenderSplitButtonDivider(classNames: ISplitButtonClassNames | undefined): JSX.Element | null {
     if (classNames && classNames.divider) {
-      return <span className={classNames.divider} aria-hidden={true} />;
+      const onClick = (ev: React.MouseEvent<HTMLSpanElement, MouseEvent>) => {
+        ev.stopPropagation();
+      };
+      return <span className={classNames.divider} aria-hidden={true} onClick={onClick} />;
     }
     return null;
   }

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CustomSplit.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.CustomSplit.Example.tsx.shot
@@ -365,6 +365,7 @@ exports[`Component Examples renders Button.CustomSplit.Example.tsx correctly 1`]
             @media screen and (-ms-high-contrast: active){& {
               background-color: WindowText;
             }
+        onClick={[Function]}
       />
     </span>
   </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Split.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Button.Split.Example.tsx.shot
@@ -371,6 +371,7 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active){& {
                 background-color: WindowText;
               }
+          onClick={[Function]}
         />
       </span>
     </div>
@@ -723,6 +724,7 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active){& {
                 background-color: WindowText;
               }
+          onClick={[Function]}
         />
       </span>
     </div>
@@ -1059,6 +1061,7 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active){& {
                 background-color: GrayText;
               }
+          onClick={[Function]}
         />
       </span>
     </div>
@@ -1400,6 +1403,7 @@ exports[`Component Examples renders Button.Split.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active){& {
                 background-color: GrayText;
               }
+          onClick={[Function]}
         />
       </span>
     </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/CommandBar.SplitDisabled.Example.tsx.shot
@@ -464,6 +464,7 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                         @media screen and (-ms-high-contrast: active){& {
                           background-color: WindowText;
                         }
+                    onClick={[Function]}
                   />
                 </span>
               </div>
@@ -867,6 +868,7 @@ exports[`Component Examples renders CommandBar.SplitDisabled.Example.tsx correct
                         @media screen and (-ms-high-contrast: active){& {
                           background-color: GrayText;
                         }
+                    onClick={[Function]}
                   />
                 </span>
               </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/FocusZone.Tabbable.Example.tsx.shot
@@ -876,6 +876,7 @@ exports[`Component Examples renders FocusZone.Tabbable.Example.tsx correctly 1`]
                 @media screen and (-ms-high-contrast: active){& {
                   background-color: WindowText;
                 }
+            onClick={[Function]}
           />
         </span>
       </div>

--- a/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
+++ b/packages/office-ui-fabric-react/src/components/__snapshots__/Keytips.Button.Example.tsx.shot
@@ -788,6 +788,7 @@ exports[`Component Examples renders Keytips.Button.Example.tsx correctly 1`] = `
               @media screen and (-ms-high-contrast: active){& {
                 background-color: WindowText;
               }
+          onClick={[Function]}
         />
       </span>
     </div>


### PR DESCRIPTION
#### Pull request checklist

- [x] Addresses an existing issue: Fixes #12307
- [x] Include a change request file using `$ yarn change`

#### Description of changes

There was an issue where hovering over the divider in a `SplitButton` was indicating that clicking on it would not trigger anything but actually triggered the main action of the button. This was happening because the event was propagating to the button container. This PR adds a click callback to the divider to stop this propagation and make clicking on the divider actually reflect the affordance that the hover styling is showing the users.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12325)