### PR TITLE
Minor fluent script fixes

### DIFF
--- a/packages/fluentui/accessibility/gulpfile.ts
+++ b/packages/fluentui/accessibility/gulpfile.ts
@@ -7,9 +7,5 @@ import '../../../gulpfile';
 task('test', series('build:docs:component-menu-behaviors', 'test:jest'));
 task(
   'test:watch',
-  series(
-    'build:docs:component-menu-behaviors',
-    'test:jest',
-    parallel('test:jest:watch', 'watch:docs:component-menu-behaviors'),
-  ),
+  series('build:docs:component-menu-behaviors', parallel('test:jest:watch', 'watch:docs:component-menu-behaviors')),
 );

--- a/scripts/gulp/tasks/bundle.ts
+++ b/scripts/gulp/tasks/bundle.ts
@@ -17,12 +17,15 @@ const packageName = config.package;
 // ----------------------------------------
 
 task('bundle:package:clean', () =>
-  del([
-    `${paths.packageDist(packageName)}/es/*`,
-    `${paths.packageDist(packageName)}/commonjs/*`,
-    `${paths.packageDist(packageName)}/umd/*`,
-    `${paths.packageDist(packageName)}/dts`,
-  ]),
+  del(
+    [
+      `${paths.packageDist(packageName)}/es/*`,
+      `${paths.packageDist(packageName)}/commonjs/*`,
+      `${paths.packageDist(packageName)}/umd/*`,
+      `${paths.packageDist(packageName)}/dts`,
+    ],
+    { force: true },
+  ),
 );
 
 // ----------------------------------------

--- a/scripts/gulp/tasks/docs.ts
+++ b/scripts/gulp/tasks/docs.ts
@@ -42,14 +42,17 @@ const handleWatchUnlink = (group: any, filePath: string) => {
 task('clean:cache', () => cache.clearAll());
 
 task('clean:docs', () =>
-  del([
-    paths.packages('ability-attributes/src/schema.ts'),
-    paths.docsSrc('componentMenu.json'),
-    paths.docsSrc('behaviorMenu.json'),
-    paths.docsDist(),
-    paths.docsSrc('exampleMenus'),
-    paths.docsSrc('exampleSources'),
-  ]),
+  del(
+    [
+      paths.packages('ability-attributes/src/schema.ts'),
+      paths.docsSrc('componentMenu.json'),
+      paths.docsSrc('behaviorMenu.json'),
+      paths.docsDist(),
+      paths.docsSrc('exampleMenus'),
+      paths.docsSrc('exampleSources'),
+    ],
+    { force: true },
+  ),
 );
 
 // ----------------------------------------

--- a/scripts/gulp/tasks/perf.ts
+++ b/scripts/gulp/tasks/perf.ts
@@ -107,7 +107,7 @@ const createMarkdownTable = (perExamplePerfMeasures: PerExamplePerfMeasures) => 
   ]);
 };
 
-task('perf:clean', () => del(paths.perfDist()));
+task('perf:clean', () => del(paths.perfDist(), { force: true }));
 
 task('perf:build', cb => {
   webpackPlugin(require('../../webpack/webpack.config.perf').default, cb);

--- a/scripts/gulp/tasks/test-e2e.ts
+++ b/scripts/gulp/tasks/test-e2e.ts
@@ -15,7 +15,7 @@ const argv = yargs
   .option('testNamePattern', { alias: 't' })
   .option('testFilePattern', { alias: 'F' }).argv;
 
-task('test:e2e:clean', () => del(paths.e2eDist()));
+task('test:e2e:clean', () => del(paths.e2eDist(), { force: true }));
 
 task('test:e2e:build', cb => {
   webpackPlugin(require('../../webpack/webpack.config.e2e').default, cb);


### PR DESCRIPTION
When cleaning, invoke `del` with `{ force: true }`, which means delete things even if it's outside the current working directory. (This comes up when running commands within individual packages, but deleting something like component info which lives in a different package.)

Fix the test script in the accessibility package to not run test before test:watch.


###### Microsoft Reviewers: [Open in CodeFlow](http://wpcp.azurewebsites.net/CodeFlowProtocolProxy2.php?pullrequest=https://github.com/OfficeDev/office-ui-fabric-react/pull/12367)