### PR TITLE
Remove self from OUFR Lists* ownership

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -84,7 +84,7 @@ packages/office-ui-fabric-react/src/components/Button/ @khmakoto
 packages/office-ui-fabric-react/src/components/Calendar/ @OfficeDev/uifabric-calendar @lorejoh
 packages/office-ui-fabric-react/src/components/Callout/ @joschect
 packages/office-ui-fabric-react/src/components/react-cards/Card/  @khmakoto
-packages/office-ui-fabric-react/src/components/Check/ @KevinTCoughlin
+packages/office-ui-fabric-react/src/components/Check/
 packages/office-ui-fabric-react/src/components/Checkbox/ @cliffkoh
 packages/office-ui-fabric-react/src/components/ChoiceGroup/ @ecraig12345
 packages/office-ui-fabric-react/src/components/Coachmark/ @leddie24
@@ -94,7 +94,7 @@ packages/office-ui-fabric-react/src/components/ComboBox/ @joschect
 packages/office-ui-fabric-react/src/components/CommandBar/ @micahgodbolt @joschect
 packages/office-ui-fabric-react/src/components/ContextualMenu/ @joschect
 packages/office-ui-fabric-react/src/components/DatePicker/ @OfficeDev/uifabric-calendar @lorejoh
-packages/office-ui-fabric-react/src/components/DetailsList/ @KevinTCoughlin
+packages/office-ui-fabric-react/src/components/DetailsList/
 packages/office-ui-fabric-react/src/components/Dialog/ @JasonGore
 packages/office-ui-fabric-react/src/components/DocumentCard/ @yiminwu
 packages/office-ui-fabric-react/src/components/Dropdown/ @joschect
@@ -104,14 +104,14 @@ packages/office-ui-fabric-react/src/components/FolderCover/ @ThomasMichon @bigba
 packages/office-ui-fabric-react/src/components/FocusTrapZone/ @JasonGore
 packages/office-ui-fabric-react/src/components/office-ui-fabric-react/src/components/FocusZone/ @JasonGore
 packages/office-ui-fabric-react/src/components/react-focus/src/components/FocusZone/ @khmakoto
-packages/office-ui-fabric-react/src/components/GroupedList/  @aditima @KevinTCoughlin
+packages/office-ui-fabric-react/src/components/GroupedList/  @aditima
 packages/office-ui-fabric-react/src/components/HoverCard/   @atneik @Jahnp @Vitalius1
 packages/office-ui-fabric-react/src/components/Icon/ @dzearing
 packages/office-ui-fabric-react/src/components/Image/ @dzearing
 packages/office-ui-fabric-react/src/components/Label/ @cliffkoh
 packages/office-ui-fabric-react/src/components/Layer/  @ThomasMichon @JasonGore
 packages/office-ui-fabric-react/src/components/Link/ @khmakoto
-packages/office-ui-fabric-react/src/components/List/ @KevinTCoughlin
+packages/office-ui-fabric-react/src/components/List/
 packages/office-ui-fabric-react/src/components/MarqueeSelection/ @dzearing
 packages/office-ui-fabric-react/src/components/MessageBar/ @ecraig12345
 packages/office-ui-fabric-react/src/components/Modal/ @JasonGore
@@ -164,7 +164,7 @@ packages/office-ui-fabric-react/src/components/ChoiceGroup/docs/   @srideshpande
 packages/office-ui-fabric-react/src/components/CommandBar/docs/   @micahgodbolt
 packages/office-ui-fabric-react/src/components/ContextualMenu/docs/  @joschect
 packages/office-ui-fabric-react/src/components/DatePicker/docs/   @OfficeDev/uifabric-calendar @lorejoh
-packages/office-ui-fabric-react/src/components/DetailsList/docs/ @KevinTCoughlin
+packages/office-ui-fabric-react/src/components/DetailsList/docs/
 # packages/office-ui-fabric-react/src/components/Dialog/docs/
 packages/office-ui-fabric-react/src/components/DocumentCard/docs/ @yiminwu
 # packages/office-ui-fabric-react/src/components/Dropdown/docs/
@@ -172,14 +172,14 @@ packages/office-ui-fabric-react/src/components/DocumentCard/docs/ @yiminwu
 # packages/office-ui-fabric-react/src/components/Facepile/docs/
 # packages/office-ui-fabric-react/src/components/FocusTrapZone/docs/
 # packages/office-ui-fabric-react/src/components/FocusZone/docs/
-packages/office-ui-fabric-react/src/components/GroupedList/docs/  @aditima @KevinTCoughlin
+packages/office-ui-fabric-react/src/components/GroupedList/docs/  @aditima
 packages/office-ui-fabric-react/src/components/HoverCard/docs/   @atneik @Jahnp @Vitalius1
 # packages/office-ui-fabric-react/src/components/Icon/docs/
 # packages/office-ui-fabric-react/src/components/Image/docs/
 # packages/office-ui-fabric-react/src/components/Label/docs/
 packages/office-ui-fabric-react/src/components/Layer/docs/  @ThomasMichon
 packages/office-ui-fabric-react/src/components/Link/docs/  @khmakoto
-packages/office-ui-fabric-react/src/components/List/docs/ @KevinTCoughlin
+packages/office-ui-fabric-react/src/components/List/docs/
 # packages/office-ui-fabric-react/src/components/MarqueeSelection/docs/
 # packages/office-ui-fabric-react/src/components/MessageBar/docs/
 # packages/office-ui-fabric-react/src/components/Modal/docs/


### PR DESCRIPTION
#### Pull request checklist

- [ ] Addresses an existing issue: Fixes #0000
- [ ] Include a change request file using `$ yarn change`

#### Description of changes

Removing myself as CODEOWNER bottleneck for `office-ui-fabric-react` List controls. In cases where a component owner is absent, it is likely best that @aditima or similar fill-in to guard against regression. That crew is still actively working with those components in production.

I will remain involved in ways that mutually benefit Fabric & SharePoint Framework.

#### Focus areas to test

(optional)

cc: @patmill 

###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12351)