### PR TITLE
fix(Dropdown): correctly generate loading and no results items

### DIFF
--- a/packages/fluentui/CHANGELOG.md
+++ b/packages/fluentui/CHANGELOG.md
@@ -33,6 +33,7 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 - `Carousel` accessibility fixes @kolaps33 ([#12050](https://github.com/OfficeDev/office-ui-fabric-react/pull/12050))
 - Fix different styles between children and shorthand API in `Button` component @mnajdova ([#12292](https://github.com/OfficeDev/office-ui-fabric-react/pull/12292))
 - Fix change handler typings of `Dropdown` to relect that we are passing `null` for event @silviuavram ([#12280](https://github.com/OfficeDev/office-ui-fabric-react/pull/12280))
+- Fix nested `<li>` elements in no results and loading messages for `Dropdown` @silviuavram ([#12330](https://github.com/OfficeDev/office-ui-fabric-react/pull/12330))
 
 ### Features
 - Export `broadcast-view-fullscreen` and `broadcast-view-left` as SVG icons @davidfoulkejr ([#12126](https://github.com/OfficeDev/office-ui-fabric-react/pull/12126))

--- a/packages/fluentui/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react/src/components/Dropdown/Dropdown.tsx
@@ -29,6 +29,7 @@ import { screenReaderContainerStyles } from '../../utils/accessibility/Styles/ac
 import Box, { BoxProps } from '../Box/Box';
 import Portal from '../Portal/Portal';
 import { ALIGNMENTS, POSITIONS, Popper, PositioningProps } from '../../utils/positioner';
+import ListItem, { ListItemProps } from '../List/ListItem';
 
 export interface DropdownSlotClassNames {
   clearIndicator: string;
@@ -126,7 +127,7 @@ export interface DropdownProps extends UIComponentProps<DropdownProps, DropdownS
   loading?: boolean;
 
   /** A message to be displayed in the list when the dropdown is loading. */
-  loadingMessage?: ShorthandValue<DropdownItemProps>;
+  loadingMessage?: ShorthandValue<ListItemProps>;
 
   /** When selecting an element with Tab, focus stays on the dropdown by default. If true, the focus will jump to next/previous element in DOM. Only available to multiple selection dropdowns. */
   moveFocusOnTab?: boolean;
@@ -135,7 +136,7 @@ export interface DropdownProps extends UIComponentProps<DropdownProps, DropdownS
   multiple?: boolean;
 
   /** A message to be displayed in the list when the dropdown has no items. */
-  noResultsMessage?: ShorthandValue<DropdownItemProps>;
+  noResultsMessage?: ShorthandValue<ListItemProps>;
 
   /**
    * Called when the dropdown's selected items index change.
@@ -700,7 +701,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
       ...items,
       loading && {
         children: () =>
-          DropdownItem.create(loadingMessage, {
+          ListItem.create(loadingMessage, {
             defaultProps: () => ({
               key: 'loading-message',
               styles: styles.loadingMessage
@@ -710,7 +711,7 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
       !loading &&
         items.length === 0 && {
           children: () =>
-            DropdownItem.create(noResultsMessage, {
+            ListItem.create(noResultsMessage, {
               defaultProps: () => ({
                 key: 'no-results-message',
                 styles: styles.noResultsMessage

--- a/packages/fluentui/react/src/components/Dropdown/Dropdown.tsx
+++ b/packages/fluentui/react/src/components/Dropdown/Dropdown.tsx
@@ -26,7 +26,6 @@ import DropdownSelectedItem, { DropdownSelectedItemProps } from './DropdownSelec
 import DropdownSearchInput, { DropdownSearchInputProps } from './DropdownSearchInput';
 import Button, { ButtonProps } from '../Button/Button';
 import { screenReaderContainerStyles } from '../../utils/accessibility/Styles/accessibilityStyles';
-import ListItem, { ListItemProps } from '../List/ListItem';
 import Box, { BoxProps } from '../Box/Box';
 import Portal from '../Portal/Portal';
 import { ALIGNMENTS, POSITIONS, Popper, PositioningProps } from '../../utils/positioner';
@@ -127,7 +126,7 @@ export interface DropdownProps extends UIComponentProps<DropdownProps, DropdownS
   loading?: boolean;
 
   /** A message to be displayed in the list when the dropdown is loading. */
-  loadingMessage?: ShorthandValue<ListItemProps>;
+  loadingMessage?: ShorthandValue<DropdownItemProps>;
 
   /** When selecting an element with Tab, focus stays on the dropdown by default. If true, the focus will jump to next/previous element in DOM. Only available to multiple selection dropdowns. */
   moveFocusOnTab?: boolean;
@@ -136,7 +135,7 @@ export interface DropdownProps extends UIComponentProps<DropdownProps, DropdownS
   multiple?: boolean;
 
   /** A message to be displayed in the list when the dropdown has no items. */
-  noResultsMessage?: ShorthandValue<ListItemProps>;
+  noResultsMessage?: ShorthandValue<DropdownItemProps>;
 
   /**
    * Called when the dropdown's selected items index change.
@@ -699,21 +698,25 @@ class Dropdown extends AutoControlledComponent<WithAsProp<DropdownProps>, Dropdo
 
     return [
       ...items,
-      loading &&
-        ListItem.create(loadingMessage, {
-          defaultProps: () => ({
-            key: 'loading-message',
-            styles: styles.loadingMessage
+      loading && {
+        children: () =>
+          DropdownItem.create(loadingMessage, {
+            defaultProps: () => ({
+              key: 'loading-message',
+              styles: styles.loadingMessage
+            })
           })
-        }),
+      },
       !loading &&
-        items.length === 0 &&
-        ListItem.create(noResultsMessage, {
-          defaultProps: () => ({
-            key: 'no-results-message',
-            styles: styles.noResultsMessage
-          })
-        })
+        items.length === 0 && {
+          children: () =>
+            DropdownItem.create(noResultsMessage, {
+              defaultProps: () => ({
+                key: 'no-results-message',
+                styles: styles.noResultsMessage
+              })
+            })
+        }
     ];
   }
 


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes https://github.com/OfficeDev/office-ui-fabric-react/issues/12316
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Create the DropdownItem for loading / noResultsMessage the same way as it's created for normal items: with a shorthand that has `children`.

#### Focus areas to test

(optional)


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12330)